### PR TITLE
[1.1.x] Update TMC26XStepper link, Use old toolchain for sanguino_atmega1284p boards (Ender 3, etc)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -112,6 +112,7 @@ build_flags   = ${common.build_flags}
 upload_speed  = 57600
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
+platform_packages = toolchain-atmelavr@1.50400.190710
 
 #
 # Melzi and clones (Optiboot bootloader)
@@ -124,6 +125,7 @@ build_flags   = ${common.build_flags}
 upload_speed  = 115200
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
+platform_packages = toolchain-atmelavr@1.50400.190710
 
 #
 # RAMBo
@@ -147,6 +149,7 @@ board         = sanguino_atmega644p
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
+platform_packages = toolchain-atmelavr@1.50400.190710
 
 #
 # Sanguinololu (ATmega1284p)
@@ -158,6 +161,7 @@ board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
+platform_packages = toolchain-atmelavr@1.50400.190710
 
 #
 # Teensy++ 2.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
+  https://github.com/MarlinFirmware/TMC26XStepper/archive/0.1.1.zip
 
 #################################
 #                               #


### PR DESCRIPTION
_This PR is a redo of https://github.com/MarlinFirmware/Marlin/pull/24783 which targets `bugfix-1.1.x` rather than `1.1.x`, and also includes the `TMC26XStepper` URL fix from `1.1.x`._

This PR fixes a 1.1.x platformio compilation problem for the Ender 3 Melzi and other boards based on the ATMega1284P.

It appears that `digitalPinToInterrupt()` stopped working correctly for the "Sanguino" board def during the 5.4.0 -> 7.3.0 avr-gcc transition.

Reverting to `avr-gcc` 5.4.0 (i.e. Arduino 1.8.8) allows 1.1.x to compile for ATMega1284P-based boards when using platformio.

Context:
- https://github.com/MarlinFirmware/Marlin/issues/24782
- https://github.com/MarlinFirmware/Marlin/issues/15540
- https://github.com/MarlinFirmware/Marlin/issues/15770
