### PR TITLE
Made Arduino DUE port compile and work again

### DIFF
--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -210,7 +210,7 @@ public:
   static void adc_init() {}
 
   // Called by Temperature::init for each sensor at startup
-  static void adc_enable(const uint8_t) {}
+  static void adc_enable(const uint8_t /*ch*/) {}
 
   // Begin ADC sampling on the given channel. Called from Temperature::isr!
   static void adc_start(const uint8_t ch) { adc_result = analogRead(ch); }

--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -210,7 +210,7 @@ public:
   static void adc_init() {}
 
   // Called by Temperature::init for each sensor at startup
-  static void adc_enable(const uint8_t ch) {}
+  static void adc_enable(const uint8_t) {}
 
   // Begin ADC sampling on the given channel. Called from Temperature::isr!
   static void adc_start(const uint8_t ch) { adc_result = analogRead(ch); }

--- a/Marlin/src/HAL/DUE/HAL_SPI.cpp
+++ b/Marlin/src/HAL/DUE/HAL_SPI.cpp
@@ -247,12 +247,12 @@
       b <<= 1; // little setup time
 
       WRITE(SD_SCK_PIN, HIGH);
-      DELAY_NS(spiDelayNS);
+      DELAY_NS_VAR(spiDelayNS);
 
       b |= (READ(SD_MISO_PIN) != 0);
 
       WRITE(SD_SCK_PIN, LOW);
-      DELAY_NS(spiDelayNS);
+      DELAY_NS_VAR(spiDelayNS);
     } while (--bits);
     return b;
   }

--- a/Marlin/src/HAL/DUE/InterruptVectors.cpp
+++ b/Marlin/src/HAL/DUE/InterruptVectors.cpp
@@ -41,7 +41,16 @@
    practice, we need alignment to 256 bytes to make this work in all
    cases */
 __attribute__ ((aligned(256)))
-static DeviceVectors ram_tab = { nullptr };
+static DeviceVectors ram_tab = {
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
+  nullptr,nullptr,nullptr,nullptr,nullptr
+};
 
 /**
  * This function checks if the exception/interrupt table is already in SRAM or not.

--- a/Marlin/src/HAL/DUE/InterruptVectors.cpp
+++ b/Marlin/src/HAL/DUE/InterruptVectors.cpp
@@ -41,16 +41,7 @@
    practice, we need alignment to 256 bytes to make this work in all
    cases */
 __attribute__ ((aligned(256)))
-static DeviceVectors ram_tab = {
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-  nullptr,nullptr,nullptr,nullptr,nullptr
-};
+static DeviceVectors ram_tab[61] = { nullptr };
 
 /**
  * This function checks if the exception/interrupt table is already in SRAM or not.

--- a/Marlin/src/HAL/DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/DUE/usb/usb_task.c
@@ -62,7 +62,7 @@ void usb_task_idle(void) {
     // Attend SD card access from the USB MSD -- Prioritize access to improve speed
     int delay = 2;
     while (main_b_msc_enable && --delay > 0) {
-      if (udi_msc_process_trans()) delay = 10000;
+      if (udi_msc_process_trans()) delay = 20;
 
       // Reset the watchdog, just to be sure
       REG_WDT_CR = WDT_CR_WDRSTT | WDT_CR_KEY(0xA5);

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -99,8 +99,8 @@ struct Flags {
   void set(const int n)                    { b |=  (bits_t)_BV(n); }
   void clear(const int n)                  { b &= ~(bits_t)_BV(n); }
   bool test(const int n) const             { return TEST(b, n); }
-  const bool operator[](const int n)       { return test(n); }
-  const bool operator[](const int n) const { return test(n); }
+  bool operator[](const int n)             { return test(n); }
+  bool operator[](const int n) const       { return test(n); }
   int size() const                         { return sizeof(b); }
 };
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -192,11 +192,11 @@ typedef struct PlannerBlock {
 
   volatile block_flags_t flag;              // Block flags
 
-  volatile bool is_fan_sync() { return TERN0(LASER_SYNCHRONOUS_M106_M107, flag.sync_fans); }
-  volatile bool is_pwr_sync() { return TERN0(LASER_POWER_SYNC, flag.sync_laser_pwr); }
-  volatile bool is_sync() { return flag.sync_position || is_fan_sync() || is_pwr_sync(); }
-  volatile bool is_page() { return TERN0(DIRECT_STEPPING, flag.page); }
-  volatile bool is_move() { return !(is_sync() || is_page()); }
+  bool is_fan_sync() { return TERN0(LASER_SYNCHRONOUS_M106_M107, flag.sync_fans); }
+  bool is_pwr_sync() { return TERN0(LASER_POWER_SYNC, flag.sync_laser_pwr); }
+  bool is_sync() { return flag.sync_position || is_fan_sync() || is_pwr_sync(); }
+  bool is_page() { return TERN0(DIRECT_STEPPING, flag.page); }
+  bool is_move() { return !(is_sync() || is_page()); }
 
   // Fields used by the motion planner to manage acceleration
   float nominal_speed,                      // The nominal speed for this block in (mm/sec)


### PR DESCRIPTION
### Description

I am updating my printer with the latest changes, and found out the Arduino Due port was not compiling due to changes in the DELAY_*() macros. So, this pull request represents the bare minimum to make 2.1.x work on Due

### Requirements

Arduino Due with RAMPS2DUE board

### Benefits

Due target compiles with the Arduino Due environment

### Configurations

I am using the MakerParts configuration, exactly as found in the Config repo

