### PR TITLE
Simplify scripts with pathlib

### DIFF
--- a/buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
@@ -3,30 +3,29 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import os,shutil,marlin
-	from SCons.Script import DefaultEnvironment
-	from platformio import util
+	import shutil,marlin
+	from pathlib import Path
 
-	env = DefaultEnvironment()
+	Import("env")
 	platform = env.PioPlatform()
 	board = env.BoardConfig()
 
-	FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoststm32-maple")
-	assert os.path.isdir(FRAMEWORK_DIR)
+	FRAMEWORK_DIR = Path(platform.get_package_dir("framework-arduinoststm32-maple"))
+	assert FRAMEWORK_DIR.is_dir()
 
-	source_root = os.path.join("buildroot", "share", "PlatformIO", "variants")
-	assert os.path.isdir(source_root)
+	source_root = Path("buildroot/share/PlatformIO/variants")
+	assert source_root.is_dir()
 
 	variant = board.get("build.variant")
-	variant_dir = os.path.join(FRAMEWORK_DIR, "STM32F1", "variants", variant)
+	variant_dir = FRAMEWORK_DIR / "STM32F1/variants" / variant
 
-	source_dir = os.path.join(source_root, variant)
-	assert os.path.isdir(source_dir)
+	source_dir = source_root / variant
+	assert source_dir.is_dir()
 
-	if os.path.isdir(variant_dir):
+	if variant_dir.is_dir():
 		shutil.rmtree(variant_dir)
 
-	if not os.path.isdir(variant_dir):
-		os.mkdir(variant_dir)
+	if not variant_dir.is_dir():
+		variant_dir.mkdir()
 
 	marlin.copytree(source_dir, variant_dir)

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -4,9 +4,7 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import os,random,struct,uuid,marlin
-	# Relocate firmware from 0x08000000 to 0x08008800
-	marlin.relocate_firmware("0x08008800")
+	import struct,uuid
 
 	def calculate_crc(contents, seed):
 		accumulating_xor_value = seed;
@@ -105,13 +103,13 @@ if pioutil.is_pio_build():
 
 	# Encrypt ${PROGNAME}.bin and save it as 'update.cbd'
 	def encrypt(source, target, env):
-		firmware = open(target[0].path, "rb")
-		update = open(target[0].dir.path + '/update.cbd', "wb")
-		length = os.path.getsize(target[0].path)
+		from pathlib import Path
+		fwpath = Path(target[0].path)
+		fwsize = fwpath.stat().st_size
+		fwfile = fwpath.open("rb")
+		upfile = Path(target[0].dir.path, 'update.cbd').open("wb")
+		encrypt_file(fwfile, upfile, fwsize)
 
-		encrypt_file(firmware, update, length)
-
-		firmware.close()
-		update.close()
-
+	import marlin
+	marlin.relocate_firmware("0x08008800")
 	marlin.add_post_action(encrypt);

--- a/buildroot/share/PlatformIO/scripts/download_mks_assets.py
+++ b/buildroot/share/PlatformIO/scripts/download_mks_assets.py
@@ -5,45 +5,49 @@
 import pioutil
 if pioutil.is_pio_build():
 	Import("env")
-	import os,requests,zipfile,tempfile,shutil
+	import requests,zipfile,tempfile,shutil
+	from pathlib import Path
 
 	url = "https://github.com/makerbase-mks/Mks-Robin-Nano-Marlin2.0-Firmware/archive/0263cdaccf.zip"
-	deps_path = env.Dictionary("PROJECT_LIBDEPS_DIR")
-	zip_path = os.path.join(deps_path, "mks-assets.zip")
-	assets_path = os.path.join(env.Dictionary("PROJECT_BUILD_DIR"), env.Dictionary("PIOENV"), "assets")
+	deps_path = Path(env.Dictionary("PROJECT_LIBDEPS_DIR"))
+	zip_path = deps_path / "mks-assets.zip"
+	assets_path = Path(env.Dictionary("PROJECT_BUILD_DIR"), env.Dictionary("PIOENV"), "assets")
 
 	def download_mks_assets():
 		print("Downloading MKS Assets")
 		r = requests.get(url, stream=True)
 		# the user may have a very clean workspace,
 		# so create the PROJECT_LIBDEPS_DIR directory if not exits
