### PR TITLE
More reporting for M22 / M23

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -174,6 +174,7 @@
 #define STR_SD_VOL_INIT_FAIL                "volume.init failed"
 #define STR_SD_OPENROOT_FAIL                "openRoot failed"
 #define STR_SD_CARD_OK                      "SD card ok"
+#define STR_SD_CARD_RELEASED                "SD card released"
 #define STR_SD_WORKDIR_FAIL                 "workDir open failed"
 #define STR_SD_OPEN_FILE_FAIL               "open failed, File: "
 #define STR_SD_FILE_OPENED                  "File opened: "

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -547,6 +547,7 @@ void CardReader::release() {
   #if ALL(SDCARD_SORT_ALPHA, SDSORT_USES_RAM, SDSORT_CACHE_NAMES)
     nrFiles = 0;
   #endif
+  SERIAL_ECHO_MSG(STR_SD_CARD_RELEASED);
 }
 
 /**

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -643,7 +643,10 @@ void announceOpen(const uint8_t doing, const char * const path) {
 //   - 2 : Resuming from a sub-procedure
 //
 void CardReader::openFileRead(const char * const path, const uint8_t subcall_type/*=0*/) {
-  if (!isMounted()) return;
+  if (!isMounted()) {
+	  openFailed(path);
+	  return;
+  }
 
   switch (subcall_type) {
     case 0:      // Starting a new print. "Now fresh file: ..."
@@ -685,7 +688,10 @@ void CardReader::openFileRead(const char * const path, const uint8_t subcall_typ
 
   SdFile *diveDir;
   const char * const fname = diveToFile(true, diveDir, path);
-  if (!fname) return;
+  if (!fname) {
+	  openFailed(path);
+	  return;
+  }
 
   if (file.open(diveDir, fname, O_READ)) {
     filesize = file.fileSize();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -643,10 +643,7 @@ void announceOpen(const uint8_t doing, const char * const path) {
 //   - 2 : Resuming from a sub-procedure
 //
 void CardReader::openFileRead(const char * const path, const uint8_t subcall_type/*=0*/) {
-  if (!isMounted()) {
-	  openFailed(path);
-	  return;
-  }
+  if (!isMounted()) return openFailed(path);
 
   switch (subcall_type) {
     case 0:      // Starting a new print. "Now fresh file: ..."
@@ -688,10 +685,7 @@ void CardReader::openFileRead(const char * const path, const uint8_t subcall_typ
 
   SdFile *diveDir;
   const char * const fname = diveToFile(true, diveDir, path);
-  if (!fname) {
-	  openFailed(path);
-	  return;
-  }
+  if (!fname) return openFailed(path);
 
   if (file.open(diveDir, fname, O_READ)) {
     filesize = file.fileSize();
@@ -727,21 +721,20 @@ void CardReader::openFileWrite(const char * const path) {
 
   SdFile *diveDir;
   const char * const fname = diveToFile(false, diveDir, path);
-  if (!fname) return;
+  if (!fname) return openFailed(path);
 
-  #if ENABLED(SDCARD_READONLY)
-    openFailed(fname);
-  #else
+  #if DISABLED(SDCARD_READONLY)
     if (file.open(diveDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
       flag.saving = true;
       selectFileByName(fname);
       TERN_(EMERGENCY_PARSER, emergency_parser.disable());
       echo_write_to_file(fname);
       ui.set_status(fname);
+      return;
     }
-    else
-      openFailed(fname);
   #endif
+
+  openFailed(fname);
 }
 
 //


### PR DESCRIPTION
### Description

1)

Currently SD card initialization (`M21`) responds on success with: "`SD card ok`" but release (`M22`) says nothing.

External software (like OctoPrint) has no way to know if `M22` happened and succeeded.

Add "SD card released" serial response to `M22`.

"SD card released" string will be supported in OctoPrint 1.9+. On earlier versions it only reacts to:

- "`SD init fail`"
- "`volume.init failed`"
- "`openRoot failed`"

which do not match for `M22`.

2)

M23 doesn't report failure in few cases. Turns out
CardReader::openFileRead() sometimes fails silently
and sometimes fails loudly.

Make it consistent to always report failure over serial.

Now:
```
Send: M22
Recv: ok P15 B3
Send: M23 /AAA.GCO
Recv: ok P15 B3
```

With fix:
```
Send: M22
Recv: ok P15 B3
Send: M23 /AAA.GCO
Recv: open failed, File: /AAA.GCO.
Recv: ok P15 B3
```


### Benefits

- External software can react to media release (and OctoPrint 1.9+ does that).
- Consistent failure reporting in `CardReader::openFileRead()` and no silent fails.
