### PR TITLE
EXP header pin numbers redux

### DIFF
--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -128,23 +128,23 @@
  *                 EXP1                                   EXP2
  */
 
-#define EXP1_08_PIN                           17
-#define EXP1_07_PIN                           15
-#define EXP1_06_PIN                           16
-#define EXP1_05_PIN                            0
-#define EXP1_04_PIN                            4
-#define EXP1_03_PIN                           21
-#define EXP1_02_PIN                           13
 #define EXP1_01_PIN                          149
+#define EXP1_02_PIN                           13
+#define EXP1_03_PIN                           21
+#define EXP1_04_PIN                            4
+#define EXP1_05_PIN                            0
+#define EXP1_06_PIN                           16
+#define EXP1_07_PIN                           15
+#define EXP1_08_PIN                           17
 
-#define EXP2_08_PIN                           -1  // RESET
-#define EXP2_07_PIN                           34
-#define EXP2_06_PIN                           23
-#define EXP2_05_PIN                           12
-#define EXP2_04_PIN                            5
-#define EXP2_03_PIN                           14
-#define EXP2_02_PIN                           18
 #define EXP2_01_PIN                           19
+#define EXP2_02_PIN                           18
+#define EXP2_03_PIN                           14
+#define EXP2_04_PIN                            5
+#define EXP2_05_PIN                           12
+#define EXP2_06_PIN                           23
+#define EXP2_07_PIN                           34
+#define EXP2_08_PIN                           -1  // RESET
 
 //
 // MicroSD card

--- a/Marlin/src/pins/esp32/pins_PANDA_common.h
+++ b/Marlin/src/pins/esp32/pins_PANDA_common.h
@@ -90,19 +90,19 @@
  *             ------                              ------
  *              EXP2                                EXP1
  */
-#define EXP1_05_PIN                           14
-#define EXP1_04_PIN                           27
-#define EXP1_03_PIN                           26
-#define EXP1_02_PIN                           12
 #define EXP1_01_PIN                          129
+#define EXP1_02_PIN                           12
+#define EXP1_03_PIN                           26
+#define EXP1_04_PIN                           27
+#define EXP1_05_PIN                           14
 
-#define EXP2_07_PIN                            2  // ?
-#define EXP2_06_PIN                           23  // ?
-#define EXP2_05_PIN                           32
-#define EXP2_04_PIN                            5  // ?
-#define EXP2_03_PIN                           33
-#define EXP2_02_PIN                           18  // ?
 #define EXP2_01_PIN                           19  // ?
+#define EXP2_02_PIN                           18  // ?
+#define EXP2_03_PIN                           33
+#define EXP2_04_PIN                            5  // ?
+#define EXP2_05_PIN                           32
+#define EXP2_06_PIN                           23  // ?
+#define EXP2_07_PIN                            2  // ?
 
 //
 // SD Card

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -66,23 +66,23 @@
  *         ------                  ------
  *          EXP1                    EXP2
  */
-#define EXP1_08_PIN                        -1     // NC
-#define EXP1_07_PIN                        -1     // NC
-#define EXP1_06_PIN                        -1     // NC
-#define EXP1_05_PIN                        P0_15
-#define EXP1_04_PIN                        P0_16
-#define EXP1_03_PIN                        P0_18
-#define EXP1_02_PIN                        P2_11
 #define EXP1_01_PIN                        P1_30
+#define EXP1_02_PIN                        P2_11
+#define EXP1_03_PIN                        P0_18
+#define EXP1_04_PIN                        P0_16
+#define EXP1_05_PIN                        P0_15
+#define EXP1_06_PIN                        -1     // NC
+#define EXP1_07_PIN                        -1     // NC
+#define EXP1_08_PIN                        -1     // NC
 
-#define EXP2_08_PIN                        -1     // RESET
-#define EXP2_07_PIN                        P1_31
-#define EXP2_06_PIN                        P0_18
-#define EXP2_05_PIN                        P3_25
-#define EXP2_04_PIN                        P1_23
-#define EXP2_03_PIN                        P3_26
-#define EXP2_02_PIN                        P0_15
 #define EXP2_01_PIN                        P0_17
+#define EXP2_02_PIN                        P0_15
+#define EXP2_03_PIN                        P3_26
+#define EXP2_04_PIN                        P1_23
+#define EXP2_05_PIN                        P3_25
+#define EXP2_06_PIN                        P0_18
+#define EXP2_07_PIN                        P1_31
+#define EXP2_08_PIN                        -1     // RESET
 
 /**
  * LCD / Controller

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -199,23 +199,23 @@
  *                 ------                                     ------
  *                  EXP1                                       EXP2
  */
-#define EXP1_08_PIN                        P1_23
-#define EXP1_07_PIN                        P1_22
-#define EXP1_06_PIN                        P1_21
-#define EXP1_05_PIN                        P1_20
-#define EXP1_04_PIN                        P1_19
-#define EXP1_03_PIN                        P1_18
-#define EXP1_02_PIN                        P0_28
 #define EXP1_01_PIN                        P1_30
+#define EXP1_02_PIN                        P0_28
+#define EXP1_03_PIN                        P1_18
+#define EXP1_04_PIN                        P1_19
+#define EXP1_05_PIN                        P1_20
+#define EXP1_06_PIN                        P1_21
+#define EXP1_07_PIN                        P1_22
+#define EXP1_08_PIN                        P1_23
 
-#define EXP2_08_PIN                        -1
-#define EXP2_07_PIN                        P1_31
-#define EXP2_06_PIN                        P0_18
-#define EXP2_05_PIN                        P3_25
-#define EXP2_04_PIN                        P0_16
-#define EXP2_03_PIN                        P3_26
-#define EXP2_02_PIN                        P0_15
 #define EXP2_01_PIN                        P0_17
+#define EXP2_02_PIN                        P0_15
+#define EXP2_03_PIN                        P3_26
+#define EXP2_04_PIN                        P0_16
+#define EXP2_05_PIN                        P3_25
+#define EXP2_06_PIN                        P0_18
+#define EXP2_07_PIN                        P1_31
+#define EXP2_08_PIN                        -1
 
 #if HAS_WIRED_LCD
   #if ENABLED(ANET_FULL_GRAPHICS_LCD_ALT_WIRING)

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -239,11 +239,11 @@
     *
     *                  BEFORE                          AFTER
     *                  ------                          ------
-    *           (CLK) | 1  2 | (BEEPER)      (BEEPER) | 1  2 | --
-    *              -- | 3  4 | (BTN_ENC)    (BTN_ENC) | 3  4 | (CLK)
-    *           (SID)   5  6 | (BTN_EN1)    (BTN_EN1)   5  6 | (SID)
-    *            (CS) | 7  8 | (BTN_EN2)    (BTN_EN2) | 7  8 | (CS)
-    *             GND | 9 10 | 5V                 GND | 9 10 | 5V
+    *           (CLK) | 1  2 | (BEEPER)      (BEEPER) |10  9 | --
+    *              -- | 3  4 | (BTN_ENC)    (BTN_ENC) | 8  7 | (CLK)
+    *           (SID)   5  6 | (BTN_EN1)    (BTN_EN1)   6  5 | (SID)
+    *            (CS) | 7  8 | (BTN_EN2)    (BTN_EN2) | 4  3 | (CS)
+    *             GND | 9 10 | 5V                 GND | 2  1 | 5V
     *                  ------                          ------
     *                   LCD                             LCD
     */
@@ -274,11 +274,11 @@
      *
      *                  BEFORE                      AFTER
      *                  ______                     ______
