### PR TITLE
[Fix/Upgrade] Many releases/features + Fix critical bug in TOOLCHANGE_PARK

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3258,6 +3258,8 @@
  * *** CAUTION ***
  *
  * LED Type. Enable only one of the following two options.
+ * Require PWM frequency between 50 <> 100hz (Check hal or variant settings)
+ * Use FAST_PWM_FAN if possible, fans can be noisy.
  */
 //#define RGB_LED
 //#define RGBW_LED
@@ -3267,6 +3269,8 @@
   //#define RGB_LED_G_PIN 43
   //#define RGB_LED_B_PIN 35
   //#define RGB_LED_W_PIN -1
+  #define RGB_STARTUP_ANIMATION // If pwm pins, fade between all colors if not only switch.
+  #define RGB_STARTUP_ANIM_SLOWING_MS 10 // (ms) Reduce or increase fading speed.
 #endif
 
 // Support for Adafruit NeoPixel LED driver

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -873,6 +873,9 @@
 
 //#define QUICK_HOME                          // If G28 contains XY do a diagonal move first
 //#define HOME_Y_BEFORE_X                     // If G28 contains XY home Y before X
+#if ENABLED(HOME_Y_BEFORE_X)
+  #define OPPOSITE_AXIS_BACKOFF_MM  10      // (linear=mm, rotational=°) Backoff X before Y homing or inverse (prevent colision with opposite axis endstop)
+#endif
 //#define HOME_Z_FIRST                        // Home Z first. Requires a Z-MIN endstop (not a probe).
 //#define CODEPENDENT_XY_HOMING               // If X/Y can't home without homing Y/X first
 
@@ -2524,6 +2527,7 @@
 
     // Cool after prime to reduce stringing
     #define TOOLCHANGE_FS_FAN                 -1  // Fan index or -1 to skip
