### PR TITLE
Fix automatic upload port selection for LPC1768 on Darwin and Linux

### DIFF
--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -82,11 +82,11 @@ if pioutil.is_pio_build():
 					for drive in drives:
 						try:
 							fpath = mpath / drive
-							files = [ x for x in fpath.iterdir() if x.is_file() ]
+							filenames = [ x.name for x in fpath.iterdir() if x.is_file() ]
 						except:
 							continue
 						else:
-							if target_filename in files:
+							if target_filename in filenames:
 								upload_disk = mpath / drive
 								target_file_found = True
 								break
@@ -104,21 +104,21 @@ if pioutil.is_pio_build():
 				# platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
 				#
 				dpath = Path('/Volumes')  # human readable names
-				drives = [ x for x in dpath.iterdir() ]
+				drives = [ x for x in dpath.iterdir() if x.is_dir() ]
 				if target_drive in drives and not target_file_found:  # set upload if not found target file yet
 					target_drive_found = True
 					upload_disk = dpath / target_drive
 				for drive in drives:
 					try:
-						fpath = dpath / drive   # will get an error if the drive is protected
-						files = [ x for x in fpath.iterdir() ]
+						fpath = dpath / drive	# will get an error if the drive is protected
+						filenames = [ x.name for x in fpath.iterdir() if x.is_file() ]
 					except:
 						continue
 					else:
-						if target_filename in files:
-							if not target_file_found:
-								upload_disk = dpath / drive
+						if target_filename in filenames:
+							upload_disk = dpath / drive
 							target_file_found = True
+							break
 
 			#
 			# Set upload_port to drive if found


### PR DESCRIPTION
### Description

Following <https://github.com/MarlinFirmware/Marlin/pull/24574>, automatic upload port stopped working. Instead, you just get the error:

```
Looking for upload disk...
Error: Please specify `upload_port` for environment or use global `--upload-port` option.
```

This is due to the default `__str__` behaviour of `Pathlib.Path` producing the full path, so we need to keep the `filenames` concept. Otherwise, the target drive cannot be found automatically. (Alternately, the filename check could become `any(target_filename == x.name for x in files)`.

I also made the loop-termination logic on MacOS the same as Linux, and unified the `is_dir()` and `is_file()` checks between the two.

Tested on MacOS.

Tabs preserved to match existing code.

### Requirements

LPC1768 or LPC1769 board, MacOS (Darwin) or Linux build host.

### Benefits

Restores automatic selection of `upload_port` by detecting current firmware file.

### Configurations

Does not need a specific printer config. Minimum diff for my environment from `bugfix-2.1.x` is just:

- set `default_envs` to `LPC1769` in `platformio.ini`
- change `#define MOTHERBOARD` to `BOARD_BTT_SKR_V1_4_TURBO` in `Marlin/Configuration.h`

### Related Issues
