### PR TITLE
Remove non-const XY*val comparison operators

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -436,15 +436,9 @@ struct XYval {
   FI XYval<T>& operator<<=(const int &v)                { _LS(x);    _LS(y);    return *this; }
 
   // Exact comparisons. For floats a "NEAR" operation may be better.
-  FI bool      operator==(const XYval<T>   &rs)         { return x == rs.x && y == rs.y; }
-  FI bool      operator==(const XYZval<T>  &rs)         { return x == rs.x && y == rs.y; }
-  FI bool      operator==(const XYZEval<T> &rs)         { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYval<T>   &rs)   const { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYZval<T>  &rs)   const { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYZEval<T> &rs)   const { return x == rs.x && y == rs.y; }
-  FI bool      operator!=(const XYval<T>   &rs)         { return !operator==(rs); }
-  FI bool      operator!=(const XYZval<T>  &rs)         { return !operator==(rs); }
-  FI bool      operator!=(const XYZEval<T> &rs)         { return !operator==(rs); }
   FI bool      operator!=(const XYval<T>   &rs)   const { return !operator==(rs); }
   FI bool      operator!=(const XYZval<T>  &rs)   const { return !operator==(rs); }
   FI bool      operator!=(const XYZEval<T> &rs)   const { return !operator==(rs); }
@@ -599,9 +593,7 @@ struct XYZval {
   FI XYZval<T>& operator<<=(const int &v)              { NUM_AXIS_CODE(_LS(x),    _LS(y),    _LS(z),    _LS(i),    _LS(j),    _LS(k),    _LS(u),    _LS(v),    _LS(w));    return *this; }
 
   // Exact comparisons. For floats a "NEAR" operation may be better.
-  FI bool       operator==(const XYZEval<T> &rs)       { return true NUM_AXIS_GANG(&& x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
   FI bool       operator==(const XYZEval<T> &rs) const { return true NUM_AXIS_GANG(&& x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
-  FI bool       operator!=(const XYZEval<T> &rs)       { return !operator==(rs); }
   FI bool       operator!=(const XYZEval<T> &rs) const { return !operator==(rs); }
 };
 
@@ -750,13 +742,9 @@ struct XYZEval {
   FI XYZEval<T>& operator<<=(const int &v)                { LOGICAL_AXIS_CODE(_LS(e),    _LS(x),    _LS(y),    _LS(z),    _LS(i),    _LS(j),    _LS(k),    _LS(u),    _LS(v),    _LS(w));    return *this; }
 
   // Exact comparisons. For floats a "NEAR" operation may be better.
-  FI bool        operator==(const XYZval<T>  &rs)         { return true NUM_AXIS_GANG(&& x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
   FI bool        operator==(const XYZval<T>  &rs)   const { return true NUM_AXIS_GANG(&& x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
-  FI bool        operator==(const XYZEval<T> &rs)         { return true LOGICAL_AXIS_GANG(&& e == rs.e, && x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
   FI bool        operator==(const XYZEval<T> &rs)   const { return true LOGICAL_AXIS_GANG(&& e == rs.e, && x == rs.x, && y == rs.y, && z == rs.z, && i == rs.i, && j == rs.j, && k == rs.k, && u == rs.u, && v == rs.v, && w == rs.w); }
-  FI bool        operator!=(const XYZval<T>  &rs)         { return !operator==(rs); }
   FI bool        operator!=(const XYZval<T>  &rs)   const { return !operator==(rs); }
-  FI bool        operator!=(const XYZEval<T> &rs)         { return !operator==(rs); }
   FI bool        operator!=(const XYZEval<T> &rs)   const { return !operator==(rs); }
 };
 


### PR DESCRIPTION
### Description

Remove the non-const operator==/operator!= for the XY*val structs.

!=/== do not modify the LHS so they're redundant and can generate ambiguous conversions failures when LHS/RHS differ in const-ness and an overloaded conversion is taking place:

```
warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
  287 |     if (const_xy_val != non_const_xyz_val) {
      |                      ^~
core/types.h:439:16: note: candidate 1: 'bool XYval<T>::operator==(const XYval<T>&) [with T = long int]' (rewritten)
  439 |   FI bool      operator==(const XYval<T>   &rs)         { return x == rs.x && y == rs.y; }
      |                ^~~~~~~~
core/types.h:440:16: note: candidate 2: 'bool XYval<T>::operator==(const XYZval<T>&) [with T = long int]' (reversed)
  440 |   FI bool      operator==(const XYZval<T>  &rs)         { return x == rs.x && y == rs.y; }
      |                ^~~~~~~~
```

### Requirements

n/a

### Benefits

Reduces explicit const_casts required to get valid comparisons/conversions.

### Configurations

n/a

### Related Issues

n/a