### PR TITLE
Allow USB host shield to work on lpc1768

### DIFF
--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/message.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/message.cpp
@@ -59,7 +59,7 @@ void E_NotifyStr(char const * msg, int lvl) {
 void E_Notify(uint8_t b, int lvl) {
   if (UsbDEBUGlvl < lvl) return;
   USB_HOST_SERIAL.print(b
-    #if !defined(ARDUINO) || ARDUINO < 100
+    #if !defined(ARDUINO) && !defined(ARDUINO_ARCH_LPC176X)
       , DEC
     #endif
   );


### PR DESCRIPTION
**SUMMARY**
This small change allows the USB host shield to work on the lpc1768 processor.

**INITIAL PROBLEM**
Before this fix, if you enabled the USB host shield and tried to compile for any mainboard that used an LPC1768 it would fail to compile.

**SOLUTION**
This fix literally just just reflects the logic on line 40 of the same file (message.cpp). See [here](https://github.com/MarlinFirmware/Marlin/blob/e16cab207689cd476ae865b9e25aca882b4b3a42/Marlin/src/sd/usb_flashdrive/lib-uhs2/message.cpp#L40).

**TESTING**
I tested it on my printer and compilation succeeded. Using USB flash drive instead of sd card then worked.