### PR TITLE
add FYSETC_MINI_12864_2_1 pins to Creality_V4

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -265,9 +265,9 @@
    *
    *                 Board (RET6 12864 LCD)              Display
    *                 ------                               ------
-   *  (EN2)    PC6  | 1  2 | PB2  (BTN_ENC)           5V |10  9 | GND
+   *  (EN1)    PC6  | 1  2 | PB2  (BTN_ENC)           5V |10  9 | GND
    *  (LCD_CS) PB10 | 3  4 | PB11 (LCD RESET)         -- | 8  7 | --
-   *  (LCD_A0) PB14   5  6 | PB13 (EN1)           (DIN)  | 6  5   (LCD RESET)
+   *  (LCD_A0) PB14   5  6 | PB13 (EN2)           (DIN)  | 6  5   (LCD RESET)
    *  (LCD_SCK)PB12 | 7  8 | PB15 (MOSI)        (LCD_A0) | 4  3 | (LCD_CS)
    *            GND | 9 10 | 5V                (BTN_ENC) | 2  1 | --
    *                 ------                               ------
@@ -288,8 +288,8 @@
    */
 
   #define BTN_ENC                    EXP1_02_PIN
-  #define BTN_EN1                    EXP1_06_PIN
-  #define BTN_EN2                    EXP1_01_PIN
+  #define BTN_EN1                    EXP1_01_PIN
+  #define BTN_EN2                    EXP1_06_PIN
   #define BEEPER_PIN                        -1
 
   #define DOGLCD_CS                  EXP1_03_PIN

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -266,7 +266,7 @@
    *                 Board (RET6 12864 LCD)              Display
    *                 ------                               ------
    *  (EN2)    PC6  | 1  2 | PB2  (BTN_ENC)           5V |10  9 | GND
-   *  (LCD_CS) PB10 | 3  4 | PE8  (LCD RESET)         -- | 8  7 | --
+   *  (LCD_CS) PB10 | 3  4 | PB11 (LCD RESET)         -- | 8  7 | --
    *  (LCD_A0) PB14   5  6 | PB13 (EN1)           (DIN)  | 6  5   (LCD RESET)
    *  (LCD_SCK)PB12 | 7  8 | PB15 (MOSI)        (LCD_A0) | 4  3 | (LCD_CS)
    *            GND | 9 10 | 5V                (BTN_ENC) | 2  1 | --

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -161,7 +161,7 @@
 #define SDIO_SUPPORT
 #define NO_SD_HOST_DRIVE                          // This board's SD is only seen by the printer
 
-#if ANY(CR10_STOCKDISPLAY, FYSETC_MINI_12864_2_1)
+#if EITHER(CR10_STOCKDISPLAY, FYSETC_MINI_12864_2_1)
 
   #if ENABLED(RET6_12864_LCD)
 

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -161,7 +161,7 @@
 #define SDIO_SUPPORT
 #define NO_SD_HOST_DRIVE                          // This board's SD is only seen by the printer
 
-#if ENABLED(CR10_STOCKDISPLAY)
+#if ANY(CR10_STOCKDISPLAY, FYSETC_MINI_12864_2_1)
 
   #if ENABLED(RET6_12864_LCD)
 
@@ -169,7 +169,7 @@
      *    RET6 12864 LCD
      *        ------
      *  PC6  | 1  2 | PB2
-     *  PB10 | 3  4 | PE8
+     *  PB10 | 3  4 | PB11
      *  PB14   5  6 | PB13
      *  PB12 | 7  8 | PB15
      *   GND | 9 10 | 5V
@@ -179,15 +179,11 @@
     #define EXP1_01_PIN                     PC6
     #define EXP1_02_PIN                     PB2
     #define EXP1_03_PIN                     PB10
-    #define EXP1_04_PIN                     PE8
+    #define EXP1_04_PIN                     PB11
     #define EXP1_05_PIN                     PB14
     #define EXP1_06_PIN                     PB13
     #define EXP1_07_PIN                     PB12
     #define EXP1_08_PIN                     PB15
-
-    #ifndef HAS_PIN_27_BOARD
-      #define BEEPER_PIN             EXP1_01_PIN
-    #endif
 
   #elif ENABLED(VET6_12864_LCD)
 