-		if os.path.exists(deps_path) == False:
-			os.mkdir(deps_path)
-		with open(zip_path, 'wb') as fd:
+		if not deps_path.exists():
+			deps_path.mkdir()
+		with zip_path.open('wb') as fd:
 			for chunk in r.iter_content(chunk_size=128):
 				fd.write(chunk)
 
 	def copy_mks_assets():
 		print("Copying MKS Assets")
-		output_path = tempfile.mkdtemp()
+		output_path = Path(tempfile.mkdtemp())
 		zip_obj = zipfile.ZipFile(zip_path, 'r')
 		zip_obj.extractall(output_path)
 		zip_obj.close()
-		if os.path.exists(assets_path) == True and os.path.isdir(assets_path) == False:
-			os.unlink(assets_path)
-		if os.path.exists(assets_path) == False:
-			os.mkdir(assets_path)
+		if assets_path.exists() and not assets_path.is_dir():
+			assets_path.unlink()
+		if not assets_path.exists():
+			assets_path.mkdir()
 		base_path = ''
-		for filename in os.listdir(output_path):
+		for filename in output_path.iterdir():
 			base_path = filename
-		for filename in os.listdir(os.path.join(output_path, base_path, 'Firmware', 'mks_font')):
-			shutil.copy(os.path.join(output_path, base_path, 'Firmware', 'mks_font', filename), assets_path)
-		for filename in os.listdir(os.path.join(output_path, base_path, 'Firmware', 'mks_pic')):
-			shutil.copy(os.path.join(output_path, base_path, 'Firmware', 'mks_pic', filename), assets_path)
+		fw_path = (output_path / base_path / 'Firmware')
+		font_path = fw_path / 'mks_font'
+		for filename in font_path.iterdir():
+			shutil.copy(font_path / filename, assets_path)
+		pic_path = fw_path / 'mks_pic'
+		for filename in pic_path.iterdir():
+			shutil.copy(pic_path / filename, assets_path)
 		shutil.rmtree(output_path, ignore_errors=True)
 
-	if os.path.exists(zip_path) == False:
+	if not zip_path.exists():
 		download_mks_assets()
 
-	if os.path.exists(assets_path) == False:
+	if not assets_path.exists():
 		copy_mks_assets()

--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -7,16 +7,14 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import os,shutil,marlin
-	from SCons.Script import DefaultEnvironment
-	from platformio import util
-
-	env = DefaultEnvironment()
+	import shutil,marlin
+	from pathlib import Path
 
 	#
 	# Get the platform name from the 'platform_packages' option,
 	# or look it up by the platform.class.name.
 	#
+	env = marlin.env
 	platform = env.PioPlatform()
 
 	from platformio.package.meta import PackageSpec
@@ -37,8 +35,8 @@ if pioutil.is_pio_build():
 	if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "usb-host-msc-cdc-msc-3", "tool-stm32duino", "biqu-bx-workaround", "main" ]:
 		platform_name = "framework-arduinoststm32"
 
-	FRAMEWORK_DIR = platform.get_package_dir(platform_name)
-	assert os.path.isdir(FRAMEWORK_DIR)
+	FRAMEWORK_DIR = Path(platform.get_package_dir(platform_name))
+	assert FRAMEWORK_DIR.is_dir()
 
 	board = env.BoardConfig()
 
@@ -47,14 +45,14 @@ if pioutil.is_pio_build():
 	#series = mcu_type[:7].upper() + "xx"
 
 	# Prepare a new empty folder at the destination
-	variant_dir = os.path.join(FRAMEWORK_DIR, "variants", variant)
-	if os.path.isdir(variant_dir):
+	variant_dir = FRAMEWORK_DIR / "variants" / variant
+	if variant_dir.is_dir():
 		shutil.rmtree(variant_dir)
