### PR TITLE
Correct multidimensional array indexing when printing leveling grid

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -154,7 +154,7 @@ void reset_bed_level() {
       #endif
       LOOP_L_N(x, sx) {
         SERIAL_CHAR(' ');
-        const float offset = values[x * sx + y];
+        const float offset = values[x * sy + y];
         if (!isnan(offset)) {
           if (offset >= 0) SERIAL_CHAR('+');
           SERIAL_ECHO_F(offset, int(precision));


### PR DESCRIPTION
### Description

`print_2d_array()` does not print bed levelling info correctly if the grid has a different number of rows to columns.

### Requirements

Mesh or bilinear bed levelling.

### Benefits

Bed levelling is correctly reported and indexing outside the multidimensional array no longer occurs.

### Configurations

See #24336.

### Related Issues

#24336
