### PR TITLE
Fix UBL Build Mesh Menu when PREHEAT_COUNT > 5

### DIFF
--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -335,6 +335,9 @@ void _lcd_ubl_build_mesh() {
           BUILD_MESH_GCODE_ITEM(3);
           #if PREHEAT_COUNT > 4
             BUILD_MESH_GCODE_ITEM(4);
+            #if PREHEAT_COUNT > 5
+              BUILD_MESH_GCODE_ITEM(5);
+            #endif
           #endif
         #endif
       #endif

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -312,11 +312,7 @@ void _lcd_ubl_build_mesh() {
   START_MENU();
   BACK_ITEM(MSG_UBL_TOOLS);
   #if HAS_PREHEAT
-    #if HAS_HEATED_BED
-      #define PREHEAT_BED_GCODE(M) "M190I" STRINGIFY(M) "\n"
-    #else
-      #define PREHEAT_BED_GCODE(M) ""
-    #endif
+    #define PREHEAT_BED_GCODE(M) TERN(HAS_HEATED_BED, "M190I" STRINGIFY(M) "\n", "")
     #define BUILD_MESH_GCODE_ITEM(M) GCODES_ITEM_f(ui.get_preheat_label(M), MSG_UBL_BUILD_MESH_M, \
       F( \
         "G28\n" \
@@ -325,23 +321,8 @@ void _lcd_ubl_build_mesh() {
         "G29P1\n" \
         "M104S0\n" \
         "M140S0" \
-      ) )
-    BUILD_MESH_GCODE_ITEM(0);
-    #if PREHEAT_COUNT > 1
-      BUILD_MESH_GCODE_ITEM(1);
-      #if PREHEAT_COUNT > 2
-        BUILD_MESH_GCODE_ITEM(2);
-        #if PREHEAT_COUNT > 3
-          BUILD_MESH_GCODE_ITEM(3);
-          #if PREHEAT_COUNT > 4
-            BUILD_MESH_GCODE_ITEM(4);
-            #if PREHEAT_COUNT > 5
-              BUILD_MESH_GCODE_ITEM(5);
-            #endif
-          #endif
-        #endif
-      #endif
-    #endif
+      ) );
+    REPEAT(PREHEAT_COUNT, BUILD_MESH_GCODE_ITEM)
   #endif // HAS_PREHEAT
 
   SUBMENU(MSG_UBL_BUILD_CUSTOM_MESH, _lcd_ubl_custom_mesh);


### PR DESCRIPTION
### Description

Up to 6 preheat constants can be enabled, but one would be missing in the UBL Mesh Menu if all 6 were enabled.

### Requirements

UBL + 6 preheat options enabled

### Benefits

All preheat options will show up.

### Related Issues

None. Found while trying to add >6 preheat options in my PrusaAIO fork to match Prusa firmware's 9 preheat options.