-	if not os.path.isdir(variant_dir):
-		os.mkdir(variant_dir)
+	if not variant_dir.is_dir():
+		variant_dir.mkdir()
 
 	# Source dir is a local variant sub-folder
-	source_dir = os.path.join("buildroot/share/PlatformIO/variants", variant)
-	assert os.path.isdir(source_dir)
+	source_dir = Path("buildroot/share/PlatformIO/variants", variant)
+	assert source_dir.is_dir()
 
 	marlin.copytree(source_dir, variant_dir)

--- a/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
@@ -4,37 +4,32 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import os,marlin
+
 	# Append ${PROGNAME}.bin firmware after bootloader and save it as 'jgaurora_firmware.bin'
 	def addboot(source, target, env):
-		firmware = open(target[0].path, "rb")
-		lengthfirmware = os.path.getsize(target[0].path)
-		bootloader_bin = "buildroot/share/PlatformIO/scripts/" + "jgaurora_bootloader.bin"
-		bootloader = open(bootloader_bin, "rb")
-		lengthbootloader = os.path.getsize(bootloader_bin)
+		from pathlib import Path
 
-		firmware_with_boothloader_bin = target[0].dir.path + '/firmware_with_bootloader.bin'
-		if os.path.exists(firmware_with_boothloader_bin):
-			os.remove(firmware_with_boothloader_bin)
-		firmwareimage = open(firmware_with_boothloader_bin, "wb")
-		position = 0
-		while position < lengthbootloader:
-			byte = bootloader.read(1)
-			firmwareimage.write(byte)
-			position += 1
-		position = 0
-		while position < lengthfirmware:
-			byte = firmware.read(1)
-			firmwareimage.write(byte)
-			position += 1
-		bootloader.close()
-		firmware.close()
-		firmwareimage.close()
+		fw_path = Path(target[0].path)
+		fwb_path = fw_path.parent / 'firmware_with_bootloader.bin'
+		with fwb_path.open("wb") as fwb_file:
+			bl_path = Path("buildroot/share/PlatformIO/scripts/jgaurora_bootloader.bin")
+			bl_file = bl_path.open("rb")
+			while True:
+				b = bl_file.read(1)
+				if b == b'': break
+				else: fwb_file.write(b)
 
-		firmware_without_bootloader_bin = target[0].dir.path + '/firmware_for_sd_upload.bin'
-		if os.path.exists(firmware_without_bootloader_bin):
-			os.remove(firmware_without_bootloader_bin)
-		os.rename(target[0].path, firmware_without_bootloader_bin)
-		#os.rename(target[0].dir.path+'/firmware_with_bootloader.bin', target[0].dir.path+'/firmware.bin')
+			with fw_path.open("rb") as fw_file:
+				while True:
+					b = fw_file.read(1)
+					if b == b'': break
+					else: fwb_file.write(b)
 
+		fws_path = Path(target[0].dir.path, 'firmware_for_sd_upload.bin')
+		if fws_path.exists():
+			fws_path.unlink()
+
+		fw_path.rename(fws_path)
+
+	import marlin
 	marlin.add_post_action(addboot);

--- a/buildroot/share/PlatformIO/scripts/lerdge.py
+++ b/buildroot/share/PlatformIO/scripts/lerdge.py
@@ -8,10 +8,8 @@
 import pioutil
 if pioutil.is_pio_build():
 	import os,marlin
-	Import("env")
 
-	from SCons.Script import DefaultEnvironment
-	board = DefaultEnvironment().BoardConfig()
+	board = marlin.env.BoardConfig()
 
 	def encryptByte(byte):
 		byte = 0xFF & ((byte << 6) | (byte >> 2))

--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -10,12 +10,10 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import os,sys,marlin
-	Import("env")
+	import sys,marlin
 
-	from SCons.Script import DefaultEnvironment
-	board = DefaultEnvironment().BoardConfig()
-
+	env = marlin.env
+	board = env.BoardConfig()
 	board_keys = board.get("build").keys()
 
 	#
