### PR TITLE
Specify MarlinFirmware/U8glib

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -37,7 +37,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_LCDPRINT                           = src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = U8glib-HAL@~0.5.2
+HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@~0.5.2
                                          src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft> +<src/lcd/tft_io>
 HAS_FSMC_TFT                           = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>


### PR DESCRIPTION
### Description

Specify MarlinFirmware/U8glib

### Benefits

Prevent warnings (and potential security issues) when other U8glib libraries are registered with PIO:

```prolog
Library Manager: Installing U8glib-HAL @ ~0.5.2
Library Manager: Warning! More than one package has been found by U8glib-HAL @ ~0.5.2 requirements:
Library Manager:  - marlinfirmware/U8glib-HAL@0.5.2
Library Manager:  - zander22091988/U8glib-HAL@0.5.2
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (shown above) to avoid name conflicts
```