### PR TITLE
Fix: Z at right edge out of mesh border is being overcompensated if UBL is active

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -423,10 +423,12 @@
       LIMIT(icell.x, 0, GRID_MAX_CELLS_X);
       LIMIT(icell.y, 0, GRID_MAX_CELLS_Y);
 
-      float z_x0y0 = z_values[icell.x  ][icell.y  ],  // z at lower left corner
-            z_x1y0 = z_values[icell.x+1][icell.y  ],  // z at upper left corner
-            z_x0y1 = z_values[icell.x  ][icell.y+1],  // z at lower right corner
-            z_x1y1 = z_values[icell.x+1][icell.y+1];  // z at upper right corner
+      const int8_t ncellx = _MIN(icell.x+1, GRID_MAX_CELLS_X),
+                   ncelly = _MIN(icell.y+1, GRID_MAX_CELLS_Y);
+      float z_x0y0 = z_values[icell.x][icell.y],  // z at lower left corner
+            z_x1y0 = z_values[ncellx ][icell.y],  // z at upper left corner
+            z_x0y1 = z_values[icell.x][ncelly ],  // z at lower right corner
+            z_x1y1 = z_values[ncellx ][ncelly ];  // z at upper right corner
 
       if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating planner.leveling_active (G29 A)
       if (isnan(z_x1y0)) z_x1y0 = 0;              //   should refuse if any invalid mesh points


### PR DESCRIPTION
Fix https://github.com/MarlinFirmware/Marlin/issues/24630 in file **ubl_motion.cpp**, function: **unified_bed_leveling::line_to_destination_segmented**. 
```
  z_values[icell.x+1][icell.y  ],
  z_values[icell.x  ][icell.y+1] and
  z_values[icell.x+1][icell.y+1]
```
are undefined if `icell.x/y` becomes `GRID_MAX_CELLS_X/Y `

https://github.com/MarlinFirmware/Marlin/blob/c84f839fc7e7e931a49ebb5f0b7c6c5b949e84a5/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp#L423-L429

Without this PR:
```
Send: G0 X205 Y160
Recv: icell.x: 8 icell.y: 6
Recv: z_x0y0: 0.03
Recv: z_x1y0: 212.00   <<< BUG!
Recv: z_x0y1: 0.02
Recv: z_x1y1: 0.00
```
With this PR:

```
Send: G0 X205 Y160
Recv: icell.x: 8 icell.y: 6
Recv: z_x0y0: 0.02
Recv: z_x1y0: 0.02
Recv: z_x0y1: 0.01
Recv: z_x1y1: 0.01
```