### PR TITLE
include gcode.h for extruder-less laser systems

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -63,7 +63,7 @@
   #include "../feature/host_actions.h"
 #endif
 
-#if HAS_TEMP_SENSOR
+#if EITHER(HAS_TEMP_SENSOR, LASER_FEATURE)
   #include "../gcode/gcode.h"
 #endif
 


### PR DESCRIPTION
### Description

includes gcode.h into temperature.cpp even if there is no extruder / temp sensor. See issue #24526

### Requirements

none

### Benefits

Fixes incompatibility between EXTRUDERS 0 and LASER_FEATURE, see issue #24526

### Configurations

[Configs.zip](https://github.com/MarlinFirmware/Marlin/files/9152076/Configs.zip)

### Related Issues

#24526
