### PR TITLE
Fix MKS Robin E3 extruder SPI bus conflicts

### DIFF
--- a/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
+++ b/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
@@ -106,7 +106,7 @@
 #define FAN2_PIN                             135
 #define FAN3_PIN                             136
 
-// #define FAN_SOFT_PWM_REQUIRED // check if needed
+//#define FAN_SOFT_PWM_REQUIRED // check if needed
 
 // Neopixel Rings
 #define NEOPIXEL_PIN                          14

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -522,7 +522,7 @@
 #elif MB(MKS_ROBIN_PRO)
   #include "stm32f1/pins_MKS_ROBIN_PRO.h"       // STM32F1                                env:mks_robin_pro env:mks_robin_pro_maple
 #elif MB(MKS_ROBIN_E3)
-  #include "stm32f1/pins_MKS_ROBIN_E3.h"        // STM32F1                                env:mks_robin_e3 env:mks_robin_e3_maple
+  #include "stm32f1/pins_MKS_ROBIN_E3.h"        // STM32F1                                env:mks_robin_e3
 #elif MB(MKS_ROBIN_E3_V1_1)
   #include "stm32f1/pins_MKS_ROBIN_E3_V1_1.h"   // STM32F1                                env:mks_robin_e3
 #elif MB(MKS_ROBIN_E3D)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
@@ -103,7 +103,7 @@
 // SD Card
 //
 #define SD_DETECT_PIN                       PC7
-#define NO_SD_HOST_DRIVE                          // SD is only seen by the printer
+#define NO_SD_HOST_DRIVE                          // This board's SD is only seen by the printer
 
 #define SDIO_SUPPORT                              // Extra added by Creality
 #define SDIO_CLOCK                       6000000  // In original source code overridden by Creality in sdio.h

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -204,10 +204,10 @@
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN            EXP1_05_PIN
     #define NEOPIXEL_PIN             EXP1_06_PIN
-    #define DOGLCD_MOSI              EXP2_06_PIN
-    #define DOGLCD_SCK               EXP2_02_PIN
-    #define FORCE_SOFT_SPI
-    #define SOFTWARE_SPI
+    #define DOGLCD_MOSI              EXP2_06_PIN  // SPI2_MOSI
+    #define DOGLCD_SCK               EXP2_02_PIN  // SPI2_SCK
+    //#define FORCE_SOFT_SPI
+    //#define SOFTWARE_SPI
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
 
   #else
@@ -249,17 +249,23 @@
 //
 // SD Card
 //
-#define SDCARD_CONNECTION                ONBOARD
-#define SPI_DEVICE                             2
-#define ONBOARD_SPI_DEVICE                     2
-#define SDSS                           SD_SS_PIN
-#define ONBOARD_SD_CS_PIN              SD_SS_PIN
-#define SD_DETECT_PIN                       PC10  // EXP2_07_PIN
-#define NO_SD_HOST_DRIVE
+// DEFAULT_SPI  == 2 defines the following pins
+//
+// #define PIN_SPI_SS            PB12
+// #define PIN_SPI_MOSI          PB15
+// #define PIN_SPI_MISO          PB14
+// #define PIN_SPI_SCK           PB13
+//
+// Onboard SDCARD uses thes pins and is shared on EXP2 for LCD's
+//
+// SPI2_CS   PA15
+// SPI2_MOSI PB15
+// SPI2_SCK  PB13
+// SPI2_MISO PB14
+// SPI2_DET  PC10
 
-// TODO: This is the only way to set SPI for SD on STM32 (for now)
-#define ENABLE_SPI2
-#define SD_SCK_PIN                   EXP2_02_PIN
-#define SD_MISO_PIN                  EXP2_01_PIN
-#define SD_MOSI_PIN                  EXP2_06_PIN
-#define SD_SS_PIN                    EXP2_04_PIN
+#if ENABLED(SDSUPPORT)
+  #define NO_SD_HOST_DRIVE
+  #define SDSS                                EXP2_04_PIN // PA15
+  #define SD_DETECT_PIN                       EXP2_07_PIN // PC10
+#endif 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -165,13 +165,13 @@
 #define EXP2_05_PIN                         PB0
 #define EXP2_06_PIN                         PB15
 #define EXP2_07_PIN                         PC10
