### PR TITLE
Update MPCTEMP Autotune Comment

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -653,7 +653,7 @@
  *
  * Use a physical model of the hotend to control temperature. When configured correctly
  * this gives better responsiveness and stability than PID and it also removes the need
- * for PID_EXTRUSION_SCALING and PID_FAN_SCALING. Use M306 to autotune the model.
+ * for PID_EXTRUSION_SCALING and PID_FAN_SCALING. Use M306 T to autotune the model.
  */
 #if ENABLED(MPCTEMP)
   //#define MPC_EDIT_MENU                             // Add MPC editing to the "Advanced Settings" menu. (~1300 bytes of flash)


### PR DESCRIPTION
### Description

`M306` simply reports current values. `M306 T` starts autotune process.

### Requirements

`MPCTEMP`

### Benefits

Users won't be left wondering why autotune process doesn't start if they are only reading the config/header and send `M306` with no `T` parameter.

It wouldn't hurt to link to [/docs/features/model_predictive_control.html](https://marlinfw.org/docs/features/model_predictive_control.html) & [/docs/gcode/M306.html](https://marlinfw.org/docs/gcode/M306.html), but I left them out for now.