### PR TITLE
Elegoo neptune 3

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -421,6 +421,10 @@
 #define BOARD_ARTILLERY_RUBY          4238  // Artillery Ruby (STM32F401RC)
 #define BOARD_FYSETC_SPIDER_V2_2      4239  // FYSETC Spider V2.2 (STM32F446VE)
 #define BOARD_CREALITY_V24S1_301F4    4240  // Creality v2.4.S1_301F4 (STM32F401RC) as found in the Ender-3 S1 F4
+#define BOARD_ZNP_ROBIN_NANO_V1_3     4241  // Elegoo Neptune 2 v1.3 board
+#define BOARD_MKS_NEPTUNE_X           4242  // Elegoo Neptune X
+#define BOARD_ZNP_ROBIN_NANO          4243  // Elegoo Neptune 2 v1.2 board
+#define BOARD_MKS_NEPTUNE_3           4243  // Elegoo Neptune 3
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -509,6 +509,8 @@
   #include "stm32f1/pins_CHITU3D.h"             // STM32F103ZE                            env:STM32F103ZE env:STM32F103RE_maple
 #elif MB(MKS_ROBIN)
   #include "stm32f1/pins_MKS_ROBIN.h"           // STM32F1                                env:mks_robin env:mks_robin_maple
+#elif MB(ZNP_ROBIN_NANO)
+  #include "stm32f1/pins_MKS_ROBIN_NANO.h"      // STM32F1                                env:znp_robin_nano35
 #elif MB(MKS_ROBIN_MINI)
   #include "stm32f1/pins_MKS_ROBIN_MINI.h"      // STM32F1                                env:mks_robin_mini env:mks_robin_mini_maple
 #elif MB(MKS_ROBIN_NANO)
@@ -679,6 +681,12 @@
   #include "stm32f4/pins_MKS_ROBIN_NANO_V3.h"   // STM32F4                                env:mks_robin_nano_v3 env:mks_robin_nano_v3_usb_flash_drive env:mks_robin_nano_v3_usb_flash_drive_msc
 #elif MB(MKS_ROBIN_NANO_V3_1)
   #include "stm32f4/pins_MKS_ROBIN_NANO_V3.h"   // STM32F4                                env:mks_robin_nano_v3_1 env:mks_robin_nano_v3_1_usb_flash_drive env:mks_robin_nano_v3_1_usb_flash_drive_msc
+#elif MB(MKS_NEPTUNE_X)
+  #include "stm32f4/pins_MKS_NEPTUNE_X.h"       // STM32F4                                env:mks_neptune_x
+#elif MB(MKS_NEPTUNE_3)
+  #include "stm32f4/pins_NEPTUNE_3.h"           // STM32F4                                env:mks_neptune_3
+#elif MB(ZNP_ROBIN_NANO_V1_3)
+  #include "stm32f4/pins_MKS_ROBIN_NANO_V1_3_F4.h" // STM32F4                             env:znp_robin_nano_v1_3
 #elif MB(ANET_ET4)
   #include "stm32f4/pins_ANET_ET4.h"            // STM32F4                                env:Anet_ET4_no_bootloader env:Anet_ET4_OpenBLT
 #elif MB(ANET_ET4P)

