### PR TITLE
Improve MKS UI About Screen

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_about.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_about.cpp
@@ -31,7 +31,7 @@
 
 extern lv_group_t *g;
 static lv_obj_t *scr;
-static lv_obj_t *fw_type, *board;
+static lv_obj_t *fw_type, *board, *website, *uuid, *protocol;
 
 enum { ID_A_RETURN = 1 };
 
@@ -48,11 +48,20 @@ void lv_draw_about() {
   scr = lv_screen_create(ABOUT_UI);
   lv_big_button_create(scr, "F:/bmp_return.bin", common_menu.text_back, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_A_RETURN);
 
-  fw_type = lv_label_create(scr, "Firmware: Marlin " SHORT_BUILD_VERSION);
-  lv_obj_align(fw_type, nullptr, LV_ALIGN_CENTER, 0, -20);
+  board = lv_label_create(scr, BOARD_INFO_NAME);
+  lv_obj_align(board, nullptr, LV_ALIGN_CENTER, 0, -80);
 
-  board = lv_label_create(scr, "Board: " BOARD_INFO_NAME);
-  lv_obj_align(board, nullptr, LV_ALIGN_CENTER, 0, -60);
+  fw_type = lv_label_create(scr, "Marlin " SHORT_BUILD_VERSION " (" STRING_DISTRIBUTION_DATE ")");
+  lv_obj_align(fw_type, nullptr, LV_ALIGN_CENTER, 0, -50);
+
+  website = lv_label_create(scr, WEBSITE_URL);
+  lv_obj_align(website, nullptr, LV_ALIGN_CENTER, 0, -20);
+
+  uuid = lv_label_create(scr, "UUID: " DEFAULT_MACHINE_UUID);
+  lv_obj_align(uuid, nullptr, LV_ALIGN_CENTER, 0, 10);
+
+  protocol = lv_label_create(scr, "Protocol: " PROTOCOL_VERSION);
+  lv_obj_align(protocol, nullptr, LV_ALIGN_CENTER, 0, 40);
 }
 
 void lv_clear_about() {

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -29,7 +29,7 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
-#define BOARD_INFO_NAME "MKS Robin Nano"
+#define BOARD_INFO_NAME "MKS Robin Nano V1"
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role


### PR DESCRIPTION
### Description

As requested in #24417, I've updated MKS' TFT UI (`TFT_LVGL_UI`) About screen to now include:

- Firmware distribution date
- URL
- UUID
- Protocol

Note: I had to adjust label positions a bit to prevent the UUID label from overlapping the "Back" button.

<img width="654" alt="image" src="https://github.com/MarlinFirmware/Marlin/assets/13375512/4158bd7b-b9be-431b-8e48-97ce07ab7972">

### Requirements

`TFT_LVGL_UI`

### Benefits

Users will see more information about their firmware in the About screen while using `TFT_LVGL_UI`.

### Configurations

[Configuration.h.zip](https://github.com/MarlinFirmware/Marlin/files/9288543/Configuration.h.zip)

### Related Issues

- #24417