### PR TITLE
Add M524 to emergency parser to allow fast(er) sd print stopping remotely.

### DIFF
--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -33,6 +33,7 @@
 // Static data members
 bool EmergencyParser::killed_by_M112, // = false
      EmergencyParser::quickstop_by_M410,
+     EmergencyParser::abortsdprint_by_M524,
      EmergencyParser::enabled;
 
 #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -33,7 +33,7 @@
 // Static data members
 bool EmergencyParser::killed_by_M112, // = false
      EmergencyParser::quickstop_by_M410,
-     EmergencyParser::abortsdprint_by_M524,
+     EmergencyParser::sd_abort_by_M524,
      EmergencyParser::enabled;
 
 #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -33,7 +33,9 @@
 // Static data members
 bool EmergencyParser::killed_by_M112, // = false
      EmergencyParser::quickstop_by_M410,
-     EmergencyParser::sd_abort_by_M524,
+     #if ENABLED(SDSUPPORT)
+       EmergencyParser::sd_abort_by_M524,
+     #endif
      EmergencyParser::enabled;
 
 #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -49,7 +49,7 @@ class EmergencyParser {
 
 public:
 
-  // Currently looking for: M108, M112, M410, M876 S[0-9], S000, P000, R000
+  // Currently looking for: M108, M112, M410, M524, M876 S[0-9], S000, P000, R000
   enum State : uint8_t {
     EP_RESET,
     EP_N,
@@ -58,6 +58,7 @@ public:
     EP_M10, EP_M108,
     EP_M11, EP_M112,
     EP_M4, EP_M41, EP_M410,
+    EP_M5, EP_M52, EP_M524,
     #if ENABLED(HOST_PROMPT_SUPPORT)
       EP_M8, EP_M87, EP_M876, EP_M876S, EP_M876SN,
     #endif
@@ -75,6 +76,7 @@ public:
 
   static bool killed_by_M112;
   static bool quickstop_by_M410;
+  static bool abortsdprint_by_M524;
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
     static uint8_t M876_reason;
@@ -145,6 +147,7 @@ public:
           case ' ': break;
           case '1': state = EP_M1;     break;
           case '4': state = EP_M4;     break;
+          case '5': state = EP_M5;     break;
           #if ENABLED(HOST_PROMPT_SUPPORT)
             case '8': state = EP_M8;     break;
           #endif
@@ -164,6 +167,9 @@ public:
       case EP_M11: state = (c == '2') ? EP_M112 : EP_IGNORE; break;
       case EP_M4:  state = (c == '1') ? EP_M41  : EP_IGNORE; break;
       case EP_M41: state = (c == '0') ? EP_M410 : EP_IGNORE; break;
+      case EP_M5:  state = (c == '2') ? EP_M52  : EP_IGNORE; break;
+      case EP_M52: state = (c == '4') ? EP_M524 : EP_IGNORE; break;
+
 
       #if ENABLED(HOST_PROMPT_SUPPORT)
 
@@ -200,6 +206,7 @@ public:
             case EP_M108: wait_for_user = wait_for_heatup = false; break;
             case EP_M112: killed_by_M112 = true; break;
             case EP_M410: quickstop_by_M410 = true; break;
+            case EP_M524: abortsdprint_by_M524 = true; break;
             #if ENABLED(HOST_PROMPT_SUPPORT)
               case EP_M876SN: hostui.handle_response(M876_reason); break;
             #endif

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -58,7 +58,9 @@ public:
     EP_M10, EP_M108,
     EP_M11, EP_M112,
     EP_M4, EP_M41, EP_M410,
-    EP_M5, EP_M52, EP_M524,
+    #if ENABLED(SDSUPPORT)
+      EP_M5, EP_M52, EP_M524,
+    #endif
     #if ENABLED(HOST_PROMPT_SUPPORT)
       EP_M8, EP_M87, EP_M876, EP_M876S, EP_M876SN,
     #endif
@@ -76,7 +78,10 @@ public:
 
   static bool killed_by_M112;
   static bool quickstop_by_M410;
-  static bool sd_abort_by_M524;
+
+  #if ENABLED(SDSUPPORT)
+    static bool sd_abort_by_M524;
+  #endif
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
     static uint8_t M876_reason;
@@ -147,7 +152,9 @@ public:
           case ' ': break;
           case '1': state = EP_M1;     break;
           case '4': state = EP_M4;     break;
-          case '5': state = EP_M5;     break;
+          #if ENABLED(SDSUPPORT)
+            case '5': state = EP_M5;   break;
+          #endif
           #if ENABLED(HOST_PROMPT_SUPPORT)
             case '8': state = EP_M8;     break;
           #endif
@@ -167,8 +174,11 @@ public:
       case EP_M11: state = (c == '2') ? EP_M112 : EP_IGNORE; break;
       case EP_M4:  state = (c == '1') ? EP_M41  : EP_IGNORE; break;
       case EP_M41: state = (c == '0') ? EP_M410 : EP_IGNORE; break;
-      case EP_M5:  state = (c == '2') ? EP_M52  : EP_IGNORE; break;
-      case EP_M52: state = (c == '4') ? EP_M524 : EP_IGNORE; break;
+
+      #if ENABLED(SDSUPPORT)
+        case EP_M5:  state = (c == '2') ? EP_M52  : EP_IGNORE; break;
+        case EP_M52: state = (c == '4') ? EP_M524 : EP_IGNORE; break;
+      #endif
 
       #if ENABLED(HOST_PROMPT_SUPPORT)
 
@@ -205,7 +215,9 @@ public:
             case EP_M108: wait_for_user = wait_for_heatup = false; break;
             case EP_M112: killed_by_M112 = true; break;
             case EP_M410: quickstop_by_M410 = true; break;
-            case EP_M524: sd_abort_by_M524 = true; break;
+            #if ENABLED(SDSUPPORT)
+              case EP_M524: sd_abort_by_M524 = true; break;
+            #endif
             #if ENABLED(HOST_PROMPT_SUPPORT)
               case EP_M876SN: hostui.handle_response(M876_reason); break;
             #endif

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -76,7 +76,7 @@ public:
 
   static bool killed_by_M112;
   static bool quickstop_by_M410;
-  static bool abortsdprint_by_M524;
+  static bool sd_abort_by_M524;
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
     static uint8_t M876_reason;
@@ -170,7 +170,6 @@ public:
       case EP_M5:  state = (c == '2') ? EP_M52  : EP_IGNORE; break;
       case EP_M52: state = (c == '4') ? EP_M524 : EP_IGNORE; break;
 
-
       #if ENABLED(HOST_PROMPT_SUPPORT)
 
         case EP_M8:  state = (c == '7') ? EP_M87  : EP_IGNORE; break;
@@ -206,7 +205,7 @@ public:
             case EP_M108: wait_for_user = wait_for_heatup = false; break;
             case EP_M112: killed_by_M112 = true; break;
             case EP_M410: quickstop_by_M410 = true; break;
-            case EP_M524: abortsdprint_by_M524 = true; break;
+            case EP_M524: sd_abort_by_M524 = true; break;
             #if ENABLED(HOST_PROMPT_SUPPORT)
               case EP_M876SN: hostui.handle_response(M876_reason); break;
             #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1849,8 +1849,8 @@ void Temperature::task() {
       quickstop_stepper();
     }
 
