### PR TITLE
Small bug fixes post arc and planner optimisations

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -356,14 +356,14 @@ void plan_arc(
         planner.apply_leveling(raw);
       #endif
 
-      hints.curve_radius = i > 1 ? radius : 0;
-
       // calculate safe speed for stopping by the end of the arc
       arc_mm_remaining -= segment_mm;
       hints.safe_exit_speed_sqr = _MIN(limiting_speed_sqr, 2 * limiting_accel * arc_mm_remaining);
 
       if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, hints))
         break;
+
+      hints.curve_radius = radius;
     }
   }
 

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -294,11 +294,12 @@ void plan_arc(
     // An arc can always complete within limits from a speed which...
     // a) is <= any configured maximum speed,
     // b) does not require centripetal force greater than any configured maximum acceleration,
-    // c) allows the print head to stop in the remining length of the curve within all configured maximum accelerations.
+    // c) is <= nominal speed,
+    // d) allows the print head to stop in the remining length of the curve within all configured maximum accelerations.
     // The last has to be calculated every time through the loop.
     const float limiting_accel = _MIN(planner.settings.max_acceleration_mm_per_s2[axis_p], planner.settings.max_acceleration_mm_per_s2[axis_q]),
                 limiting_speed = _MIN(planner.settings.max_feedrate_mm_s[axis_p], planner.settings.max_acceleration_mm_per_s2[axis_q]),
-                limiting_speed_sqr = _MIN(sq(limiting_speed), limiting_accel * radius);
+                limiting_speed_sqr = _MIN(sq(limiting_speed), limiting_accel * radius, sq(scaled_fr_mm_s));
     float arc_mm_remaining = flat_mm;
 
     for (uint16_t i = 1; i < segments; i++) { // Iterate (segments-1) times
@@ -355,10 +356,10 @@ void plan_arc(
         planner.apply_leveling(raw);
       #endif
 
+      hints.curve_radius = i > 1 ? radius : 0;
+
       // calculate safe speed for stopping by the end of the arc
       arc_mm_remaining -= segment_mm;
-
-      hints.curve_radius = i > 1 ? radius : 0;
       hints.safe_exit_speed_sqr = _MIN(limiting_speed_sqr, 2 * limiting_accel * arc_mm_remaining);
 
       if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, hints))
@@ -383,6 +384,7 @@ void plan_arc(
   #endif
 
   hints.curve_radius = 0;
+  hints.safe_exit_speed_sqr = 0.0f;
   planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, hints);
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -806,7 +806,7 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
     float accelerate_steps_float = (nominal_rate_sq - sq(float(initial_rate))) * (0.5f / accel);
     accelerate_steps = CEIL(accelerate_steps_float);
     const float decelerate_steps_float = (nominal_rate_sq - sq(float(final_rate))) * (0.5f / accel);
-    decelerate_steps = decelerate_steps_float;
+    decelerate_steps = FLOOR(decelerate_steps_float);
 
     // Steps between acceleration and deceleration, if any
     plateau_steps -= accelerate_steps + decelerate_steps;


### PR DESCRIPTION
### Description

This PR contains two small fixes and a precautionary reversion.

#### 1. Arc safe exit speed
#24366 added a safe exit speed hint to the planner. This hint is supposed to give a value no larger than what the planner would have calculated as the exit speed for the segment being added if the planner knew about as yet unplanned segments to come.

The calculation in `G2_G3.cpp` was not including nominal speed when calculating safe exit speed. Consequently `Planner::calculate_trapezoid_for_block` was ending up with a segment that had `final_rate > block->nominal_rate`, which resulted in a negative deceleration distance.

#### 2. Arc deceleration distance
The last segment added for an arc should have a zero safe exit speed. However the code was accidentally re-using the value from the previous segment. This resulted in very sudden stops at the end of the arc.

#### 3. FLOOR

#24484 changed the way some values were calculated to make the calculations cheaper. It also included one actual functionality change, to remove the `FLOOR()` in this line:

https://github.com/MarlinFirmware/Marlin/blob/920799e38d192f056b76b25a35886f19543308e6/Marlin/src/module/planner.cpp#L796

Since the value should never be negative this seemed like a safe move. In retrospect a tiny floating point rounding error could, in principle, result in a value very slightly less than zero, which `FLOOR()` would round to zero and which truncation to an integer would round to -1.

So `FLOOR` is back in.

### Benefits

Fix two errors in the safe exit speed hint passed to the planner when printing arcs.

Remove potential rounding error, returning behaviour to the way it was before #24484.

### Related Issues

#24366
#24484