### PR TITLE
add SKR_MINI_SCREEN_ADAPTER support to BTT skr mini E3 V3 pins

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -186,44 +186,43 @@
 #elif HAS_WIRED_LCD
 
   #if ENABLED(SKR_MINI_SCREEN_ADAPTER)
-    /* https://github.com/VoronDesign/Voron-Hardware/tree/master/SKR-Mini_Screen_Adaptor/SRK%20Mini%20E3%20V3.0
-    *
-    *             SKR Mini E3 V3.0                   SKR Mini Screen Adaptor
-    *                  ------                                ------
-    *            +5V  | 1  2 | GND                     MISO | 1  2 | SCK
-    *             CS  | 3  4 | SCK               (EN1) PA10 | 3  4 |
-    *           MOSI  | 5  6 | MISO              (EN2)  PA9   5  6 | MOSI
-    *            3V3  | 7  8 | GND                          | 7  8 |
-    *                  ------                           GND | 9  10| RESET (Kill)
-    *                   SPI                                  ------
-    *                                                         EXP2
-    *
-    *                  ------                                ------
-    *             PB5 | 1  2 | PA15                     N/C | 1  2 | PB5  (BTN_ENC)
-    *             PA9 | 3  4 | RESET           (LCD CS) PB8 | 3  4 | PD6  (LCD_A0)
-    *            PA10   5  6 | PB9              (RESET) PB9   5  6 | PA15 (DIN)
-    *             PB8 | 7  8 | PD6                      N/C | 7  8 | N/C
-    *             GND | 9  10| 5V                       GND | 9  10| +5v
-    *                  ------                                ------
-    *                   EXP1                                  EXP1
-    */
-
+    /** https://github.com/VoronDesign/Voron-Hardware/tree/master/SKR-Mini_Screen_Adaptor/SRK%20Mini%20E3%20V3.0
+     *
+     *            SKR Mini E3 V3.0                   SKR Mini Screen Adaptor
+     *                 ------                                ------
+     *           +5V  | 1  2 | GND                     MISO | 1  2 | SCK
+     *            CS  | 3  4 | SCK               (EN1) PA10 | 3  4 |
+     *          MOSI  | 5  6 | MISO              (EN2)  PA9   5  6 | MOSI
+     *           3V3  | 7  8 | GND                          | 7  8 |
+     *                 ------                           GND | 9  10| RESET (Kill)
+     *                  SPI                                  ------
+     *                                                        EXP2
+     *
+     *                 ------                                ------
+     *            PB5 | 1  2 | PA15                     N/C | 1  2 | PB5  (BTN_ENC)
+     *            PA9 | 3  4 | RESET           (LCD CS) PB8 | 3  4 | PD6  (LCD_A0)
+     *           PA10   5  6 | PB9              (RESET) PB9   5  6 | PA15 (DIN)
+     *            PB8 | 7  8 | PD6                      N/C | 7  8 | N/C
+     *            GND | 9  10| 5V                       GND | 9  10| +5v
+     *                 ------                                ------
+     *                  EXP1                                  EXP1
+     */
     #if ENABLED(FYSETC_MINI_12864_2_1)
       #define BTN_ENC                EXP1_01_PIN
       #define BTN_EN1                EXP1_03_PIN
       #define BTN_EN2                EXP1_05_PIN
-      #define BEEPER_PIN                      -1
+      #define BEEPER_PIN                    -1
       #define LCD_RESET_PIN          EXP1_06_PIN
       #define DOGLCD_CS              EXP1_07_PIN
       #define DOGLCD_A0              EXP1_08_PIN
-      #define DOGLCD_SCK                     PA5
-      #define DOGLCD_MOSI                    PA7
+      #define DOGLCD_SCK                    PA5
+      #define DOGLCD_MOSI                   PA7
 
       #define FORCE_SOFT_SPI
-      #define LCD_BACKLIGHT_PIN               -1
+      #define LCD_BACKLIGHT_PIN             -1
       #define NEOPIXEL_PIN           EXP1_02_PIN
     #else