-    if (emergency_parser.abortsdprint_by_M524) { // abort sd print immediately
-      emergency_parser.abortsdprint_by_M524 = false;
+    if (emergency_parser.sd_abort_by_M524) { // abort SD print immediately
+      emergency_parser.sd_abort_by_M524 = false;
       card.flag.abort_sd_printing = true;
       gcode.process_subcommands_now(F("M524"));
     }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1848,6 +1848,12 @@ void Temperature::task() {
       emergency_parser.quickstop_by_M410 = false; // quickstop_stepper may call idle so clear this now!
       quickstop_stepper();
     }
+
+    if (emergency_parser.abortsdprint_by_M524) { // abort sd print immediately
+      emergency_parser.abortsdprint_by_M524 = false;
+      card.flag.abort_sd_printing = true;
+      gcode.process_subcommands_now(F("M524"));
+    }
   #endif
 
   if (!updateTemperaturesIfReady()) return; // Will also reset the watchdog if temperatures are ready


### PR DESCRIPTION
Currently there is no equivalent of "Stop print" (from LCD) that can be run remotely and get *fast* printing stop.

That's a problem if you observe that something is not going to work with print and want to stop as fast
as possible (but not to kill everything like M112). Currently any sane gcode (M524, M25) will end up in queue
and will be run way too late.

Add M524 (abort sd print) to emergency parser which does the job and allows to remotely stop [1] the print.
So the fast stopping behaviour will be available from lcd (as it is now) and also remotely.

1. In my case printer is on separate floor and I often start and monitor prints remotely.

Note that I'm not familiar with a best way to do this in Marlin but this way seems to be working (tested on a printer).