### PR TITLE
Adds Opulo LumenPnP Motherboard REV04 to Marlin

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -421,6 +421,7 @@
 #define BOARD_ARTILLERY_RUBY          4238  // Artillery Ruby (STM32F401RC)
 #define BOARD_FYSETC_SPIDER_V2_2      4239  // FYSETC Spider V2.2 (STM32F446VE)
 #define BOARD_CREALITY_V24S1_301F4    4240  // Creality v2.4.S1_301F4 (STM32F401RC) as found in the Ender-3 S1 F4
+#define BOARD_OPULO_LUMEN_REV4        4241  // Opulo Lumen PnP Controller REV4 (STM32F407VE / STM32F407VG)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -701,6 +701,8 @@
   #include "stm32f4/pins_ARTILLERY_RUBY.h"      // STM32F4                                env:Artillery_Ruby
 #elif MB(CREALITY_V24S1_301F4)
   #include "stm32f4/pins_CREALITY_V24S1_301F4.h" // STM32F4                               env:STM32F401RC_creality env:STM32F401RC_creality_jlink env:STM32F401RC_creality_stlink
+#elif MB(OPULO_LUMEN_REV4)
+  #include "stm32f4/pins_OPULO_LUMEN_REV4.h"    // STM32F4                                env:Opulo_Lumen_REV4
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
@@ -1,0 +1,206 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * STM32F407VET6 on Opulo Lumen PnP Rev3
+ * Website - https://opulo.io/
+ */
+
+#define ALLOW_STM32DUINO
+#include "env_validate.h"
+
+#define BOARD_INFO_NAME      "LumenPnP Motherboard REV04"
+#define DEFAULT_MACHINE_NAME "LumenPnP"
+
+/**
+ * By default, the extra stepper motor configuration is:
+ * I = Left Head
+ * J = Right Head
+ * K = Auxiliary (Conveyor belt)
+ */
+
+#define SRAM_EEPROM_EMULATION
+#define MARLIN_EEPROM_SIZE                0x2000  // 8K
+
+// I2C MCP3426 (16-Bit, 240SPS, dual-channel ADC)
+#define HAS_MCP3426_ADC
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PB10
+#define SERVO1_PIN                          PB11
+
+//
+// Limit Switches
+//
+#define X_STOP_PIN                          PC6
+#define Y_STOP_PIN                          PD15
+#define Z_STOP_PIN                          PD14
+
+// None of these require limit switches by default, so we leave these commented
+// here for your reference.
+//#define I_MIN_PIN                         PA8
+//#define I_MAX_PIN                         PA8
+//#define J_MIN_PIN                         PD13
+//#define J_MAX_PIN                         PD13
+//#define K_MIN_PIN                         PC9
+//#define K_MAX_PIN                         PC9
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PB15
+#define X_DIR_PIN                           PB14
+#define X_ENABLE_PIN                        PD9
+
+#define Y_STEP_PIN                          PE15
+#define Y_DIR_PIN                           PE14
+#define Y_ENABLE_PIN                        PB13
+
+#define Z_STEP_PIN                          PE7
+#define Z_DIR_PIN                           PB1
+#define Z_ENABLE_PIN                        PE9
+
+#define I_STEP_PIN                          PC4
+#define I_DIR_PIN                           PA4
+#define I_ENABLE_PIN                        PB0
+
+#define J_STEP_PIN                          PE11
+#define J_DIR_PIN                           PE10
+#define J_ENABLE_PIN                        PE13
+
+#define K_STEP_PIN                          PD6
+#define K_DIR_PIN                           PD7
+#define K_ENABLE_PIN                        PA3
+
+#if HAS_TMC_SPI
+  /**
+   * Make sure to configure the jumpers on the back side of the Mobo according to
+   * this diagram: https://github.com/MarlinFirmware/Marlin/pull/23851
+   */
+  #error "SPI drivers require a custom jumper configuration, see comment above! Comment out this line to continue."
+
+  #if AXIS_HAS_SPI(X)
+    #define X_CS_PIN                        PD8
+  #endif
+  #if AXIS_HAS_SPI(Y)
+    #define Y_CS_PIN                        PB12
+  #endif
+  #if AXIS_HAS_SPI(Z)
+    #define Z_CS_PIN                        PE8
+  #endif
+  #if AXIS_HAS_SPI(I)
+    #define I_CS_PIN                        PC5
+  #endif
+  #if AXIS_HAS_SPI(J)
+    #define J_CS_PIN                        PE12
+  #endif
+  #if AXIS_HAS_SPI(K)
+    #define K_CS_PIN                        PA2
+  #endif
+
+#elif HAS_TMC_UART
+
+  #define X_SERIAL_TX_PIN                   PD8
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PB12
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PE8
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define I_SERIAL_TX_PIN                   PC5
+  #define I_SERIAL_RX_PIN        I_SERIAL_TX_PIN
+
+  #define J_SERIAL_TX_PIN                   PE12
+  #define J_SERIAL_RX_PIN        J_SERIAL_TX_PIN
+
+  #define K_SERIAL_TX_PIN                   PA2
+  #define K_SERIAL_RX_PIN        K_SERIAL_TX_PIN
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
+
+#endif
+
+//
+// Heaters / Fans
+//
+#define FAN_PIN                             PE2
+#define FAN1_PIN                            PE3
+#define FAN2_PIN                            PE4
+#define FAN3_PIN                            PE5
+
+#define FAN_SOFT_PWM_REQUIRED
+
+//
+// Neopixel
+//
+#define NEOPIXEL_PIN                        PC7
+#define NEOPIXEL2_PIN                       PC8
+
+//
+// SPI
+//
+#define MISO_PIN                            PB4
+#define MOSI_PIN                            PB5
+#define SCK_PIN                             PB3
+
+#define TMC_SW_MISO                     MISO_PIN
+#define TMC_SW_MOSI                     MOSI_PIN
+#define TMC_SW_SCK                       SCK_PIN
+
+//
+// I2C
+//
+#define I2C_SDA_PIN                         PB7
+#define I2C_SCL_PIN                         PB6
+
+/**
+ * The index mobo rev03 has 3 aux ports. We define them here so they may be used
+ * in other places and to make sure someone doesn't have to go look up the pinout
+ * in the board files. Each 12 pin aux port has this pinout:
+ *
+ * VDC    1   2    GND
+ * 3.3V   3   4    SCL  (I2C_SCL_PIN)
+ * PWM1   5   6    SDA  (I2C_SDA_PIN)
+ * PWM2   7   8    CIPO (MISO_PIN)
+ * A1     9  10    COPI (MOSI_PIN)
+ * A2     11 12    SCK  (SCK_PIN)
+ */
+#define LUMEN_AUX1_PWM1                     PA15
+#define LUMEN_AUX1_PWM2                     PA5
+#define LUMEN_AUX1_A1                       PC0
+#define LUMEN_AUX1_A2                       PC1
+
+#define LUMEN_AUX2_PWM1                     PA6
+#define LUMEN_AUX2_PWM2                     PA7
+#define LUMEN_AUX2_A1                       PC2
+#define LUMEN_AUX2_A2                       PC3
+
+#define LUMEN_AUX3_PWM1                     PB8
+#define LUMEN_AUX3_PWM2                     PB9
+#define LUMEN_AUX3_A1                       PA0
+#define LUMEN_AUX3_A2                       PA1

