### PR TITLE
Update PlatformIO Configuration.py to use UTF-8

### DIFF
--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -67,7 +67,7 @@ def apply_opt(name, val, conf=None):
 
         # Prepend the new option after the first set of #define lines
         fullpath = config_path("Configuration.h")
-        with fullpath.open() as f:
+        with fullpath.open(encoding='utf-8') as f:
             lines = f.readlines()
             linenum = 0
             gotdef = False

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -10,7 +10,7 @@ def blab(str,level=1):
     if verbose >= level: print(f"[config] {str}")
 
 def config_path(cpath):
-    return Path("Marlin", cpath)
+    return Path("Marlin", cpath, encoding='utf-8')
 
 # Apply a single name = on/off ; name = value ; etc.
 # TODO: Limit to the given (optional) configuration

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -23,7 +23,7 @@ def apply_opt(name, val, conf=None):
     # Find and enable and/or update all matches
     for file in ("Configuration.h", "Configuration_adv.h"):
         fullpath = config_path(file)
-        lines = fullpath.read_text().split('\n')
+        lines = fullpath.read_text(encoding='utf-8').split('\n')
         found = False
         for i in range(len(lines)):
             line = lines[i]
@@ -46,7 +46,7 @@ def apply_opt(name, val, conf=None):
 
         # If the option was found, write the modified lines
         if found:
-            fullpath.write_text('\n'.join(lines))
+            fullpath.write_text('\n'.join(lines), encoding='utf-8')
             break
 
     # If the option didn't appear in either config file, add it
@@ -79,7 +79,7 @@ def apply_opt(name, val, conf=None):
                     break
                 linenum += 1
             lines.insert(linenum, f"{prefix}#define {added} // Added by config.ini\n")
-            fullpath.write_text('\n'.join(lines))
+            fullpath.write_text('\n'.join(lines), encoding='utf-8')
 
 # Fetch configuration files from GitHub given the path.
 # Return True if any files were fetched.


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Was receiving the following error when trying to build Marlin on windows with VSCode Platform io

```
Verbose mode can be enabled via `-v, --verbose` option
[config] ==================== Gather 'config.ini' entries...
[config] [config] apply section key: config:all
[config] Set motherboard to BOARD_RAMPS_14_EFB
[config] Set serial_port to 0
[config] Set baudrate to 250000
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 83931: character maps to <undefined>:
  File "C:\Users\ButchMonkey\.platformio\penv\lib\site-packages\platformio\builder\main.py", line 186:
    env.SConscript(item, exports="env")
  File "C:\Users\ButchMonkey\.platformio\packages\tool-scons\scons-local-4.4.0\SCons\Script\SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\ButchMonkey\.platformio\packages\tool-scons\scons-local-4.4.0\SCons\Script\SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "E:\ButchMonkey\Documents\Printer\Marlin-2.1.1\buildroot\share\PlatformIO\scripts\configuration.py", line 239:
    apply_config_ini(ProjectConfig())
  File "E:\ButchMonkey\Documents\Printer\Marlin-2.1.1\buildroot\share\PlatformIO\scripts\configuration.py", line 203:
    apply_sections(cp, 'config:' + ckey, addbase)
  File "E:\ButchMonkey\Documents\Printer\Marlin-2.1.1\buildroot\share\PlatformIO\scripts\configuration.py", line 167:
    apply_ini_by_name(cp, ckey)
  File "E:\ButchMonkey\Documents\Printer\Marlin-2.1.1\buildroot\share\PlatformIO\scripts\configuration.py", line 138:
    apply_opt(item[0], item[1])
  File "E:\ButchMonkey\Documents\Printer\Marlin-2.1.1\buildroot\share\PlatformIO\scripts\configuration.py", line 26:
    lines = fullpath.read_text().split('\n')
  File "C:\Users\ButchMonkey\.platformio\python3\lib\pathlib.py", line 1267:
    return f.read()
  File "C:\Users\ButchMonkey\.platformio\python3\lib\encodings\cp1252.py", line 23:
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
```

`pathlib` was trying to open the file with Windows-1252 encoding and throwing a fatal error. This fix forces `pathlib` to read it as UTF-8. 
If other encodings are needed, then this should be switched to a try catch in a loop and attempt to read in other encodings on fail.
This PR passes fixes the encoding issue in `config_path` and the `write_text`s / `read_text`s
Feel free to edit as necessary or provide me with a list and I would be more than happy to update the PR myself

### Requirements
-

### Benefits

The ability to build when the config.ini is UTF-8 on a windows machine 😛 

### Configurations

None specific

### Related Issues

Could not find any open bugs, consider this my bug report 😊
