### PR TITLE
Update Creality 4.2.2 Driver Warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -711,8 +711,8 @@
   #warning "Don't forget to update your TFT settings in Configuration.h."
 #endif
 
-#if ENABLED(EMIT_CREALITY_422_WARNING)
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225). (Define EMIT_CREALITY_422_WARNING false to suppress this warning.)"
+#if ENABLED(EMIT_CREALITY_422_WARNING) && DISABLED(NO_CREALITY_422_DRIVER_WARNING)
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
 #if PRINTCOUNTER_SYNC

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V422.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V422.h
@@ -28,8 +28,6 @@
 #define BOARD_INFO_NAME      "Creality v4.2.2"
 #define DEFAULT_MACHINE_NAME "Creality3D"
 
-#ifndef EMIT_CREALITY_422_WARNING
-  #define EMIT_CREALITY_422_WARNING
-#endif
+#define EMIT_CREALITY_422_WARNING
 
 #include "pins_CREALITY_V4.h"


### PR DESCRIPTION
### Description

Follow existing "Define xxxx to suppress this warning." method instead of TRUE/FALSE.

### Requirements

Creality 4.2.2 board

### Benefits

Follow existing methods to suppress config warnings.
