### PR TITLE
Add spindle/laser feature reporting in M115 

### DIFF
--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -130,6 +130,10 @@ void GcodeSuite::M115() {
     cap_line(F("TOGGLE_LIGHTS"), ENABLED(CASE_LIGHT_ENABLE));
     cap_line(F("CASE_LIGHT_BRIGHTNESS"), TERN0(CASE_LIGHT_ENABLE, caselight.has_brightness()));
 
+    // SPINDLE AND LASER CONTROL (M3, M4, M5)
+    cap_line(F("SPINDLE"), ENABLED(SPINDLE_FEATURE));
+    cap_line(F("LASER"), ENABLED(LASER_FEATURE));
+    
     // EMERGENCY_PARSER (M108, M112, M410, M876)
     cap_line(F("EMERGENCY_PARSER"), ENABLED(EMERGENCY_PARSER));
 

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -131,9 +131,12 @@ void GcodeSuite::M115() {
     cap_line(F("CASE_LIGHT_BRIGHTNESS"), TERN0(CASE_LIGHT_ENABLE, caselight.has_brightness()));
 
     // SPINDLE AND LASER CONTROL (M3, M4, M5)
-    cap_line(F("SPINDLE"), ENABLED(SPINDLE_FEATURE));
-    cap_line(F("LASER"), ENABLED(LASER_FEATURE));
-    
+    #if ENABLED(SPINDLE_FEATURE)
+      cap_line(F("SPINDLE"), true);
+    #elif ENABLED(SPINDLE_FEATURE)
+      cap_line(F("LASER"), true);
+    #endif
+
     // EMERGENCY_PARSER (M108, M112, M410, M876)
     cap_line(F("EMERGENCY_PARSER"), ENABLED(EMERGENCY_PARSER));
 


### PR DESCRIPTION
### Description

Add Spindle/Laser feature reporting in the M115 command. 

### Benefits

Adding Spindle/Laser feature reporting will enable the host controller/software to allow feature-specific controls for M3, M4, and M5 commands.
