### PR TITLE
Fix SKR mini E2 V2 + BTT_MINI_12864_V1 display

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2823,6 +2823,8 @@
 
 //
 // BigTreeTech Mini 12864 V1.0 is an alias for FYSETC_MINI_12864_2_1. Type A/B. NeoPixel RGB Backlight.
+// If the display lights up but does not show characters, edit the parameter in the file: Marlin\src\lcd\dogm\marlinui_DOGM.cpp
+// change parameter: void MarlinUI::_set_contrast() { u8g.setContrast(contrast); } change to: void MarlinUI::_set_contrast() { u8g.setContrast(255); }
 //
 //#define BTT_MINI_12864_V1
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2823,8 +2823,6 @@
 
 //
 // BigTreeTech Mini 12864 V1.0 is an alias for FYSETC_MINI_12864_2_1. Type A/B. NeoPixel RGB Backlight.
-// If the display lights up but does not show characters, edit the parameter in the file: Marlin\src\lcd\dogm\marlinui_DOGM.cpp
-// change parameter: void MarlinUI::_set_contrast() { u8g.setContrast(contrast); } change to: void MarlinUI::_set_contrast() { u8g.setContrast(255); }
 //
 //#define BTT_MINI_12864_V1
 

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -21,7 +21,9 @@
  */
 #pragma once
 
-#define SKR_MINI_E3_V2
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME "BTT SKR Mini E3 V2.0"
+#endif
 
 #define BOARD_CUSTOM_BUILD_FLAGS -DTONE_CHANNEL=4 -DTONE_TIMER=4 -DTIMER_TONE=4
 
@@ -29,33 +31,50 @@
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
   #define SOFT_I2C_EEPROM
-  #define MARLIN_EEPROM_SIZE 0x1000                 // 4K
-  #define I2C_SDA_PIN                      PB7
-  #define I2C_SCL_PIN                      PB6
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4K
+  #define I2C_SDA_PIN                       PB7
+  #define I2C_SCL_PIN                       PB6
   #undef NO_EEPROM_SELECTED
 #endif
 
-#include "pins_BTT_SKR_MINI_E3_common.h"
+#define FAN_PIN                             PC6
 
-#ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "BTT SKR Mini E3 V2.0"
-#endif
+//
+// USB connect control
+//
+#define USB_CONNECT_PIN                     PA14
+
+/**
+ *            SKR Mini E3 V2.0
+ *                 ------
+ * (BEEPER)  PB5  | 1  2 | PA15 (BTN_ENC)
+ * (BTN_EN1) PA9  | 3  4 | RESET
+ * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
+ * (LCD_RS)  PB8  | 7  8 | PB15 (LCD_EN)
+ *            GND | 9 10 | 5V
+ *                 ------
+ *                  EXP1
+ */
+#define EXP1_02_PIN                         PA15
+#define EXP1_08_PIN                         PB15
+
+#include "pins_BTT_SKR_MINI_E3_common.h"
 
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG
 
 #ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                     PA8   // LED driving pin
+  #define NEOPIXEL_PIN                      PA8   // LED driving pin
 #endif
 
 #ifndef PS_ON_PIN
-  #define PS_ON_PIN                        PC13  // Power Supply Control
+  #define PS_ON_PIN                         PC13  // Power Supply Control
 #endif
 
-#define FAN1_PIN                           PC7
+#define FAN1_PIN                            PC7
 
 #ifndef CONTROLLER_FAN_PIN
-  #define CONTROLLER_FAN_PIN               FAN1_PIN
+  #define CONTROLLER_FAN_PIN            FAN1_PIN
 #endif
 
 #if HAS_TMC_UART

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -290,12 +290,9 @@
      * for backlight configuration see steps 2 (V2.1) and 3 in https://wiki.fysetc.com/Mini12864_Panel/
      */
 
-    //#define LCD_PINS_RS            EXP1_03_PIN  // CS
-    //#define LCD_PINS_ENABLE               PA3   // MOSI
     #define LCD_BACKLIGHT_PIN               -1
     #define NEOPIXEL_PIN             EXP1_07_PIN
     #define LCD_CONTRAST                     255
-    //#define LCD_RESET_PIN          EXP1_05_PIN
 
     #define DOGLCD_CS                EXP1_03_PIN
     #define DOGLCD_A0                EXP1_01_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -269,8 +269,8 @@
      *
      *            ---                   ------
      *       RST | 1 |          (MISO) |10  9 | SCK
-     * (RX2) PA2 | 2 |         BTN_EN1 | 8  7 | (SS)
-     * (TX2) PA3 | 3 |         BTN_EN2 | 6  5 | MOSI
+     * (RX2) PA3 | 2 |         BTN_EN1 | 8  7 | (SS)
+     * (TX2) PA2 | 3 |         BTN_EN2 | 6  5 | MOSI
      *       GND | 4 |            (CD) | 4  3 | (RST)
      *        5V | 5 |           (GND) | 2  1 | (KILL)
      *            ---                   ------
@@ -285,24 +285,24 @@
      *   EXP1-8 ----------- EXP2-6   EN2
      *   EXP1-7 ----------- EXP1-5   RED
      *   EXP1-6 ----------- EXP2-8   EN1
-     *   EXP1-5 ----------- EXP1-6   LCD_RST
-     *   EXP1-4 ----------- n/c
+     *   EXP1-5 ----------- n/c
+     *   EXP1-4 ----------- EXP2-3   RESET
      *   EXP1-3 ----------- EXP1-8   LCD_CS
      *   EXP1-2 ----------- EXP1-9   ENC
      *   EXP1-1 ----------- EXP1-7   LCD_A0
      *
