### PR TITLE
UBL G28 leveling fix (2.0.9.4 and later)

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -76,7 +76,7 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
 
     // Get the corrected leveled / unleveled position
     planner.apply_modifiers(current_position, true);    // Physical position with all modifiers
-    planner.leveling_active ^= true;              // Toggle leveling between apply and unapply
+    planner.leveling_active ^= true;                    // Toggle leveling between apply and unapply
     planner.unapply_modifiers(current_position, true);  // Logical position with modifiers removed
 
     sync_plan_position();

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -75,9 +75,9 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
     planner.synchronize();
 
     // Get the corrected leveled / unleveled position
-    planner.apply_modifiers(current_position);    // Physical position with all modifiers
+    planner.apply_modifiers(current_position, true);    // Physical position with all modifiers
     planner.leveling_active ^= true;              // Toggle leveling between apply and unapply
-    planner.unapply_modifiers(current_position);  // Logical position with modifiers removed
+    planner.unapply_modifiers(current_position, true);  // Logical position with modifiers removed
 
     sync_plan_position();
     _report_leveling();

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -407,7 +407,7 @@ void unified_bed_leveling::G29() {
           z_values[x][x2] += 9.999f; // We want the altered line several mesh points thick
           #if ENABLED(EXTENSIBLE_UI)
             ExtUI::onMeshUpdate(x, x, z_values[x][x]);
-            ExtUI::onMeshUpdate(x, (x2), z_values[x][x2]);
+            ExtUI::onMeshUpdate(x, x2, z_values[x][x2]);
           #endif
         }
         break;


### PR DESCRIPTION
### Description

In the routine **set_bed_leveling_enabled**, add ~**planner.leveling_active**~ **true** as an argument for both **apply_modifiers** and 
**unapply_modifiers**.

Without this, both **apply_modifiers** and **unapply_modifiers** will do nothing when UBL is enabled.  This is because the default for the optional argument ( **leveling=ENABLED(PLANNER_LEVELING**) evaluates to false when UBL is enabled.

```
      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
        TERN_(SKEW_CORRECTION, skew(pos));
        if (leveling) apply_leveling(pos);
        TERN_(FWRETRACT, apply_retract(pos));
      }

      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
        TERN_(FWRETRACT, unapply_retract(pos));
        if (leveling) unapply_leveling(pos);
        TERN_(SKEW_CORRECTION, unskew(pos));
      }
```

### Requirements

Only requirement is to have UBL enabled to see this issue.

### Benefits

The raw, logical, leveled and unleveled positions after G28 will now match what 2.0.9.3 produces. 

In 2.0.9.4 and later, the leveling was NOT being applied when G28 was called when UBL leveling was active.  The net result was the nozzle was gliding along a plane offset from the bed by the value of the mesh at the homing position.  The mesh offsets were being applied to the nozzle but they were all offset. 

### Configurations

Only requirement is to have UBL enabled to see this issue.

### Related Issues

This fixes the bug from issue #24592.

I can see why this went un-noticed for so long. My offsets are huge (about 8mm) compared to most printers so it's much more apparent on my printer.

### History

The error was introduced in PR #24188.  