### PR TITLE
VORON V2 => V1

### DIFF
--- a/Marlin/src/pins/ramps/pins_VORON.h
+++ b/Marlin/src/pins/ramps/pins_VORON.h
@@ -23,7 +23,7 @@
 
 /**
  * VORON Design v1 pin assignments
- * See https://github.com/mzbotreprap/VORON/blob/master/Firmware/Marlin/pins_RAMPS_VORON.h
+ * Originally ported from https://github.com/mzbotreprap/VORON/blob/master/Firmware/Marlin/pins_RAMPS_VORON.h
  */
 
 #define BOARD_INFO_NAME "VORON Design v1"

--- a/Marlin/src/pins/ramps/pins_VORON.h
+++ b/Marlin/src/pins/ramps/pins_VORON.h
@@ -22,11 +22,11 @@
 #pragma once
 
 /**
- * VORON Design v2 pin assignments
+ * VORON Design v1 pin assignments
  * See https://github.com/mzbotreprap/VORON/blob/master/Firmware/Marlin/pins_RAMPS_VORON.h
  */
 
-#define BOARD_INFO_NAME "VORON Design v2"
+#define BOARD_INFO_NAME "VORON Design v1"
 
 #define MOSFET_C_PIN                          11
 


### PR DESCRIPTION
### Description

The [VORON V1 (Legacy)](https://vorondesign.com/voron_legacy) was originally ported from a Marlin 1.1.8 config and added as the V2, which was incorrect. I've also put in PR https://github.com/MarlinFirmware/Configurations/pull/819 to fix the printer name.

### Requirements

VORON Legacy (V1, RAMPS-based)

### Benefits

Correct VORON Version/Name

### Related Issues

- https://github.com/MarlinFirmware/Configurations/pull/819
- https://github.com/MarlinFirmware/Marlin/pull/12705#issuecomment-452720428
