### PR TITLE
Only Apply Print Counter Sync to Emulated EEPROM

### DIFF
--- a/Marlin/src/HAL/LPC1768/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/LPC1768/inc/Conditionals_post.h
@@ -29,6 +29,6 @@
 
 // LPC1768 boards seem to lose steps when saving to EEPROM during print (issue #20785)
 // TODO: Which other boards are incompatible?
-#if defined(MCU_LPC1768) && PRINTCOUNTER_SAVE_INTERVAL > 0
+#if defined(MCU_LPC1768) && ENABLED(FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
   #define PRINTCOUNTER_SYNC 1
 #endif

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -29,6 +29,6 @@
 #endif
 
 // Some STM32F4 boards may lose steps when saving to EEPROM during print (PR #17946)
-#if defined(STM32F4xx) && PRINTCOUNTER_SAVE_INTERVAL > 0
+#if defined(STM32F4xx) && ENABLED(FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
   #define PRINTCOUNTER_SYNC 1
 #endif


### PR DESCRIPTION
### Description

As the title states, only apply Print Counter Sync to emulated EEPROM-based builds.

### Requirements

STM32F4 or LPC-based build with `PRINTCOUNTER`

### Benefits

No warnings/forced print job stops on EEPROM save for STM32F4 or LPC-based builds with real EEPROMs

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/24605