### PR TITLE
Support Trigorilla Pro disk based update.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -590,7 +590,7 @@
 #elif MB(CREALITY_V25S1)
   #include "stm32f1/pins_CREALITY_V25S1.h"      // STM32F1                                env:STM32F103RE_creality_smartPro env:STM32F103RE_creality_smartPro_maple
 #elif MB(TRIGORILLA_PRO)
-  #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple
+  #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple env:trigorilla_pro_disk
 #elif MB(FLY_MINI)
   #include "stm32f1/pins_FLY_MINI.h"            // STM32F1                                env:FLY_MINI env:FLY_MINI_maple
 #elif MB(FLSUN_HISPEED)

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -4,7 +4,7 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import struct,uuid,os,marlin
+	import struct,uuid,marlin
 
 	board = marlin.env.BoardConfig()
 
@@ -107,18 +107,20 @@ if pioutil.is_pio_build():
 	def encrypt(source, target, env):
 		from pathlib import Path
 
-		fwpath = target[0].path
-		enname = board.get("build.crypt_chitu")
-		print("Encrypting %s to %s" % (fwpath, enname))
-		fwfile = open(fwpath, "rb")
-		enfile = open(target[0].dir.path + "/" + enname, "wb")
-		length = os.path.getsize(fwpath)
+		fwpath = Path(target[0].path)
+		fwsize = fwpath.stat().st_size
 
-		encrypt_file(fwfile, enfile, length)
+		enname = board.get("build.crypt_chitu")
+		enpath = Path(target[0].dir.path)
+
+		fwfile = fwpath.open("rb")
+		enfile = (enpath / enname).open("wb")
+
+		print(f"Encrypting {fwpath} to {enname}")
+		encrypt_file(fwfile, enfile, fwsize)
 		fwfile.close()
 		enfile.close()
-		os.remove(fwpath)
+		fwpath.unlink()
 
-	import marlin
 	marlin.relocate_firmware("0x08008800")
 	marlin.add_post_action(encrypt);

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -4,7 +4,9 @@
 #
 import pioutil
 if pioutil.is_pio_build():
-	import struct,uuid
+	import struct,uuid,os,marlin
+
+	board = marlin.env.BoardConfig()
 
 	def calculate_crc(contents, seed):
 		accumulating_xor_value = seed;
@@ -104,11 +106,18 @@ if pioutil.is_pio_build():
 	# Encrypt ${PROGNAME}.bin and save it as 'update.cbd'
 	def encrypt(source, target, env):
 		from pathlib import Path
-		fwpath = Path(target[0].path)
-		fwsize = fwpath.stat().st_size
-		fwfile = fwpath.open("rb")
-		upfile = Path(target[0].dir.path, 'update.cbd').open("wb")
-		encrypt_file(fwfile, upfile, fwsize)
+
+		fwpath = target[0].path
+		enname = board.get("build.crypt_chitu")
+		print("Encrypting %s to %s" % (fwpath, enname))
+		fwfile = open(fwpath, "rb")
+		enfile = open(target[0].dir.path + "/" + enname, "wb")
+		length = os.path.getsize(fwpath)
+
+		encrypt_file(fwfile, enfile, length)
+		fwfile.close()
+		enfile.close()
+		os.remove(fwpath)
 
 	import marlin
 	marlin.relocate_firmware("0x08008800")

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -379,11 +379,30 @@ build_unflags        = ${stm32_variant.build_unflags}
                        -DUSBCON -DUSBD_USE_CDC
 
 #
+# TRIGORILLA PRO DISK BASED (STM32F103ZET6)
+# Builds for Trigorilla to update from SD
+#
+[env:trigorilla_pro_disk]
+extends              = stm32_variant
+board                = genericSTM32F103ZE
+board_build.crypt_chitu = update.zw
+board_build.variant  = MARLIN_F103Zx
+board_build.offset   = 0x8800
+build_flags          = ${stm32_variant.build_flags}
+                       -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
+build_unflags        = ${stm32_variant.build_unflags}
+                       -DUSBCON -DUSBD_USE_CDC
+extra_scripts        = ${stm32_variant.extra_scripts}
+                       buildroot/share/PlatformIO/scripts/chitu_crypt.py
+
+
+#
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]
 extends              = stm32_variant
 board                = genericSTM32F103ZE
+board_build.crypt_chitu = update.cbd
 board_build.variant  = MARLIN_F103Zx
 board_build.offset   = 0x8800
 build_flags          = ${stm32_variant.build_flags}


### PR DESCRIPTION
### Description

The trigorilla pro boards use the same encryption format as chitu. Add an environment which builds firmware which can be used to update via SD

### Requirements

Only works on a trigorilla pro (presumably meaning in an anycubic predator).

### Benefits

You don't need to open the printer, pull the boot jumper and flash using ST's utilities or solder on a ST-link. Pop in the SD card with the update firmware on it, restart and away it goes.

### Configurations

Test this on a trigorilla pro board with the example config from the config repo.

### Related Issues

No feature other than me saying "I should not have to go to all this trouble to switch to Marlin."
