### PR TITLE
Remove STM32F4 Print Counter Sanity Check

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2357,7 +2357,7 @@
  */
 //#define PRINTCOUNTER
 #if ENABLED(PRINTCOUNTER)
-  #define PRINTCOUNTER_SAVE_INTERVAL 60 // (minutes) EEPROM save interval during print
+  #define PRINTCOUNTER_SAVE_INTERVAL 60 // (minutes) EEPROM save interval during print. A value of 0 will save stats at end of print.
 #endif
 
 // @section security

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -27,3 +27,8 @@
 #elif EITHER(I2C_EEPROM, SPI_EEPROM)
   #define USE_SHARED_EEPROM 1
 #endif
+
+// Some STM32F4 boards may lose steps when saving to EEPROM during print (PR #17946)
+#if defined(STM32F4xx) && PRINTCOUNTER_SAVE_INTERVAL > 0
+  #define PRINTCOUNTER_SYNC 1
+#endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -37,11 +37,6 @@
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
 
-#if defined(STM32F4xx) && BOTH(PRINTCOUNTER, FLASH_EEPROM_EMULATION)
-  #warning "FLASH_EEPROM_EMULATION may cause long delays when writing and should not be used while printing."
-  #error "Disable PRINTCOUNTER or choose another EEPROM emulation."
-#endif
-
 #if !defined(STM32F4xx) && ENABLED(FLASH_EEPROM_LEVELING)
   #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4 hardware."
 #endif


### PR DESCRIPTION
### Description

Allow `PRINTCOUNTER` to be used on STM32F4-based boards with emulated EEPROM. Setting `PRINTCOUNTER_SAVE_INTERVAL` to 0 will save stats at the end of a print and setting it to a value >0 will result in a warning like it does for LPC:

https://github.com/MarlinFirmware/Marlin/blob/8025117ac0a446e14358f7124669f8b54230c8fc/Marlin/src/inc/Warnings.cpp#L715-L717

### Requirements

STM32F4-based board with emulated EEPROM & `PRINTCOUNTER`.

### Benefits

STM32F4-based configs with an emulated EEPROM can use `PRINTCOUNTER`.

### Related Issues / Pull Requests

- #17946
- #20856