### PR TITLE
PINS_DEBUGGING support on STM32G0B1RE

### DIFF
--- a/Marlin/src/HAL/DUE/pinsDebug.h
+++ b/Marlin/src/HAL/DUE/pinsDebug.h
@@ -70,7 +70,7 @@
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
 #define GET_ARRAY_PIN(p) pin_array[p].pin
 #define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL ? 1 : 0)
+#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
 #define IS_ANALOG(P) WITHIN(P, char(analogInputToDigitalPin(0)), char(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
 #define pwm_status(pin) (((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \

--- a/Marlin/src/HAL/SAMD51/pinsDebug.h
+++ b/Marlin/src/HAL/SAMD51/pinsDebug.h
@@ -29,7 +29,7 @@
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
 #define GET_ARRAY_PIN(p) pin_array[p].pin
 #define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL)
+#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) digitalPinToAnalogInput(p)
 #define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P)!=-1)
 #define pwm_status(pin) digitalPinHasPWM(pin)

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -112,7 +112,7 @@ const XrefInfo pin_xref[] PROGMEM = {
   #define HAS_HIGH_ANALOG_PINS 1
 #endif
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS + TERN0(HAS_HIGH_ANALOG_PINS, NUM_ANALOG_INPUTS)
-#define VALID_PIN(ANUM) ((ANUM) >= 0 && (ANUM) < NUMBER_PINS_TOTAL)
+#define VALID_PIN(ANUM) (((ANUM) >= 0 && (ANUM) < NUM_DIGITAL_PINS) TERN_(HAS_HIGH_ANALOG_PINS, || ((ANUM) >= NUM_ANALOG_FIRST  && (ANUM) < NUM_ANALOG_FIRST+NUM_ANALOG_INPUTS)))
 #define digitalRead_mod(Ard_num) extDigitalRead(Ard_num)  // must use Arduino pin numbers when doing reads
 #define PRINT_PIN(Q)
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
@@ -206,8 +206,11 @@ void port_print(const pin_t Ard_num) {
     SERIAL_ECHO_SP(7);
 
   // Print number to be used with M42
-  int calc_p = Ard_num % (NUM_DIGITAL_PINS + 1);
-  if (Ard_num > NUM_DIGITAL_PINS && calc_p > 7) calc_p += 8;
+  int calc_p = Ard_num;
+  if (Ard_num > NUM_DIGITAL_PINS) {
+    calc_p -= NUM_ANALOG_FIRST;
+    if (calc_p > 7) calc_p += 8;
+  }
   SERIAL_ECHOPGM(" M42 P", calc_p);
   SERIAL_CHAR(' ');
   if (calc_p < 100) {

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -102,17 +102,18 @@ const XrefInfo pin_xref[] PROGMEM = {
 #define PIN_NUM_ALPHA_LEFT(P) (((P & 0x000F) < 10) ? ('0' + (P & 0x000F)) : '1')
 #define PIN_NUM_ALPHA_RIGHT(P) (((P & 0x000F) > 9)  ? ('0' + (P & 0x000F) - 10) : 0 )
 #define PORT_NUM(P) ((P  >> 4) & 0x0007)
-#define PORT_ALPHA(P) ('A' + (P  >> 4))
+#define PORT_ALPHA(P) ('A' + (P >> 4))
 
 /**
  * Translation of routines & variables used by pinsDebug.h
  */
 
-#if PA0 >= NUM_DIGITAL_PINS
+#if NUM_ANALOG_FIRST >= NUM_DIGITAL_PINS
   #define HAS_HIGH_ANALOG_PINS 1
 #endif
-#define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS + TERN0(HAS_HIGH_ANALOG_PINS, NUM_ANALOG_INPUTS)
-#define VALID_PIN(ANUM) (((ANUM) >= 0 && (ANUM) < NUM_DIGITAL_PINS) TERN_(HAS_HIGH_ANALOG_PINS, || ((ANUM) >= NUM_ANALOG_FIRST  && (ANUM) < NUM_ANALOG_FIRST+NUM_ANALOG_INPUTS)))
+#define NUM_ANALOG_LAST ((NUM_ANALOG_FIRST) + (NUM_ANALOG_INPUTS) - 1)
+#define NUMBER_PINS_TOTAL ((NUM_DIGITAL_PINS) + TERN0(HAS_HIGH_ANALOG_PINS, NUM_ANALOG_INPUTS))
+#define VALID_PIN(P) (WITHIN(P, 0, (NUM_DIGITAL_PINS) - 1) || TERN0(HAS_HIGH_ANALOG_PINS, WITHIN(P, NUM_ANALOG_FIRST, NUM_ANALOG_LAST)))
 #define digitalRead_mod(Ard_num) extDigitalRead(Ard_num)  // must use Arduino pin numbers when doing reads
 #define PRINT_PIN(Q)
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
@@ -168,7 +169,7 @@ bool GET_PINMODE(const pin_t Ard_num) {
 }
 
 int8_t digital_pin_to_analog_pin(const pin_t Ard_num) {
-  if (WITHIN(Ard_num, NUM_ANALOG_FIRST, NUM_ANALOG_FIRST + NUM_ANALOG_INPUTS - 1))
+  if (WITHIN(Ard_num, NUM_ANALOG_FIRST, NUM_ANALOG_LAST))
     return Ard_num - NUM_ANALOG_FIRST;
 
   const uint32_t ind = digitalPinToAnalogInput(Ard_num);

--- a/Marlin/src/HAL/TEENSY40_41/pinsDebug.h
+++ b/Marlin/src/HAL/TEENSY40_41/pinsDebug.h
@@ -36,7 +36,7 @@
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
 #define GET_ARRAY_PIN(p) pin_array[p].pin
 #define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL ? 1 : 0)
+#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
 #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && (P) <= analogInputToDigitalPin(13)) || ((P) >= analogInputToDigitalPin(14) && (P) <= analogInputToDigitalPin(17))
 #define pwm_status(pin) HAL_pwm_status(pin)

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -313,7 +313,7 @@ void GcodeSuite::M43() {
 
   // 'P' Get the range of pins to test or watch
   uint8_t first_pin = PARSED_PIN_INDEX('P', 0),
-          last_pin = parser.seenval('P') ? first_pin : TERN(HAS_HIGH_ANALOG_PINS, NUM_DIGITAL_PINS, NUMBER_PINS_TOTAL) - 1;
+          last_pin = parser.seenval('P') ? first_pin : (NUMBER_PINS_TOTAL) - 1;
 
   if (first_pin > last_pin) return;
 

--- a/buildroot/share/PlatformIO/variants/MARLIN_G0B1RE/variant_MARLIN_STM32G0B1RE.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_G0B1RE/variant_MARLIN_STM32G0B1RE.h
@@ -124,6 +124,7 @@
 #define NUM_DIGITAL_PINS        62
 #define NUM_REMAP_PINS          2
 #define NUM_ANALOG_INPUTS       16
+#define NUM_ANALOG_FIRST        PA0
 
 // SPI definitions
 #ifndef PIN_SPI_SS


### PR DESCRIPTION
Resolves issue #23386 by adding missing NUM_ANALOG_FIRST.

Updates VALID_PIN so analog pins starting at 0xc0; which is great than NUM_PINS_TOTAL; are not filtered out of M43 output.  Please see #22896 for good background description on values.

Updates "M42 P" output to start at P0 instead of P4.  First 11 analog pins are printed correctly but A11 is incorrectly shown as P19 instead of P26.

### Description

Compile issue is addressed by addition of NUM_ANALOG_INPUTS for this variant.  Output is not correct though and needs remaining updates to improve.

Since PNUM_ANALOG_BASE is 0xc0, it seems like similar issues would have existed in #22896 which greatly improved analog pin support.  Review and testing on those boards greatly appreciated if you have them.

With this update, this is results on BTT SKR Mini E3 V3 and you can see  remaining issue with M42 Px for some analog pins.

```
Send: M43
Recv: PIN: PA0  (A0)   M42 P0           <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PA1  (A1)   M42 P1           SERVO0_PIN                             Output = 0
Recv: PIN: PA2  (A2)   M42 P2           <unused/unknown>                       Alt Function: 1  - TIM1/TIM2 (probably PWM)
Recv: PIN: PA3  (A3)   M42 P3           <unused/unknown>                       Alt Function: 1  - TIM1/TIM2 (probably PWM)
Recv: PIN: PA4  (A4)   M42 P4           SDSS                                   Output = 1
Recv: PIN: PA5  (A5)   M42 P5           DOGLCD_SCK                             Alt Function: 0  - system (misc. I/O)
Recv: PIN: PA6  (A6)   M42 P6           <unused/unknown>                       Alt Function: 0  - system (misc. I/O)
Recv: PIN: PA7  (A7)   M42 P7           DOGLCD_MOSI                            Alt Function: 0  - system (misc. I/O)
Recv: PIN: PA8         M42 P8           NEOPIXEL_PIN                           Output = 0
Recv: PIN: PA9         M42 P9           BTN_EN1                                Input  = 1
Recv: PIN: PA10        M42 P10          BTN_EN2                                Input  = 1
Recv: PIN: PA11        M42 P11          <unused/unknown>                       Input  = 0
Recv: PIN: PA12        M42 P12          <unused/unknown>                       Input  = 1
Recv: PIN: PA13        M42 P13          <unused/unknown>                       Alt Function: 0  - system (misc. I/O)
Recv: PIN: PA14        M42 P14          <unused/unknown>                       Alt Function: 0  - system (misc. I/O)
Recv: PIN: PA15        M42 P15          BTN_ENC                                Input  = 1
Recv: PIN: PB0  (A8)   M42 P16          Z_STEP_PIN                             protected
Recv: PIN: PB1  (A9)   M42 P17          Z_ENABLE_PIN                           protected
Recv: PIN: PB2  (A10)  M42 P18          Y_DIR_PIN                              protected
Recv: PIN: PB3         M42 P19          E0_STEP_PIN                            protected
Recv: PIN: PB4         M42 P20          E0_DIR_PIN                             protected
Recv: PIN: PB5         M42 P21          BEEPER_PIN                             Output = 0
Recv: PIN: PB6         M42 P22          I2C_SCL_PIN                            Input  = 1
Recv: PIN: PB7         M42 P23          I2C_SDA_PIN                            Input  = 1
Recv: PIN: PB8         M42 P24          LCD_PINS_RS                            Output = 0
Recv: PIN: PB9         M42 P25          LCD_PINS_D4                            Output = 1
Recv: PIN: PB10 (A11)  M42 P19          Y_STEP_PIN                             protected
Recv: PIN: PB11 (A12)  M42 P20          Y_ENABLE_PIN                           protected
Recv: PIN: PB12 (A13)  M42 P21          X_DIR_PIN                              protected
Recv: PIN: PB13        M42 P29          X_STEP_PIN                             protected
Recv: PIN: PB14        M42 P30          X_ENABLE_PIN                           protected
Recv: PIN: PB15        M42 P31          CONTROLLER_FAN_PIN                     protected
Recv: .                                 FAN2_PIN                               protected
Recv: PIN: PC0         M42 P32          X_MIN_PIN                              protected
Recv: .                                 X_STOP_PIN                             protected
Recv: PIN: PC1         M42 P33          Y_MIN_PIN                              protected
Recv: .                                 Y_STOP_PIN                             protected
Recv: PIN: PC2         M42 P34          Z_MIN_PIN                              protected
Recv: .                                 Z_STOP_PIN                             protected
Recv: PIN: PC3         M42 P35          SD_DETECT_PIN                          Input  = 0
Recv: PIN: PC4  (A14)  M42 P22          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PC5  (A15)  M42 P23          Z_DIR_PIN                              protected
Recv: PIN: PC6         M42 P38          FAN_PIN                                protected
Recv: PIN: PC7         M42 P39          E0_AUTO_FAN_PIN                        protected
Recv: .                                 FAN1_PIN                               protected
Recv: PIN: PC8         M42 P40          HEATER_0_PIN                           protected
Recv: PIN: PC9         M42 P41          HEATER_BED_PIN                         protected
Recv: PIN: PC10        M42 P42          <unused/unknown>                       Alt Function: 0  - system (misc. I/O)
Recv: PIN: PC11        M42 P43          <unused/unknown>                       Alt Function: 0  - system (misc. I/O)
Recv: PIN: PC12        M42 P44          POWER_LOSS_PIN                         Input  = 0
Recv: PIN: PC13        M42 P45          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PC14        M42 P46          Z_MIN_PROBE_PIN                        protected
Recv: PIN: PC15        M42 P47          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD0         M42 P48          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD1         M42 P49          E0_ENABLE_PIN                          protected
Recv: PIN: PD2         M42 P50          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD3         M42 P51          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD4         M42 P52          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD5         M42 P53          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PD6         M42 P54          LCD_PINS_ENABLE                        Output = 0
Recv: PIN: PD8         M42 P55          LED_PIN                                Output = 0
Recv: PIN: PD9         M42 P56          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PF0         M42 P57          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PF1         M42 P58          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: PF2         M42 P59          <unused/unknown>   Analog in =     0   Input  = 0
Recv: PIN: R»\x03\x08\x15 (A1)   M42 P1           <unused/unknown>                       Output = 0
Recv: PIN: R»\x03\x08\x15 (A1)   M42 P1           <unused/unknown>                       Output = 0
Recv: ok P15 B3
```

### Requirements

stm32 board with analog pins

### Benefits

Analog pins show up in more M43 output and with correct pin numbers.

### Configurations

Tested on STM32G0B1RE_btt and BTT SKR Mini E3 V3.

### Related Issues

#23386
#22896