-      #error "Only CR10_FYSETC_MINI_12864_2_1 and comptables are currently supported on the BIGTREE_SKR_MINI_E3 with SKR_MINI_SCREEN_ADAPTER"
+      #error "Only CR10_FYSETC_MINI_12864_2_1 and compatibles are currently supported on the BIGTREE_SKR_MINI_E3 with SKR_MINI_SCREEN_ADAPTER"
     #endif
 
   #else
@@ -240,7 +239,7 @@
       #define LCD_PINS_ENABLE        EXP1_08_PIN
       #define LCD_PINS_D4            EXP1_06_PIN
 
-    #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
+    #elif ENABLED(ZONESTAR_LCD)                   // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
       #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
         #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
@@ -252,7 +251,7 @@
       #define LCD_PINS_D5            EXP1_05_PIN
       #define LCD_PINS_D6            EXP1_03_PIN
       #define LCD_PINS_D7            EXP1_01_PIN
-      #define ADC_KEYPAD_PIN                 PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
+      #define ADC_KEYPAD_PIN                PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
     #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
 
@@ -266,7 +265,7 @@
       #define DOGLCD_MOSI            EXP1_08_PIN
 
       #define FORCE_SOFT_SPI
-      #define LCD_BACKLIGHT_PIN               -1
+      #define LCD_BACKLIGHT_PIN             -1
 
     #elif IS_TFTGLCD_PANEL
 
@@ -281,11 +280,11 @@
          *
          *                 Board                               Display
          *                 ------                               ------
-        * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V | 1  2 | GND
-        *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 3  4 | (SD_DET)
-        *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 5  6 | --
-        *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 7  8 | (LCD_CS)
-        *           GND | 9 10 | 5V                   (SCK)   | 9 10 | (MISO)
+         * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V | 1  2 | GND
+         *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 3  4 | (SD_DET)
+         *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 5  6 | --
+         *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 7  8 | (LCD_CS)
+         *           GND | 9 10 | 5V                   (SCK)   | 9 10 | (MISO)
          *                 ------                               ------
          *                  EXP1                                 EXP1
          *
@@ -344,7 +343,7 @@
       #define BTN_ENC                EXP1_02_PIN
       #define BTN_EN1                EXP1_06_PIN
       #define BTN_EN2                EXP1_01_PIN
-      #define BEEPER_PIN                      -1
+      #define BEEPER_PIN                    -1
 
       #define DOGLCD_CS              EXP1_03_PIN
       #define DOGLCD_A0              EXP1_05_PIN
@@ -352,7 +351,7 @@
       #define DOGLCD_MOSI            EXP1_08_PIN
 
       #define FORCE_SOFT_SPI
-      #define LCD_BACKLIGHT_PIN               -1
+      #define LCD_BACKLIGHT_PIN             -1
 
     #else
       #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, FYSETC_MINI_12864_2_1, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BIGTREE_SKR_MINI_E3."
@@ -426,8 +425,8 @@
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
 
 #define ENABLE_SPI1
-#define SDSS                  ONBOARD_SD_CS_PIN
-#define SD_SS_PIN             ONBOARD_SD_CS_PIN
+#define SDSS                   ONBOARD_SD_CS_PIN
+#define SD_SS_PIN              ONBOARD_SD_CS_PIN
 #define SD_SCK_PIN                          PA5
 #define SD_MISO_PIN                         PA6
 #define SD_MOSI_PIN                         PA7

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -191,18 +191,18 @@
      *            SKR Mini E3 V3.0                   SKR Mini Screen Adaptor
      *                 ------                                ------
      *           +5V  | 1  2 | GND                     MISO | 1  2 | SCK
-     *            CS  | 3  4 | SCK               (EN1) PA10 | 3  4 |
+     *            CS  | 3  4 | SCK               (EN1) PA10 | 3  4 | --
      *          MOSI  | 5  6 | MISO              (EN2)  PA9   5  6 | MOSI
