### PR TITLE
Prevent 0x or 0X strtof Hexidecimal parsing

### DIFF
--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -261,7 +261,7 @@ public:
       for (;;) {
         const char c = *e;
         if (c == '\0' || c == ' ') break;
-        if (c == 'E' || c == 'e') {
+        if (c == 'E' || c == 'e' || c == 'X' || c == 'x') {
           *e = '\0';
           const float ret = strtof(value_ptr, nullptr);
           *e = c;


### PR DESCRIPTION
### Description

When a G-Code command parameter starts with other than the X axis an X may be processed later in the string. A strtof lib call will sometimes convert a string such as Y0Xnn to a hexadecimal value. 
Based on the current G-Code standards only decimal values are valid e.g. 0-9
see https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=823374

This PR only adds a filter to prevent passing the character x or X to strtof during float_value processing on G-Code parameters.

### Requirements

None

### Benefits

Corrects float_value processing when X is not the first axis.

### Configurations

Any

### Related Issues

#24625