--- a/buildroot/share/PlatformIO/boards/marlin_opulo_lumen_rev4.json
+++ b/buildroot/share/PlatformIO/boards/marlin_opulo_lumen_rev4.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F407xx",
+    "f_cpu": "168000000L",
+    "hwids": [
+      [
+        "0x0483",
+        "0xdf11"
+      ],
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x0483",
+        "0x3748"
+      ]
+    ],
+    "mcu": "stm32f407vet6",
+    "variant": "MARLIN_F407VE"
+  },
+  "debug": {
+    "jlink_device": "STM32F407VE",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "stm32cube"
+  ],
+  "name": "STM32F407VE (192k RAM. 512k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 131072,
+    "maximum_size": 524288,
+    "protocol": "dfu",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink",
+      "blackmagic"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f407ve.html",
+  "vendor": "Generic"
+}

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -94,6 +94,17 @@ build_flags       = ${stm32_variant.build_flags}
 extra_scripts     = ${stm32_variant.extra_scripts}
 
 #
+# STM32F407VET6 Opulo Lumen REV4
+#
+[env:Opulo_Lumen_REV4]
+extends           = stm32_variant
+board             = marlin_opulo_lumen_rev4
+build_flags       = ${stm32_variant.build_flags}
+  -DARDUINO_BLACK_F407VE
+  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+extra_scripts     = ${stm32_variant.extra_scripts}
+
+#
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
 #
 [Anet_ET4]


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

This PR adds support for the Opulo LumenPnP REV04 Motherboard. The REV04 motherboard is an STM32F407 based controller with peripherals specific to pick and place operations. This board now includes sensorless homing for the X and Y axis, proper ESD protection, and improved vacuum sensing for part mispick detection.

You can find all the source for the motherboard [here](https://github.com/opulo-inc/lumenpnp/tree/mobo-rev04/pnp/pcb/mobo). This PR has been fully tested on actual hardware, and the adjoining configuration files have a PR filed in the Configuration repository.

### Requirements

This PR requires the LumenPnP REV04 Motherboard.

### Benefits

This PR adds support for a more robust and fully featured pick and place controller to Marlin.

### Configurations

The configuration files are attached here:
[Archive.zip](https://github.com/MarlinFirmware/Marlin/files/9480460/Archive.zip)

Note: There is an [outstanding PR](https://github.com/MarlinFirmware/Configurations/pull/808) for these configuration files in the Configuration repository.

### Related Issues

This PR does not fix a bug or fulfill a feature request.


