### PR TITLE
check for empty MARLIN_FEATURES

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -63,7 +63,7 @@ if pioutil.is_pio_build():
             raise SystemExit("Error: this script should be used after common Marlin scripts")
 
         if len(env['MARLIN_FEATURES']) == 0:
-            raise SystemExit("Error: An error occured. Please read the errors above.")
+            raise SystemExit("Error: An error occurred. Please read the errors above.")
 
         build_env = env['PIOENV']
         motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -62,8 +62,8 @@ if pioutil.is_pio_build():
         if 'MARLIN_FEATURES' not in env:
             raise SystemExit("Error: this script should be used after common Marlin scripts")
 
-        if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
-            raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
+        if len(env['MARLIN_FEATURES']) == 0:
+            raise SystemExit("Error: An error occured. Please read the errors above.")
 
         build_env = env['PIOENV']
         motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -60,10 +60,10 @@ if pioutil.is_pio_build():
             raise SystemExit("Error: Marlin requires PlatformIO >= 6.1.1. Use 'pio upgrade' to get a newer version.")
 
         if 'MARLIN_FEATURES' not in env:
-            raise SystemExit("Error: this script should be used after common Marlin scripts")
+            raise SystemExit("Error: this script should be used after common Marlin scripts.")
 
         if len(env['MARLIN_FEATURES']) == 0:
-            raise SystemExit("Error: An error occurred. Please read the errors above.")
+            raise SystemExit("Error: Failed to parse Marlin features. See previous error messages.")
 
         build_env = env['PIOENV']
         motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']


### PR DESCRIPTION
### Description

Recently something changed that result is the user getting the error 
`Error: MOTHERBOARD is not defined in Configuration.h`
As the final error when ever another error is triggered.

eg   (defining Z2_DRIVER_TYPE and Z3_DRIVER_TYPE, to cause an error
```
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/pins_postprocess.h:963:8: error: #error "No E stepper plug left for Z3!"
       #error "No E stepper plug left for Z3!"
        ^~~~~
Error: MOTHERBOARD is not defined in Configuration.h

```
User are seeing this error and presuming there is something wrong with defining the motherboard. As they generally don't look at previous errors.

The issue is the env['MARLIN_FEATURES'] is now empty, triggering a false error. 

I have updated this so now it says

```
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/pins_postprocess.h:963:8: error: #error "No E stepper plug left for Z3!"
       #error "No E stepper plug left for Z3!"
        ^~~~~
Error: An error occurred. Please read the errors above.

```
Should they actually not define a MOTHERBOARD, pins.h now catches this. (this code was already present) 

```
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/pins.h:875:6: error: #error "MOTHERBOARD not defined! Use '#define MOTHERBOARD BOARD_...' in Configuration.h."
     #error "MOTHERBOARD not defined! Use '#define MOTHERBOARD BOARD_...' in Configuration.h."
      ^~~~~
Error: An error occurred. Please read the errors above.

``` 
### Benefits

Less confused users

### Related issue
https://reprap.org/forum/read.php?415,890673,890683
