### PR TITLE
Fix G30/Single Z-Probe for JyersUI

### DIFF
--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -37,7 +37,7 @@
   #include "../../module/tool_change.h"
 #endif
 
-#if ENABLED(DWIN_LCD_PROUI)
+#if EITHER(DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
   #include "../../lcd/marlinui.h"
 #endif
 


### PR DESCRIPTION
### Description

Fix G30/Single Z-Probe for JyersUI

### Requirements

JyersUI

### Configurations

Use [MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3 V2/CrealityV422/CrealityUI](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3%20V2/CrealityV422/CrealityUI), disable `DWIN_CREALITY_LCD` and enable:
- `DWIN_CREALITY_LCD_JYERSUI`
- `BLTOUCH`
- `Z_SAFE_HOMING`

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24539