### PR TITLE
Added missing case for M255

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -792,7 +792,11 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       #if HAS_LCD_CONTRAST
         case 250: M250(); break;                                  // M250: Set LCD contrast
       #endif
-
+      
+      #if HAS_GCODE_M255
+        case 255: M255(); break;                                  // M255: Set LCD Sleep/Backlight Timeout (Minutes)
+      #endif
+      
       #if HAS_LCD_BRIGHTNESS
         case 256: M256(); break;                                  // M256: Set LCD brightness
       #endif

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -792,11 +792,11 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       #if HAS_LCD_CONTRAST
         case 250: M250(); break;                                  // M250: Set LCD contrast
       #endif
-      
+
       #if HAS_GCODE_M255
         case 255: M255(); break;                                  // M255: Set LCD Sleep/Backlight Timeout (Minutes)
       #endif
-      
+
       #if HAS_LCD_BRIGHTNESS
         case 256: M256(); break;                                  // M256: Set LCD brightness
       #endif


### PR DESCRIPTION
### Description

`case 255:` was missing from file, and the `M255` gcode command was not recognized by printer until this change was made.

### Requirements

This requires an LCD with Brightness pin to implement, but the change to the file simply allows this gcode command to function.

### Benefits

makes M255 work

### Configurations

Uncomment `//#define LCD_BACKLIGHT_TIMEOUT_MINS 1  // (minutes) Timeout before turning off the backlight` on line 1329 of `Configuration_adv.h`


### Related Issues

It seems as though there are other M255 related PRs but I didn't see any that modify the `gcode.cpp` file to include the command.