@@ -56,7 +54,7 @@ if pioutil.is_pio_build():
 	if 'rename' in board_keys:
 
 		def rename_target(source, target, env):
-			firmware = os.path.join(target[0].dir.path, board.get("build.rename"))
-			os.replace(target[0].path, firmware)
+			from pathlib import Path
+			Path(target[0].path).replace(Path(target[0].dir.path, board.get("build.rename")))
 
 		marlin.add_post_action(rename_target)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -6,10 +6,12 @@ import pioutil
 if pioutil.is_pio_build():
 
 	import os,re,sys
+	from pathlib import Path
 	Import("env")
 
 	def get_envs_for_board(board):
-		with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
+		ppath = Path("Marlin/src/pins/pins.h")
+		with ppath.open() as file:
 
 			if sys.platform == 'win32':
 				envregex = r"(?:env|win):"
@@ -77,9 +79,10 @@ if pioutil.is_pio_build():
 		#
 		# Check for Config files in two common incorrect places
 		#
-		for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
-			for f in [ "Configuration.h", "Configuration_adv.h" ]:
-				if os.path.isfile(os.path.join(p, f)):
+		epath = Path(env['PROJECT_DIR'])
+		for p in [ epath, epath / "config" ]:
+			for f in ("Configuration.h", "Configuration_adv.h"):
+				if (p / f).is_file():
 					err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
 					raise SystemExit(err)
 
@@ -87,12 +90,12 @@ if pioutil.is_pio_build():
 		# Find the name.cpp.o or name.o and remove it
 		#
 		def rm_ofile(subdir, name):
-			build_dir = os.path.join(env['PROJECT_BUILD_DIR'], build_env);
-			for outdir in [ build_dir, os.path.join(build_dir, "debug") ]:
-				for ext in [ ".cpp.o", ".o" ]:
-					fpath = os.path.join(outdir, "src", "src", subdir, name + ext)
-					if os.path.exists(fpath):
-						os.remove(fpath)
+			build_dir = Path(env['PROJECT_BUILD_DIR'], build_env);
+			for outdir in (build_dir, build_dir / "debug"):
+				for ext in (".cpp.o", ".o"):
+					fpath = outdir / "src/src" / subdir / (name + ext)
+					if fpath.exists():
+						fpath.unlink()
 
 		#
 		# Give warnings on every build
@@ -109,13 +112,13 @@ if pioutil.is_pio_build():
 		# Check for old files indicating an entangled Marlin (mixing old and new code)
 		#
 		mixedin = []
-		p = os.path.join(env['PROJECT_DIR'], "Marlin", "src", "lcd", "dogm")
+		p = Path(env['PROJECT_DIR'], "Marlin/src/lcd/dogm")
 		for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
-			if os.path.isfile(os.path.join(p, f)):
+			if (p / f).is_file():
 				mixedin += [ f ]
-		p = os.path.join(env['PROJECT_DIR'], "Marlin", "src", "feature", "bedlevel", "abl")
+		p = Path(env['PROJECT_DIR'], "Marlin/src/feature/bedlevel/abl")
 		for f in [ "abl.cpp", "abl.h" ]:
-			if os.path.isfile(os.path.join(p, f)):
+			if (p / f).is_file():
 				mixedin += [ f ]
 		if mixedin:
 			err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)

--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -1,7 +1,7 @@
 #
 # preprocessor.py
 #
-import subprocess,os,re
+import subprocess,re
 
 nocache = 1
 verbose = 0
@@ -54,51 +54,41 @@ def run_preprocessor(env, fn=None):
 #
 def search_compiler(env):
 
-	ENV_BUILD_PATH = os.path.join(env['PROJECT_BUILD_DIR'], env['PIOENV'])
-	GCC_PATH_CACHE = os.path.join(ENV_BUILD_PATH, ".gcc_path")
+	from pathlib import Path, PurePath
+
+	ENV_BUILD_PATH = Path(env['PROJECT_BUILD_DIR'], env['PIOENV'])
+	GCC_PATH_CACHE = ENV_BUILD_PATH / ".gcc_path"
 
 	try:
-		filepath = env.GetProjectOption('custom_gcc')
+		gccpath = env.GetProjectOption('custom_gcc')
 		blab("Getting compiler from env")
-		return filepath
+		return gccpath
 	except:
 		pass
 
 	# Warning: The cached .gcc_path will obscure a newly-installed toolkit
-	if not nocache and os.path.exists(GCC_PATH_CACHE):
+	if not nocache and GCC_PATH_CACHE.exists():
 		blab("Getting g++ path from cache")
-		with open(GCC_PATH_CACHE, 'r') as f:
-			return f.read()
+		return GCC_PATH_CACHE.read_text()
 
-	# Find the current platform compiler by searching the $PATH
-	# which will be in a platformio toolchain bin folder
-	path_regex = re.escape(env['PROJECT_PACKAGES_DIR'])
-	gcc = "g++"
+	# Use any item in $PATH corresponding to a platformio toolchain bin folder
+	path_separator = ':'
+	gcc_exe = '*g++'
 	if env['PLATFORM'] == 'win32':
 		path_separator = ';'
-		path_regex += r'.*\\bin'
-		gcc += ".exe"
-	else:
-		path_separator = ':'
-		path_regex += r'/.+/bin'
+		gcc_exe += ".exe"
 
-	# Search for the compiler
-	for pathdir in env['ENV']['PATH'].split(path_separator):
-		if not re.search(path_regex, pathdir, re.IGNORECASE):
-			continue
-		for filepath in os.listdir(pathdir):
-			if not filepath.endswith(gcc):
-				continue
-			# Use entire path to not rely on env PATH
-			filepath = os.path.sep.join([pathdir, filepath])
-			# Cache the g++ path to no search always
-			if not nocache and os.path.exists(ENV_BUILD_PATH):
-				blab("Caching g++ for current env")
-				with open(GCC_PATH_CACHE, 'w+') as f:
-					f.write(filepath)
+	# Search for the compiler in PATH
+	for ppath in map(Path, env['ENV']['PATH'].split(path_separator)):
+		if ppath.match(env['PROJECT_PACKAGES_DIR'] + "/**/bin"):
+			for gpath in ppath.glob(gcc_exe):
+				gccpath = str(gpath.resolve())
+				# Cache the g++ path to no search always
+				if not nocache and ENV_BUILD_PATH.exists():
+					blab("Caching g++ for current env")
+					GCC_PATH_CACHE.write_text(gccpath)
+				return gccpath
 
-			return filepath
-
-	filepath = env.get('CXX')
-	blab("Couldn't find a compiler! Fallback to %s" % filepath)
-	return filepath
+	gccpath = env.get('CXX')
+	blab("Couldn't find a compiler! Fallback to %s" % gccpath)
+	return gccpath

--- a/buildroot/share/dwin/bin/DWIN_ICO.py
+++ b/buildroot/share/dwin/bin/DWIN_ICO.py
@@ -144,7 +144,7 @@ class DWIN_ICO_File():
             # process each file:
             try:
                 index = int(dirEntry.name[0:3])
-                if (index < 0) or (index > 255):
+                if not (0 <= index <= 255):
                     print('...Ignoring invalid index on', dirEntry.path)
                     continue
                 #dirEntry.path is iconDir/name

--- a/buildroot/share/scripts/config-labels.py
+++ b/buildroot/share/scripts/config-labels.py
@@ -22,7 +22,7 @@
 # 2020-06-05 SRL style tweaks
 #-----------------------------------
 #
-import sys,os
+import sys
 from pathlib import Path
 from distutils.dir_util import copy_tree  # for copy_tree, because shutil.copytree can't handle existing files, dirs
 
@@ -58,10 +58,10 @@ def process_file(subdir: str, filename: str):
 	# Read file
 	#------------------------
 	lines = []
-	infilepath = os.path.join(input_examples_dir, subdir, filename)
+	infilepath = Path(input_examples_dir, subdir, filename)
 	try:
 		# UTF-8 because some files contain unicode chars