@@ -212,8 +208,11 @@
     #define EXP1_08_PIN                     PA7
 
   #else
-    #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."
+    #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for the LCD with the Creality V4 controller."
   #endif
+#endif
+
+#if ENABLED(CR10_STOCKDISPLAY)
 
   #define LCD_PINS_RS                EXP1_07_PIN
   #define LCD_PINS_ENABLE            EXP1_08_PIN
@@ -222,6 +221,10 @@
   #define BTN_ENC                    EXP1_02_PIN
   #define BTN_EN1                    EXP1_03_PIN
   #define BTN_EN2                    EXP1_05_PIN
+
+  #ifndef HAS_PIN_27_BOARD
+    #define BEEPER_PIN               EXP1_01_PIN
+  #endif
 
 #elif ANY(HAS_DWIN_E3V2, IS_DWIN_MARLINUI, DWIN_VET6_CREALITY_LCD)
 
@@ -247,5 +250,56 @@
   #ifndef BEEPER_PIN
     #define BEEPER_PIN               EXP1_06_PIN
   #endif
+
+#elif ENABLED(FYSETC_MINI_12864_2_1)
+
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! FYSETC_MINI_12864_2_1 and clones require wiring modifications. See 'pins_CREALITY_V4.h' for details. Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning"
+  #endif
+
+  #if SD_CONNECTION_IS(LCD) 
+    #error "The LCD sdcard is not connected with this configuration"
+  #endif
+
+  /**
+   *
+   *                 Board (RET6 12864 LCD)              Display
+   *                 ------                               ------
+   *  (EN2)    PC6  | 1  2 | PB2  (BTN_ENC)           5V |10  9 | GND
+   *  (LCD_CS) PB10 | 3  4 | PE8  (LCD RESET)         -- | 8  7 | --
+   *  (LCD_A0) PB14   5  6 | PB13 (EN1)           (DIN)  | 6  5   (LCD RESET)
+   *  (LCD_SCK)PB12 | 7  8 | PB15 (MOSI)        (LCD_A0) | 4  3 | (LCD_CS)
+   *            GND | 9 10 | 5V                (BTN_ENC) | 2  1 | --
+   *                 ------                               ------
+   *                  EXP1                                 EXP1
+   *
+   *                                                      ------
+   *                -----                             -- |10  9 | --
+   *                | 1 | VCC                    (RESET) | 8  7 | --
+   *                | 2 | PA13 (DIN)             (MOSI)  | 6  5   (EN2)
+   *                | 3 | PA14                        -- | 4  3 | (EN1)
+   *                | 4 | GND                   (LCD_SCK)| 2  1 | --
+   *                -----                                 ------
+   *              Debug port                               EXP2
+   *
+   * Needs custom cable. Connect EN2-EN2, LCD_CS-LCD_CS and so on.
+   * Debug port is just above EXP1, You need to add pins
+   *
+   */
+
+  #define BTN_ENC                    EXP1_02_PIN
+  #define BTN_EN1                    EXP1_06_PIN
+  #define BTN_EN2                    EXP1_01_PIN
+  #define BEEPER_PIN                        -1
+
+  #define DOGLCD_CS                  EXP1_03_PIN
+  #define DOGLCD_A0                  EXP1_05_PIN
+  #define DOGLCD_SCK                 EXP1_07_PIN
+  #define DOGLCD_MOSI                EXP1_08_PIN
+  #define LCD_RESET_PIN              EXP1_04_PIN
+
+  #define FORCE_SOFT_SPI
+  #define LCD_BACKLIGHT_PIN                 -1
+  #define NEOPIXEL_PIN                      PA13
 
 #endif


### PR DESCRIPTION
### Description

Add FYSETC_MINI_12864_2_1 support to Creality_V4 motherboard via custom cable.
Important: this is basic  LCD, Encoder and Neopiexel,support only.  The sdcard on the LCDis is not supported.

### Requirements
FYSETC_MINI_12864_2_1 or compatible LCD
Board that uses Creality_V4 pins.

### Benefits

FYSETC_MINI_12864_2_1 LCD works on these Controller.

### Config files
[Example Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/9352443/Example.Configuration.zip)

### Related Issues
Requested on discord. https://discord.com/channels/461605380783472640/830232451430744105/1007686957188526160