### PR TITLE
[1.1.x] Use old toolchain for sanguino_atmega1284p (Ender 3)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -153,6 +153,7 @@ monitor_speed = 250000
 #
 [env:sanguino_atmega1284p]
 platform      = atmelavr
+platform_packages = toolchain-atmelavr@1.50400.190710
 framework     = arduino
 board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}


### PR DESCRIPTION
This PR fixes a 1.1.x compilation problem for the Ender 3 Melzi boards based on the ATMega1284P.

The problem was that `digitalPinToInterrupt()` stopped working correctly for the "Sanguino" board def during the 5.4.0 -> 7.3.0 avr-gcc transition.

Reverting to `avr-gcc` 5.4.0 (i.e. Arduino 1.8.8) allows 1.1.x to compile for the Ender 3.

Context:
- https://github.com/MarlinFirmware/Marlin/issues/24782
- https://github.com/MarlinFirmware/Marlin/issues/15540
- https://github.com/MarlinFirmware/Marlin/issues/15770
