### PR TITLE
Fix Freeze Feature

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -488,7 +488,7 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
     }
   #endif
 
-  #if HAS_FREEZE_PIN
+  #if ENABLED(FREEZE_FEATURE)
     stepper.frozen = READ(FREEZE_PIN) == FREEZE_STATE;
   #endif
 


### PR DESCRIPTION
### Description

`HAS_FREEZE_PIN` was dropped at some point, so use `ENABLED(FREEZE_FEATURE)` instead.

### Benefits

`FREEZE_FEATURE` will work correctly.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/24662