### PR TITLE
Fix 1024x600 TFT Upscale with no Touchscreen

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1469,8 +1469,13 @@
 #elif ENABLED(TFT_RES_1024x600)
   #define TFT_WIDTH  1024
   #define TFT_HEIGHT 600
-  #define GRAPHICAL_TFT_UPSCALE 6
-  #define TFT_PIXEL_OFFSET_X 120
+  #if ENABLED(TOUCH_SCREEN)
+    #define GRAPHICAL_TFT_UPSCALE 6
+    #define TFT_PIXEL_OFFSET_X 120
+  #else
+    #define GRAPHICAL_TFT_UPSCALE 8
+    #define TFT_PIXEL_OFFSET_X 0
+  #endif
 #endif
 
 // FSMC/SPI TFT Panels using standard HAL/tft/tft_(fsmc|spi|ltdc).h

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2971,8 +2971,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 #endif
 
-#if defined(GRAPHICAL_TFT_UPSCALE) && !WITHIN(GRAPHICAL_TFT_UPSCALE, 2, 6)
-  #error "GRAPHICAL_TFT_UPSCALE must be between 2 and 6."
+#if defined(GRAPHICAL_TFT_UPSCALE) && !WITHIN(GRAPHICAL_TFT_UPSCALE, 2, 8)
+  #error "GRAPHICAL_TFT_UPSCALE must be between 2 and 8."
 #endif
 
 #if BOTH(CHIRON_TFT_STANDARD, CHIRON_TFT_NEW)

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -791,7 +791,7 @@ static void z_minus() { moveAxis(Z_AXIS, -1); }
   }
 #endif
 
-#if HAS_BED_PROBE
+#if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
   static void z_select() {
     motionAxisState.z_selection *= -1;
     quick_feedback();

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -771,7 +771,7 @@ static void z_minus() { moveAxis(Z_AXIS, -1); }
   }
 #endif
 
-#if HAS_BED_PROBE
+#if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
   static void z_select() {
     motionAxisState.z_selection *= -1;
     quick_feedback();

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -772,7 +772,7 @@ static void z_minus() { moveAxis(Z_AXIS, -1); }
   }
 #endif
 
-#if HAS_BED_PROBE
+#if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
   static void z_select() {
     motionAxisState.z_selection *= -1;
     quick_feedback();


### PR DESCRIPTION
### Description

Follow up to https://github.com/MarlinFirmware/Marlin/pull/24387

With `TFT_CLASSIC_UI` enabled & `TOUCH_SCREEN` disabled, Marlin's UI is resized as if the onscreen buttons were enabled, but results in a large blank section at the bottom of the screen.

With this PR, Marlin’s UI uses the full screen.

Now you can *really* see the screen across the room/house/yard/street. Benchy for scale:

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/13375512/180657761-d0cb9d32-40da-40d1-8aaa-cfba8e45df81.png">

### Requirements

- `BIQU_BX_TFT70`
- `TFT_CLASSIC_UI`
- `TOUCH_SCREEN` (disabled)

### Benefits

Marlin's UI will now be full screen when `TFT_CLASSIC_UI` is enabled & `TOUCH_SCREEN` is disabled.

### Configurations

Use [/Configurations/tree/bugfix-2.1.x/config/examples/BIQU/BX](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/BIQU/BX) & modify them as noted above.

### Related Issues

None. Found while testing different configs on my BX.
