### PR TITLE
fix a probe bug of BDsensor

### DIFF
--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -96,6 +96,7 @@ void BDS_Leveling::process() {
       const float z_sensor = (tmp & 0x3FF) / 100.0f;
       if (cur_z < 0) config_state = 0;
       //float abs_z = current_position.z > cur_z ? (current_position.z - cur_z) : (cur_z - current_position.z);
+#if ENABLED(BABYSTEPPING)      
       if ( cur_z < config_state * 0.1f
         && config_state > 0
         && old_cur_z == cur_z
@@ -112,6 +113,7 @@ void BDS_Leveling::process() {
         //if (old_cur_z <= cur_z) Z_DIR_WRITE(!INVERT_Z_DIR);
         stepper.set_directions();
       }
+#endif      
       old_cur_z = cur_z;
       old_buf_z = current_position.z;
       endstops.bdp_state_update(z_sensor <= 0.01f);

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -96,24 +96,23 @@ void BDS_Leveling::process() {
       const float z_sensor = (tmp & 0x3FF) / 100.0f;
       if (cur_z < 0) config_state = 0;
       //float abs_z = current_position.z > cur_z ? (current_position.z - cur_z) : (cur_z - current_position.z);
-#if ENABLED(BABYSTEPPING)      
-      if ( cur_z < config_state * 0.1f
-        && config_state > 0
-        && old_cur_z == cur_z
-        && old_buf_z == current_position.z
-        && z_sensor < (MAX_BD_HEIGHT)
-      ) {
-        babystep.set_mm(Z_AXIS, cur_z - z_sensor);
-        #if ENABLED(DEBUG_OUT_BD)
-          SERIAL_ECHOLNPGM("BD:", z_sensor, ", Z:", cur_z, "|", current_position.z);
-        #endif
-      }
-      else {
-        babystep.set_mm(Z_AXIS, 0);
-        //if (old_cur_z <= cur_z) Z_DIR_WRITE(!INVERT_Z_DIR);
-        stepper.set_directions();
-      }
-#endif      
+      #if ENABLED(BABYSTEPPING)
+        if (cur_z < config_state * 0.1f
+          && config_state > 0
+          && old_cur_z == cur_z
+          && old_buf_z == current_position.z
+          && z_sensor < (MAX_BD_HEIGHT)
+        ) {
+          babystep.set_mm(Z_AXIS, cur_z - z_sensor);
+          #if ENABLED(DEBUG_OUT_BD)
+            SERIAL_ECHOLNPGM("BD:", z_sensor, ", Z:", cur_z, "|", current_position.z);
+          #endif
+        }
+        else {
+          babystep.set_mm(Z_AXIS, 0);          //if (old_cur_z <= cur_z) Z_DIR_WRITE(!INVERT_Z_DIR);
+          stepper.set_directions();
+        }
+      #endif
       old_cur_z = cur_z;
       old_buf_z = current_position.z;
       endstops.bdp_state_update(z_sensor <= 0.01f);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -882,7 +882,9 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   // Move the probe to the starting XYZ
   do_blocking_move_to(npos, feedRate_t(XY_PROBE_FEEDRATE_MM_S));
 
-  TERN_(BD_SENSOR, return (current_position.z-bdl.read()));
+  #if ENABLED(BD_SENSOR)
+    return current_position.z - bdl.read(); // Difference between Z-home-relative Z and sensor reading
+  #endif
 
   float measured_z = NAN;
   if (!deploy()) {

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -882,7 +882,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   // Move the probe to the starting XYZ
   do_blocking_move_to(npos, feedRate_t(XY_PROBE_FEEDRATE_MM_S));
 
-  TERN_(BD_SENSOR, return bdl.read());
+  TERN_(BD_SENSOR, return (current_position.z-bdl.read()));
 
   float measured_z = NAN;
   if (!deploy()) {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
The auto bed level sensor BDsensor return the distance value not the probe value we wanted,so needs to modify it from `bdl.read()` to `current_position.z-bdl.read()`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