-     *           3V3  | 7  8 | GND                          | 7  8 |
+     *           3V3  | 7  8 | GND                       -- | 7  8 | --
      *                 ------                           GND | 9  10| RESET (Kill)
      *                  SPI                                  ------
      *                                                        EXP2
      *
      *                 ------                                ------
-     *            PB5 | 1  2 | PA15                     N/C | 1  2 | PB5  (BTN_ENC)
+     *            PB5 | 1  2 | PA15                      -- | 1  2 | PB5  (BTN_ENC)
      *            PA9 | 3  4 | RESET           (LCD CS) PB8 | 3  4 | PD6  (LCD_A0)
      *           PA10   5  6 | PB9              (RESET) PB9   5  6 | PA15 (DIN)
-     *            PB8 | 7  8 | PD6                      N/C | 7  8 | N/C
+     *            PB8 | 7  8 | PD6                       -- | 7  8 | --
      *            GND | 9  10| 5V                       GND | 9  10| +5v
      *                 ------                                ------
      *                  EXP1                                  EXP1

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -75,10 +75,6 @@
   #define POWER_LOSS_PIN                    PC12  // Power Loss Detection: PWR-DET
 #endif
 
-#ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                      PA8   // LED driving pin
-#endif
-
 #ifndef PS_ON_PIN
   #define PS_ON_PIN                         PC13  // Power Supply Control
 #endif
@@ -153,8 +149,16 @@
  *                  ------
  *                   EXP1
  */
+#define EXP1_01_PIN                         PB5
 #define EXP1_02_PIN                         PA15
+#define EXP1_03_PIN                         PA9
+#define EXP1_04_PIN                         -1
+#define EXP1_05_PIN                         PA10
+#define EXP1_06_PIN                         PB9
+#define EXP1_07_PIN                         PB8
 #define EXP1_08_PIN                         PD6
+#define EXP1_09_PIN                         -1
+#define EXP1_10_PIN                         -1
 
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
   /**
@@ -176,93 +180,136 @@
 
   #define BEEPER_PIN                 EXP1_02_PIN
   #define BTN_EN1                    EXP1_08_PIN
-  #define BTN_EN2                           PB8
-  #define BTN_ENC                           PB5
+  #define BTN_EN2                    EXP1_07_PIN
+  #define BTN_ENC                    EXP1_01_PIN
 
 #elif HAS_WIRED_LCD
 
-  #if ENABLED(CR10_STOCKDISPLAY)
+  #if ENABLED(SKR_MINI_SCREEN_ADAPTER)
+    /* https://github.com/VoronDesign/Voron-Hardware/tree/master/SKR-Mini_Screen_Adaptor/SRK%20Mini%20E3%20V3.0
+    *
+    *             SKR Mini E3 V3.0                   SKR Mini Screen Adaptor
+    *                  ------                                ------
+    *            +5V  | 1  2 | GND                     MISO | 1  2 | SCK
+    *             CS  | 3  4 | SCK               (EN1) PA10 | 3  4 |
+    *           MOSI  | 5  6 | MISO              (EN2)  PA9   5  6 | MOSI
+    *            3V3  | 7  8 | GND                          | 7  8 |
+    *                  ------                           GND | 9  10| RESET (Kill)
+    *                   SPI                                  ------
+    *                                                         EXP2
+    *
+    *                  ------                                ------
+    *             PB5 | 1  2 | PA15                     N/C | 1  2 | PB5  (BTN_ENC)
+    *             PA9 | 3  4 | RESET           (LCD CS) PB8 | 3  4 | PD6  (LCD_A0)
+    *            PA10   5  6 | PB9              (RESET) PB9   5  6 | PA15 (DIN)
+    *             PB8 | 7  8 | PD6                      N/C | 7  8 | N/C
+    *             GND | 9  10| 5V                       GND | 9  10| +5v
+    *                  ------                                ------
+    *                   EXP1                                  EXP1
+    */
 
