### PR TITLE
clean up creality v521, #24760 followup

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -355,7 +355,7 @@
 #define BOARD_CREALITY_V431_D         4051  // Creality v4.3.1d (STM32F103RC / STM32F103RE)
 #define BOARD_CREALITY_V452           4052  // Creality v4.5.2 (STM32F103RC / STM32F103RE)
 #define BOARD_CREALITY_V453           4053  // Creality v4.5.3 (STM32F103RC / STM32F103RE)
-#define BOARD_CREALITY_V521           4054  // SV04 Board
+#define BOARD_CREALITY_V521           4054  // Creality v5.2.1 (STM32F103VE) as found in the SV04
 #define BOARD_CREALITY_V24S1          4055  // Creality v2.4.S1 (STM32F103RC / STM32F103RE) v101 as found in the Ender-7
 #define BOARD_CREALITY_V24S1_301      4056  // Creality v2.4.S1_301 (STM32F103RC / STM32F103RE) v301 as found in the Ender-3 S1
 #define BOARD_CREALITY_V25S1          4057  // Creality v2.5.S1 (STM32F103RE) as found in the CR-10 Smart Pro

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -591,6 +591,8 @@
   #include "stm32f1/pins_CREALITY_V24S1_301.h"  // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V25S1)
   #include "stm32f1/pins_CREALITY_V25S1.h"      // STM32F1                                env:STM32F103RE_creality_smartPro env:STM32F103RE_creality_smartPro_maple
+#elif MB(CREALITY_V521)
+  #include "stm32f1/pins_CREALITY_V521.h"       // STM32F1                                env:STM32F103VE_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple env:trigorilla_pro_disk
 #elif MB(FLY_MINI)
@@ -611,8 +613,6 @@
   #include "stm32f1/pins_ERYONE_ERY32_MINI.h"   // STM32F103VET6                          env:ERYONE_ERY32_MINI_maple
 #elif MB(PANDA_PI_V29)
   #include "stm32f1/pins_PANDA_PI_V29.h"        // STM32F103RCT6                          env:PANDA_PI_V29
-#elif MB(CREALITY_V521)
-  #include "stm32f1/pins_CREALITY_V521.h"       // STM32F103RET6                          env:STM32F103RET6_creality
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -592,7 +592,7 @@
 #elif MB(CREALITY_V25S1)
   #include "stm32f1/pins_CREALITY_V25S1.h"      // STM32F1                                env:STM32F103RE_creality_smartPro env:STM32F103RE_creality_smartPro_maple
 #elif MB(CREALITY_V521)
-  #include "stm32f1/pins_CREALITY_V521.h"       // STM32F1                                env:STM32F103VE_creality
+  #include "stm32f1/pins_CREALITY_V521.h"       // STM32F103VE                            env:STM32F103VE_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple env:trigorilla_pro_disk
 #elif MB(FLY_MINI)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -172,6 +172,16 @@ extends = STM32F103Rx_creality_xfer
 board   = genericSTM32F103RC
 
 #
+# Creality 512K (STM32F103VE)
+#
+[env:STM32F103VE_creality]
+extends             = STM32F103Rx_creality
+board               = genericSTM32F103VE
+board_build.variant = MARLIN_F103Vx
+build_flags         = ${stm32_variant.build_flags}
+                      -DSS_TIMER=4 -DTIMER_SERVO=TIM5
+                      -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
+#
 # BigTreeTech SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)
 #
 #   STM32F103RE_btt ............. RET6
@@ -467,24 +477,3 @@ board                = genericSTM32F103VE
 board_build.variant  = MARLIN_F103Vx
 build_flags          = ${ZONESTAR_ZM3E.build_flags} -DTIMER_TONE=TIM1
 board_upload.maximum_size = 499712
-
-#
-# Creality (STM32F103RET6)
-#
-[env:STM32F103RET6_creality]
-platform                    = ${common_stm32f1.platform}
-extends                     = stm32_variant
-board                       = genericSTM32F103VE
-board_build.variant         = MARLIN_F103Vx
-board_build.offset          = 0x7000
-board_upload.offset_address = 0x08007000
-build_flags                 = ${stm32_variant.build_flags}
-                              -DSS_TIMER=4 -DTIMER_SERVO=TIM5
-                              -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
-build_unflags               = ${stm32_variant.build_unflags}
-                              -DUSBCON -DUSBD_USE_CDC
-extra_scripts               = ${stm32_variant.extra_scripts}
-                              pre:buildroot/share/PlatformIO/scripts/random-bin.py
-monitor_speed               = 115200
-debug_tool                  = jlink
-upload_protocol             = jlink


### PR DESCRIPTION
### Description

Follow up to https://github.com/MarlinFirmware/Marlin/pull/24760
This new board has a STM32F103VE but used a RE build environment name.
The name also conflicts with a old name now in the renamed environment lists

Renamed environment to env:STM32F103VE_creality and used extends from STM32F103Rx_creality to shorten the environment definition. + General clean up 

### Requirements

#define MOTHERBOARD CREALITY_V521

### Benefits

No env name conflicts and cleaner

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/24760

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