-     *    TFT-2 ----------- EXP2-9   SCK
-     *    TFT-3 ----------- EXP2-5   MOSI
+     *    TFT-2 ----------- EXP2-5   SCK
+     *    TFT-3 ----------- EXP2-9   MOSI
      *
      * for backlight configuration see steps 2 (V2.1) and 3 in https://wiki.fysetc.com/Mini12864_Panel/
      */
 
-    #define LCD_PINS_RS              EXP1_03_PIN    // CS
-    #define LCD_PINS_ENABLE                 PA3     // MOSI
+    //#define LCD_PINS_RS              EXP1_03_PIN    // CS
+    //#define LCD_PINS_ENABLE                 PA3     // MOSI
     #define LCD_BACKLIGHT_PIN               -1
     #define NEOPIXEL_PIN             EXP1_07_PIN
     #define LCD_CONTRAST                    255
-    #define LCD_RESET_PIN            EXP1_05_PIN
+    //#define LCD_RESET_PIN            EXP1_05_PIN
 
     #define DOGLCD_CS                EXP1_03_PIN
     #define DOGLCD_A0                EXP1_01_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -297,12 +297,12 @@
      * for backlight configuration see steps 2 (V2.1) and 3 in https://wiki.fysetc.com/Mini12864_Panel/
      */
 
-    //#define LCD_PINS_RS              EXP1_03_PIN    // CS
-    //#define LCD_PINS_ENABLE                 PA3     // MOSI
+    //#define LCD_PINS_RS            EXP1_03_PIN  // CS
+    //#define LCD_PINS_ENABLE               PA3   // MOSI
     #define LCD_BACKLIGHT_PIN               -1
     #define NEOPIXEL_PIN             EXP1_07_PIN
-    #define LCD_CONTRAST                    255
-    //#define LCD_RESET_PIN            EXP1_05_PIN
+    #define LCD_CONTRAST                     255
+    //#define LCD_RESET_PIN          EXP1_05_PIN
 
     #define DOGLCD_CS                EXP1_03_PIN
     #define DOGLCD_A0                EXP1_01_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -279,7 +279,7 @@
      *   EXP1-7 ----------- EXP1-5   RED
      *   EXP1-6 ----------- EXP2-8   EN1
      *   EXP1-5 ----------- n/c
-     *   EXP1-4 ----------- EXP2-3   RESET
+     *   EXP1-4 ----------- EXP1-6   RESET
      *   EXP1-3 ----------- EXP1-8   LCD_CS
      *   EXP1-2 ----------- EXP1-9   ENC
      *   EXP1-1 ----------- EXP1-7   LCD_A0

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -100,38 +100,31 @@
 #define HEATER_0_PIN                        PC8   // "HE"
 #define HEATER_BED_PIN                      PC9   // "HB"
 
-#ifdef SKR_MINI_E3_V2
-  #define FAN_PIN                           PC6
-#else
+#ifndef FAN_PIN
   #define FAN_PIN                           PA8   // "FAN0"
 #endif
 
 //
 // USB connect control
 //
-#ifdef SKR_MINI_E3_V2
-  #define USB_CONNECT_PIN                   PA14
-#else
+#ifndef USB_CONNECT_PIN
   #define USB_CONNECT_PIN                   PC13
 #endif
 
 #define USB_CONNECT_INVERTING              false
 
 /**
- *        SKR Mini E3 V1.0, V1.2                      SKR Mini E3 V2.0
- *                ------                                    ------
- * (BEEPER)  PB5  | 1  2 | PB6 (BTN_ENC)    (BEEPER)  PB5  | 1  2 | PA15 (BTN_ENC)
- * (BTN_EN1) PA9  | 3  4 | RESET            (BTN_EN1) PA9  | 3  4 | RESET
- * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)    (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
- * (LCD_RS)  PB8  | 7  8 | PB7  (LCD_EN)    (LCD_RS)  PB8  | 7  8 | PB15 (LCD_EN)
- *            GND | 9 10 | 5V                          GND | 9 10 | 5V
- *                ------                                    ------
- *                 EXP1                                      EXP1
+ *        SKR Mini E3 V1.0, V1.2
+ *                ------
+ * (BEEPER)  PB5  | 1  2 | PB6 (BTN_ENC)
+ * (BTN_EN1) PA9  | 3  4 | RESET
+ * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
+ * (LCD_RS)  PB8  | 7  8 | PB7  (LCD_EN)
+ *            GND | 9 10 | 5V
+ *                ------
+ *                 EXP1
  */
-#ifdef SKR_MINI_E3_V2
-  #define EXP1_02_PIN                       PA15
-  #define EXP1_08_PIN                       PB15
-#else
+#ifndef EXP1_02_PIN
   #define EXP1_02_PIN                       PB6
   #define EXP1_08_PIN                       PB7
 #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
In the pins_BTT_SKR_MINI_E3_common.h file, there are ill-defined pins that prevent the proper functioning of the BTT_MINI_12864_V1 display
This PR solves the problem. 

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
BTT SKR mini E3 V1 - V2 and  BTT mini 12864 V1

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
functional display BTT mini 12864 V1
<!-- What does this PR fix or improve? -->


### Related Issues
https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/issues/686#issuecomment-1264644479
https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/issues/650#issuecomment-1146877576

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