-#define EXP2_08_PIN                         -1   // RESET
+#define EXP2_08_PIN                         -1    // RESET
 
 // "Ender-3 EXP1"
 #define EXP3_01_PIN                         PC1
 #define EXP3_02_PIN                         PC3
 #define EXP3_03_PIN                         PB11
-#define EXP3_04_PIN                         -1   // RESET
+#define EXP3_04_PIN                         -1    // RESET
 #define EXP3_05_PIN                         PB0
 #define EXP3_06_PIN                         PA6
 #define EXP3_07_PIN                         PA5
@@ -249,14 +249,16 @@
 //
 // SD Card
 //
-// DEFAULT_SPI  == 2 defines the following pins
+// DEFAULT_SPI == 2 defines the following pins,
+// used as overrides in HAL/STM32/spi_pins.h
 //
-// #define PIN_SPI_SS            PB12
-// #define PIN_SPI_MOSI          PB15
-// #define PIN_SPI_MISO          PB14
-// #define PIN_SPI_SCK           PB13
+//#define PIN_SPI_SS                        PB12
+//#define PIN_SPI_MOSI                      PB15
+//#define PIN_SPI_MISO                      PB14
+//#define PIN_SPI_SCK                       PB13
+
 //
-// Onboard SDCARD uses thes pins and is shared on EXP2 for LCD's
+// Onboard SDCARD uses these pins and is shared on EXP2 for LCDs
 //
 // SPI2_CS   PA15
 // SPI2_MOSI PB15
@@ -266,6 +268,6 @@
 
 #if ENABLED(SDSUPPORT)
   #define NO_SD_HOST_DRIVE
-  #define SDSS                                EXP2_04_PIN // PA15
-  #define SD_DETECT_PIN                       EXP2_07_PIN // PC10
-#endif 
+  #define SDSS                       EXP2_04_PIN
+  #define SD_DETECT_PIN              EXP2_07_PIN
+#endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -250,7 +250,7 @@
     #define SD_SCK_PIN                      PC10
     #define SD_MISO_PIN                     PC11
     #define SD_MOSI_PIN                     PC12
-    #define SD_DETECT_PIN                   PC4   // SD_DETECT_PIN doesn't work with NO_SD_HOST_DRIVE disabled
+    #define SD_DETECT_PIN                   PC4   // Doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
   #elif SD_CONNECTION_IS(LCD)
     #define ENABLE_SPI1
     #define SDSS                     EXP2_04_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -212,7 +212,7 @@
 //
 // Onboard SD card
 //
-// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
+// Detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if SD_CONNECTION_IS(ONBOARD)
   #define ENABLE_SPI3
   #define SD_SS_PIN                         -1

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -109,7 +109,7 @@ board_build.encrypt_mks     = Robin_e3.bin
 board_build.offset          = 0x5000
 board_upload.offset_address = 0x08005000
 build_flags                 = ${common_STM32F103RC_variant.build_flags}
-                              -DTIMER_SERVO=TIM5 -DDEFAULT_SPI=3
+                              -DTIMER_SERVO=TIM5 -DDEFAULT_SPI=2
 build_unflags               = ${common_STM32F103RC_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC
 debug_tool                  = stlink


### PR DESCRIPTION
### Description

Default environment used SPI3, this conflicted with extruder IO pins.
SDCARD definition was a mess
Updated and cleaned up and added some useful comments.

Tested on BOARD_MKS_ROBIN_E3D_V1_1

### Requirements

Any of these 4 boards with SDSUPPORT

BOARD_MKS_ROBIN_E3
BOARD_MKS_ROBIN_E3_V1_1
BOARD_MKS_ROBIN_E3D
BOARD_MKS_ROBIN_E3D_V1_1

### Benefits

Extruder moves as expected.

### Configurations

Bugfix 2.1.x https://github.com/MarlinFirmware/Marlin/files/9799514/changes.zip

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24882
https://github.com/MarlinFirmware/Marlin/issues/24380
https://github.com/MarlinFirmware/Marlin/issues/23715