-    #define BEEPER_PIN                      PB5
-    #define BTN_ENC                  EXP1_02_PIN
+    #if ENABLED(FYSETC_MINI_12864_2_1)
+      #define BTN_ENC                EXP1_01_PIN
+      #define BTN_EN1                EXP1_03_PIN
+      #define BTN_EN2                EXP1_05_PIN
+      #define BEEPER_PIN                      -1
+      #define LCD_RESET_PIN          EXP1_06_PIN
+      #define DOGLCD_CS              EXP1_07_PIN
+      #define DOGLCD_A0              EXP1_08_PIN
+      #define DOGLCD_SCK                     PA5
+      #define DOGLCD_MOSI                    PA7
 
-    #define BTN_EN1                         PA9
-    #define BTN_EN2                         PA10
-
-    #define LCD_PINS_RS                     PB8
-    #define LCD_PINS_ENABLE          EXP1_08_PIN
-    #define LCD_PINS_D4                     PB9
-
-  #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
-
-    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
-      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #define FORCE_SOFT_SPI
+      #define LCD_BACKLIGHT_PIN               -1
+      #define NEOPIXEL_PIN           EXP1_02_PIN
+    #else
+      #error "Only CR10_FYSETC_MINI_12864_2_1 and comptables are currently supported on the BIGTREE_SKR_MINI_E3 with SKR_MINI_SCREEN_ADAPTER"
     #endif
 
-    #define LCD_PINS_RS                     PB9
-    #define LCD_PINS_ENABLE          EXP1_02_PIN
-    #define LCD_PINS_D4                     PB8
-    #define LCD_PINS_D5                     PA10
-    #define LCD_PINS_D6                     PA9
-    #define LCD_PINS_D7                     PB5
-    #define ADC_KEYPAD_PIN                  PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
+  #else
 
-  #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
+    #if ENABLED(CR10_STOCKDISPLAY)
 
-    #define BTN_ENC                  EXP1_02_PIN
-    #define BTN_EN1                         PA9
-    #define BTN_EN2                         PA10
+      #define BEEPER_PIN             EXP1_01_PIN
+      #define BTN_ENC                EXP1_02_PIN
 
-    #define DOGLCD_CS                       PB8
-    #define DOGLCD_A0                       PB9
-    #define DOGLCD_SCK                      PB5
-    #define DOGLCD_MOSI              EXP1_08_PIN
+      #define BTN_EN1                EXP1_03_PIN
+      #define BTN_EN2                EXP1_05_PIN
 
-    #define FORCE_SOFT_SPI
-    #define LCD_BACKLIGHT_PIN               -1
+      #define LCD_PINS_RS            EXP1_07_PIN
+      #define LCD_PINS_ENABLE        EXP1_08_PIN
+      #define LCD_PINS_D4            EXP1_06_PIN
 
-  #elif IS_TFTGLCD_PANEL
-
-    #if ENABLED(TFTGLCD_PANEL_SPI)
+    #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
       #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
-        #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+        #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
       #endif
 
-      /**
-       * TFTGLCD_PANEL_SPI display pinout
-       *
-       *                 Board                               Display
-       *                 ------                               ------
-       * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V | 1  2 | GND
-       *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 3  4 | (SD_DET)
-       *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 5  6 | --
-       *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 7  8 | (LCD_CS)
-       *           GND | 9 10 | 5V                   (SCK)   | 9 10 | (MISO)
-       *                 ------                               ------
-       *                  EXP1                                 EXP1
-       *
-       * Needs custom cable:
-       *
-       *    Board             Display
-       *
-       *   EXP1-1 ----------- EXP1-10
-       *   EXP1-2 ----------- EXP1-9
-       *   SPI1-4 ----------- EXP1-6
-       *   EXP1-4 ----------- FREE
-       *   SPI1-3 ----------- EXP1-2
-       *   EXP1-6 ----------- EXP1-4
-       *   EXP1-7 ----------- FREE
-       *   EXP1-8 ----------- EXP1-3
-       *   SPI1-1 ----------- EXP1-1
-       *  EXP1-10 ----------- EXP1-7
-       */
+      #define LCD_PINS_RS            EXP1_06_PIN
+      #define LCD_PINS_ENABLE        EXP1_02_PIN
+      #define LCD_PINS_D4            EXP1_07_PIN
+      #define LCD_PINS_D5            EXP1_05_PIN
+      #define LCD_PINS_D6            EXP1_03_PIN
+      #define LCD_PINS_D7            EXP1_01_PIN
+      #define ADC_KEYPAD_PIN                 PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-      #define TFTGLCD_CS                    PA9
+    #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
 
