### PR TITLE
change to tool 0 during MESH_BED_LEVELING

### DIFF
--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -76,7 +76,7 @@ void GcodeSuite::G29() {
   #endif
 
   #if HAS_MULTI_HOTEND
-    uint8_t mbl_tool_index;
+    static uint8_t mbl_tool_index;
   #endif
 
   static int mbl_probe_index = -1;
@@ -208,6 +208,8 @@ void GcodeSuite::G29() {
         home_all_axes();
         set_bed_leveling_enabled(true);
 
+        TERN_(HAS_MULTI_HOTEND, if (mbl_tool_index != 0) tool_change(mbl_tool_index));
+
         #if ENABLED(MESH_G28_REST_ORIGIN)
           current_position.z = 0;
           line_to_current_position(homing_feedrate(Z_AXIS));
@@ -266,8 +268,6 @@ void GcodeSuite::G29() {
     SERIAL_ECHOLNPGM("MBL G29 point ", _MIN(mbl_probe_index, GRID_MAX_POINTS), " of ", GRID_MAX_POINTS);
     if (mbl_probe_index > 0) TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/%i"), GET_TEXT(MSG_PROBING_POINT), _MIN(mbl_probe_index, GRID_MAX_POINTS), int(GRID_MAX_POINTS)));
   }
-
-  TERN_(HAS_MULTI_HOTEND, if (mbl_tool_index != 0) tool_change(mbl_tool_index));
 
   report_current_position();
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -267,12 +267,6 @@ void GcodeSuite::G29() {
     if (mbl_probe_index > 0) TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/%i"), GET_TEXT(MSG_PROBING_POINT), _MIN(mbl_probe_index, GRID_MAX_POINTS), int(GRID_MAX_POINTS)));
   }
 
-  #ifdef Z_PROBE_END_SCRIPT
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
-    planner.synchronize();
-    process_subcommands_now(F(Z_PROBE_END_SCRIPT));
-  #endif
-
   TERN_(HAS_MULTI_HOTEND, if (mbl_tool_index != 0) tool_change(mbl_tool_index));
 
   report_current_position();


### PR DESCRIPTION
### Description

Make MESH_BED_LEVELING more like ABL: change to tool 0 during G29 .

Downside: Cannot use MBL to measure HOTEND_OFFSETS as attempted in issue https://github.com/MarlinFirmware/Marlin/issues/24659

### Requirements

MBL, EXTRUDERS 2

### Benefits

Prevent crashes during G29. Also, more unified logic makes documentation of G29 behaviour easier.

### Configurations

TODO

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24659