--- a/Marlin/src/pins/stm32f4/pins_MKS_NEPTUNE_X.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_NEPTUNE_X.h
@@ -1,0 +1,70 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define ALLOW_STM32DUINO
+#include "env_validate.h"
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "MKS Neptune X supports up to 2 hotends / E steppers."
+#endif
+
+#define BOARD_INFO_NAME "MKS Neptune X"
+
+#define USES_DIAG_JUMPERS
+
+#ifndef X_CS_PIN
+  #define X_CS_PIN                          PD5
+#endif
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN                          PD7
+#endif
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN                          PD4
+#endif
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN                         PD9
+#endif
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN                         PD8
+#endif
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+// This board only supports SW SPI for stepper drivers
+//
+#if HAS_TMC_SPI
+  #define TMC_USE_SW_SPI
+#endif
+#if ENABLED(TMC_USE_SW_SPI)
+  #if !defined(TMC_SW_MOSI) || TMC_SW_MOSI == -1
+    #define TMC_SW_MOSI                     PD14
+  #endif
+  #if !defined(TMC_SW_MISO) || TMC_SW_MISO == -1
+    #define TMC_SW_MISO                     PD1
+  #endif
+  #if !defined(TMC_SW_SCK) || TMC_SW_SCK == -1
+    #define TMC_SW_SCK                      PD0
+  #endif
+#endif
+
+#include "pins_MKS_NEPTUNE_X_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_NEPTUNE_X_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_NEPTUNE_X_common.h
@@ -1,0 +1,310 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+//
+// MKS Neptune X pinmap
+//
+
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
+
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER 10
+
+// Use one of these or SDCard-based Emulation will be used
+//#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
+//#define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
+#if EITHER(NO_EEPROM_SELECTED, I2C_EEPROM)
+  #define I2C_EEPROM
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4K
+  #define I2C_SCL_PIN                       PB6
+  #define I2C_SDA_PIN                       PB7
+#endif
+
+//
+// Release PB4 (Z_DIR_PIN) from JTAG NRST role
+//
+//#define DISABLE_DEBUG
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PA8   // Enable BLTOUCH
+
+//
+// Limit Switches
+//
+#define X_DIAG_PIN                          PA15
+#define Y_DIAG_PIN                          PC15
+#define Z_DIAG_PIN                          PC14
+#define E0_DIAG_PIN                         PC4
+#define E1_DIAG_PIN                         PE7
+
+#define X_STOP_PIN                    X_DIAG_PIN
+#define Y_STOP_PIN                    Y_DIAG_PIN
+#define Z_MIN_PIN                     Z_DIAG_PIN
+#define Z_MAX_PIN                    E0_DIAG_PIN
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN                        PE4
+#define X_STEP_PIN                          PE3
+#define X_DIR_PIN                           PE2
+
+#define Y_ENABLE_PIN                        PE1
+#define Y_STEP_PIN                          PE0
+#define Y_DIR_PIN                           PB9
+
+#define Z_ENABLE_PIN                        PB8
+#define Z_STEP_PIN                          PB5
+#define Z_DIR_PIN                           PB4
+
+#define E0_ENABLE_PIN                       PB3
+#define E0_STEP_PIN                         PD6
+#define E0_DIR_PIN                          PD3
+
+#define E1_ENABLE_PIN                       PA3
+#define E1_STEP_PIN                         PA6
+#define E1_DIR_PIN                          PA1
+
+#if HAS_TMC_UART
+  //
+  // Software serial
+  // No Hardware serial for steppers
+  //
+  #define X_SERIAL_TX_PIN                   PD5
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PD7
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PD4
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                  PD9
+  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
+
+  #define E1_SERIAL_TX_PIN                  PD8
+  #define E1_SERIAL_RX_PIN      E1_SERIAL_TX_PIN
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
+#endif
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PC1   // TH1
+#define TEMP_1_PIN                          PA2   // TH2
+#define TEMP_BED_PIN                        PC0   // TB1
+
+#if HOTENDS == 1 && !REDUNDANT_TEMP_MATCH(SOURCE, E1)
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN            TEMP_1_PIN
+  #elif TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN          TEMP_1_PIN
+  #endif
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PC3   // HEATER1
+#define HEATER_1_PIN                        PB0   // HEATER2
+#define HEATER_BED_PIN                      PA0   // HOT BED
+
+#define FAN_PIN                             PC14  // FAN
+#define FAN1_PIN                            PB1   // FAN1
+
+//
+// Thermocouples
+//
+//#define TEMP_0_CS_PIN             HEATER_0_PIN  // TC1 - CS1
+//#define TEMP_0_CS_PIN             HEATER_1_PIN  // TC2 - CS2
+
+//
+// Misc. Functions
+//
+#if HAS_TFT_LVGL_UI
+  #define MT_DET_1_PIN                      PA4   // MT_DET
+  #define MT_DET_2_PIN                      PE6
+  #define MT_DET_PIN_STATE                  LOW
+#endif
+
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA4
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                   PE6
+#endif
+
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                    PA2  // PW_DET
+#endif
+
+//#define SUICIDE_PIN                       PB2
+//#define LED_PIN                           PB2
+//#define KILL_PIN                          PA2
+//#define KILL_PIN_STATE                    LOW
+
+//
+// Power Supply Control
+//
+#if ENABLED(MKS_PWC)
+  #if ENABLED(TFT_LVGL_UI)
+    #if ENABLED(PSU_CONTROL)
+      #error "PSU_CONTROL is incompatible with MKS_PWC plus TFT_LVGL_UI."
+    #endif
+    #undef MKS_PWC
+    #define SUICIDE_PIN                     PB2
+    #define SUICIDE_PIN_STATE               LOW
+  #else
+    #define PS_ON_PIN                       PB2   // PW_OFF
+  #endif
+  #define KILL_PIN                          PA13  // PW_DET
+  #define KILL_PIN_STATE                    HIGH
+#endif
+
+// Random Info
+#define USB_SERIAL              -1  // USB Serial
+#define WIFI_SERIAL              3  // USART3
+#define MKS_WIFI_MODULE_SERIAL   1  // USART1
+#define MKS_WIFI_MODULE_SPI      2  // SPI2
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
+// MKS WIFI MODULE
+#if ENABLED(MKS_WIFI_MODULE)
+  #define WIFI_IO0_PIN                      PC13
+  #define WIFI_IO1_PIN                      PC7
+  #define WIFI_RESET_PIN                    PE9
+#endif
+
+// MKS TEST
+#if ENABLED(MKS_TEST)
+  #define MKS_TEST_POWER_LOSS_PIN           PA13  // PW_DET
+  #define MKS_TEST_PS_ON_PIN                PB2   // PW_OFF
+#endif
+
+//
+// TFT with FSMC interface
+//
+#if HAS_FSMC_TFT
+  /**
+   * Note: MKS Robin TFT screens use various TFT controllers.
+   * If the screen stays white, disable 'TFT_RESET_PIN'
+   * to let the bootloader init the screen.
+   */
+  #define TFT_RESET_PIN                     PC6   // FSMC_RST
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
+  #define DOGLCD_SCK                        -1
+
+  #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
+  #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK
+  #define TOUCH_MISO_PIN                    PB14  // SPI2_MISO
+  #define TOUCH_MOSI_PIN                    PB15  // SPI2_MOSI
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define TFT_CS_PIN                 FSMC_CS_PIN
+  #define TFT_RS_PIN                 FSMC_RS_PIN
+
+  #define TOUCH_BUTTONS_HW_SPI
+  #define TOUCH_BUTTONS_HW_SPI_DEVICE          2
+
+  #define TFT_BUFFER_SIZE                  14400
+#endif
+
+//
+// Onboard SD card
+//
+// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
+#if SD_CONNECTION_IS(ONBOARD)
+  #define ENABLE_SPI3
+  #define SD_SS_PIN                         -1
+  #define SDSS                              PC9
+  #define SD_SCK_PIN                        PC10
+  #define SD_MISO_PIN                       PC11
+  #define SD_MOSI_PIN                       PC12
+  #define SD_DETECT_PIN                     PD12
+#endif
+
+#define SPI_FLASH
+#if ENABLED(SPI_FLASH)
+  #define HAS_SPI_FLASH                        1
+  #define SPI_DEVICE                           2
+  #define SPI_FLASH_SIZE               0x1000000
+  #define SPI_FLASH_CS_PIN                  PB12
+  #define SPI_FLASH_MOSI_PIN                PC3
+  #define SPI_FLASH_MISO_PIN                PC2
+  #define SPI_FLASH_SCK_PIN                 PB13
+#endif
+
+//
+// LCD / Controller
+//
+#define BEEPER_PIN                          PC5
+
+//
+// TFT with FSMC interface
+//
+#if HAS_FSMC_TFT
+  /**
+   * Note: MKS Robin TFT screens use various TFT controllers.
+   * If the screen stays white, disable 'TFT_RESET_PIN'
+   * to let the bootloader init the screen.
+   */
+  #define TFT_RESET_PIN                     PC6   // FSMC_RST
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
+  #define DOGLCD_SCK                        -1
+
+  #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
+  #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK
+  #define TOUCH_MISO_PIN                    PB14  // SPI2_MISO
+  #define TOUCH_MOSI_PIN                    PB15  // SPI2_MOSI
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define TFT_CS_PIN                 FSMC_CS_PIN
+  #define TFT_RS_PIN                 FSMC_RS_PIN
+
+  #define TOUCH_BUTTONS_HW_SPI
+  #define TOUCH_BUTTONS_HW_SPI_DEVICE          2
+
+  #define TFT_BUFFER_SIZE                  14400
+#endif