-    #endif
+      #define BTN_ENC                EXP1_02_PIN
+      #define BTN_EN1                EXP1_03_PIN
+      #define BTN_EN2                EXP1_05_PIN
 
-  #elif ENABLED(FYSETC_MINI_12864_2_1)
+      #define DOGLCD_CS              EXP1_07_PIN
+      #define DOGLCD_A0              EXP1_06_PIN
+      #define DOGLCD_SCK             EXP1_01_PIN
+      #define DOGLCD_MOSI            EXP1_08_PIN
+
+      #define FORCE_SOFT_SPI
+      #define LCD_BACKLIGHT_PIN               -1
+
+    #elif IS_TFTGLCD_PANEL
+
+      #if ENABLED(TFTGLCD_PANEL_SPI)
+
+        #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+          #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+        #endif
+
+        /**
+         * TFTGLCD_PANEL_SPI display pinout
+         *
+         *                 Board                               Display
+         *                 ------                               ------
+        * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V | 1  2 | GND
+        *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 3  4 | (SD_DET)
+        *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 5  6 | --
+        *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 7  8 | (LCD_CS)
+        *           GND | 9 10 | 5V                   (SCK)   | 9 10 | (MISO)
+         *                 ------                               ------
+         *                  EXP1                                 EXP1
+         *
+         * Needs custom cable:
+         *
+         *    Board             Display
+         *
+         *   EXP1-1 ----------- EXP1-10
+         *   EXP1-2 ----------- EXP1-9
+         *   SPI1-4 ----------- EXP1-6
+         *   EXP1-4 ----------- FREE
+         *   SPI1-3 ----------- EXP1-2
+         *   EXP1-6 ----------- EXP1-4
+         *   EXP1-7 ----------- FREE
+         *   EXP1-8 ----------- EXP1-3
+         *   SPI1-1 ----------- EXP1-1
+         *  EXP1-10 ----------- EXP1-7
+         */
+
+        #define TFTGLCD_CS           EXP1_03_PIN
+
+      #endif
+
+    #elif ENABLED(FYSETC_MINI_12864_2_1)
 
       #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
         #error "CAUTION! FYSETC_MINI_12864_2_1 and clones require wiring modifications. See 'pins_BTT_SKR_MINI_E3_V3_0.h' for details. Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning"
