### PR TITLE
Example is C++, not C

### DIFF
--- a/docs/Bresenham.md
+++ b/docs/Bresenham.md
@@ -233,7 +233,7 @@ Error update equations:
   ε'[new] = ε' + 2.ΔY - 2.ΔX.r                  [7]
 ```
 
-This can be implemented in C as:
+This can be implemented in C++ as:
 
 ```cpp
   class OversampledBresenham {


### PR DESCRIPTION
### Description

Fix documentation: The file docs/Bresenham.md gives an example in C++ but said it was C.

Documentation only. No functional change to any code.

### Requirements

None.

### Benefits

Improves the docs.

### Configurations

None.

### Related Issues

None.
