### PR TITLE
Update STM32 Print Counter Sanity Check

### DIFF
--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -37,9 +37,9 @@
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
 
-#if defined(STM32F4xx) && BOTH(PRINTCOUNTER, FLASH_EEPROM_EMULATION)
-  #warning "FLASH_EEPROM_EMULATION may cause long delays when writing and should not be used while printing."
-  #error "Disable PRINTCOUNTER or choose another EEPROM emulation."
+#if defined(STM32F4xx) && BOTH(PRINTCOUNTER, FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
+  #warning "PRINTCOUNTER with FLASH_EEPROM_EMULATION and PRINTCOUNTER_SAVE_INTERVAL > 0 may cause long delays when writing and should not be used while printing."
+  #error "Set PRINTCOUNTER_SAVE_INTERVAL to 0 or choose another EEPROM emulation."
 #endif
 
 #if !defined(STM32F4xx) && ENABLED(FLASH_EEPROM_LEVELING)


### PR DESCRIPTION
### Description

Allow `PRINTCOUNTER` to be used on STM32-based boards with emulated EEPROM if `PRINTCOUNTER_SAVE_INTERVAL > 0` since it disables saving print stats until the print is complete.

### Requirements

STM32-based board with emulated EEPROM & `PRINTCOUNTER`.

### Benefits

STM32 users with an emulated EEPROM can use `PRINTCOUNTER`.