@@ -294,22 +341,24 @@
        * Check twice index position!!! (marked as # here)
        * On BTT boards pins from IDC10 connector are numbered in unusual order.
        */
-    #define BTN_ENC                  EXP1_02_PIN
-    #define BTN_EN1                         PB9
-    #define BTN_EN2                         PB5
-    #define BEEPER_PIN                      -1
+      #define BTN_ENC                EXP1_02_PIN
+      #define BTN_EN1                EXP1_06_PIN
+      #define BTN_EN2                EXP1_01_PIN
+      #define BEEPER_PIN                      -1
 
-    #define DOGLCD_CS                       PA9
-    #define DOGLCD_A0                       PA10
-    #define DOGLCD_SCK                      PB8
-    #define DOGLCD_MOSI                     PD6
+      #define DOGLCD_CS              EXP1_03_PIN
+      #define DOGLCD_A0              EXP1_05_PIN
+      #define DOGLCD_SCK             EXP1_07_PIN
+      #define DOGLCD_MOSI            EXP1_08_PIN
 
-    #define FORCE_SOFT_SPI
-    #define LCD_BACKLIGHT_PIN               -1
+      #define FORCE_SOFT_SPI
+      #define LCD_BACKLIGHT_PIN               -1
 
-  #else
-    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, FYSETC_MINI_12864_2_1, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BIGTREE_SKR_MINI_E3."
-  #endif
+    #else
+      #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, FYSETC_MINI_12864_2_1, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BIGTREE_SKR_MINI_E3."
+    #endif
+
+  #endif // SKR_MINI_SCREEN_ADAPTER
 
 #endif // HAS_WIRED_LCD
 
@@ -352,9 +401,8 @@
 
   #define BEEPER_PIN                 EXP1_02_PIN
 
-  #define CLCD_MOD_RESET                    PA9
-  #define CLCD_SPI_CS                       PB8
-
+  #define CLCD_MOD_RESET             EXP1_03_PIN
+  #define CLCD_SPI_CS                EXP1_07_PIN
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
 
 //
@@ -368,8 +416,8 @@
 #if SD_CONNECTION_IS(ONBOARD)
   #define SD_DETECT_PIN                     PC3
 #elif SD_CONNECTION_IS(LCD) && (BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050) || IS_TFTGLCD_PANEL)
-  #define SD_DETECT_PIN                     PB5
-  #define SD_SS_PIN                         PA10
+  #define SD_DETECT_PIN              EXP1_01_PIN
+  #define SD_SS_PIN                  EXP1_05_PIN
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
   #error "SD CUSTOM_CABLE is not compatible with SKR Mini E3."
 #endif
@@ -378,8 +426,15 @@
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
 
 #define ENABLE_SPI1
-#define SDSS                   ONBOARD_SD_CS_PIN
-#define SD_SS_PIN              ONBOARD_SD_CS_PIN
+#define SDSS                  ONBOARD_SD_CS_PIN
+#define SD_SS_PIN             ONBOARD_SD_CS_PIN
 #define SD_SCK_PIN                          PA5
 #define SD_MISO_PIN                         PA6
 #define SD_MOSI_PIN                         PA7
+
+//
+// Default NEOPIXEL_PIN
+//
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA8   // LED driving pin
+#endif

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -190,7 +190,7 @@
      *
      *            SKR Mini E3 V3.0                   SKR Mini Screen Adaptor
      *                 ------                                ------
-     *           +5V  | 1  2 | GND                     MISO | 1  2 | SCK
+     *            5V  | 1  2 | GND                     MISO | 1  2 | SCK
      *            CS  | 3  4 | SCK               (EN1) PA10 | 3  4 | --
      *          MOSI  | 5  6 | MISO              (EN2)  PA9   5  6 | MOSI
      *           3V3  | 7  8 | GND                       -- | 7  8 | --
@@ -203,7 +203,7 @@
      *            PA9 | 3  4 | RESET           (LCD CS) PB8 | 3  4 | PD6  (LCD_A0)
      *           PA10   5  6 | PB9              (RESET) PB9   5  6 | PA15 (DIN)
      *            PB8 | 7  8 | PD6                       -- | 7  8 | --
-     *            GND | 9  10| 5V                       GND | 9  10| +5v
+     *            GND | 9  10| 5V                       GND | 9  10| 5V
      *                 ------                                ------
      *                  EXP1                                  EXP1
      */


### PR DESCRIPTION
### Description

Use Exp pins instead of raw IO pins
Add support for the voron SKR-Mini_Screen_Adaptor  (#define SKR_MINI_SCREEN_ADAPTER) 
https://github.com/VoronDesign/Voron-Hardware/tree/master/SKR-Mini_Screen_Adaptor/SRK%20Mini%20E3%20V3.0

This has limitations:  The on lcd sdcard slot is not supported. The LCD reset button by default is not connected (Kill jumper on adapter needs to be bridged to enable this). The buzzer is not connected.   

### Requirements

BTT skr mini E3 V3 
Voron SKR-Mini_Screen_Adaptor 
FYSETC_MINI_12864_2_1 or compatable  LCD

### Benefits

The Voron SKR-Mini_Screen_Adaptor works on marlin.  

### Configurations

Simple example config
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/9137600/Configuration.zip)

### Related Issues
Was mentioned on Marlin discord https://discord.com/channels/461605380783472640/830232451430744105/994091389921013770