### PR TITLE
Fix simulation for TFT LCDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tests-single-ci:
 
 tests-single-local:
 	@if ! test -n "$(TEST_TARGET)" ; then echo "***ERROR*** Set TEST_TARGET=<your-module> or use make tests-all-local" ; return 1; fi
-	export PATH=./buildroot/bin/:./buildroot/tests/:${PATH} \
+	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
 	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
 	  && run_tests . $(TEST_TARGET) "$(ONLY_TEST)"
 .PHONY: tests-single-local
@@ -38,7 +38,7 @@ tests-single-local-docker:
 .PHONY: tests-single-local-docker
 
 tests-all-local:
-	export PATH=./buildroot/bin/:./buildroot/tests/:${PATH} \
+	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
 	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
 	  && for TEST_TARGET in $$(./get_test_targets.py) ; do echo "Running tests for $$TEST_TARGET" ; run_tests . $$TEST_TARGET ; done
 .PHONY: tests-all-local

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1496,7 +1496,7 @@
   #endif
 #elif ENABLED(TFT_GENERIC)
   #define TFT_DEFAULT_ORIENTATION (TFT_EXCHANGE_XY | TFT_INVERT_X | TFT_INVERT_Y)
-  #if NONE(TFT_RES_320x240, TFT_RES_480x272, TFT_RES_480x320)
+  #if NONE(TFT_RES_320x240, TFT_RES_480x272, TFT_RES_480x320, TFT_RES_1024x600)
     #define TFT_RES_320x240
   #endif
   #if NONE(TFT_INTERFACE_FSMC, TFT_INTERFACE_SPI)
@@ -1574,6 +1574,9 @@
   #elif TFT_HEIGHT == 600
     #if ENABLED(TFT_INTERFACE_LTDC)
       #define TFT_1024x600_LTDC
+    #else
+      // "Simulation" - for testing purposes only
+      #define TFT_1024x600_SIM
     #endif
   #endif
 #endif
@@ -1584,7 +1587,7 @@
   #define HAS_UI_480x320 1
 #elif EITHER(TFT_480x272, TFT_480x272_SPI)
   #define HAS_UI_480x272 1
-#elif defined(TFT_1024x600_LTDC)
+#elif EITHER(TFT_1024x600_LTDC, TFT_1024x600_SIM)
   #define HAS_UI_1024x600 1
 #endif
 #if ANY(HAS_UI_320x240, HAS_UI_480x320, HAS_UI_480x272)

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1575,8 +1575,7 @@
     #if ENABLED(TFT_INTERFACE_LTDC)
       #define TFT_1024x600_LTDC
     #else
-      // "Simulation" - for testing purposes only
-      #define TFT_1024x600_SIM
+      #define TFT_1024x600_SIM  // "Simulation" - for testing purposes only
     #endif
   #endif
 #endif

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1726,7 +1726,7 @@ void MarlinUI::init() {
     );
   }
 
-  #if LCD_WITH_BLINK
+  #if LCD_WITH_BLINK && DISABLED(HAS_GRAPHICAL_TFT)
     typedef void (*PrintProgress_t)();
     void MarlinUI::rotate_progress() { // Renew and redraw all enabled progress strings
       const PrintProgress_t progFunc[] = {

--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -450,6 +450,19 @@
       #ifndef TOUCH_OFFSET_Y
         #define TOUCH_OFFSET_Y                 1
       #endif
+    #elif ENABLED(TFT_RES_1024x600)
+      #ifndef TOUCH_CALIBRATION_X
+        #define TOUCH_CALIBRATION_X        65533
+      #endif
+      #ifndef TOUCH_CALIBRATION_Y
+        #define TOUCH_CALIBRATION_Y        38399
+      #endif
+      #ifndef TOUCH_OFFSET_X
+        #define TOUCH_OFFSET_X                 2
+      #endif
+      #ifndef TOUCH_OFFSET_Y
+        #define TOUCH_OFFSET_Y                 1
+      #endif
     #endif
   #endif
 


### PR DESCRIPTION
### Description
This PR fixes building the simulation target with TFT LCD and ColorUI, in particular the 1024x600 needed some love.

Additionally I've included a small fix for the Makefile to handle `$PATH` containing spaces (as it happens e.g. in WSL).

Note: touch registers but doesn't trigger any actions on 1024x600, but I think that's a separate issue.

### Requirements
None

### Benefits
(see description)
Allows testing ColorUI in simulation

### Configurations
`examples/Simulator`

### Related Issues
#24843