### PR TITLE
🐛 fix touchscreen sleep with color_ui

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -191,11 +191,12 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 
   uint8_t MarlinUI::sleep_timeout_minutes; // Initialized by settings.load()
   millis_t MarlinUI::screen_timeout_millis = 0;
-  void MarlinUI::refresh_screen_timeout() {
-    screen_timeout_millis = sleep_timeout_minutes ? millis() + sleep_timeout_minutes * 60UL * 1000UL : 0;
-    sleep_display(false);
-  }
-
+  #if DISABLED(TFT_COLOR_UI)
+    void MarlinUI::refresh_screen_timeout() {
+      screen_timeout_millis = sleep_timeout_minutes ? millis() + sleep_timeout_minutes * 60UL * 1000UL : 0;
+      sleep_display(false);
+    }
+  #endif
 #endif
 
 void MarlinUI::init() {
@@ -1065,7 +1066,7 @@ void MarlinUI::init() {
 
           #if LCD_BACKLIGHT_TIMEOUT_MINS
             refresh_backlight_timeout();
-          #elif HAS_DISPLAY_SLEEP
+          #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
             refresh_screen_timeout();
           #endif
 
@@ -1178,9 +1179,9 @@ void MarlinUI::init() {
           WRITE(LCD_BACKLIGHT_PIN, LOW); // Backlight off
           backlight_off_ms = 0;
         }
-      #elif HAS_DISPLAY_SLEEP
+      #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
         if (screen_timeout_millis && ELAPSED(ms, screen_timeout_millis))
-          sleep_display();
+          sleep_display(true);
       #endif
 
       // Change state of drawing flag between screen updates

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -550,7 +550,7 @@ void menu_configuration() {
   //
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     EDIT_ITEM(uint8, MSG_SCREEN_TIMEOUT, &ui.backlight_timeout_minutes, ui.backlight_timeout_min, ui.backlight_timeout_max, ui.refresh_backlight_timeout);
-  #elif HAS_DISPLAY_SLEEP
+  #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
     EDIT_ITEM(uint8, MSG_SCREEN_TIMEOUT, &ui.sleep_timeout_minutes, ui.sleep_timeout_min, ui.sleep_timeout_max, ui.refresh_screen_timeout);
   #endif
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -642,7 +642,7 @@ void MarlinSettings::postprocess() {
 
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     ui.refresh_backlight_timeout();
-  #elif HAS_DISPLAY_SLEEP
+  #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
     ui.refresh_screen_timeout();
   #endif
 }
@@ -3167,7 +3167,7 @@ void MarlinSettings::reset() {
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     ui.backlight_timeout_minutes = LCD_BACKLIGHT_TIMEOUT_MINS;
   #elif HAS_DISPLAY_SLEEP
-    ui.sleep_timeout_minutes = DISPLAY_SLEEP_MINUTES;
+    ui.sleep_timeout_minutes = TERN(TOUCH_SCREEN, TOUCH_IDLE_SLEEP_MINS, DISPLAY_SLEEP_MINUTES);
   #endif
 
   //


### PR DESCRIPTION
sleep_display() do not exist in COLOR_UI, it use own function
could use further revision, but this plugs the hole