### PR TITLE
Fix LPC1768 upload path autodetection

### DIFF
--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -73,7 +73,7 @@ if pioutil.is_pio_build():
                 #
                 import getpass
                 user = getpass.getuser()
-                mpath = Path('media', user)
+                mpath = Path('/media', user)
                 drives = [ x for x in mpath.iterdir() if x.is_dir() ]
                 if target_drive in drives:  # If target drive is found, use it.
                     target_drive_found = True


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR adds a missing `/` in the path used to autodetect the upload path for LPC1768. Without this change, the `upload_extra_script.py` script does look in `./media` instead of `/media` resulting in the following error:
```
Unable to find destination disk ([Errno 2] No such file or directory: 'media/renaud')
```

### Requirements

Any LPC1768 board
Attempting to upload the compiled firmware on a Linux machine

### Benefits

It fixes the upload_port detection

### Configurations

If testing on an SKR 1.3, you can use my configuration files available [here](https://github.com/Renaud11232/Marlin/tree/2.1.x-anet-skr-bltouch/Marlin)

### Related Issues

None
