### PR TITLE
ESP32 eeprom saves needs planner sync.

### DIFF
--- a/Marlin/src/HAL/ESP32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/ESP32/inc/Conditionals_post.h
@@ -20,3 +20,9 @@
  *
  */
 #pragma once
+
+// ESP32 boards seem to lose steps when saving to EEPROM during print (see issue #20785)
+// TODO: Which other boards are incompatible?
+#if PRINTCOUNTER_SAVE_INTERVAL > 0
+  #define PRINTCOUNTER_SYNC 1
+#endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
This is related to #17946. On my platform ESP32 there is a delay of around 1-second whenever an EEPROM save occurs, which happens during the print counter save step. This causes layer shifts.
Is there any reason not to enable PRINTCOUNTER_SYNC globally for all platforms?

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
