### PR TITLE
update pid debug formatting

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1374,13 +1374,13 @@ void Temperature::min_temp_error(const heater_id_t heater_id) {
     FORCE_INLINE void debug(const_celsius_float_t c, const_float_t pid_out, FSTR_P const name=nullptr, const int8_t index=-1) {
       if (TERN0(HAS_PID_DEBUG, thermalManager.pid_debug_flag)) {
         SERIAL_ECHO_START();
-        if (name) SERIAL_ECHOLNF(name);
+        if (name) SERIAL_ECHOF(name);
         if (index >= 0) SERIAL_ECHO(index);
         SERIAL_ECHOLNPGM(
           STR_PID_DEBUG_INPUT, c,
           STR_PID_DEBUG_OUTPUT, pid_out
           #if DISABLED(PID_OPENLOOP)
-            , "pTerm", work_pid.Kp, "iTerm", work_pid.Ki, "dTerm", work_pid.Kd
+            , " pTerm ", work_pid.Kp, " iTerm ", work_pid.Ki, " dTerm ", work_pid.Kd
           #endif
         );
       }


### PR DESCRIPTION
### Description

While looking an another issue I enabled PID_DEBUG, only to find the output was a mess

Eg of current output 
```
echo:E
0: Input 30.96 Output 0.00pTerm0.00iTerm0.00dTerm0.00
echo:E
0: Input 30.99 Output 0.00pTerm0.00iTerm0.00dTerm0.00
```

Eg of updated output
```
echo:E0: Input 31.02 Output 0.00 pTerm 0.00 iTerm 0.00 dTerm 0.00
echo:E0: Input 30.96 Output 0.00 pTerm 0.00 iTerm 0.00 dTerm 0.00
```

### Requirements

#define PIDTEMP
#define PID_DEBUG
M303 D 

### Benefits

Clean readable output. 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24644