--- a/Marlin/src/pins/stm32f4/pins_NEPTUNE_3.h
+++ b/Marlin/src/pins/stm32f4/pins_NEPTUNE_3.h
@@ -1,0 +1,139 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+//
+// MKS Robin E3 V2 pinmap
+//
+
+// Avoid conflict with TIMER_TONE
+#include "env_validate.h"
+//
+#define ALLOW_STM32F4
+
+// Release PB4 (Z_DIR_PIN) from JTAG NRST role
+//
+// #define DISABLE_DEBUG
+
+#define BOARD_INFO_NAME "MKS Robin Nano E3"
+
+// Use one of these or SDCard-based Emulation will be used
+//#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
+//#define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
+#if EITHER(NO_EEPROM_SELECTED, I2C_EEPROM)
+  #define I2C_EEPROM
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4KB
+  #define I2C_SCL_PIN                       PB6
+  #define I2C_SDA_PIN                       PB7
+#endif
+
+//
+// Release PB4 (Z_DIR_PIN) from JTAG NRST role
+//
+//#define DISABLE_DEBUG
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PA8   // Enable BLTOUCH
+
+//
+// Limit Switches 
+//
+#define ZNP_TEST                            0
+#if ZNP_TEST  
+#define X_DIAG_PIN                          PC14    // PA13   X-;//PC14 Z+  
+#else
+#define X_DIAG_PIN                          PA13    // PA13   X-;//PC14 Z+
+#endif
+
+#define Y_DIAG_PIN                          PB8
+#define Z_DIAG_PIN                          PC13
+
+#define X_STOP_PIN                        X_DIAG_PIN
+#define Y_STOP_PIN                        Y_DIAG_PIN
+#define Z_MIN_PIN                         Z_DIAG_PIN
+#define Z_MAX_PIN                         PC14   //PB9    //-1//
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN                        PD2
+#define X_STEP_PIN                          PC12
+#define X_DIR_PIN                           PB3
+
+#define Y_ENABLE_PIN                        PC10
+#define Y_STEP_PIN                          PC11
+#define Y_DIR_PIN                           PA15
+
+#define Z_ENABLE_PIN                        PC8
+#define Z_STEP_PIN                          PC7
+#define Z_DIR_PIN                           PC9
+
+#define E0_ENABLE_PIN                       PC6
+#define E0_STEP_PIN                         PB10
+#define E0_DIR_PIN                          PB1
+
+#define E1_ENABLE_PIN                       PC5
+#define E1_STEP_PIN                         PC4
+#define E1_DIR_PIN                          PA4
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PC1   // TH1
+#define TEMP_1_PIN                          PC2   // TH2
+#define TEMP_BED_PIN                        PC0   // TB1
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PA6   // HEATER1
+#define HEATER_BED_PIN                      PA5   // HOT BED
+
+#define FAN_PIN                             PB0  // FAN
+// #define FAN1_PIN                            PA7   // FAN1
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
+  #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
+  #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK
+  #define TOUCH_MISO_PIN                    PB14  // SPI2_MISO
+  #define TOUCH_MOSI_PIN                    PB15  // SPI2_MOSI
+
+//
+// Onboard SD card
+//
+// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
+#if SD_CONNECTION_IS(ONBOARD)
+  #define ENABLE_SPI3
+  #define SD_SS_PIN                         -1
+  #define SDSS                              PB12
+  #define SD_SCK_PIN                        PB13
+  #define SD_MISO_PIN                       PB14
+  #define SD_MOSI_PIN                       PB15
+  #define SD_DETECT_PIN                     PC3
+  #define SD_SPI_SPEED                      SPI_HALF_SPEED
+#endif

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -216,6 +216,25 @@ build_unflags               = ${stm32_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC
 
 #
+# ZNP Robin Nano V1.2
+#
+[env:znp_robin_nano35]
+extends                     = stm32_variant
+board                       = genericSTM32F103VE
+board_build.variant         = MARLIN_F103Vx
+board_build.encrypt_mks     = elegoo.bin
+board_build.offset          = 0x7000
+board_upload.offset_address = 0x08007000
+build_flags                 = ${stm32_variant.build_flags}
+                              -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC
+debug_tool                  = jlink
+upload_protocol             = jlink
+
+
+#
 # MKS Robin Nano V1.2 and V2
 #
 [env:mks_robin_nano35]

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -253,6 +253,24 @@ debug_tool                  = jlink
 upload_protocol             = jlink
 
 #
+# ZNP Robin Nano V1.2
+#
+[env:znp_robin_nano35]
+extends                     = stm32_variant
+board                       = genericSTM32F103VE
+board_build.variant         = MARLIN_F103Vx
+board_build.encrypt_mks     = elegoo.bin
+board_build.offset          = 0x7000
+board_upload.offset_address = 0x08007000
+build_flags                 = ${stm32_variant.build_flags}
+                              -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC
+debug_tool                  = jlink
+upload_protocol             = jlink
+
+#
 # Mingda MPX_ARM_MINI
 #
 [env:mingda_mpx_arm_mini]

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -29,6 +29,17 @@ build_flags   = ${common_stm32.build_flags}
                 -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing
 
 #
+# STM32F401VE
+# 'STEVAL-3DP001V1' STM32F401VE board - https://www.st.com/en/evaluation-tools/steval-3dp001v1.html
+#
+[env:STM32F401VE_STEVAL]
+extends           = stm32_variant
+board             = marlin_STEVAL_STM32F401VE
+build_flags       = ${stm32_variant.build_flags}
+                    -DSTM32F401xE -DDISABLE_GENERIC_SERIALUSB
+                    -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+
+#
 # STM32F401RC
 #
 [env:FYSETC_CHEETAH_V20]
@@ -83,11 +94,11 @@ build_flags       = ${stm32_variant.build_flags}
                     -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
 
 #
-# STM32F407VET6 Opulo Lumen REV3
+# STM32F407VET6 Index Mobo Rev 03
 #
-[env:Opulo_Lumen_REV3]
+[env:Index_Mobo_Rev03]
 extends           = stm32_variant
-board             = marlin_opulo_lumen_rev3
+board             = marlin_index_mobo_rev03
 build_flags       = ${stm32_variant.build_flags}
   -DARDUINO_BLACK_F407VE
   -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
@@ -95,34 +106,24 @@ extra_scripts     = ${stm32_variant.extra_scripts}
 
 #
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
+# For use with with davidtgbe's OpenBLT bootloader https://github.com/davidtgbe/openblt/releases
+# Comment out board_build.offset = 0x10000 if you don't plan to use OpenBLT/flashing directly to 0x08000000.
 #
-[Anet_ET4]
+[env:Anet_ET4_OpenBLT]
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
+board_build.encrypt_mks     = firmware.srec
+board_build.offset          = 0x10000
+board_upload.offset_address = 0x08010000
 build_flags                 = ${stm32_variant.build_flags}
                               -DHAL_SD_MODULE_ENABLED -DHAL_SRAM_MODULE_ENABLED
 build_unflags               = ${stm32_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
-
-#
-# Anet ET4 directly flashed via ST-Link
-#
-[env:Anet_ET4_no_bootloader]
-extends                     = Anet_ET4
-debug_tool                  = stlink
-upload_protocol             = stlink
-
-#
-# Anet ET4 with OpenBLT from https://github.com/davidtgbe/openblt/releases
-#
-[env:Anet_ET4_OpenBLT]
-extends                     = Anet_ET4
-board_build.encode          = firmware.srec
-board_build.offset          = 0x10000
-board_upload.offset_address = 0x08010000
 extra_scripts               = ${stm32_variant.extra_scripts}
                               buildroot/share/PlatformIO/scripts/openblt.py
+debug_tool                  = jlink
+upload_protocol             = jlink
 
 #
 # BigTreeTech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
@@ -397,6 +398,52 @@ upload_protocol             = jlink
 build_flags = -DPIN_WIRE_SCL=PB6 -DPIN_WIRE_SDA=PB7
 
 #
+# MKS Neptune X
+#
+[env:mks_neptune_x]
+extends                     = stm32_variant
+board                       = marlin_STM32F407VGT6_CCM
+board_build.variant         = MARLIN_F4x7Vx
+board_build.offset          = 0xC000
+board_upload.offset_address = 0x0800C000
+board_build.rename          = elegoo.bin
+platform_packages = ${stm_flash_drive.platform_packages}
+build_flags                 = ${stm32_variant.build_flags} ${stm32f4_I2C1.build_flags} ${stm_flash_drive.build_flags}
+                              -DHAL_PCD_MODULE_ENABLED
+							  -DUSE_USBHOST_HS
+							  -DUSBD_IRQ_PRIO=5
+							  -DUSBD_IRQ_SUBPRIO=6
+							  -DUSE_USB_HS_IN_FS
+							  -DMCU_STM32F407VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+                              -DSTM32_FLASH_SIZE=512
+                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+                              -DHAL_SD_MODULE_ENABLED
+                              -DHAL_SRAM_MODULE_ENABLED
+debug_tool                  = jlink
+upload_protocol             = jlink
+
+#
+# MKS Neptune 3
+#
+[env:mks_neptune_3]
+extends                     = stm32_variant
+board                       = marlin_STM32F407VGT6_CCM
+board_build.variant         = MARLIN_F4x7Vx
+board_build.offset          = 0xC000
+board_upload.offset_address = 0x0800C000
+board_build.rename          = elegoo.bin
+platform_packages = ${stm_flash_drive.platform_packages}
+build_flags                 = ${stm32_variant.build_flags}
+                              -DMCU_STM32F407VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+                              -DSTM32_FLASH_SIZE=512
+                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+                              -DHAL_SD_MODULE_ENABLED
+                              -DHAL_SRAM_MODULE_ENABLED
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC
+debug_tool                  = jlink
+upload_protocol             = jlink
+#
 # MKS Robin Nano V3
 #
 [env:mks_robin_nano_v3]
@@ -504,7 +551,7 @@ build_unflags     = -DUSBD_USE_CDC
 build_flags = -DPIN_WIRE_SCL=PB8 -DPIN_WIRE_SDA=PB9
 
 #
-# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4)
+# MKS Monster8
 #
 [env:mks_monster8]
 extends                     = stm32_variant
@@ -520,7 +567,7 @@ debug_tool                  = jlink
 upload_protocol             = jlink
 
 #
-# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support
+# MKS Monster8 with USB Flash Drive Support
 # Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_monster8_usb_flash_drive]
@@ -533,7 +580,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flag
                     -DUSE_USB_HS_IN_FS
 
 #
-# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support and Shared Media
+# MKS Monster8 with USB Flash Drive Support and Shared Media
 # Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_monster8_usb_flash_drive_msc]
@@ -545,30 +592,40 @@ build_unflags     = -DUSBD_USE_CDC
 #
 # TH3D EZBoard v2.0 (STM32F405RGT6 ARM Cortex-M4)
 #
-[TH3D_EZBoard_V2]
+[env:TH3D_EZBoard_V2]
 extends                     = stm32_variant
 board                       = genericSTM32F405RG
 board_build.variant         = MARLIN_TH3D_EZBOARD_V2
-build_flags                 = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0
-
-#
-# TH3D EZBoard v2.0 directly flashed via ST-Link
-#
-[env:TH3D_EZBoard_V2_no_bootloader]
-extends                     = TH3D_EZBoard_V2
-debug_tool                  = stlink
-upload_protocol             = stlink
-
-#
-# TH3D EZBoard v2.0 with OpenBLT from https://github.com/rhapsodyv/OpenBLT-STM32
-#
-[env:TH3D_EZBoard_V2_OpenBLT]
-extends                     = TH3D_EZBoard_V2
-board_build.encode          = firmware.bin
+board_build.encrypt_mks     = firmware.bin
 board_build.offset          = 0xC000
 board_upload.offset_address = 0x0800C000
+build_flags                 = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0
+debug_tool                  = stlink
+upload_protocol             = stlink
 extra_scripts               = ${stm32_variant.extra_scripts}
                               buildroot/share/PlatformIO/scripts/openblt.py
+
+#
+# BOARD_ZNP_ROBIN_NANO_V1_3
+# Elegoo Neptune 2
+#
+[env:znp_robin_nano_v1_3]
+extends                     = stm32_variant
+board                       = marlin_STM32F407VGT6_CCM
+board_build.variant         = MARLIN_F4x7Vx
+board_build.offset          = 0x8000
+board_upload.offset_address = 0x08008000
+board_build.rename          = elegoo.bin
+build_flags                 = ${stm32_variant.build_flags}
+                              -DMCU_STM32F407VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+                              -DSTM32_FLASH_SIZE=512
+                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+                              -DHAL_SD_MODULE_ENABLED
+                              -DHAL_SRAM_MODULE_ENABLED
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC
+debug_tool                  = jlink
+upload_protocol             = jlink
 
 #
 # BOARD_MKS_ROBIN_NANO_V1_3_F4


### PR DESCRIPTION


### Description
Added new board definitions and pins and updated .ini files for platformio for the Elegoo Neptune series of printers.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
N/A
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Adds boards to make custom compiling firmware for the Elegoo Neptune series of printers easier, duplicates and renames the 2 boards that come in the Neptune 2 printers to make it more straightforward and adds the missing board files for the Neptune X and Neptune 3

### Configurations
N/A
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
N/A
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