-		with open(infilepath, 'rt', encoding="utf-8") as infile:
+		with infilepath.open('rt', encoding="utf-8") as infile:
 			lines = infile.readlines()
 
 	except Exception as e:
@@ -123,25 +123,24 @@ def process_file(subdir: str, filename: str):
 	#-------------------------
 	#     Output file
 	#-------------------------
-	outdir      = os.path.join(output_examples_dir, subdir)
-	outfilepath = os.path.join(outdir, filename)
+	outdir      = Path(output_examples_dir, subdir)
+	outfilepath = outdir / filename
 
 	if file_modified:
 		# Note: no need to create output dirs, as the initial copy_tree
 		# will do that.
 
-		print('  writing ' + str(outfilepath))
+		print('  writing ' + outfilepath)
 		try:
 			# Preserve unicode chars; Avoid CR-LF on Windows.
-			with open(outfilepath, "w", encoding="utf-8", newline='\n') as outfile:
-				outfile.write("\n".join(outlines))
-				outfile.write("\n")
+			with outfilepath.open("w", encoding="utf-8", newline='\n') as outfile:
+				outfile.write("\n".join(outlines) + "\n")
 
 		except Exception as e:
 			print('Failed to write file: ' + str(e) )
 			raise Exception
 	else:
-		print('  no change for ' + str(outfilepath))
+		print('  no change for ' + outfilepath)
 
 #----------
 def main():
@@ -159,8 +158,8 @@ def main():
 	output_examples_dir = output_examples_dir.strip()
 	output_examples_dir = output_examples_dir.rstrip('\\/')
 
-	for dir in [input_examples_dir, output_examples_dir]:
-		if not (os.path.exists(dir)):
+	for dir in (input_examples_dir, output_examples_dir):
+		if not Path(dir).exists():
 			print('Directory not found: ' + dir)
 			sys.exit(1)
 
@@ -181,8 +180,7 @@ def main():
 	#-----------------------------
 	# Find and process files
 	#-----------------------------
-	len_input_examples_dir = len(input_examples_dir);
-	len_input_examples_dir += 1
+	len_input_examples_dir = 1 + len(input_examples_dir)
 
 	for filename in files_to_mod:
 		input_path = Path(input_examples_dir)

--- a/buildroot/share/vscode/auto_build.py
+++ b/buildroot/share/vscode/auto_build.py
@@ -252,7 +252,7 @@ def resolve_path(path):
     while 0 <= path.find('../'):
       end = path.find('../') - 1
       start = path.find('/')
-      while 0 <= path.find('/', start) and end > path.find('/', start):
+      while 0 <= path.find('/', start) < end:
         start = path.find('/', start) + 1
       path = path[0:start] + path[end + 4:]
 
@@ -674,7 +674,7 @@ def line_print(line_input):
         if 0 == highlight[1]:
           found_1 = text.find(' ')
           found_tab = text.find('\t')
-          if found_1 < 0 or found_1 > found_tab:
+          if not (0 <= found_1 <= found_tab):
             found_1 = found_tab
           write_to_screen_queue(text[:found_1 + 1])
           for highlight_2 in highlights:
@@ -684,7 +684,7 @@ def line_print(line_input):
             if found >= 0:
               found_space = text.find(' ', found_1 + 1)
               found_tab = text.find('\t', found_1 + 1)
-              if found_space < 0 or found_space > found_tab:
+              if not (0 <= found_space <= found_tab):
                 found_space = found_tab
               found_right = text.find(']', found + 1)
               write_to_screen_queue(text[found_1 + 1:found_space + 1], highlight[2])
@@ -701,7 +701,7 @@ def line_print(line_input):
         break
     if did_something == False:
       r_loc = text.find('\r') + 1
-      if r_loc > 0 and r_loc < len(text):  # need to split this line
+      if 0 < r_loc < len(text):  # need to split this line
         text = text.split('\r')
         for line in text:
           if line != '':


### PR DESCRIPTION
Use the `pathlib` package to simplify some path and file handling in Marlin build scripts.