### PR TITLE
patch for 644p and 1284p serial port 1 sanity check

### DIFF
--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -37,7 +37,8 @@
   || X_ENA_PIN  == N || Y_ENA_PIN  == N || Z_ENA_PIN  == N \
   || BTN_EN1    == N || BTN_EN2    == N \
 )
-#if CONF_SERIAL_IS(0) // D0-D1. No known conflicts.
+#if CONF_SERIAL_IS(0)
+  // D0-D1. No known conflicts.
 #endif
 #if NOT_TARGET(__AVR_ATmega644P__, __AVR_ATmega1284P__)
   #if CONF_SERIAL_IS(1) && (CHECK_SERIAL_PIN(18) || CHECK_SERIAL_PIN(19))

--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -35,11 +35,18 @@
   || X_STEP_PIN == N || Y_STEP_PIN == N || Z_STEP_PIN == N \
   || X_DIR_PIN  == N || Y_DIR_PIN  == N || Z_DIR_PIN  == N \
   || X_ENA_PIN  == N || Y_ENA_PIN  == N || Z_ENA_PIN  == N \
+  || BTN_EN1    == N || BTN_EN2    == N \
 )
 #if CONF_SERIAL_IS(0) // D0-D1. No known conflicts.
 #endif
-#if CONF_SERIAL_IS(1) && (CHECK_SERIAL_PIN(18) || CHECK_SERIAL_PIN(19))
-  #error "Serial Port 1 pin D18 and/or D19 conflicts with another pin on the board."
+#if NOT_TARGET(__AVR_ATmega644P__, __AVR_ATmega1284P__)
+  #if CONF_SERIAL_IS(1) && (CHECK_SERIAL_PIN(18) || CHECK_SERIAL_PIN(19))
+    #error "Serial Port 1 pin D18 and/or D19 conflicts with another pin on the board."
+  #endif
+#else
+  #if CONF_SERIAL_IS(1) && (CHECK_SERIAL_PIN(10) || CHECK_SERIAL_PIN(11))
+    #error "Serial Port 1 pin D10 and/or D11 conflicts with another pin on the board."
+  #endif
 #endif
 #if CONF_SERIAL_IS(2) && (CHECK_SERIAL_PIN(16) || CHECK_SERIAL_PIN(17))
   #error "Serial Port 2 pin D16 and/or D17 conflicts with another pin on the board."


### PR DESCRIPTION
### Description

The AVR serial sanity check for conflicting pin definitions does not check if its a 644p or a 1284p 
These use D10 and D11 for serial port 1
 
### Requirements

644p or 1284p with serial port 1

### Benefits

No false positives on 644p or 1284p over pins D18 and D19  

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/24148#discussion_r933990726