### PR TITLE
Add sanity check for INTEGRATED_BABYSTEPPING for I2S stream on ESP32 platform

### DIFF
--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -45,6 +45,10 @@
   #error "FAST_PWM_FAN is not available on TinyBee."
 #endif
 
+#if BOTH(I2S_STEPPER_STREAM, BABYSTEPPING) && DISABLED(INTEGRATED_BABYSTEPPING)
+  #error "BABYSTEPPING on I2S stream requires INTEGRATED_BABYSTEPPING."
+#endif
+
 #if USING_PULLDOWNS
   #error "PULLDOWN pin mode is not available on ESP32 boards."
 #endif


### PR DESCRIPTION
### Description

Adds Sanity check that `INTEGRATED_BABYSTEPPING` is enabled on I2S for ESP32 platform, when `BABYSTEPPING` is enabled.

### Benefits

Saves users from misconfigs and Marlin crashes