-     *                 | 1  2 | (MOSI)     (MOSI) | 1  2 | --
-     *       (BTN_ENC) | 3  4 | (SCK)   (BTN_ENC) | 3  4 | (SCK)
-     *       (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   5  6 | (SID)
-     *       (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 7  8 | (CS)
-     *              5V | 9 10 | GND           GND | 9 10 | 5V
+     *                 | 1  2 | (MOSI)     (MOSI) |10  9 | --
+     *       (BTN_ENC) | 3  4 | (SCK)   (BTN_ENC) | 8  7 | (SCK)
+     *       (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   6  5 | (SID)
+     *       (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 4  3 | (CS)
+     *              5V | 9 10 | GND           GND | 2  1 | 5V
      *                  ------                     ------
      *                   LCD                        LCD
      */

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -300,11 +300,11 @@
      *
      *                BEFORE                     AFTER
      *                ------                     ------
-     *      (BEEPER) | 1  2 | (CLK)    (BEEPER) | 1  2 | (CLK)
-     *     (BTN_ENC) | 3  4 | --      (BTN_ENC) | 3  4 | --
-     *     (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   5  6 | (SID)
-     *     (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 7  8 | (CS)
-     *            5V | 9 10 | GND           GND | 9 10 | 5V
+     *      (BEEPER) | 1  2 | (CLK)    (BEEPER) |10  9 | (CLK)
+     *     (BTN_ENC) | 3  4 | --      (BTN_ENC) | 8  7 | --
+     *     (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   6  5 | (SID)
+     *     (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 4  3 | (CS)
+     *            5V | 9 10 | GND           GND | 2  1 | 5V
      *                ------                     ------
      *                 LCD                        LCD
      */
@@ -336,11 +336,11 @@
     *
     *            BEFORE                     AFTER
     *            ------                     ------
-    *  (BEEPER) | 1  2 | (CLK)    (BEEPER) | 1  2 | --
-    * (BTN_ENC) | 3  4 | --      (BTN_ENC) | 3  4 | (CLK)
-    * (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   5  6 | (SID)
-    * (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 7  8 | (CS)
-    *        5V | 9 10 | GND           GND | 9 10 | 5V
+    *  (BEEPER) | 1  2 | (CLK)    (BEEPER) |10  9 | --
+    * (BTN_ENC) | 3  4 | --      (BTN_ENC) | 8  7 | (CLK)
+    * (BTN_EN1)   5  6 | (SID)   (BTN_EN1)   6  5 | (SID)
+    * (BTN_EN2) | 7  8 | (CS)    (BTN_EN2) | 4  3 | (CS)
+    *        5V | 9 10 | GND           GND | 2  1 | 5V
     *            ------                     ------
     *             LCD                        LCD
     */

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -254,23 +254,23 @@
  *        ------                ------
  *         EXP1                  EXP2
  */
-#define EXP1_08_PIN                        P1_23
-#define EXP1_07_PIN                        P1_22
-#define EXP1_06_PIN                        P1_21
-#define EXP1_05_PIN                        P1_20
-#define EXP1_04_PIN                        P1_19
-#define EXP1_03_PIN                        P1_18
-#define EXP1_02_PIN                        P0_28
 #define EXP1_01_PIN                        P1_30
+#define EXP1_02_PIN                        P0_28
+#define EXP1_03_PIN                        P1_18
+#define EXP1_04_PIN                        P1_19
+#define EXP1_05_PIN                        P1_20
+#define EXP1_06_PIN                        P1_21
+#define EXP1_07_PIN                        P1_22
+#define EXP1_08_PIN                        P1_23
 
-#define EXP2_08_PIN                        -1     // RESET
-#define EXP2_07_PIN                        P1_31
-#define EXP2_06_PIN                        P0_18
-#define EXP2_05_PIN                        P3_25
-#define EXP2_04_PIN                        P0_16
-#define EXP2_03_PIN                        P3_26
-#define EXP2_02_PIN                        P0_15
 #define EXP2_01_PIN                        P0_17
+#define EXP2_02_PIN                        P0_15
+#define EXP2_03_PIN                        P3_26
+#define EXP2_04_PIN                        P0_16
+#define EXP2_05_PIN                        P3_25
+#define EXP2_06_PIN                        P0_18
+#define EXP2_07_PIN                        P1_31
+#define EXP2_08_PIN                        -1     // RESET
 
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
 

--- a/Marlin/src/pins/lpc1768/pins_EMOTRONIC.h
+++ b/Marlin/src/pins/lpc1768/pins_EMOTRONIC.h
@@ -91,25 +91,25 @@
 //
 // Extension ports
 //
-#define EXP1_10_PIN                        P0_28  // SCL0
-#define EXP1_09_PIN                        P0_27  // SDA0
-#define EXP1_08_PIN                        P0_16  // SSEL0
-#define EXP1_07_PIN                        P0_15  // SCK0
-#define EXP1_06_PIN                        P0_18  // MOSI0
-#define EXP1_05_PIN                        P0_17  // MISO0
-#define EXP1_04_PIN                        P1_31
-#define EXP1_03_PIN                        P1_30
-#define EXP1_02_PIN                        P0_02  // TX0
 #define EXP1_01_PIN                        P0_03  // RX0
+#define EXP1_02_PIN                        P0_02  // TX0
+#define EXP1_03_PIN                        P1_30
+#define EXP1_04_PIN                        P1_31
+#define EXP1_05_PIN                        P0_17  // MISO0
+#define EXP1_06_PIN                        P0_18  // MOSI0
+#define EXP1_07_PIN                        P0_15  // SCK0
+#define EXP1_08_PIN                        P0_16  // SSEL0
+#define EXP1_09_PIN                        P0_27  // SDA0
+#define EXP1_10_PIN                        P0_28  // SCL0
 
-#define EXP2_08_PIN                        P1_27
-#define EXP2_07_PIN                        P1_26
-#define EXP2_06_PIN                        P1_29
-#define EXP2_05_PIN                        P1_28
-#define EXP2_04_PIN                        P0_01  // SCL1
-#define EXP2_03_PIN                        P0_00  // SDA1
-#define EXP2_02_PIN                        P0_11
 #define EXP2_01_PIN                        P0_10
+#define EXP2_02_PIN                        P0_11
+#define EXP2_03_PIN                        P0_00  // SDA1
+#define EXP2_04_PIN                        P0_01  // SCL1
+#define EXP2_05_PIN                        P1_28
+#define EXP2_06_PIN                        P1_29
+#define EXP2_07_PIN                        P1_26
+#define EXP2_08_PIN                        P1_27
 
 //
 // SD Support

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -239,23 +239,23 @@
  *                ------                                        ------
  *                 EXP1                                          EXP2
  */
-#define EXP1_08_PIN                        P1_22
-#define EXP1_07_PIN                        P1_00
-#define EXP1_06_PIN                        P0_17
-#define EXP1_05_PIN                        P0_15
-#define EXP1_04_PIN                        P0_16
-#define EXP1_03_PIN                        P0_18
-#define EXP1_02_PIN                        P1_30
 #define EXP1_01_PIN                        P1_31
+#define EXP1_02_PIN                        P1_30
+#define EXP1_03_PIN                        P0_18
+#define EXP1_04_PIN                        P0_16
+#define EXP1_05_PIN                        P0_15
+#define EXP1_06_PIN                        P0_17
+#define EXP1_07_PIN                        P1_00
+#define EXP1_08_PIN                        P1_22
 
-#define EXP2_08_PIN                        -1     // RESET
-#define EXP2_07_PIN                        P0_27
-#define EXP2_06_PIN                        P0_09
-#define EXP2_05_PIN                        P3_26
-#define EXP2_04_PIN                        P0_28
-#define EXP2_03_PIN                        P3_25
-#define EXP2_02_PIN                        P0_07
 #define EXP2_01_PIN                        P0_08
+#define EXP2_02_PIN                        P0_07
+#define EXP2_03_PIN                        P3_25
+#define EXP2_04_PIN                        P0_28
+#define EXP2_05_PIN                        P3_26
+#define EXP2_06_PIN                        P0_09
+#define EXP2_07_PIN                        P0_27
+#define EXP2_08_PIN                        -1     // RESET
 
 #ifndef SDCARD_CONNECTION
   #define SDCARD_CONNECTION              ONBOARD

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -194,14 +194,14 @@
  *                  ------
  *                   EXP
  */
-#define EXP1_08_PIN                        P0_18
-#define EXP1_07_PIN                        P0_17
-#define EXP1_06_PIN                        P0_15
-#define EXP1_05_PIN                        P0_20
-#define EXP1_04_PIN                        -1
-#define EXP1_03_PIN                        P0_19
-#define EXP1_02_PIN                        P0_16
 #define EXP1_01_PIN                        P2_08
+#define EXP1_02_PIN                        P0_16
+#define EXP1_03_PIN                        P0_19
+#define EXP1_04_PIN                        -1
+#define EXP1_05_PIN                        P0_20
+#define EXP1_06_PIN                        P0_15
+#define EXP1_07_PIN                        P0_17
+#define EXP1_08_PIN                        P0_18
 
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
   #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -210,12 +210,12 @@
 
  /**
   *          Ender 3 V2 display                       SKR E3 Turbo (EXP1)                Ender 3 V2 display --> SKR E3 Turbo
-  *                ------                                     ------                                  RX  8 -->  5  P0_15
-  *           --  | 1  2 | --                (BEEPER)  P2_08 | 1  2 | P0_16 (BTN_ENC)                 TX  7 -->  9  P0_16
-  * (SKR_TX1) RX  | 3  4 | TX (SKR_RX1)      (BTN_EN1) P0_19 | 3  4 | RESET                       BEEPER  5 --> 10  P2_08
-  * (BTN_ENC) ENT   5  6 | BEEPER            (BTN_EN2) P0_20   5  6 | P0_15 (LCD_D4)
-  * (BTN_E2)  B   | 7  8 | A  (BTN_E1)       (LCD_RS)  P0_17 | 7  8 | P0_18 (LCD_EN)
-  *           GND | 9 10 | 5V                            GND | 9 10 | 5V
+  *                ------                                     ------                                  RX  3 -->  5  P0_15
+  *           --  | 1  2 | --                (BEEPER)  P2_08 |10  9 | P0_16 (BTN_ENC)                 TX  4 -->  9  P0_16
+  * (SKR_TX1) RX  | 3  4 | TX (SKR_RX1)      (BTN_EN1) P0_19 | 8  7 | RESET                       BEEPER  6 --> 10  P2_08
+  * (BTN_ENC) ENT   5  6 | BEEPER            (BTN_EN2) P0_20   6  5 | P0_15 (LCD_D4)
+  * (BTN_E2)  B   | 7  8 | A  (BTN_E1)       (LCD_RS)  P0_17 | 4  3 | P0_18 (LCD_EN)
+  *           GND | 9 10 | 5V                            GND | 2  1 | 5V
   *                ------                                     ------
   */
 

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -278,23 +278,23 @@
  *                 ------                                     ------
  *                  EXP1                                       EXP2
  */
-#define EXP1_08_PIN                        P1_22
-#define EXP1_07_PIN                        P1_00
-#define EXP1_06_PIN                        P0_17
-#define EXP1_05_PIN                        P0_15
-#define EXP1_04_PIN                        P0_16
-#define EXP1_03_PIN                        P0_18
-#define EXP1_02_PIN                        P1_30
 #define EXP1_01_PIN                        P1_31
+#define EXP1_02_PIN                        P1_30
+#define EXP1_03_PIN                        P0_18
+#define EXP1_04_PIN                        P0_16
+#define EXP1_05_PIN                        P0_15
+#define EXP1_06_PIN                        P0_17
+#define EXP1_07_PIN                        P1_00
+#define EXP1_08_PIN                        P1_22
 
-#define EXP2_08_PIN                        -1     // RESET
-#define EXP2_07_PIN                        P0_27
-#define EXP2_06_PIN                        P0_09
-#define EXP2_05_PIN                        P3_26
-#define EXP2_04_PIN                        P0_28
-#define EXP2_03_PIN                        P3_25
-#define EXP2_02_PIN                        P0_07
 #define EXP2_01_PIN                        P0_08
+#define EXP2_02_PIN                        P0_07
+#define EXP2_03_PIN                        P3_25
+#define EXP2_04_PIN                        P0_28
+#define EXP2_05_PIN                        P3_26
+#define EXP2_06_PIN                        P0_09
+#define EXP2_07_PIN                        P0_27
+#define EXP2_08_PIN                        -1     // RESET
 
 #if IS_TFTGLCD_PANEL
 

--- a/Marlin/src/pins/lpc1769/pins_TH3D_EZBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_TH3D_EZBOARD.h
@@ -171,14 +171,14 @@
  * A remote SD card is currently not supported because the pins routed to the EXP2
  * connector are shared with the onboard SD card.
  */
-#define EXP1_08_PIN                        P0_18
-#define EXP1_07_PIN                        P0_16
-#define EXP1_06_PIN                        P0_15
-#define EXP1_05_PIN                        P3_25
-#define EXP1_04_PIN                        P2_11
-#define EXP1_03_PIN                        P3_26
-#define EXP1_02_PIN                        P1_30
 #define EXP1_01_PIN                        P1_31
+#define EXP1_02_PIN                        P1_30
+#define EXP1_03_PIN                        P3_26
+#define EXP1_04_PIN                        P2_11
+#define EXP1_05_PIN                        P3_25
+#define EXP1_06_PIN                        P0_15
+#define EXP1_07_PIN                        P0_16
+#define EXP1_08_PIN                        P0_18
 
 #if ENABLED(CR10_STOCKDISPLAY)
   /**          ------

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -898,28 +898,28 @@
    *
    *               Board                            Display
    *               ------                           ------
-   *    (MISO) 50 | 1  2 | 52 (SCK)             5V | 1  2 | GND
-   * (BTN_EN2) 33 | 3  4 | 53 (SD_CS)        RESET | 3  4 | (SD_DET)
-   * (BTN_EN1) 31   5  6 | 51 (MOSI)        (MOSI)   5  6 | (LCD_CS)
-   *  (SD_DET) 49 | 7  8 | RESET           (SD_CS) | 7  8 | (MOD_RESET)
-   *          GND | 9 10 | --                (SCK) | 9 10 | (MISO)
+   *    (MISO) 50 | 1  2 | 52 (SCK)             5V |10  9 | GND
+   *  (LCD_CS) 33 | 3  4 | 53 (SD_CS)        RESET | 8  7 | (SD_DET)
+   *           31   5  6 | 51 (MOSI)        (MOSI)   6  5 | (LCD_CS)
+   *  (SD_DET) 49 | 7  8 | RESET           (SD_CS) | 4  3 | (MOD_RESET)
+   *          GND | 9 10 | --                (SCK) | 2  1 | (MISO)
    *               ------                           ------
-   *                EXP2
+   *                EXP2                             EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
-   *   EXP2-1 ----------- EXP1-10
-   *   EXP2-2 ----------- EXP1-9
-   *   EXP2-4 ----------- EXP1-8
-   *   EXP2-4 ----------- EXP1-7
-   *   EXP2-3 ----------- EXP1-6
-   *   EXP2-6 ----------- EXP1-5
-   *   EXP2-7 ----------- EXP1-4
-   *   EXP2-8 ----------- EXP1-3
-   *   EXP2-1 ----------- EXP1-2
-   *   EXP1-10 ---------- EXP1-1
+   *   ----------------------------------
+   *   EXP2-1 <--diode--- EXP1-1    MISO
+   *   EXP2-2 ----------- EXP1-2    SCK
+   *   EXP2-4 ----------- EXP1-3    MOD_RST
+   *   EXP2-4 ----------- EXP1-4    SD_CS
+   *   EXP2-3 ----------- EXP1-5    LCD_CS
+   *   EXP2-6 ----------- EXP1-6    MOSI
+   *   EXP2-7 ----------- EXP1-7    SD DET
+   *   EXP2-8 ----------- EXP1-8    RESET
+   *   EXP2-1 ----------- EXP1-9    MISO->GND
+   *   EXP1-10 ---------- EXP1-10   5V
    *
    *  NOTE: The MISO pin should not get a 5V signal.
    *        To fix, insert a 1N4148 diode in the MISO line.

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -515,18 +515,18 @@
  */
 #ifndef EXP1_08_PIN
 
-  #define EXP1_08_PIN                AUX4_13_PIN
-  #define EXP1_07_PIN                AUX4_14_PIN
-  #define EXP1_06_PIN                AUX4_15_PIN
-  #define EXP1_05_PIN                AUX4_16_PIN
-  #define EXP1_04_PIN                AUX4_18_PIN
   #define EXP1_03_PIN                AUX4_17_PIN
+  #define EXP1_04_PIN                AUX4_18_PIN
+  #define EXP1_05_PIN                AUX4_16_PIN
+  #define EXP1_06_PIN                AUX4_15_PIN
+  #define EXP1_07_PIN                AUX4_14_PIN
+  #define EXP1_08_PIN                AUX4_13_PIN
 
-  #define EXP2_07_PIN                AUX3_02_PIN
-  #define EXP2_06_PIN                AUX3_04_PIN
-  #define EXP2_04_PIN                AUX3_06_PIN
-  #define EXP2_02_PIN                AUX3_05_PIN
   #define EXP2_01_PIN                AUX3_03_PIN
+  #define EXP2_02_PIN                AUX3_05_PIN
+  #define EXP2_04_PIN                AUX3_06_PIN
+  #define EXP2_06_PIN                AUX3_04_PIN
+  #define EXP2_07_PIN                AUX3_02_PIN
 
   #if ENABLED(G3D_PANEL)
     /**                  Gadgets3D Smart Adapter
@@ -539,12 +539,12 @@
      *              ------                        ------
      *               EXP1                          EXP2
      */
-    #define EXP1_02_PIN              AUX4_12_PIN
     #define EXP1_01_PIN              AUX4_11_PIN
+    #define EXP1_02_PIN              AUX4_12_PIN
 
-    #define EXP2_08_PIN              AUX4_07_PIN
-    #define EXP2_05_PIN              AUX4_09_PIN
     #define EXP2_03_PIN              AUX4_10_PIN
+    #define EXP2_05_PIN              AUX4_09_PIN
+    #define EXP2_08_PIN              AUX4_07_PIN
 
   #else
 
@@ -558,17 +558,17 @@
      *             ------                           ------
      *              EXP1                             EXP2
      */
-    #define EXP1_02_PIN              AUX4_10_PIN
     #define EXP1_01_PIN              AUX4_09_PIN
+    #define EXP1_02_PIN              AUX4_10_PIN
 
     #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
-      #define EXP2_08_PIN                     -1  // RESET
-      #define EXP2_05_PIN            AUX4_12_PIN
       #define EXP2_03_PIN            AUX4_11_PIN
+      #define EXP2_05_PIN            AUX4_12_PIN
+      #define EXP2_08_PIN                     -1  // RESET
     #else
-      #define EXP2_08_PIN            AUX4_07_PIN
-      #define EXP2_05_PIN            AUX4_11_PIN
       #define EXP2_03_PIN            AUX4_12_PIN
+      #define EXP2_05_PIN            AUX4_11_PIN
+      #define EXP2_08_PIN            AUX4_07_PIN
     #endif
 
   #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_PLUS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_PLUS.h
@@ -73,22 +73,22 @@
  *         ------                     ------
  *          EXP1                       EXP2
  */
-#define EXP1_08_PIN                           44
-#define EXP1_07_PIN                           42
-#define EXP1_06_PIN                           23
-#define EXP1_05_PIN                           33
-#define EXP1_04_PIN                           41
-#define EXP1_03_PIN                           31
-#define EXP1_02_PIN                           35
 #define EXP1_01_PIN                           37
+#define EXP1_02_PIN                           35
+#define EXP1_03_PIN                           31
+#define EXP1_04_PIN                           41
+#define EXP1_05_PIN                           33
+#define EXP1_06_PIN                           23
+#define EXP1_07_PIN                           42
+#define EXP1_08_PIN                           44
 
-#define EXP2_08_PIN                           27
-#define EXP2_07_PIN                           49
-#define EXP2_06_PIN                           51
-#define EXP2_05_PIN                           25
-#define EXP2_04_PIN                           53
-#define EXP2_03_PIN                           29
-#define EXP2_02_PIN                           52
 #define EXP2_01_PIN                           50
+#define EXP2_02_PIN                           52
+#define EXP2_03_PIN                           29
+#define EXP2_04_PIN                           53
+#define EXP2_05_PIN                           25
+#define EXP2_06_PIN                           51
+#define EXP2_07_PIN                           49
+#define EXP2_08_PIN                           27
 
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_ZRIB_V53.h
+++ b/Marlin/src/pins/ramps/pins_ZRIB_V53.h
@@ -309,23 +309,23 @@
  */
 
 #ifndef EXP1_08_PIN
-  #define EXP1_08_PIN                         29
-  #define EXP1_07_PIN                         27
-  #define EXP1_06_PIN                         25
-  #define EXP1_05_PIN                         23
-  #define EXP1_04_PIN                         16
-  #define EXP1_03_PIN                         17
-  #define EXP1_02_PIN                         35
   #define EXP1_01_PIN                         37
+  #define EXP1_02_PIN                         35
+  #define EXP1_03_PIN                         17
+  #define EXP1_04_PIN                         16
+  #define EXP1_05_PIN                         23
+  #define EXP1_06_PIN                         25
+  #define EXP1_07_PIN                         27
+  #define EXP1_08_PIN                         29
 
-  #define EXP2_08_PIN                         41
-  #define EXP2_07_PIN                         49
-  #define EXP2_06_PIN                 XS6_05_PIN
-  #define EXP2_05_PIN                         33
-  #define EXP2_04_PIN                         53
-  #define EXP2_03_PIN                         31
-  #define EXP2_02_PIN                 XS6_03_PIN
   #define EXP2_01_PIN                 XS6_07_PIN
+  #define EXP2_02_PIN                 XS6_03_PIN
+  #define EXP2_03_PIN                         31
+  #define EXP2_04_PIN                         53
+  #define EXP2_05_PIN                         33
+  #define EXP2_06_PIN                 XS6_05_PIN
+  #define EXP2_07_PIN                         49
+  #define EXP2_08_PIN                         41
 #endif
 
 //////////////////////////

--- a/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
@@ -143,23 +143,23 @@
  *         ------                     ------
  *          EXP1                       EXP2
  */
-#define EXP1_08_PIN                           17
-#define EXP1_07_PIN                           16
-#define EXP1_06_PIN                           23
-#define EXP1_05_PIN                           25
-#define EXP1_04_PIN                           27
-#define EXP1_03_PIN                           29
-#define EXP1_02_PIN                           35
 #define EXP1_01_PIN                           37
+#define EXP1_02_PIN                           35
+#define EXP1_03_PIN                           29
+#define EXP1_04_PIN                           27
+#define EXP1_05_PIN                           25
+#define EXP1_06_PIN                           23
+#define EXP1_07_PIN                           16
+#define EXP1_08_PIN                           17
 
-#define EXP2_08_PIN                           -1
-#define EXP2_07_PIN                           49
-#define EXP2_06_PIN                           75
-#define EXP2_05_PIN                           33
-#define EXP2_04_PIN                            4
-#define EXP2_03_PIN                           31
-#define EXP2_02_PIN                           76
 #define EXP2_01_PIN                           74
+#define EXP2_02_PIN                           76
+#define EXP2_03_PIN                           31
+#define EXP2_04_PIN                            4
+#define EXP2_05_PIN                           33
+#define EXP2_06_PIN                           75
+#define EXP2_07_PIN                           49
+#define EXP2_08_PIN                           -1
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -118,23 +118,23 @@
    *         ------                     ------
    *          EXP1                       EXP2
    */
-  #define EXP1_08_PIN                         44
-  #define EXP1_07_PIN                         42
-  #define EXP1_06_PIN                         23
-  #define EXP1_05_PIN                         33
-  #define EXP1_04_PIN                         41
-  #define EXP1_03_PIN                         31
-  #define EXP1_02_PIN                         35
   #define EXP1_01_PIN                         37
+  #define EXP1_02_PIN                         35
+  #define EXP1_03_PIN                         31
+  #define EXP1_04_PIN                         41
+  #define EXP1_05_PIN                         33
+  #define EXP1_06_PIN                         23
+  #define EXP1_07_PIN                         42
+  #define EXP1_08_PIN                         44
 
-  #define EXP2_08_PIN                         27
-  #define EXP2_07_PIN                         49
-  #define EXP2_06_PIN                         51
-  #define EXP2_05_PIN                         25
-  #define EXP2_04_PIN                         53
-  #define EXP2_03_PIN                         29
-  #define EXP2_02_PIN                         52
   #define EXP2_01_PIN                         50
+  #define EXP2_02_PIN                         52
+  #define EXP2_03_PIN                         29
+  #define EXP2_04_PIN                         53
+  #define EXP2_05_PIN                         25
+  #define EXP2_06_PIN                         51
+  #define EXP2_07_PIN                         49
+  #define EXP2_08_PIN                         27
 
 #endif
 

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
@@ -193,23 +193,23 @@
  *              ------                                ------
  *               EXP1                                  EXP2
  */
-#define EXP1_08_PIN                           53
-#define EXP1_07_PIN                           52
-#define EXP1_06_PIN                           50
-#define EXP1_05_PIN                           48
-#define EXP1_04_PIN                           63
-#define EXP1_03_PIN                           64
-#define EXP1_02_PIN                           40
 #define EXP1_01_PIN                           62
+#define EXP1_02_PIN                           40
+#define EXP1_03_PIN                           64
+#define EXP1_04_PIN                           63
+#define EXP1_05_PIN                           48
+#define EXP1_06_PIN                           50
+#define EXP1_07_PIN                           52
+#define EXP1_08_PIN                           53
 
-#define EXP2_08_PIN                           -1  // RESET
-#define EXP2_07_PIN                           51
-#define EXP2_06_PIN                           75  // MOSI
-#define EXP2_05_PIN                           42
-#define EXP2_04_PIN                           10
-#define EXP2_03_PIN                           44
-#define EXP2_02_PIN                           76  // SCK
 #define EXP2_01_PIN                           74  // MISO
+#define EXP2_02_PIN                           76  // SCK
+#define EXP2_03_PIN                           44
+#define EXP2_04_PIN                           10
+#define EXP2_05_PIN                           42
+#define EXP2_06_PIN                           75  // MOSI
+#define EXP2_07_PIN                           51
+#define EXP2_08_PIN                           -1  // RESET
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
@@ -183,23 +183,23 @@
  *              ------                                ------
  *               EXP1                                  EXP2
  */
-#define EXP1_08_PIN                           53
-#define EXP1_07_PIN                           52
-#define EXP1_06_PIN                           50
-#define EXP1_05_PIN                           48
-#define EXP1_04_PIN                           63
-#define EXP1_03_PIN                           64
-#define EXP1_02_PIN                           40
 #define EXP1_01_PIN                           62
+#define EXP1_02_PIN                           40
+#define EXP1_03_PIN                           64
+#define EXP1_04_PIN                           63
+#define EXP1_05_PIN                           48
+#define EXP1_06_PIN                           50
+#define EXP1_07_PIN                           52
+#define EXP1_08_PIN                           53
 
-#define EXP2_08_PIN                           -1  // RESET
-#define EXP2_07_PIN                           51
-#define EXP2_06_PIN                           75  // MOSI
-#define EXP2_05_PIN                           42
-#define EXP2_04_PIN                           10
-#define EXP2_03_PIN                           44
-#define EXP2_02_PIN                           76  // SCK
 #define EXP2_01_PIN                           74  // MISO
+#define EXP2_02_PIN                           76  // SCK
+#define EXP2_03_PIN                           44
+#define EXP2_04_PIN                           10
+#define EXP2_05_PIN                           42
+#define EXP2_06_PIN                           75  // MOSI
+#define EXP2_07_PIN                           51
+#define EXP2_08_PIN                           -1  // RESET
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -166,33 +166,33 @@
  *      BTN_ENCODER 40         KILL_PIN      49
  */
 
-#define EXP1_08_PIN                           39
-#define EXP1_07_PIN                           38
-#define EXP1_06_PIN                           37
-#define EXP1_05_PIN                           36
-#define EXP1_04_PIN                           34
-#define EXP1_03_PIN                           35
-#define EXP1_02_PIN                           40
 #define EXP1_01_PIN                           41
+#define EXP1_02_PIN                           40
+#define EXP1_03_PIN                           35
+#define EXP1_04_PIN                           34
+#define EXP1_05_PIN                           36
+#define EXP1_06_PIN                           37
+#define EXP1_07_PIN                           38
+#define EXP1_08_PIN                           39
 
-#define EXP2_10_PIN                           49
-#define EXP2_07_PIN                           44
-#define EXP2_06_PIN                           51
-#define EXP2_05_PIN                           42
-#define EXP2_04_PIN                           53
-#define EXP2_03_PIN                           43
-#define EXP2_02_PIN                           52
 #define EXP2_01_PIN                           50
+#define EXP2_02_PIN                           52
+#define EXP2_03_PIN                           43
+#define EXP2_04_PIN                           53
+#define EXP2_05_PIN                           42
+#define EXP2_06_PIN                           51
+#define EXP2_07_PIN                           44
+#define EXP2_10_PIN                           49
 
 #if ENABLED(CR10_STOCKDISPLAY)
-  #define EXP3_03_PIN                EXP1_08_PIN
-  #define EXP3_04_PIN                EXP1_07_PIN
-  #define EXP3_05_PIN                EXP1_06_PIN
-  #define EXP3_06_PIN                EXP1_05_PIN
-  #define EXP3_07_PIN                EXP1_04_PIN
-  #define EXP3_08_PIN                EXP1_03_PIN
-  #define EXP3_09_PIN                EXP1_02_PIN
-  #define EXP3_10_PIN                EXP1_01_PIN
+  #define EXP3_01_PIN                EXP1_01_PIN
+  #define EXP3_02_PIN                EXP1_02_PIN
+  #define EXP3_03_PIN                EXP1_03_PIN
+  #define EXP3_04_PIN                EXP1_04_PIN
+  #define EXP3_05_PIN                EXP1_05_PIN
+  #define EXP3_06_PIN                EXP1_06_PIN
+  #define EXP3_07_PIN                EXP1_07_PIN
+  #define EXP3_08_PIN                EXP1_08_PIN
 #endif
 
 /************************************/

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -218,33 +218,33 @@
  *      BTN_ENCODER 40
  */
 
-#define EXP1_08_PIN                           39
-#define EXP1_07_PIN                           38
-#define EXP1_06_PIN                           37
-#define EXP1_05_PIN                           36
-#define EXP1_04_PIN                           34
-#define EXP1_03_PIN                           35
-#define EXP1_02_PIN                           40
 #define EXP1_01_PIN                           41
+#define EXP1_02_PIN                           40
+#define EXP1_03_PIN                           35
+#define EXP1_04_PIN                           34
+#define EXP1_05_PIN                           36
+#define EXP1_06_PIN                           37
+#define EXP1_07_PIN                           38
+#define EXP1_08_PIN                           39
 
-#define EXP2_10_PIN                           49
-#define EXP2_07_PIN                           44
-#define EXP2_06_PIN                           51
-#define EXP2_05_PIN                           42
-#define EXP2_04_PIN                           53
-#define EXP2_03_PIN                           43
-#define EXP2_02_PIN                           52
 #define EXP2_01_PIN                           50
+#define EXP2_02_PIN                           52
+#define EXP2_03_PIN                           43
+#define EXP2_04_PIN                           53
+#define EXP2_05_PIN                           42
+#define EXP2_06_PIN                           51
+#define EXP2_07_PIN                           44
+#define EXP2_10_PIN                           49
 
 #if ENABLED(CR10_STOCKDISPLAY)
-  #define EXP3_03_PIN                EXP1_08_PIN
-  #define EXP3_04_PIN                EXP1_07_PIN
-  #define EXP3_05_PIN                EXP1_06_PIN
-  #define EXP3_06_PIN                EXP1_05_PIN
-  #define EXP3_07_PIN                EXP1_04_PIN
-  #define EXP3_08_PIN                EXP1_03_PIN
-  #define EXP3_09_PIN                EXP1_02_PIN
-  #define EXP3_10_PIN                EXP1_01_PIN
+  #define EXP3_01_PIN                EXP1_01_PIN
+  #define EXP3_02_PIN                EXP1_02_PIN
+  #define EXP3_03_PIN                EXP1_03_PIN
+  #define EXP3_04_PIN                EXP1_04_PIN
+  #define EXP3_05_PIN                EXP1_05_PIN
+  #define EXP3_06_PIN                EXP1_06_PIN
+  #define EXP3_07_PIN                EXP1_07_PIN
+  #define EXP3_08_PIN                EXP1_08_PIN
 #endif
 
 /************************************/

--- a/Marlin/src/pins/sanguino/pins_ZMIB_V2.h
+++ b/Marlin/src/pins/sanguino/pins_ZMIB_V2.h
@@ -171,18 +171,18 @@
  *      (GND) | 9 10 | (5V)
  *             ------
  */
-#define EXP1_08_PIN                            2
-#define EXP1_07_PIN                           29
+#define EXP1_01_PIN                            5
+#define EXP1_02_PIN                            7
+#define EXP1_03_PIN                           11
+#define EXP1_04_PIN                           10
+#define EXP1_05_PIN                           12
 #ifndef IS_ZMIB_V2
   #define EXP1_06_PIN                          4  // ZMIB V1
 #else
   #define EXP1_06_PIN                          3  // ZMIB V2
 #endif
-#define EXP1_05_PIN                           12
-#define EXP1_04_PIN                           10
-#define EXP1_03_PIN                           11
-#define EXP1_02_PIN                            7
-#define EXP1_01_PIN                            5
+#define EXP1_07_PIN                           29
+#define EXP1_08_PIN                            2
 
 #if ENABLED(ZONESTAR_12864LCD)
   //

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -234,28 +234,28 @@
    *
    *                   Board                                   Display
    *                   ------                                  ------
-   * (SD_DET)    PA15 | 1  2 | PB6 (BEEPER)                5V | 1  2 | GND
-   * (MOD_RESET) PA9  | 3  4 | RESET                  (RESET) | 3  4 | (SD_DET)
-   * (SD_CS)     PA10   5  6 | PB9                    (MOSI)    5  6 | (LCD_CS)
-   * (LCD_CS)    PB8  | 7  8 | PB7                    (SD_CS) | 7  8 | (MOD_RESET)
-   *              GND | 9 10 | 5V                     (SCK)   | 9 10 | (MISO)
+   * (SD_DET)    PA15 | 1  2 | PB6 (BEEPER)                5V |10  9 | GND
+   * (MOD_RESET) PA9  | 3  4 | RESET                  (RESET) | 8  7 | (SD_DET)
+   * (SD_CS)     PA10   5  6 | PB9                    (MOSI)    6  5 | (LCD_CS)
+   * (LCD_CS)    PB8  | 7  8 | PB7                    (SD_CS) | 4  3 | (MOD_RESET)
+   *              GND | 9 10 | 5V                     (SCK)   | 2  1 | (MISO)
    *                   ------                                  ------
    *                    EXP1                                    EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
-   *   EXP1-1 ----------- EXP1-10
-   *   EXP1-2 ----------- EXP1-9
-   *   SPI1-4 ----------- EXP1-6
-   *   EXP1-4 ----------- EXP1-5
-   *   SP11-3 ----------- EXP1-2
-   *   EXP1-6 ----------- EXP1-4
-   *   EXP1-7 ----------- EXP1-8
-   *   EXP1-8 ----------- EXP1-3
-   *   SPI1-1 ----------- EXP1-1
-   *  EXP1-10 ----------- EXP1-7
+   *   ----------------------------------
+   *   EXP1-10 ---------- EXP1-10  5V
+   *   EXP1-9 ----------- EXP1-9   GND
+   *   SPI1-4 ----------- EXP1-6   MOSI
+   *   EXP1-7 ----------- EXP1-5   LCD_CS
+   *   SP11-3 ----------- EXP1-2   SCK
+   *   EXP1-5 ----------- EXP1-4   SD_CS
+   *   EXP1-4 ----------- EXP1-8   RESET
+   *   EXP1-3 ----------- EXP1-3   MOD_RST
+   *   SPI1-1 ----------- EXP1-1   MISO
+   *   EXP1-1 ----------- EXP1-7   SD_DET
    */
 
   #define CLCD_SPI_BUS                         1  // SPI1 connector

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -139,11 +139,11 @@
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
   /**
    *        ------                ------                ------
-   * (ENT) | 1  2 | (BEEP)       | 1  2 |              | 1  2 |
-   *  (RX) | 3  4 |         (RX) | 3  4 | (TX)      RX | 3  4 | TX
-   *  (TX)   5  6 |        (ENT)   5  6 | (BEEP)   ENT | 5  6 | BEEP
-   *   (B) | 7  8 | (A)      (B) | 7  8 | (A)        B | 7  8 | A
-   *   GND | 9 10 | (VCC)    GND | 9 10 | VCC      GND | 9 10 | VCC
+   * (ENT) | 1  2 | (BEEP)       |10  9 |              |10  9 |
+   *  (RX) | 3  4 |         (RX) | 8  7 | (TX)      RX | 8  7 | TX
+   *  (TX)   5  6 |        (ENT)   6  5 | (BEEP)   ENT | 6  5 | BEEP
+   *   (B) | 7  8 | (A)      (B) | 4  3 | (A)        B | 4  3 | A
+   *   GND | 9 10 | (VCC)    GND | 2  1 | VCC      GND | 2  1 | VCC
    *        ------                ------                ------
    *         EXP1                  DWIN               DWIN (plug)
    *
@@ -214,28 +214,28 @@
        *
        *                   Board                        Display
        *                   ------                        ------
-       * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)      5V | 1  2 | GND
-       * (MOD_RESET) PA9  | 3  4 | RESET             -- | 3  4 | (SD_DET)
-       * (SD_CS)     PA10   5  6 | PB9          (MOSI)  | 5  6 | --
-       * (LCD_CS)    PB8  | 7  8 | PB7          (SD_CS) | 7  8 | (LCD_CS)
-       *              GND | 9 10 | 5V           (SCK)   | 9 10 | (MISO)
+       * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)      5V |10  9 | GND
+       * (MOD_RESET) PA9  | 3  4 | RESET             -- | 8  7 | (SD_DET)
+       * (SD_CS)     PA10   5  6 | PB9          (MOSI)  | 6  5 | --
+       * (LCD_CS)    PB8  | 7  8 | PB7          (SD_CS) | 4  3 | (LCD_CS)
+       *              GND | 9 10 | 5V           (SCK)   | 2  1 | (MISO)
        *                   ------                        ------
        *                    EXP1                          EXP1
        *
        * Needs custom cable:
        *
-       *    Board             Display
-       *
-       *   EXP1-1 ----------- EXP1-10
-       *   EXP1-2 ----------- EXP1-9
-       *   SPI1-4 ----------- EXP1-6
-       *   EXP1-4 ----------- FREE
-       *   SPI1-3 ----------- EXP1-2
-       *   EXP1-6 ----------- EXP1-4
-       *   EXP1-7 ----------- FREE
-       *   EXP1-8 ----------- EXP1-3
-       *   SPI1-1 ----------- EXP1-1
-       *  EXP1-10 ----------- EXP1-7
+       *    Board   Adapter   Display
+       *   ----------------------------------
+       *   EXP1-10 ---------- EXP1-10  5V
+       *   EXP1-9 ----------- EXP1-9   GND
+       *   SPI1-4 ----------- EXP1-6   MOSI
+       *   EXP1-7 ----------- n/c
+       *   SPI1-3 ----------- EXP1-2   SCK
+       *   EXP1-5 ----------- EXP1-4   SD_CS
+       *   EXP1-4 ----------- n/c
+       *   EXP1-3 ----------- EXP1-3   LCD_CS
+       *   SPI1-1 ----------- EXP1-1   MISO
+       *   EXP1-1 ----------- EXP1-7   SD_DET
        */
 
       #define TFTGLCD_CS                    PA9
@@ -253,20 +253,20 @@
      *
      *       Board                      Display
      *       ------                     ------
-     * PB5  | 1  2 | PA15       (BEEP) | 1  2 | BTN_ENC
-     * PA9  | 3  4 | RESET      LCD_CS | 3  4 | LCD A0
-     * PA10 | 5  6 | PB9       LCD_RST | 5  6 | RED
-     * PB8  | 7  8 | PB15      (GREEN) | 7  8 | (BLUE)
-     * GND  | 9 10 | 5V            GND | 9 10 | 5V
+     * PB5  | 1  2 | PA15       (BEEP) |10  9 | BTN_ENC
+     * PA9  | 3  4 | RESET      LCD_CS | 8  7 | LCD A0
+     * PA10 | 5  6 | PB9       LCD_RST | 6  5 | RED
+     * PB8  | 7  8 | PB15      (GREEN) | 4  3 | (BLUE)
+     * GND  | 9 10 | 5V            GND | 2  1 | 5V
      *       ------                     ------
      *        EXP1                       EXP1
      *
      *            ---                   ------
-     *       RST | 1 |          (MISO) | 1  2 | SCK
-     * (RX2) PA2 | 2 |         BTN_EN1 | 3  4 | (SS)
-     * (TX2) PA3 | 3 |         BTN_EN2 | 5  6 | MOSI
-     *       GND | 4 |            (CD) | 7  8 | (RST)
-     *        5V | 5 |           (GND) | 9 10 | (KILL)
+     *       RST | 1 |          (MISO) |10  9 | SCK
+     * (RX2) PA2 | 2 |         BTN_EN1 | 8  7 | (SS)
+     * (TX2) PA3 | 3 |         BTN_EN2 | 6  5 | MOSI
+     *       GND | 4 |            (CD) | 4  3 | (RST)
+     *        5V | 5 |           (GND) | 2  1 | (KILL)
      *            ---                   ------
      *            TFT                    EXP2
      *
@@ -274,18 +274,19 @@
      *
      *    Board             Display
      *
-     *   EXP1-1 ----------- EXP1-1
-     *   EXP1-2 ----------- EXP1-2
-     *   EXP1-3 ----------- EXP2-6
-     *   EXP1-4 ----------- EXP1-5
-     *   EXP1-5 ----------- EXP2-8
-     *   EXP1-6 ----------- EXP1-6
-     *   EXP1-8 ----------- EXP1-8
-     *   EXP1-9 ----------- EXP1-9
-     *  EXP1-10 ----------- EXP1-7
+     *   EXP1-10 ---------- EXP1-1   5V
+     *   EXP1-9 ----------- EXP1-2   GND
+     *   EXP1-8 ----------- EXP2-6   EN2
+     *   EXP1-7 ----------- EXP1-5   RED
+     *   EXP1-6 ----------- EXP2-8   EN1
+     *   EXP1-5 ----------- EXP1-6   LCD_RST
+     *   EXP1-4 ----------- n/c
+     *   EXP1-3 ----------- EXP1-8   LCD_CS
+     *   EXP1-2 ----------- EXP1-9   ENC
+     *   EXP1-1 ----------- EXP1-7   LCD_A0
      *
-     *    TFT-2 ----------- EXP2-9
-     *    TFT-3 ----------- EXP2-5
+     *    TFT-2 ----------- EXP2-9   SCK
+     *    TFT-3 ----------- EXP2-5   MOSI
      *
      * for backlight configuration see steps 2 (V2.1) and 3 in https://wiki.fysetc.com/Mini12864_Panel/
      */
@@ -325,28 +326,28 @@
    *
    *                   Board                            Display
    *                   ------                           ------
-   * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)         5V | 1  2 | GND
-   * (MOD_RESET) PA9  | 3  4 | RESET           (RESET) | 3  4 | (SD_DET)
-   * (SD_CS)     PA10   5  6 | PB9             (MOSI)  | 5  6 | (LCD_CS)
-   * (LCD_CS)    PB8  | 7  8 | PB7             (SD_CS) | 7  8 | (MOD_RESET)
-   *              GND | 9 10 | 5V              (SCK)   | 9 10 | (MISO)
+   * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)         5V |10  9 | GND
+   * (MOD_RESET) PA9  | 3  4 | RESET           (RESET) | 8  7 | (SD_DET)
+   * (SD_CS)     PA10   5  6 | PB9             (MOSI)  | 6  5 | (LCD_CS)
+   * (LCD_CS)    PB8  | 7  8 | PB7             (SD_CS) | 4  3 | (MOD_RESET)
+   *              GND | 9 10 | 5V              (SCK)   | 2  1 | (MISO)
    *                   ------                           ------
    *                    EXP1                             EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
-   *   EXP1-1 ----------- EXP1-10
-   *   EXP1-2 ----------- EXP1-9
-   *   SPI1-4 ----------- EXP1-6
-   *   EXP1-4 ----------- EXP1-5
-   *   SPI1-3 ----------- EXP1-2
-   *   EXP1-6 ----------- EXP1-4
-   *   EXP1-7 ----------- EXP1-8
-   *   EXP1-8 ----------- EXP1-3
-   *   SPI1-1 ----------- EXP1-1
-   *  EXP1-10 ----------- EXP1-7
+   *   ----------------------------------
+   *   EXP1-10 ---------- EXP1-10  5V
+   *   EXP1-9 ----------- EXP1-9   GND
+   *   SPI1-4 ----------- EXP1-6   MOSI
+   *   EXP1-7 ----------- EXP1-5   LCD_CS
+   *   SPI1-3 ----------- EXP1-2   SCK
+   *   EXP1-5 ----------- EXP1-4   SD_CS
+   *   EXP1-4 ----------- EXP1-8   RESET
+   *   EXP1-3 ----------- EXP1-3   MOD_RST
+   *   SPI1-1 ----------- EXP1-1   MISO
+   *   EXP1-1 ----------- EXP1-7   SD_DET
    */
 
   #define CLCD_SPI_BUS 1                          // SPI1 connector

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -129,11 +129,11 @@
  *                 EXP1                                      EXP1
  */
 #ifdef SKR_MINI_E3_V2
-  #define EXP1_9                            PA15
-  #define EXP1_3                            PB15
+  #define EXP1_02_PIN                       PA15
+  #define EXP1_08_PIN                       PB15
 #else
-  #define EXP1_9                            PB6
-  #define EXP1_3                            PB7
+  #define EXP1_02_PIN                       PB6
+  #define EXP1_08_PIN                       PB7
 #endif
 
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
@@ -154,8 +154,8 @@
     #error "CAUTION! Ender-3 V2 display requires a custom cable. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
   #endif
 
-  #define BEEPER_PIN                      EXP1_9
-  #define BTN_EN1                         EXP1_3
+  #define BEEPER_PIN                 EXP1_02_PIN
+  #define BTN_EN1                    EXP1_08_PIN
   #define BTN_EN2                           PB8
   #define BTN_ENC                           PB5
 
@@ -164,13 +164,13 @@
   #if ENABLED(CR10_STOCKDISPLAY)
 
     #define BEEPER_PIN                      PB5
-    #define BTN_ENC                       EXP1_9
+    #define BTN_ENC                  EXP1_02_PIN
 
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define LCD_PINS_RS                     PB8
-    #define LCD_PINS_ENABLE               EXP1_3
+    #define LCD_PINS_ENABLE          EXP1_08_PIN
     #define LCD_PINS_D4                     PB9
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
@@ -180,7 +180,7 @@
     #endif
 
     #define LCD_PINS_RS                     PB9
-    #define LCD_PINS_ENABLE               EXP1_9
+    #define LCD_PINS_ENABLE          EXP1_02_PIN
     #define LCD_PINS_D4                     PB8
     #define LCD_PINS_D5                     PA10
     #define LCD_PINS_D6                     PA9
@@ -189,14 +189,14 @@
 
   #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
 
-    #define BTN_ENC                       EXP1_9
+    #define BTN_ENC                  EXP1_02_PIN
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define DOGLCD_CS                       PB8
     #define DOGLCD_A0                       PB9
     #define DOGLCD_SCK                      PB5
-    #define DOGLCD_MOSI                   EXP1_3
+    #define DOGLCD_MOSI              EXP1_08_PIN
 
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN               -1
@@ -349,9 +349,9 @@
    *  EXP1-10 ----------- EXP1-7
    */
 
-  #define CLCD_SPI_BUS                         1  // SPI1 connector
+  #define CLCD_SPI_BUS 1                          // SPI1 connector
 
-  #define BEEPER_PIN                      EXP1_9
+  #define BEEPER_PIN                 EXP1_02_PIN
 
   #define CLCD_MOD_RESET                    PA9
   #define CLCD_SPI_CS                       PB8
@@ -375,7 +375,7 @@
   #error "SD CUSTOM_CABLE is not compatible with SKR Mini E3."
 #endif
 
-#define ONBOARD_SPI_DEVICE                     1  // SPI1 -> used only by HAL/STM32F1...
+#define ONBOARD_SPI_DEVICE 1                      // SPI1 -> used only by HAL/STM32F1...
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
 
 #define ENABLE_SPI1

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
@@ -119,23 +119,23 @@
  *                 ------                                    ------
  *                  EXP1                                      EXP2
  */
-#define EXP1_08_PIN                         PC14
-#define EXP1_07_PIN                         PC15
-#define EXP1_06_PIN                         PB7
-#define EXP1_05_PIN                         PC13
-#define EXP1_04_PIN                         PC12
-#define EXP1_03_PIN                         PB6
-#define EXP1_02_PIN                         PC11
 #define EXP1_01_PIN                         PC10
+#define EXP1_02_PIN                         PC11
+#define EXP1_03_PIN                         PB6
+#define EXP1_04_PIN                         PC12
+#define EXP1_05_PIN                         PC13
+#define EXP1_06_PIN                         PB7
+#define EXP1_07_PIN                         PC15
+#define EXP1_08_PIN                         PC14
 
-#define EXP2_08_PIN                         -1    // RESET
-#define EXP2_07_PIN                         PB9
-#define EXP2_06_PIN                         PB5
-#define EXP2_05_PIN                         PB8
-#define EXP2_04_PIN                         PA15
-#define EXP2_03_PIN                         PD2
-#define EXP2_02_PIN                         PB3
 #define EXP2_01_PIN                         PB4
+#define EXP2_02_PIN                         PB3
+#define EXP2_03_PIN                         PD2
+#define EXP2_04_PIN                         PA15
+#define EXP2_05_PIN                         PB8
+#define EXP2_06_PIN                         PB5
+#define EXP2_07_PIN                         PB9
+#define EXP2_08_PIN                         -1    // RESET
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
+++ b/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
@@ -131,14 +131,14 @@
  *       ------
  *        EXP1
  */
-#define EXP1_08_PIN                         PA4
-#define EXP1_07_PIN                         PB7
-#define EXP1_06_PIN                         PB8
-#define EXP1_05_PIN                         PA3
-#define EXP1_04_PIN                         -1   // RESET
-#define EXP1_03_PIN                         PA2
-#define EXP1_02_PIN                         PB6
 #define EXP1_01_PIN                         PB5
+#define EXP1_02_PIN                         PB6
+#define EXP1_03_PIN                         PA2
+#define EXP1_04_PIN                         -1   // RESET
+#define EXP1_05_PIN                         PA3
+#define EXP1_06_PIN                         PB8
+#define EXP1_07_PIN                         PB7
+#define EXP1_08_PIN                         PA4
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -176,17 +176,17 @@
      *        ------
      *         EXP1
      */
-    #define EXP1_03_PIN                     PB15
-    #define EXP1_04_PIN                     PB12
-    #define EXP1_05_PIN                     PB13
-    #define EXP1_06_PIN                     PB14
-    #define EXP1_07_PIN                     PE8
-    #define EXP1_08_PIN                     PB10
-    #define EXP1_09_PIN                     PB2
-    #define EXP1_10_PIN                     PC6
+    #define EXP1_01_PIN                     PC6
+    #define EXP1_02_PIN                     PB2
+    #define EXP1_03_PIN                     PB10
+    #define EXP1_04_PIN                     PE8
+    #define EXP1_05_PIN                     PB14
+    #define EXP1_06_PIN                     PB13
+    #define EXP1_07_PIN                     PB12
+    #define EXP1_08_PIN                     PB15
 
     #ifndef HAS_PIN_27_BOARD
-      #define BEEPER_PIN             EXP1_10_PIN
+      #define BEEPER_PIN             EXP1_01_PIN
     #endif
 
   #elif ENABLED(VET6_12864_LCD)
@@ -202,50 +202,50 @@
      *        ------
      *         EXP1
      */
-    #define EXP1_03_PIN                     PA7
-    #define EXP1_04_PIN                     PA4
-    #define EXP1_05_PIN                     PA5
-    #define EXP1_06_PIN                     PA6
-    #define EXP1_07_PIN                     -1
-    #define EXP1_08_PIN                     PB10
-    #define EXP1_09_PIN                     PC5
-    #define EXP1_10_PIN                     -1
+    #define EXP1_01_PIN                     -1
+    #define EXP1_02_PIN                     PC5
+    #define EXP1_03_PIN                     PB10
+    #define EXP1_04_PIN                     -1
+    #define EXP1_05_PIN                     PA6
+    #define EXP1_06_PIN                     PA5
+    #define EXP1_07_PIN                     PA4
+    #define EXP1_08_PIN                     PA7
 
   #else
     #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."
   #endif
 
-  #define LCD_PINS_RS                EXP1_04_PIN
-  #define LCD_PINS_ENABLE            EXP1_03_PIN
-  #define LCD_PINS_D4                EXP1_05_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_D4                EXP1_06_PIN
 
-  #define BTN_ENC                    EXP1_09_PIN
-  #define BTN_EN1                    EXP1_08_PIN
-  #define BTN_EN2                    EXP1_06_PIN
+  #define BTN_ENC                    EXP1_02_PIN
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_05_PIN
 
 #elif ANY(HAS_DWIN_E3V2, IS_DWIN_MARLINUI, DWIN_VET6_CREALITY_LCD)
 
   #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
     // RET6 DWIN ENCODER LCD
-    #define EXP1_03_PIN                     PB15
-    #define EXP1_04_PIN                     PB12
-    #define EXP1_05_PIN                     PB13
-    #define EXP1_06_PIN                     PB14
+    #define EXP1_05_PIN                     PB14
+    #define EXP1_06_PIN                     PB13
+    #define EXP1_07_PIN                     PB12
+    #define EXP1_08_PIN                     PB15
     //#define LCD_LED_PIN                   PB2
   #else
     // VET6 DWIN ENCODER LCD
-    #define EXP1_03_PIN                     PA7
-    #define EXP1_04_PIN                     PA4
-    #define EXP1_05_PIN                     PA5
-    #define EXP1_06_PIN                     PA6
+    #define EXP1_05_PIN                     PA6
+    #define EXP1_06_PIN                     PA5
+    #define EXP1_07_PIN                     PA4
+    #define EXP1_08_PIN                     PA7
   #endif
 
-  #define BTN_ENC                    EXP1_06_PIN
-  #define BTN_EN1                    EXP1_03_PIN
-  #define BTN_EN2                    EXP1_04_PIN
+  #define BTN_ENC                    EXP1_05_PIN
+  #define BTN_EN1                    EXP1_08_PIN
+  #define BTN_EN2                    EXP1_07_PIN
 
   #ifndef BEEPER_PIN
-    #define BEEPER_PIN               EXP1_05_PIN
+    #define BEEPER_PIN               EXP1_06_PIN
   #endif
 
 #endif

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
@@ -158,14 +158,14 @@
      *        ------
      *         EXP1
      */
-    #define EXP1_08_PIN                     PB15
-    #define EXP1_07_PIN                     PB12
-    #define EXP1_06_PIN                     PB13
-    #define EXP1_05_PIN                     PB14
-    #define EXP1_04_PIN                     PE8
-    #define EXP1_03_PIN                     PB10
-    #define EXP1_02_PIN                     PB2
     #define EXP1_01_PIN                     PC6
+    #define EXP1_02_PIN                     PB2
+    #define EXP1_03_PIN                     PB10
+    #define EXP1_04_PIN                     PE8
+    #define EXP1_05_PIN                     PB14
+    #define EXP1_06_PIN                     PB13
+    #define EXP1_07_PIN                     PB12
+    #define EXP1_08_PIN                     PB15
 
     #define BEEPER_PIN               EXP1_01_PIN
 
@@ -182,14 +182,14 @@
      *        ------
      *         EXP1
      */
-    #define EXP1_08_PIN                     PA7
-    #define EXP1_07_PIN                     PA4
-    #define EXP1_06_PIN                     PA5
-    #define EXP1_05_PIN                     PA6
-    #define EXP1_04_PIN                     -1
-    #define EXP1_03_PIN                     PB10
-    #define EXP1_02_PIN                     PC5
     #define EXP1_01_PIN                     -1
+    #define EXP1_02_PIN                     PC5
+    #define EXP1_03_PIN                     PB10
+    #define EXP1_04_PIN                     -1
+    #define EXP1_05_PIN                     PA6
+    #define EXP1_06_PIN                     PA5
+    #define EXP1_07_PIN                     PA4
+    #define EXP1_08_PIN                     PA7
 
   #else
     #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."

--- a/Marlin/src/pins/stm32f1/pins_FLY_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_FLY_MINI.h
@@ -131,23 +131,23 @@
  *                ------                                        ------
  *                 EXP1                                          EXP2
  */
-#define EXP1_08_PIN                        PB4
-#define EXP1_07_PIN                        PB5
-#define EXP1_06_PIN                        PB6
-#define EXP1_05_PIN                        PB7
-#define EXP1_04_PIN                        PB8
-#define EXP1_03_PIN                        PB9
-#define EXP1_02_PIN                        PC13
 #define EXP1_01_PIN                        PC14
+#define EXP1_02_PIN                        PC13
+#define EXP1_03_PIN                        PB9
+#define EXP1_04_PIN                        PB8
+#define EXP1_05_PIN                        PB7
+#define EXP1_06_PIN                        PB6
+#define EXP1_07_PIN                        PB5
+#define EXP1_08_PIN                        PB4
 
-#define EXP2_08_PIN                        -1     // RESET
-#define EXP2_07_PIN                        PB11
-#define EXP2_06_PIN                        PB15
-#define EXP2_05_PIN                        PD2
-#define EXP2_04_PIN                        PB12
-#define EXP2_03_PIN                        PB3
-#define EXP2_02_PIN                        PB13
 #define EXP2_01_PIN                        PB14
+#define EXP2_02_PIN                        PB13
+#define EXP2_03_PIN                        PB3
+#define EXP2_04_PIN                        PB12
+#define EXP2_05_PIN                        PD2
+#define EXP2_06_PIN                        PB15
+#define EXP2_07_PIN                        PB11
+#define EXP2_08_PIN                        -1     // RESET
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
@@ -146,14 +146,14 @@
  *  - Functionally the pins are assigned in the same order as on the Ender-3 board.
  *  - Pin 4 on the Cheetah board is assigned to an I/O, it is assigned to RESET on the Ender-3 board.
  */
-#define EXP1_08_PIN                         PB15
-#define EXP1_07_PIN                         PB12
-#define EXP1_06_PIN                         PB13
-#define EXP1_05_PIN                         PC10
-#define EXP1_04_PIN                         PB14
-#define EXP1_03_PIN                         PC11
-#define EXP1_02_PIN                         PC12
 #define EXP1_01_PIN                         PC9
+#define EXP1_02_PIN                         PC12
+#define EXP1_03_PIN                         PC11
+#define EXP1_04_PIN                         PB14
+#define EXP1_05_PIN                         PC10
+#define EXP1_06_PIN                         PB13
+#define EXP1_07_PIN                         PB12
+#define EXP1_08_PIN                         PB15
 
 #if HAS_WIRED_LCD
   #define BEEPER_PIN                 EXP1_01_PIN

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -215,23 +215,23 @@
  *        ------                  ------
  *         EXP1                    EXP2
  */
-#define EXP1_08_PIN                         PD10
-#define EXP1_07_PIN                         PD11
-#define EXP1_06_PIN                         PE15
-#define EXP1_05_PIN                         PE14
-#define EXP1_04_PIN                         PC6
-#define EXP1_03_PIN                         PD13
-#define EXP1_02_PIN                         PE13
 #define EXP1_01_PIN                         PC5
+#define EXP1_02_PIN                         PE13
+#define EXP1_03_PIN                         PD13
+#define EXP1_04_PIN                         PC6
+#define EXP1_05_PIN                         PE14
+#define EXP1_06_PIN                         PE15
+#define EXP1_07_PIN                         PD11
+#define EXP1_08_PIN                         PD10
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PE12
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PE11
-#define EXP2_04_PIN                         PE10
-#define EXP2_03_PIN                         PE8
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PE8
+#define EXP2_04_PIN                         PE10
+#define EXP2_05_PIN                         PE11
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PE12
+#define EXP2_08_PIN                         -1
 
 //
 // SD Card

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -149,33 +149,33 @@
  *                ------                                    ------                                  ------
  *                 EXP1                                      EXP2                                "Ender-3 EXP1"
  */
-#define EXP1_08_PIN                         PC5
-#define EXP1_07_PIN                         PC4
-#define EXP1_06_PIN                         PA7
-#define EXP1_05_PIN                         PA6
-#define EXP1_04_PIN                         PA5
-#define EXP1_03_PIN                         PA4
-#define EXP1_02_PIN                         PC3
 #define EXP1_01_PIN                         PC1
+#define EXP1_02_PIN                         PC3
+#define EXP1_03_PIN                         PA4
+#define EXP1_04_PIN                         PA5
+#define EXP1_05_PIN                         PA6
+#define EXP1_06_PIN                         PA7
+#define EXP1_07_PIN                         PC4
+#define EXP1_08_PIN                         PC5
 
-#define EXP2_08_PIN                         -1   // RESET
-#define EXP2_07_PIN                         PC10
-#define EXP2_06_PIN                         PB15
-#define EXP2_05_PIN                         PB0
-#define EXP2_04_PIN                         PA15
-#define EXP2_03_PIN                         PB11
-#define EXP2_02_PIN                         PB13
 #define EXP2_01_PIN                         PB14
+#define EXP2_02_PIN                         PB13
+#define EXP2_03_PIN                         PB11
+#define EXP2_04_PIN                         PA15
+#define EXP2_05_PIN                         PB0
+#define EXP2_06_PIN                         PB15
+#define EXP2_07_PIN                         PC10
+#define EXP2_08_PIN                         -1   // RESET
 
 // "Ender-3 EXP1"
-#define EXP3_08_PIN                         PA4
-#define EXP3_07_PIN                         PA5
-#define EXP3_06_PIN                         PA6
-#define EXP3_05_PIN                         PB0
-#define EXP3_04_PIN                         -1   // RESET
-#define EXP3_03_PIN                         PB11
-#define EXP3_02_PIN                         PC3
 #define EXP3_01_PIN                         PC1
+#define EXP3_02_PIN                         PC3
+#define EXP3_03_PIN                         PB11
+#define EXP3_04_PIN                         -1   // RESET
+#define EXP3_05_PIN                         PB0
+#define EXP3_06_PIN                         PA6
+#define EXP3_07_PIN                         PA5
+#define EXP3_08_PIN                         PA4
 
 #if HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
@@ -88,16 +88,16 @@
  *                 ------
  *               "E3" EXP1
  */
-#define EXP3_10_PIN                         -1    // 5V
-#define EXP3_09_PIN                         -1    // GND
-#define EXP3_08_PIN                         PC2
-#define EXP3_07_PIN                         PC3
-#define EXP3_06_PIN                         PC1
-#define EXP3_05_PIN                         PB4
-#define EXP3_04_PIN                         PA11  // RESET?
-#define EXP3_03_PIN                         PB5
-#define EXP3_02_PIN                         PB3
 #define EXP3_01_PIN                         PD2
+#define EXP3_02_PIN                         PB3
+#define EXP3_03_PIN                         PB5
+#define EXP3_04_PIN                         PA11  // RESET?
+#define EXP3_05_PIN                         PB4
+#define EXP3_06_PIN                         PC1
+#define EXP3_07_PIN                         PC3
+#define EXP3_08_PIN                         PC2
+#define EXP3_09_PIN                         -1    // GND
+#define EXP3_10_PIN                         -1    // 5V
 
 //
 // LCD Pins

--- a/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
+++ b/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
@@ -179,30 +179,30 @@
 
   /** FYSETC TFT TFT81050 display pinout
    *
-   *               Board                                     Display
-   *               -----                                      -----
-   *           5V | 1 2 | GND               (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
-   * (FREE)   PB7 | 3 4 | PB8  (LCD_CS)     (PA9)  MOD_RESET | 3 4 | SD_CS (PA10)
-   * (FREE)   PB9 | 5 6   PA10 (SD_CS)      (PB8)     LCD_CS | 5 6   MOSI  (SPI1-MOSI)
-   *        RESET | 7 8 | PA9  (MOD_RESET)  (PA15)    SD_DET | 7 8 | RESET
-   * (BEEPER) PB6 | 9 10| PA15 (SD_DET)                  GND | 9 10| 5V
-   *               -----                                      -----
-   *                EXP1                                       EXP1
+   *                   Board                                   Display
+   *                   ------                                  ------
+   * (SD_DET)    PA15 | 1  2 | PB6 (BEEPER)  (SPI1-MISO) MISO | 1  2 | SCK   (SPI1-SCK)
+   * (MOD_RESET) PA9  | 3  4 | RESET                MOD_RESET | 3  4 | SD_CS
+   * (SD_CS)     PA10   5  6 | PB9 (FREE)              LCD_CS | 5  6   MOSI  (SPI1-MOSI)
+   * (LCD_CS)    PB8  | 7  8 | PB7 (FREE)              SD_DET | 7  8 | RESET
+   *             GND  | 9 10 |  5V                        GND | 9 10 | 5V
+   *                   ------                                  ------
+   *                    EXP1                                    EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
-   *   EXP1-1 ----------- EXP1-10
-   *   EXP1-2 ----------- EXP1-9
-   *   SPI1-4 ----------- EXP1-6
-   *   EXP1-4 ----------- EXP1-5
-   *   SP11-3 ----------- EXP1-2
-   *   EXP1-6 ----------- EXP1-4
-   *   EXP1-7 ----------- EXP1-8
-   *   EXP1-8 ----------- EXP1-3
-   *   SPI1-1 ----------- EXP1-1
-   *  EXP1-10 ----------- EXP1-7
+   *   ----------------------------------
+   *   EXP1-10 ---------- EXP1-10  5V
+   *   EXP1-9 ----------- EXP1-9   GND
+   *   SPI1-4 ----------- EXP1-6   MOSI
+   *   EXP1-7 ----------- EXP1-5   LCD_CS
+   *   SP11-3 ----------- EXP1-2   SCK
+   *   EXP1-5 ----------- EXP1-4   SD_CS
+   *   EXP1-4 ----------- EXP1-8   RESET
+   *   EXP1-3 ----------- EXP1-3   MOD_RST
+   *   SPI1-1 ----------- EXP1-1   MISO
+   *   EXP1-1 ----------- EXP1-7   SD_DET
    */
 
   #define CLCD_SPI_BUS                         1  // SPI1 connector

--- a/Marlin/src/pins/stm32f1/pins_ZM3E2_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_ZM3E2_V1_0.h
@@ -72,14 +72,14 @@
 //   2 +5V
 //   1 GND
 
-#define EXP1_08_PIN                         PB11
-#define EXP1_07_PIN                         PB10
-#define EXP1_06_PIN                         PB2
-#define EXP1_05_PIN                         PC5
-#define EXP1_04_PIN                         PA10
-#define EXP1_03_PIN                         PA9
-#define EXP1_02_PIN                         PB0
 #define EXP1_01_PIN                         PB1
+#define EXP1_02_PIN                         PB0
+#define EXP1_03_PIN                         PA9
+#define EXP1_04_PIN                         PA10
+#define EXP1_05_PIN                         PC5
+#define EXP1_06_PIN                         PB2
+#define EXP1_07_PIN                         PB10
+#define EXP1_08_PIN                         PB11
 
 // AUX1 connector
 //  1 +5V

--- a/Marlin/src/pins/stm32f1/pins_ZM3E4_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_ZM3E4_V1_0.h
@@ -89,14 +89,14 @@
 //   2 +5V                    +5V
 //   1 GND                    GND
 
-#define EXP1_08_PIN                         PE14
-#define EXP1_07_PIN                         PE15
-#define EXP1_06_PIN                         PE9
-#define EXP1_05_PIN                         PE8
-#define EXP1_04_PIN                         PE10
-#define EXP1_03_PIN                         PE12
-#define EXP1_02_PIN                         PE11
 #define EXP1_01_PIN                         PE13
+#define EXP1_02_PIN                         PE11
+#define EXP1_03_PIN                         PE12
+#define EXP1_04_PIN                         PE10
+#define EXP1_05_PIN                         PE8
+#define EXP1_06_PIN                         PE9
+#define EXP1_07_PIN                         PE15
+#define EXP1_08_PIN                         PE14
 
 // EXP2 connector
 //     MARK     I/O     ZONESTAR_LCD12864   REPRAPDISCOUNT_LCD12864
@@ -111,12 +111,12 @@
 //   2 +5V                    +5V
 //   1 GND                    GND
 
-#define EXP2_08_PIN                         PB3
-#define EXP2_07_PIN                         PB5
-#define EXP2_06_PIN                         PB4
-#define EXP2_05_PIN                         PA15
-#define EXP2_04_PIN                         PA10
 #define EXP2_03_PIN                         PA9
+#define EXP2_04_PIN                         PA10
+#define EXP2_05_PIN                         PA15
+#define EXP2_06_PIN                         PB4
+#define EXP2_07_PIN                         PB5
+#define EXP2_08_PIN                         PB3
 
 // AUX1 connector
 //  1 +5V

--- a/Marlin/src/pins/stm32f1/pins_ZM3E4_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_ZM3E4_V2_0.h
@@ -90,14 +90,14 @@
 //   2 +5V
 //   1 GND
 
-#define EXP1_08_PIN                         PE14
-#define EXP1_07_PIN                         PE15
-#define EXP1_06_PIN                         PE9
-#define EXP1_05_PIN                         PE8
-#define EXP1_04_PIN                         PE10
-#define EXP1_03_PIN                         PE12
-#define EXP1_02_PIN                         PE11
 #define EXP1_01_PIN                         PE13
+#define EXP1_02_PIN                         PE11
+#define EXP1_03_PIN                         PE12
+#define EXP1_04_PIN                         PE10
+#define EXP1_05_PIN                         PE8
+#define EXP1_06_PIN                         PE9
+#define EXP1_07_PIN                         PE15
+#define EXP1_08_PIN                         PE14
 
 // EXP2 connector
 //     MARK     I/O     ZONESTAR_LCD12864   REPRAPDISCOUNT_LCD12864
@@ -112,14 +112,14 @@
 //   2 +5V
 //   1 GND
 
-#define EXP2_08_PIN                         PB3
-#define EXP2_07_PIN                         PB5
-#define EXP2_06_PIN                         PB4
-#define EXP2_05_PIN                         PA15
-#define EXP2_04_PIN                         PA10
-#define EXP2_03_PIN                         PA9
-#define EXP2_02_PIN                         PE7
 #define EXP2_01_PIN                         PC0
+#define EXP2_02_PIN                         PE7
+#define EXP2_03_PIN                         PA9
+#define EXP2_04_PIN                         PA10
+#define EXP2_05_PIN                         PA15
+#define EXP2_06_PIN                         PB4
+#define EXP2_07_PIN                         PB5
+#define EXP2_08_PIN                         PB3
 
 // AUX1 connector
 //  1 +5V

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -208,24 +208,24 @@
  *                 EXP1                                      EXP2               |
  * ------------------------------------------------------------------------------
  */
-#define EXP1_08_PIN                         PE13
-#define EXP1_07_PIN                         PE12
-#define EXP1_06_PIN                         PE11
-#define EXP1_05_PIN                         PE10
-#define EXP1_04_PIN                         PE8
-#define EXP1_03_PIN                         PE9
-#define EXP1_02_PIN                         PB1
 #define EXP1_01_PIN                         PE7
+#define EXP1_02_PIN                         PB1
+#define EXP1_03_PIN                         PE9
+#define EXP1_04_PIN                         PE8
+#define EXP1_05_PIN                         PE10
+#define EXP1_06_PIN                         PE11
+#define EXP1_07_PIN                         PE12
+#define EXP1_08_PIN                         PE13
 
-#define EXP2_10_PIN                         PA3
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PC4
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PB0
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PC5
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PC5
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PB0
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC4
+#define EXP2_08_PIN                         -1
+#define EXP2_10_PIN                         PA3
 
 // HAL SPI1 pins
 #define SD_SCK_PIN                   EXP2_02_PIN  // SPI1 SCLK

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -219,28 +219,28 @@
       *
       *               BTT E3 RRF                                   Display Ribbon
       *                ------                                         ------
-      * (BEEPER)  PE8 | 1  2 | PE9  (BTN_ENC)                    GND | 1  2 | 5V
-      * (BTN_EN1) PE7 | 3  4 | RESET                          BEEPER | 3  4 | ESTOP    (RESET)
-      * (BTN_EN2) PB2   5  6 | PE10 (LCD_D4)       (BTN_ENC) ENC_BTN | 5  6 | LCD_SCLK (LCD_D4)
-      * (LCD_RS)  PB1 | 7  8 | PE11 (LCD_EN)       (BTN_EN2) ENC_A   | 7  8 | LCD_DATA (LCD_EN)
-      *           GND | 9 10 | 5V                  (BTN_EN1) ENC_B   | 9 10 | LCD_CS   (LCD_RS)
+      * (BEEPER)  PE8 | 1  2 | PE9  (BTN_ENC)                    GND |10  9 | 5V
+      * (BTN_EN1) PE7 | 3  4 | RESET                          BEEPER | 8  7 | ESTOP    (RESET)
+      * (BTN_EN2) PB2   5  6 | PE10 (LCD_D4)       (BTN_ENC) ENC_BTN | 6  5 | LCD_SCLK (LCD_D4)
+      * (LCD_RS)  PB1 | 7  8 | PE11 (LCD_EN)       (BTN_EN2) ENC_A   | 4  3 | LCD_DATA (LCD_EN)
+      *           GND | 9 10 | 5V                  (BTN_EN1) ENC_B   | 2  1 | LCD_CS   (LCD_RS)
       *                ------                                         ------
-      *                 EXP1                                          Ribbon
+      *                 EXP1                                           LCD
       *
       * Needs custom cable:
       *
       *    Board   Adapter   Display Ribbon (coming from display)
-      *
-      *   EXP1-1 ----------- EXP1-9
-      *   EXP1-2 ----------- EXP1-10
-      *   EXP1-3 ----------- EXP1-3
-      *   EXP1-4 ----------- EXP1-1
-      *   EXP1-5 ----------- EXP1-5
-      *   EXP1-6 ----------- EXP1-4
-      *   EXP1-7 ----------- EXP1-7
-      *   EXP1-8 ----------- EXP1-8
-      *   EXP1-9 ----------- EXP1-6
-      *  EXP1-10 ----------- EXP1-8
+      *  ----------------------------------
+      *  EXP1-10 ---------- LCD-9   5V
+      *  EXP1-9 ----------- LCD-10  GND
+      *  EXP1-8 ----------- LCD-3   LCD_EN
+      *  EXP1-7 ----------- LCD-1   LCD_RS
+      *  EXP1-6 ----------- LCD-5   LCD_D4
+      *  EXP1-5 ----------- LCD-4   EN2
+      *  EXP1-4 ----------- LCD-7   RESET
+      *  EXP1-3 ----------- LCD-2   EN1
+      *  EXP1-2 ----------- LCD-6   BTN
+      *  EXP1-1 ----------- LCD-8   BEEPER
       */
 
     #endif
@@ -286,28 +286,28 @@
        *
        *                  Board                       Display
        *                  ------                       ------
-       * (SD_DET)    PE8 | 1  2 | PE9 (BEEPER)     5V | 1  2 | GND
-       * (MOD_RESET) PE7 | 3  4 | RESET            -- | 3  4 | (SD_DET)
-       * (SD_CS)     PB2   5  6 | PE10        (MOSI)    5  6 | --
-       * (LCD_CS)    PB1 | 7  8 | PE11        (SD_CS) | 7  8 | (LCD_CS)
-       *             GND | 9 10 | 5V          (SCK)   | 9 10 | (MISO)
+       * (SD_DET)    PE8 | 1  2 | PE9 (BEEPER)     5V |10  9 | GND
+       * (MOD_RESET) PE7 | 3  4 | RESET            -- | 8  7 | (SD_DET)
+       * (SD_CS)     PB2   5  6 | PE10        (MOSI)    6  5 | --
+       * (LCD_CS)    PB1 | 7  8 | PE11        (SD_CS) | 4  3 | (LCD_CS)
+       *             GND | 9 10 | 5V          (SCK)   | 2  1 | (MISO)
        *                  ------                       ------
        *                   EXP1                         EXP1
        *
        * Needs custom cable:
        *
        *    Board   Adapter   Display
-       *           _________
-       *   EXP1-1 ----------- EXP1-10
-       *   EXP1-2 ----------- EXP1-9
-       *   SPI1-4 ----------- EXP1-6
-       *   EXP1-4 ----------- FREE
-       *   SPI1-3 ----------- EXP1-2
-       *   EXP1-6 ----------- EXP1-4
-       *   EXP1-7 ----------- FREE
-       *   EXP1-8 ----------- EXP1-3
-       *   SPI1-1 ----------- EXP1-1
-       *  EXP1-10 ----------- EXP1-7
+       *   ----------------------------------
+       *   EXP1-10 ---------- EXP1-10  5V
+       *   EXP1-9 ----------- EXP1-9   GND
+       *   SPI1-4 ----------- EXP1-6   MOSI
+       *   EXP1-7 ----------- n/c
+       *   SPI1-3 ----------- EXP1-2   SCK
+       *   EXP1-5 ----------- EXP1-4   SD_CS
+       *   EXP1-4 ----------- n/c
+       *   EXP1-3 ----------- EXP1-3   LCD_CS
+       *   SPI1-1 ----------- EXP1-1   MISO
+       *   EXP1-1 ----------- EXP1-7   SD_DET
        */
 
       #define TFTGLCD_CS                    PE7
@@ -341,28 +341,28 @@
    *
    *                  Board                          Display
    *                  ------                          ------
-   * (SD_DET)    PE8 | 1  2 | PE9 (BEEPER)        5V | 1  2 | GND
-   * (MOD_RESET) PE7 | 3  4 | RESET            RESET | 3  4 | (SD_DET)
-   * (SD_CS)     PB2   5  6 | PE10           (MOSI)  | 5  6 | (LCD_CS)
-   * (LCD_CS)    PB1 | 7  8 | PE11           (SD_CS) | 7  8 | (MOD_RESET)
-   *             GND | 9 10 | 5V             (SCK)   | 9 10 | (MISO)
+   * (SD_DET)    PE8 | 1  2 | PE9 (BEEPER)        5V |10  9 | GND
+   * (MOD_RESET) PE7 | 3  4 | RESET            RESET | 8  7 | (SD_DET)
+   * (SD_CS)     PB2   5  6 | PE10           (MOSI)  | 6  5 | (LCD_CS)
+   * (LCD_CS)    PB1 | 7  8 | PE11           (SD_CS) | 4  3 | (MOD_RESET)
+   *             GND | 9 10 | 5V             (SCK)   | 2  1 | (MISO)
    *                  ------                          ------
    *                   EXP1                            EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *
-   *   EXP1-1 ----------- EXP1-10
-   *   EXP1-2 ----------- EXP1-9
-   *   SPI1-4 ----------- EXP1-6
-   *   EXP1-4 ----------- EXP1-5
-   *   SPI1-3 ----------- EXP1-2
-   *   EXP1-6 ----------- EXP1-4
-   *   EXP1-7 ----------- EXP1-8
-   *   EXP1-8 ----------- EXP1-3
-   *   SPI1-1 ----------- EXP1-1
-   *  EXP1-10 ----------- EXP1-7
+   *   ----------------------------------
+   *   EXP1-10 ---------- EXP1-10  5V
+   *   EXP1-9 ----------- EXP1-9   GND
+   *   SPI1-4 ----------- EXP1-6   MOSI
+   *   EXP1-7 ----------- EXP1-5   LCD_CS
+   *   SPI1-3 ----------- EXP1-2   SCK
+   *   EXP1-5 ----------- EXP1-4   SD_CS
+   *   EXP1-4 ----------- EXP1-8   RESET
+   *   EXP1-3 ----------- EXP1-3   MOD_RST
+   *   SPI1-1 ----------- EXP1-1   MISO
+   *   EXP1-1 ----------- EXP1-7   SD_DET
    */
 
   #define CLCD_SPI_BUS                         1  // SPI1 connector

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -374,22 +374,22 @@
  *                ------                                     ------
  *                 EXP1                                       EXP2
  */
-#define EXP1_08_PIN                         PG5
-#define EXP1_07_PIN                         PG6
-#define EXP1_06_PIN                         PG7
-#define EXP1_05_PIN                         PG8
-#define EXP1_04_PIN                         PA8
-#define EXP1_03_PIN                         PC10
-#define EXP1_02_PIN                         PA15
 #define EXP1_01_PIN                         PC11
+#define EXP1_02_PIN                         PA15
+#define EXP1_03_PIN                         PC10
+#define EXP1_04_PIN                         PA8
+#define EXP1_05_PIN                         PG8
+#define EXP1_06_PIN                         PG7
+#define EXP1_07_PIN                         PG6
+#define EXP1_08_PIN                         PG5
 
-#define EXP2_07_PIN                         PB10
-#define EXP2_06_PIN                         PB15
-#define EXP2_05_PIN                         PH10
-#define EXP2_04_PIN                         PB12
-#define EXP2_03_PIN                         PD10
-#define EXP2_02_PIN                         PB13
 #define EXP2_01_PIN                         PB14
+#define EXP2_02_PIN                         PB13
+#define EXP2_03_PIN                         PD10
+#define EXP2_04_PIN                         PB12
+#define EXP2_05_PIN                         PH10
+#define EXP2_06_PIN                         PB15
+#define EXP2_07_PIN                         PB10
 
 //
 // LCDs and Controllers

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -330,23 +330,23 @@
  *                ------                                      ------
  *                 EXP1                                        EXP2
  */
-#define EXP1_08_PIN                         PE15
-#define EXP1_07_PIN                         PE14
-#define EXP1_06_PIN                         PE13
-#define EXP1_05_PIN                         PE12
-#define EXP1_04_PIN                         PE10
-#define EXP1_03_PIN                         PE9
-#define EXP1_02_PIN                         PE7
 #define EXP1_01_PIN                         PE8
+#define EXP1_02_PIN                         PE7
+#define EXP1_03_PIN                         PE9
+#define EXP1_04_PIN                         PE10
+#define EXP1_05_PIN                         PE12
+#define EXP1_06_PIN                         PE13
+#define EXP1_07_PIN                         PE14
+#define EXP1_08_PIN                         PE15
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PC15
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PB2
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PB1
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PB1
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PB2
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC15
+#define EXP2_08_PIN                         -1
 
 //
 // Onboard SD card

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -553,10 +553,10 @@
 
 /**
  *          ------
- *      RX | 3  4 | 3.3V      GPIO0  PF14 ... Leave as unused (ESP3D software configures this with a pullup so OK to leave as floating)
- *   GPIO0 | 5  6 | Reset     GPIO2  PF15 ... must be high (ESP3D software configures this with a pullup so OK to leave as floating)
- *   GPIO2 | 7  8 | Enable    Reset  PG0  ... active low, probably OK to leave floating
- *     GND | 9 10 | TX        Enable PG1  ... Must be high for module to run
+ *      RX | 8  7 | 3.3V      GPIO0  PF14 ... Leave as unused (ESP3D software configures this with a pullup so OK to leave as floating)
+ *   GPIO0 | 6  5 | Reset     GPIO2  PF15 ... must be high (ESP3D software configures this with a pullup so OK to leave as floating)
+ *   GPIO2 | 4  3 | Enable    Reset  PG0  ... active low, probably OK to leave floating
+ *     GND | 2  1 | TX        Enable PG1  ... Must be high for module to run
  *          ------
  *            W1
  */

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -321,23 +321,23 @@
  *                ------                                      ------
  *                 EXP1                                        EXP2
  */
-#define EXP1_08_PIN                         PG7
-#define EXP1_07_PIN                         PG6
-#define EXP1_06_PIN                         PG3
-#define EXP1_05_PIN                         PG2
-#define EXP1_04_PIN                         PD10
-#define EXP1_03_PIN                         PD11
-#define EXP1_02_PIN                         PA8
 #define EXP1_01_PIN                         PG4
+#define EXP1_02_PIN                         PA8
+#define EXP1_03_PIN                         PD11
+#define EXP1_04_PIN                         PD10
+#define EXP1_05_PIN                         PG2
+#define EXP1_06_PIN                         PG3
+#define EXP1_07_PIN                         PG6
+#define EXP1_08_PIN                         PG7
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PF12
-#define EXP2_06_PIN                         PB15
-#define EXP2_05_PIN                         PF11
-#define EXP2_04_PIN                         PB12
-#define EXP2_03_PIN                         PG10
-#define EXP2_02_PIN                         PB13
 #define EXP2_01_PIN                         PB14
+#define EXP2_02_PIN                         PB13
+#define EXP2_03_PIN                         PG10
+#define EXP2_04_PIN                         PB12
+#define EXP2_05_PIN                         PF11
+#define EXP2_06_PIN                         PB15
+#define EXP2_07_PIN                         PF12
+#define EXP2_08_PIN                         -1
 
 //
 // Onboard SD card

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -344,23 +344,23 @@
  *                ------                                   ------
  *                 EXP1                                     EXP2
  */
-#define EXP1_08_PIN                         PE13
-#define EXP1_07_PIN                         PE12
-#define EXP1_06_PIN                         PE11
-#define EXP1_05_PIN                         PE10
-#define EXP1_04_PIN                         PE9
-#define EXP1_03_PIN                         PB1
-#define EXP1_02_PIN                         PB0
 #define EXP1_01_PIN                         PC5
+#define EXP1_02_PIN                         PB0
+#define EXP1_03_PIN                         PB1
+#define EXP1_04_PIN                         PE9
+#define EXP1_05_PIN                         PE10
+#define EXP1_06_PIN                         PE11
+#define EXP1_07_PIN                         PE12
+#define EXP1_08_PIN                         PE13
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PC4
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PB2
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PE7
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PE7
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PB2
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC4
+#define EXP2_08_PIN                         -1
 
 //
 // Onboard SD card

--- a/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
+++ b/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
@@ -185,23 +185,23 @@
  *        ------                ------
  *         EXP1                  EXP2
  */
-#define EXP1_08_PIN                         PE7
-#define EXP1_07_PIN                         PE8
-#define EXP1_06_PIN                         PE9
-#define EXP1_05_PIN                         PE10
-#define EXP1_04_PIN                         PE12
-#define EXP1_03_PIN                         PE14
-#define EXP1_02_PIN                         PE15
 #define EXP1_01_PIN                         PB10
+#define EXP1_02_PIN                         PE15
+#define EXP1_03_PIN                         PE14
+#define EXP1_04_PIN                         PE12
+#define EXP1_05_PIN                         PE10
+#define EXP1_06_PIN                         PE9
+#define EXP1_07_PIN                         PE8
+#define EXP1_08_PIN                         PE7
 
-#define EXP2_08_PIN                         -1    // RESET
-#define EXP2_07_PIN                         PB2
-#define EXP2_06_PIN                         PB15
-#define EXP2_05_PIN                         PC4
-#define EXP2_04_PIN                         PF11
-#define EXP2_03_PIN                         PC5
-#define EXP2_02_PIN                         PB13
 #define EXP2_01_PIN                         PB14
+#define EXP2_02_PIN                         PB13
+#define EXP2_03_PIN                         PC5
+#define EXP2_04_PIN                         PF11
+#define EXP2_05_PIN                         PC4
+#define EXP2_06_PIN                         PB15
+#define EXP2_07_PIN                         PB2
+#define EXP2_08_PIN                         -1    // RESET
 
 //
 // Onboard SD support

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
@@ -160,23 +160,23 @@
  *                      EXP3
  */
 
-#define EXP1_08_PIN                         PB7
-#define EXP1_07_PIN                         PB6
-#define EXP1_06_PIN                         PB14
-#define EXP1_05_PIN                         PB13
-#define EXP1_04_PIN                         PB12
-#define EXP1_03_PIN                         PB15
-#define EXP1_02_PIN                         PC12
 #define EXP1_01_PIN                         PC9
+#define EXP1_02_PIN                         PC12
+#define EXP1_03_PIN                         PB15
+#define EXP1_04_PIN                         PB12
+#define EXP1_05_PIN                         PB13
+#define EXP1_06_PIN                         PB14
+#define EXP1_07_PIN                         PB6
+#define EXP1_08_PIN                         PB7
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PC3
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PC11
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PC10
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PC10
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PC11
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC3
+#define EXP2_08_PIN                         -1
 
 #if HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -207,23 +207,23 @@
  *         ------                 ------
  *          EXP1                   EXP2
  */
-#define EXP1_08_PIN                         PD1
-#define EXP1_07_PIN                         PD0
-#define EXP1_06_PIN                         PC12
-#define EXP1_05_PIN                         PC10
-#define EXP1_04_PIN                         PD2
-#define EXP1_03_PIN                         PC11
-#define EXP1_02_PIN                         PA8
 #define EXP1_01_PIN                         PC9
+#define EXP1_02_PIN                         PA8
+#define EXP1_03_PIN                         PC11
+#define EXP1_04_PIN                         PD2
+#define EXP1_05_PIN                         PC10
+#define EXP1_06_PIN                         PC12
+#define EXP1_07_PIN                         PD0
+#define EXP1_08_PIN                         PD1
 
-#define EXP2_08_PIN                         -1    // RESET
-#define EXP2_07_PIN                         PB10
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PC7
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PC6
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PC6
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PC7
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PB10
+#define EXP2_08_PIN                         -1    // RESET
 
 //
 // SPI / SD Card

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -221,23 +221,23 @@
  *                  ------                                      ------
  *                   EXP1                                        EXP2
  */
-#define EXP1_08_PIN                         PE7
-#define EXP1_07_PIN                         PE15
-#define EXP1_06_PIN                         PD8
-#define EXP1_05_PIN                         PD9
-#define EXP1_04_PIN                         PD10
-#define EXP1_03_PIN                         PE11
-#define EXP1_02_PIN                         PE10
 #define EXP1_01_PIN                         PB2
+#define EXP1_02_PIN                         PE10
+#define EXP1_03_PIN                         PE11
+#define EXP1_04_PIN                         PD10
+#define EXP1_05_PIN                         PD9
+#define EXP1_06_PIN                         PD8
+#define EXP1_07_PIN                         PE15
+#define EXP1_08_PIN                         PE7
 
-#define EXP2_08_PIN                         -1    // RESET
-#define EXP2_07_PIN                         PB11
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PE8
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PE9
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PE9
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PE8
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PB11
+#define EXP2_08_PIN                         -1    // RESET
 
 #if ENABLED(SDSUPPORT)
   #ifndef SDCARD_CONNECTION

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -244,23 +244,23 @@
  *                ------                                     ------
  *                 EXP1                                       EXP2
  */
-#define EXP1_08_PIN                         PD10
-#define EXP1_07_PIN                         PD11
-#define EXP1_06_PIN                         PE15
-#define EXP1_05_PIN                         PE14
-#define EXP1_04_PIN                         PC6
-#define EXP1_03_PIN                         PD13
-#define EXP1_02_PIN                         PE13
 #define EXP1_01_PIN                         PC5
+#define EXP1_02_PIN                         PE13
+#define EXP1_03_PIN                         PD13
+#define EXP1_04_PIN                         PC6
+#define EXP1_05_PIN                         PE14
+#define EXP1_06_PIN                         PE15
+#define EXP1_07_PIN                         PD11
+#define EXP1_08_PIN                         PD10
 
-#define EXP2_08_PIN                         -1    // RESET
-#define EXP2_07_PIN                         PE12
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PE11
-#define EXP2_04_PIN                         PE10
-#define EXP2_03_PIN                         PE8
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PE8
+#define EXP2_04_PIN                         PE10
+#define EXP2_05_PIN                         PE11
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PE12
+#define EXP2_08_PIN                         -1    // RESET
 
 //
 // SPI SD Card

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -238,23 +238,23 @@
  *                ------                                      ------
  *                 EXP1                                        EXP2
  */
-#define EXP1_08_PIN                     PD10
-#define EXP1_07_PIN                     PD11
-#define EXP1_06_PIN                     PE15
-#define EXP1_05_PIN                     PE14
-#define EXP1_04_PIN                     PC6
-#define EXP1_03_PIN                     PD13
-#define EXP1_02_PIN                     PE13
 #define EXP1_01_PIN                     PC5
+#define EXP1_02_PIN                     PE13
+#define EXP1_03_PIN                     PD13
+#define EXP1_04_PIN                     PC6
+#define EXP1_05_PIN                     PE14
+#define EXP1_06_PIN                     PE15
+#define EXP1_07_PIN                     PD11
+#define EXP1_08_PIN                     PD10
 
-#define EXP2_08_PIN                     -1    // RESET
-#define EXP2_07_PIN                     PE12
-#define EXP2_06_PIN                     PA7
-#define EXP2_05_PIN                     PE11
-#define EXP2_04_PIN                     PE10
-#define EXP2_03_PIN                     PE8
-#define EXP2_02_PIN                     PA5
 #define EXP2_01_PIN                     PA6
+#define EXP2_02_PIN                     PA5
+#define EXP2_03_PIN                     PE8
+#define EXP2_04_PIN                     PE10
+#define EXP2_05_PIN                     PE11
+#define EXP2_06_PIN                     PA7
+#define EXP2_07_PIN                     PE12
+#define EXP2_08_PIN                     -1    // RESET
 
 //
 // LCD SD

--- a/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
@@ -213,14 +213,14 @@
  * A remote SD card is currently not supported because the pins routed to the EXP2
  * connector are shared with the onboard SD card.
  */
-#define EXP1_08_PIN                         PB15
-#define EXP1_07_PIN                         PB12
-#define EXP1_06_PIN                         PB13
-#define EXP1_05_PIN                         PC5
-//#define EXP1_04_PIN                       -1
-#define EXP1_03_PIN                         PC4
-#define EXP1_02_PIN                         PB0
 #define EXP1_01_PIN                         PA14
+#define EXP1_02_PIN                         PB0
+#define EXP1_03_PIN                         PC4
+//#define EXP1_04_PIN                       -1
+#define EXP1_05_PIN                         PC5
+#define EXP1_06_PIN                         PB13
+#define EXP1_07_PIN                         PB12
+#define EXP1_08_PIN                         PB15
 
 #if ENABLED(CR10_STOCKDISPLAY)
   /**          ------

--- a/Marlin/src/pins/stm32f4/pins_VAKE403D.h
+++ b/Marlin/src/pins/stm32f4/pins_VAKE403D.h
@@ -175,23 +175,23 @@
  *        ------                  ------
  *         EXP1                    EXP2
  */
-#define EXP1_08_PIN                         PD4
-#define EXP1_07_PIN                         PD3
-#define EXP1_06_PIN                         PD2
-#define EXP1_05_PIN                         PD1
-#define EXP1_04_PIN                         PC12
-#define EXP1_03_PIN                         PD7
-#define EXP1_02_PIN                         PB12
 #define EXP1_01_PIN                         PC9
+#define EXP1_02_PIN                         PB12
+#define EXP1_03_PIN                         PD7
+#define EXP1_04_PIN                         PC12
+#define EXP1_05_PIN                         PD1
+#define EXP1_06_PIN                         PD2
+#define EXP1_07_PIN                         PD3
+#define EXP1_08_PIN                         PD4
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PB7
-//#define EXP2_06_PIN                       ?
-#define EXP2_05_PIN                         PD0
-//#define EXP2_04_PIN                       ?
-#define EXP2_03_PIN                         PD6
-//#define EXP2_02_PIN                       ?
 //#define EXP2_01_PIN                       ?
+//#define EXP2_02_PIN                       ?
+#define EXP2_03_PIN                         PD6
+//#define EXP2_04_PIN                       ?
+#define EXP2_05_PIN                         PD0
+//#define EXP2_06_PIN                       ?
+#define EXP2_07_PIN                         PB7
+#define EXP2_08_PIN                         -1
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -163,11 +163,11 @@
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
   /**
    *        ------                ------                ------
-   * (ENT) | 1  2 | (BEEP)       | 1  2 |              | 1  2 |
-   *  (RX) | 3  4 |         (RX) | 3  4 | (TX)      RX | 3  4 | TX
-   *  (TX)   5  6 |        (ENT)   5  6 | (BEEP)   ENT | 5  6 | BEEP
-   *   (B) | 7  8 | (A)      (B) | 7  8 | (A)        B | 7  8 | A
-   *   GND | 9 10 | (VCC)    GND | 9 10 | VCC      GND | 9 10 | VCC
+   * (ENT) | 1  2 | (BEEP)       |10  9 |              |10  9 |
+   *  (RX) | 3  4 |         (RX) | 8  7 | (TX)      RX | 8  7 | TX
+   *  (TX)   5  6 |        (ENT)   6  5 | (BEEP)   ENT | 6  5 | BEEP
+   *   (B) | 7  8 | (A)      (B) | 4  3 | (A)        B | 4  3 | A
+   *   GND | 9 10 | (VCC)    GND | 2  1 | VCC      GND | 2  1 | VCC
    *        ------                ------                ------
    *         EXP1                  DWIN               DWIN (plug)
    *
@@ -280,11 +280,11 @@
          *
          *                 Board                               Display
          *                 ------                               ------
-         * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V | 1  2 | GND
-         *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 3  4 | (SD_DET)
-         *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 5  6 | --
-         *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 7  8 | (LCD_CS)
-         *           GND | 9 10 | 5V                   (SCK)   | 9 10 | (MISO)
+         * (BEEPER) PB6  | 1  2 | PB5  (SD_DET)             5V |10  9 | GND
+         *         RESET | 3  4 | PA9  (MOD_RESET)          -- | 8  7 | (SD_DET)
+         *          PB9    5  6 | PA10 (SD_CS)         (MOSI)  | 6  5 | --
+         *          PB7  | 7  8 | PB8  (LCD_CS)        (SD_CS) | 4  3 | (LCD_CS)
+         *           GND | 9 10 | 5V                   (SCK)   | 2  1 | (MISO)
          *                 ------                               ------
          *                  EXP1                                 EXP1
          *
@@ -292,16 +292,16 @@
          *
          *    Board             Display
          *
-         *   EXP1-1 ----------- EXP1-10
-         *   EXP1-2 ----------- EXP1-9
-         *   SPI1-4 ----------- EXP1-6
-         *   EXP1-4 ----------- FREE
-         *   SPI1-3 ----------- EXP1-2
-         *   EXP1-6 ----------- EXP1-4
-         *   EXP1-7 ----------- FREE
-         *   EXP1-8 ----------- EXP1-3
-         *   SPI1-1 ----------- EXP1-1
-         *  EXP1-10 ----------- EXP1-7
+         *  EXP1-10 ----------- EXP1-10  5V
+         *  EXP1-9 ------------ EXP1-9   GND
+         *  SPI1-4 ------------ EXP1-6   MOSI
+         *  EXP1-7 ------------ n/c
+         *  SPI1-3 ------------ EXP1-2   SCK
+         *  EXP1-5 ------------ EXP1-4   SD_CS
+         *  EXP1-4 ------------ n/c
+         *  EXP1-3 ------------ EXP1-3   LCD_CS
+         *  SPI1-1 ------------ EXP1-1   MISO
+         *  EXP1-1 ------------ EXP1-7   SD_DET
          */
 
         #define TFTGLCD_CS           EXP1_03_PIN
@@ -318,26 +318,26 @@
        *
        *                 Board                               Display
        *                 ------                               ------
-       *    (EN2)  PB5  | 1  2 | PA15(BTN_ENC)            5V | 1  2 | GND
-       *  (LCD_CS) PA9  | 3  4 | RST (RESET)              -- | 3  4 | --
-       *  (LCD_A0) PA10 |#6  5 | PB9 (EN1)            (DIN)  | 6  5#| (RESET)
-       *  (LCD_SCK)PB8  | 7  8 | PD6 (MOSI)         (LCD_A0) | 7  8 | (LCD_CS)
-       *            GND | 9 10 | 5V                (BTN_ENC) | 9 10 | --
+       *    (EN2)  PB5  | 1  2 | PA15(BTN_ENC)            5V |10  9 | GND
+       *  (LCD_CS) PA9  | 3  4 | RST (RESET)              -- | 8  7 | --
+       *  (LCD_A0) PA10   5  6 | PB9 (EN1)            (DIN)  | 6  5   (RESET)
+       *  (LCD_SCK)PB8  | 7  8 | PD6 (MOSI)         (LCD_A0) | 4  3 | (LCD_CS)
+       *            GND | 9 10 | 5V                (BTN_ENC) | 2  1 | --
        *                 ------                               ------
        *                  EXP1                                 EXP1
        *
        *                                                      ------
-       *                                                  -- | 1  2 | --
-       *                   ---                       (RESET) | 3  4 | --
-       *                  | 3 |                      (MOSI)  | 6  5#| (EN2)
-       *                  | 2 | (DIN)                     -- | 7  8 | (EN1)
-       *                  | 1 |                     (LCD_SCK)| 9 10 | --
+       *                                                  -- |10  9 | --
+       *                   ---                       (RESET) | 8  7 | --
+       *                  | 3 |                      (MOSI)  | 6  5   (EN2)
+       *                  | 2 | (DIN)                     -- | 4  3 | (EN1)
+       *                  | 1 |                     (LCD_SCK)| 2  1 | --
        *                   ---                                ------
        *                Neopixel                               EXP2
        *
        * Needs custom cable. Connect EN2-EN2, LCD_CS-LCD_CS and so on.
        *
-       * Check twice index position!!! (marked as # here)
+       * Check the index/notch position twice!!!
        * On BTT boards pins from IDC10 connector are numbered in unusual order.
        */
       #define BTN_ENC                EXP1_02_PIN
@@ -372,28 +372,28 @@
    *
    *                   Board                             Display
    *                   ------                            ------
-   * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)          5V | 1  2 | GND
-   * (MOD_RESET) PA9  | 3  4 | RESET            (RESET) | 3  4 | (SD_DET)
-   * (SD_CS)     PA10   5  6 | PB9 (FREE)       (MOSI)  | 5  6 | (LCD_CS)
-   * (LCD_CS)    PB8  | 7  8 | PB7 (FREE)       (SD_CS) | 7  8 | (MOD_RESET)
-   *               5V | 9 10 | GND              (SCK)   | 9 10 | (MISO)
+   * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)          5V |10  9 | GND
+   * (MOD_RESET) PA9  | 3  4 | RESET            (RESET) | 8  7 | (SD_DET)
+   * (SD_CS)     PA10   5  6 | PB9 (FREE)       (MOSI)  | 6  5 | (LCD_CS)
+   * (LCD_CS)    PB8  | 7  8 | PB7 (FREE)       (SD_CS) | 4  3 | (MOD_RESET)
+   *               5V | 9 10 | GND              (SCK)   | 2  1 | (MISO)
    *                   ------                            ------
    *                    EXP1                              EXP1
    *
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
-   *   EXP1-1 ----------- EXP1-10
-   *   EXP1-2 ----------- EXP1-9
-   *   SPI1-4 ----------- EXP1-6
-   *   EXP1-4 ----------- EXP1-5
-   *   SPI1-3 ----------- EXP1-2
-   *   EXP1-6 ----------- EXP1-4
-   *   EXP1-7 ----------- EXP1-8
-   *   EXP1-8 ----------- EXP1-3
-   *   SPI1-1 ----------- EXP1-1
-   *  EXP1-10 ----------- EXP1-7
+   *   ----------------------------------
+   *   EXP1-10 ----------- EXP1-10  5V
+   *   EXP1-9 ------------ EXP1-9   GND
+   *   SPI1-4 ------------ EXP1-6   MOSI
+   *   EXP1-7 ------------ EXP1-5   LCD_CS
+   *   SPI1-3 ------------ EXP1-2   SCK
+   *   EXP1-5 ------------ EXP1-4   SD_CS
+   *   EXP1-4 ------------ EXP1-8   RESET
+   *   EXP1-3 ------------ EXP1-3   MOD_RST
+   *   SPI1-1 ------------ EXP1-1   MISO
+   *   EXP1-1 ------------ EXP1-7   SD_DET
    */
 
   #define CLCD_SPI_BUS                         1  // SPI1 connector

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -371,14 +371,14 @@
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)
-  /**       -----                        -----
-   *    -- | . . | GND               -- | . . | GND
-   *    -- | . . | M1EN            M2EN | . . | M3EN
-   * M1STP | . .   M1DIR           M1RX | . .   M1DIAG
-   * M2DIR | . . | M2STP           M2RX | . . | M2DIAG
-   * M3DIR | . . | M3STP           M3RX | . . | M3DIAG
-   *        -----                        -----
-   *        EXP2                         EXP1
+  /**        ------                  ------
+   * M3DIAG | 1  2 | M3RX     M3STP | 1  2 | M3DIR
+   * M2DIAG | 3  4 | M2RX     M2STP | 3  4 | M2DIR
+   * M1DIAG   5  6 | M1RX     M1DIR   5  6 | M1STP
+   * M3EN   | 7  8 | M2EN     M1EN  | 7  8 |    --
+   * GND    | 9 10 |   --     GND   | 9 10 |    --
+   *         ------                  ------
+   *          EXP1                    EXP2
    *
    * NB In EXP_MOT_USE_EXP2_ONLY mode EXP1 is not used and M2EN and M3EN need to be jumpered to M1EN
    */

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -334,23 +334,23 @@
  *                ------                                   ------
  *                 EXP1                                     EXP2
  */
-#define EXP1_08_PIN                         PE12
-#define EXP1_07_PIN                         PE11
-#define EXP1_06_PIN                         PE10
-#define EXP1_05_PIN                         PE9
-#define EXP1_04_PIN                         PE8
-#define EXP1_03_PIN                         PB1
-#define EXP1_02_PIN                         PB0
 #define EXP1_01_PIN                         PC5
+#define EXP1_02_PIN                         PB0
+#define EXP1_03_PIN                         PB1
+#define EXP1_04_PIN                         PE8
+#define EXP1_05_PIN                         PE9
+#define EXP1_06_PIN                         PE10
+#define EXP1_07_PIN                         PE11
+#define EXP1_08_PIN                         PE12
 
-#define EXP2_08_PIN                         -1
-#define EXP2_07_PIN                         PC4
-#define EXP2_06_PIN                         PA7
-#define EXP2_05_PIN                         PB2
-#define EXP2_04_PIN                         PA4
-#define EXP2_03_PIN                         PE7
-#define EXP2_02_PIN                         PA5
 #define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PE7
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PB2
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC4
+#define EXP2_08_PIN                         -1
 
 //
 // Onboard SD card


### PR DESCRIPTION
- Sort the renamed pins in numerical order.
- Revert some renumbered LCD / other EXP pins.
- Update adapter cable numbering.
- Update latecomer `stm32f1/pins_CREALITY_V4.h`.