### PR TITLE
disable DEBUG_DGUSLCD in dgus_reloaded/DGUSDisplay.h

### DIFF
--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
@@ -33,7 +33,7 @@
 #include "../../../inc/MarlinConfigPre.h"
 #include "../../../MarlinCore.h"
 
-#define DEBUG_DGUSLCD // Uncomment for debug messages
+//#define DEBUG_DGUSLCD // Uncomment for debug messages
 #define DEBUG_OUT ENABLED(DEBUG_DGUSLCD)
 #include "../../../core/debug_out.h"
 


### PR DESCRIPTION
### Description

If you enable dgus_reloaded  the serail port is flooded with debug messages such as 

Recv: < 90 165 (3) # 130 79 75 # >
Recv: < 90 165 (3) # 130 79 75 # >
Recv: < 90 165 (3) # 130 79 75 # >
Recv: < 90 165 (3) # 130 79 75 # >

### Requirements

DGUS_LCD_UI_RELOADED

### Benefits

No debug info

### Related Issues
https://reprap.org/forum/read.php?415,890593