+    #define TOOLCHANGE_ACTIVE_TOOL_FAN            //Active extruder fan activation, override TOOLCHANGE_FAN_FS
     #define TOOLCHANGE_FS_FAN_SPEED          255  // 0-255
     #define TOOLCHANGE_FS_FAN_TIME            10  // (seconds)
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -69,6 +69,32 @@ void LEDLights::setup() {
     #if ENABLED(RGBW_LED)
       if (PWM_PIN(RGB_LED_W_PIN)) SET_PWM(RGB_LED_W_PIN); else SET_OUTPUT(RGB_LED_W_PIN);
     #endif
+    #ifdef RGB_STARTUP_ANIMATION
+      int8_t led_pin_count = 0;
+      uint16_t led_pwm;
+      if (PWM_PIN(RGB_LED_R_PIN)  && PWM_PIN(RGB_LED_G_PIN) && PWM_PIN(RGB_LED_B_PIN)) led_pin_count = 3;
+      #if ENABLED(RGBW_LED)
+        if (PWM_PIN(RGB_LED_W_PIN) && led_pin_count) led_pin_count++;
+      #endif
+      //Startup animation
+      if (led_pin_count){
+        for (uint8_t i = 0; i < led_pin_count; i++) {
+          for (uint8_t b = 0; b < 201; b++) {
+            if (b <= 100) led_pwm = b;
+            if (b > 100) --led_pwm ;
+            LIMIT(led_pwm,0,100);
+            if (i == 0 && PWM_PIN(RGB_LED_R_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_R_PIN), led_pwm); else WRITE(RGB_LED_R_PIN, b < 100 ? HIGH : LOW);
+            if (i == 0 && PWM_PIN(RGB_LED_G_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_G_PIN), led_pwm); else WRITE(RGB_LED_G_PIN, b < 100 ? HIGH : LOW);
+            if (i == 0 && PWM_PIN(RGB_LED_B_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_B_PIN), led_pwm); else WRITE(RGB_LED_B_PIN, b < 100 ? HIGH : LOW);
+            #if ENABLED(RGBW_LED)
+              if (i == 0 && PWM_PIN(RGB_LED_W_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_W_PIN), led_pwm); else WRITE(RGB_LED_W_PIN, b < 100 ? HIGH : LOW);
+            #endif
+            delay(RGB_STARTUP_ANIM_SLOWING_MS);
+          }
+        }
+        delay(1000);
+      }
+    #endif//RGB_STARTUP_ANIMATION
   #endif
   TERN_(NEOPIXEL_LED, neo.init());
   TERN_(PCA9533, PCA9533_init());

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1994,6 +1994,17 @@ void prepare_line_to_destination() {
       }
     #endif
 
+    //
+    // Back away to prevent opposite endstop damage
+    //
+    #if !defined(SENSORLESS_BACKOFF_MM) && defined(OPPOSITE_AXIS_BACKOFF_MM)
+      if (axis == Y_AXIS || axis == X_AXIS ){
+       const AxisEnum opposite_axis = axis == Y_AXIS ? X_AXIS : Y_AXIS ;
+       const float backoff_length = -ABS(OPPOSITE_AXIS_BACKOFF_MM) * home_dir(opposite_axis);
+       do_homing_move(opposite_axis, backoff_length, homing_feedrate(opposite_axis));
+      }
+    #endif
+
     // Determine if a homing bump will be done and the bumps distance
     // When homing Z with probe respect probe clearance
     const bool use_probe_bump = TERN0(HOMING_Z_WITH_PROBE, axis == Z_AXIS && home_bump_mm(axis));


### PR DESCRIPTION
### Description
Low sensibility/risk : 

- **RGBW leds animation** : Swap all colors at startup (cosmetic feature) with warning about PWM frequency , fading only be seen by eyes between 50<>100 hz, if more, pwm works only from 0 to 5. No gradient colors can be produced with the firmware presets ' orange/purple or any )
- **Toolchange active extruder Fan** : Now use the "active extruder fan" for cooling in toolchange , and not only one (For multi extruders toolhead)
- **Switching Nozzle Zraise feature** : Now have Z_raise + park ( Toolchange with purge need to park / More security when carriage is raised to move for applying hotends offsets / Return to the start of the next line instead of recover the new tool on the last old extrusion with 'TOOLCHANGE_NO_RETURN'). No risk because no lost functionnality , all can be disabled in cfg/adv to be exactly the same as before
- **X/Y opposite backoff**: Absolute necessary option for HOME_Y_BEFORE_X , to avoid detroying the limit switch if carriage is too close of the zero(or negative) on the other axis
- **Bug in TOOLCHANGE_PARK**
- **Code reduction/cleaning by deleting void toolchange_prime()**
---------------------------------------------------------------------------------------------
 **TOOLCHANGE_PARK fix**  but useless , look below , we can make a code reduction and this bug will disapear

      `extruder_prime();

      // Move back
      #if ENABLED(TOOLCHANGE_PARK)
        if (ok) {
          #if ENABLED(TOOLCHANGE_NO_RETURN)
            const float temp = destination.z;
            destination = current_position;
            destination.z = temp;
       Fix ->   #else                               
       Fix->     destination.e = current_position.e;
          #endif
          prepare_internal_move_to_destination(TERN(TOOLCHANGE_NO_RETURN, planner.settings.max_feedrate_mm_s[Z_AXIS], MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE)));
        }
      #endif`
- destination.e =0 before tool change
- extruder_prime add swap (60mm) + purge 100mm) - CUTTING WIPE =-10 now current.e=150mm
- prepare_internal_move_to_destination will return to xy pos + make 150mm of RETRACTION 
- FILAMENT IS EJECTED PRINT IS DEAD
- Fixed by setting destination.e just before
-----------------------------------------------------------------------------------------------------------------
**void toolchange_prime()  function can be totally deleted**
- Explaination:  T0 when first used need toolchange_prime() , but T1 can first prime just with toolchange... It's an old code not updated and buggy (explained here) , we can make a code reduction by deleting this function and make a special authorisation for T0 . Easy and no risk , because all the toolchange_prime() function have exactly the same cloned code in tool change
- Toolchange have lot of confusion 
- And now you can delete old code  about TOOLCHANGE_FS_INIT_BEFORE_SWAP that is totally UNUSED anywhere

Code cleaning , bug , feature , hope you will agree

Thks


