### PR TITLE
🔨 Suppressible Creality 4.2.2 stepper warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -708,8 +708,10 @@
 #endif
 
 // Ender 3 Pro (but, apparently all Creality 4.2.2 boards)
-#if ENABLED(EMIT_CREALITY_422_WARNING) || MB(CREALITY_V4)
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225)."
+#ifndef NO_CREALITY_STEPPER_WARNING
+  #if ENABLED(EMIT_CREALITY_422_WARNING) || MB(CREALITY_V4)
+    #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225). (Define NO_CREALITY_STEPPER_WARNING to suppress this warning.)"
+  #endif
 #endif
 
 #if PRINTCOUNTER_SYNC

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -707,11 +707,8 @@
   #warning "Don't forget to update your TFT settings in Configuration.h."
 #endif
 
-// Ender 3 Pro (but, apparently all Creality 4.2.2 boards)
-#ifndef NO_CREALITY_STEPPER_WARNING
-  #if ENABLED(EMIT_CREALITY_422_WARNING) || MB(CREALITY_V4)
-    #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225). (Define NO_CREALITY_STEPPER_WARNING to suppress this warning.)"
-  #endif
+#if ENABLED(EMIT_CREALITY_422_WARNING)
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225). (Define EMIT_CREALITY_422_WARNING false to suppress this warning.)"
 #endif
 
 #if PRINTCOUNTER_SYNC

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V422.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V422.h
@@ -28,4 +28,8 @@
 #define BOARD_INFO_NAME      "Creality v4.2.2"
 #define DEFAULT_MACHINE_NAME "Creality3D"
 
+#ifndef EMIT_CREALITY_422_WARNING
+  #define EMIT_CREALITY_422_WARNING
+#endif
+
 #include "pins_CREALITY_V4.h"


### PR DESCRIPTION
### Description

Adds the ability to suppress the following warning:
`Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225).`

### Benefits

If someone has properly configured the stepper driver type, there is no need to display this warning on compile time.
