### PR TITLE
Fix issue with debugging when using PlatformIO

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -2,39 +2,54 @@
 # common-cxxflags.py
 # Convenience script to apply customizations to CPP flags
 #
+
+import shutil
+
 import pioutil
+
+
 if pioutil.is_pio_build():
-	Import("env")
+    Import("env")
 
-	cxxflags = [
-		#"-Wno-incompatible-pointer-types",
-		#"-Wno-unused-const-variable",
-		#"-Wno-maybe-uninitialized",
-		#"-Wno-sign-compare"
-	]
-	if "teensy" not in env['PIOENV']:
-		cxxflags += ["-Wno-register"]
-	env.Append(CXXFLAGS=cxxflags)
+    cxxflags = [
+        # "-Wno-incompatible-pointer-types",
+        # "-Wno-unused-const-variable",
+        # "-Wno-maybe-uninitialized",
+        # "-Wno-sign-compare"
+    ]
+    if "teensy" not in env["PIOENV"]:
+        cxxflags += ["-Wno-register"]
+    env.Append(CXXFLAGS=cxxflags)
 
-	#
-	# Add CPU frequency as a compile time constant instead of a runtime variable
-	#
-	def add_cpu_freq():
-		if 'BOARD_F_CPU' in env:
-			env['BUILD_FLAGS'].append('-DBOARD_F_CPU=' + env['BOARD_F_CPU'])
+    #
+    # Add CPU frequency as a compile time constant instead of a runtime variable
+    #
+    def add_cpu_freq():
+        if "BOARD_F_CPU" in env:
+            env["BUILD_FLAGS"].append("-DBOARD_F_CPU=" + env["BOARD_F_CPU"])
 
-	# Useful for JTAG debugging
-	#
-	# It will separate release and debug build folders.
-	# It useful to keep two live versions: a debug version for debugging and another for
-	# release, for flashing when upload is not done automatically by jlink/stlink.
-	# Without this, PIO needs to recompile everything twice for any small change.
-	#
-	#if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink', 'custom']:
-	#	env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
+    # Useful for JTAG debugging
+    #
+    # It will separate release and debug build folders.
+    # It useful to keep two live versions: a debug version for debugging and another for
+    # release, for flashing when upload is not done automatically by jlink/stlink.
+    # Without this, PIO needs to recompile everything twice for any small change.
+    if env.GetBuildType() == "debug" and env.get("UPLOAD_PROTOCOL") not in [
+        "jlink",
+        "stlink",
+        "custom",
+    ]:
+        env["BUILD_DIR"] = "$PROJECT_BUILD_DIR/$PIOENV/debug"
 
-	# On some platform, F_CPU is a runtime variable. Since it's used to convert from ns
-	# to CPU cycles, this adds overhead preventing small delay (in the order of less than
-	# 30 cycles) to be generated correctly. By using a compile time constant instead
-	# the compiler will perform the computation and this overhead will be avoided
-	add_cpu_freq()
+        def on_program_ready(source, target, env):
+            shutil.copy(
+                target[0].get_abspath(), env.subst("$PROJECT_BUILD_DIR/$PIOENV")
+            )
+
+        env.AddPostAction("$PROGPATH", on_program_ready)
+
+    # On some platform, F_CPU is a runtime variable. Since it's used to convert from ns
+    # to CPU cycles, this adds overhead preventing small delay (in the order of less than
+    # 30 cycles) to be generated correctly. By using a compile time constant instead
+    # the compiler will perform the computation and this overhead will be avoided
+    add_cpu_freq()

--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -3,11 +3,7 @@
 # Convenience script to apply customizations to CPP flags
 #
 
-import shutil
-
 import pioutil
-
-
 if pioutil.is_pio_build():
     Import("env")
 
@@ -34,17 +30,12 @@ if pioutil.is_pio_build():
     # It useful to keep two live versions: a debug version for debugging and another for
     # release, for flashing when upload is not done automatically by jlink/stlink.
     # Without this, PIO needs to recompile everything twice for any small change.
-    if env.GetBuildType() == "debug" and env.get("UPLOAD_PROTOCOL") not in [
-        "jlink",
-        "stlink",
-        "custom",
-    ]:
+    if env.GetBuildType() == "debug" and env.get("UPLOAD_PROTOCOL") not in ["jlink", "stlink", "custom"]:
         env["BUILD_DIR"] = "$PROJECT_BUILD_DIR/$PIOENV/debug"
 
         def on_program_ready(source, target, env):
-            shutil.copy(
-                target[0].get_abspath(), env.subst("$PROJECT_BUILD_DIR/$PIOENV")
-            )
+            import shutil
+            shutil.copy(target[0].get_abspath(), env.subst("$PROJECT_BUILD_DIR/$PIOENV"))
 
         env.AddPostAction("$PROGPATH", on_program_ready)
 

--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -30,8 +30,8 @@ if pioutil.is_pio_build():
 	# release, for flashing when upload is not done automatically by jlink/stlink.
 	# Without this, PIO needs to recompile everything twice for any small change.
 	#
-	# 	if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink', 'custom']:
-	# 		env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
+	#if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink', 'custom']:
+	#	env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
 
 	# On some platform, F_CPU is a runtime variable. Since it's used to convert from ns
 	# to CPU cycles, this adds overhead preventing small delay (in the order of less than

--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -29,8 +29,9 @@ if pioutil.is_pio_build():
 	# It useful to keep two live versions: a debug version for debugging and another for
 	# release, for flashing when upload is not done automatically by jlink/stlink.
 	# Without this, PIO needs to recompile everything twice for any small change.
-	if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink', 'custom']:
-		env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
+	#
+	# 	if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink', 'custom']:
+	# 		env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
 
 	# On some platform, F_CPU is a runtime variable. Since it's used to convert from ns
 	# to CPU cycles, this adds overhead preventing small delay (in the order of less than

--- a/buildroot/share/PlatformIO/scripts/simulator.py
+++ b/buildroot/share/PlatformIO/scripts/simulator.py
@@ -2,13 +2,14 @@
 # simulator.py
 # PlatformIO pre: script for simulator builds
 #
+
+# Get the environment thus far for the build
+Import("env")
+
+#print(env.Dump())
+
 import pioutil
 if pioutil.is_pio_build():
-	# Get the environment thus far for the build
-	Import("env")
-
-	#print(env.Dump())
-
 	#
 	# Give the binary a distinctive name
 	#
@@ -50,3 +51,11 @@ if pioutil.is_pio_build():
 
 			# Break out of the PIO build immediately
 			sys.exit(1)
+
+from marlin import copytree
+def debug_mv(*args, **kwargs):
+	from pathlib import Path
+	bpath = Path(env['PROJECT_BUILD_DIR'], env['PIOENV'])
+	copytree(bpath / "debug", bpath)
+
+env.AddCustomTarget("fastdebug", "$BUILD_DIR/${PROGNAME}", debug_mv, "Fast Debug")

--- a/buildroot/share/PlatformIO/scripts/simulator.py
+++ b/buildroot/share/PlatformIO/scripts/simulator.py
@@ -3,13 +3,13 @@
 # PlatformIO pre: script for simulator builds
 #
 
-# Get the environment thus far for the build
-Import("env")
-
-#print(env.Dump())
-
 import pioutil
 if pioutil.is_pio_build():
+	# Get the environment thus far for the build
+	Import("env")
+
+	#print(env.Dump())
+
 	#
 	# Give the binary a distinctive name
 	#
@@ -51,11 +51,3 @@ if pioutil.is_pio_build():
 
 			# Break out of the PIO build immediately
 			sys.exit(1)
-
-from marlin import copytree
-def debug_mv(*args, **kwargs):
-	from pathlib import Path
-	bpath = Path(env['PROJECT_BUILD_DIR'], env['PIOENV'])
-	copytree(bpath / "debug", bpath)
-
-env.AddCustomTarget("fastdebug", "$BUILD_DIR/${PROGNAME}", debug_mv, "Fast Debug")


### PR DESCRIPTION
See https://github.com/platformio/platformio-core/issues/4371

Currently, it is not possible to override `BUILD_DIR` in runtime. The [build_dir](https://docs.platformio.org/en/latest/projectconf/section_platformio.html#build-dir) should be used. I also opened a feature request ( https://github.com/platformio/platformio-core/issues/4373 ) but need to think about how to implement it correctly. There are frontend and backend parts in PlatformIO. The backend (build side) uses `BUILD_DIR`, which is equal to `config.build_dir` (PlatformIO configures it at the beginning), and the frontend part always uses `config.build_dir`.

Regarding the "recompilation" on release/debug. The solution to this use case is to declare an extra working env that switched a build type to `debug`. PlatformIO debugging engine will look firstly to it:


```ini

[env:myevn]
platform = ...


[env:debug_myevn]
extends = myevn
build_type = debug

```