### PR TITLE
Fix FTDUI Status Screen Timeout

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -3611,7 +3611,7 @@
     #define LCD_TIMEOUT_TO_STATUS 15000
   #endif
   #if LCD_TIMEOUT_TO_STATUS
-    #define SCREENS_CAN_TIME_OUT 1
+    #define HAS_SCREEN_TIMEOUT 1
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -3605,7 +3605,7 @@
   #endif
 #endif
 
-#if HAS_MARLINUI_MENU
+#if EITHER(HAS_MARLINUI_MENU, TOUCH_UI_FTDI_EVE)
   // LCD timeout to status screen default is 15s
   #ifndef LCD_TIMEOUT_TO_STATUS
     #define LCD_TIMEOUT_TO_STATUS 15000

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
@@ -45,8 +45,9 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
     return false;
   }
 
-  #if SCREENS_CAN_TIME_OUT
+  #if LCD_TIMEOUT_TO_STATUS > 0
     if (EventLoop::get_pressed_tag() != 0) {
+      SERIAL_ECHO_MSG("buttonStyleCallback, resetting timeout");
       reset_menu_timeout();
     }
   #endif
@@ -65,7 +66,10 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 }
 
 void BaseScreen::onIdle() {
-  #if SCREENS_CAN_TIME_OUT
+  #if LCD_TIMEOUT_TO_STATUS > 0
+    if (EventLoop::get_pressed_tag() != 0) {
+      reset_menu_timeout();
+    }
     if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
       reset_menu_timeout();
       #if ENABLED(TOUCH_UI_DEBUG)
@@ -77,10 +81,12 @@ void BaseScreen::onIdle() {
 }
 
 void BaseScreen::reset_menu_timeout() {
-  TERN_(SCREENS_CAN_TIME_OUT, last_interaction = millis());
+  #if LCD_TIMEOUT_TO_STATUS > 0
+    last_interaction = millis();
+  #endif
 }
 
-#if SCREENS_CAN_TIME_OUT
+#if LCD_TIMEOUT_TO_STATUS > 0
   uint32_t BaseScreen::last_interaction;
 #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
@@ -45,7 +45,7 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
     return false;
   }
 
-  #if SCREENS_CAN_TIME_OUT
+  #if HAS_SCREEN_TIMEOUT
     if (EventLoop::get_pressed_tag() != 0) {
       #if ENABLED(TOUCH_UI_DEBUG)
         SERIAL_ECHO_MSG("buttonStyleCallback, resetting timeout");
@@ -66,7 +66,7 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 }
 
 void BaseScreen::onIdle() {
-  #if SCREENS_CAN_TIME_OUT
+  #if HAS_SCREEN_TIMEOUT
     if (EventLoop::get_pressed_tag() != 0)
       reset_menu_timeout();
 
@@ -81,10 +81,10 @@ void BaseScreen::onIdle() {
 }
 
 void BaseScreen::reset_menu_timeout() {
-  TERN_(SCREENS_CAN_TIME_OUT, last_interaction = millis());
+  TERN_(HAS_SCREEN_TIMEOUT, last_interaction = millis());
 }
 
-#if SCREENS_CAN_TIME_OUT
+#if HAS_SCREEN_TIMEOUT
   uint32_t BaseScreen::last_interaction;
 #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.cpp
@@ -45,16 +45,16 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
     return false;
   }
 
-  #if LCD_TIMEOUT_TO_STATUS > 0
+  #if SCREENS_CAN_TIME_OUT
     if (EventLoop::get_pressed_tag() != 0) {
-      SERIAL_ECHO_MSG("buttonStyleCallback, resetting timeout");
+      #if ENABLED(TOUCH_UI_DEBUG)
+        SERIAL_ECHO_MSG("buttonStyleCallback, resetting timeout");
+      #endif
       reset_menu_timeout();
     }
   #endif
 
-  if (buttonIsPressed(tag)) {
-    options = OPT_FLAT;
-  }
+  if (buttonIsPressed(tag)) options = OPT_FLAT;
 
   if (style & cmd.STYLE_DISABLED) {
     cmd.tag(0);
@@ -66,10 +66,10 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 }
 
 void BaseScreen::onIdle() {
-  #if LCD_TIMEOUT_TO_STATUS > 0
-    if (EventLoop::get_pressed_tag() != 0) {
+  #if SCREENS_CAN_TIME_OUT
+    if (EventLoop::get_pressed_tag() != 0)
       reset_menu_timeout();
-    }
+
     if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
       reset_menu_timeout();
       #if ENABLED(TOUCH_UI_DEBUG)
@@ -81,12 +81,10 @@ void BaseScreen::onIdle() {
 }
 
 void BaseScreen::reset_menu_timeout() {
-  #if LCD_TIMEOUT_TO_STATUS > 0
-    last_interaction = millis();
-  #endif
+  TERN_(SCREENS_CAN_TIME_OUT, last_interaction = millis());
 }
 
-#if LCD_TIMEOUT_TO_STATUS > 0
+#if SCREENS_CAN_TIME_OUT
   uint32_t BaseScreen::last_interaction;
 #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
@@ -27,7 +27,7 @@
 
 class BaseScreen : public UIScreen {
   protected:
-    #if LCD_TIMEOUT_TO_STATUS > 0
+    #if SCREENS_CAN_TIME_OUT
       static uint32_t last_interaction;
     #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
@@ -27,7 +27,7 @@
 
 class BaseScreen : public UIScreen {
   protected:
-    #if SCREENS_CAN_TIME_OUT
+    #if HAS_SCREEN_TIMEOUT
       static uint32_t last_interaction;
     #endif
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/base_screen.h
@@ -27,7 +27,7 @@
 
 class BaseScreen : public UIScreen {
   protected:
-    #if SCREENS_CAN_TIME_OUT
+    #if LCD_TIMEOUT_TO_STATUS > 0
       static uint32_t last_interaction;
     #endif
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -316,7 +316,7 @@ void MarlinUI::init() {
     #endif
   #endif
 
-  #if SCREENS_CAN_TIME_OUT
+  #if HAS_SCREEN_TIMEOUT
     bool MarlinUI::defer_return_to_status;
     millis_t MarlinUI::return_to_status_ms = 0;
   #endif
@@ -1171,7 +1171,7 @@ void MarlinUI::init() {
           NOLESS(max_display_update_time, millis() - ms);
       }
 
-      #if SCREENS_CAN_TIME_OUT
+      #if HAS_SCREEN_TIMEOUT
         // Return to Status Screen after a timeout
         if (on_status_screen() || defer_return_to_status)
           reset_status_timeout(ms);

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -545,7 +545,7 @@ public:
   #endif
 
   static void reset_status_timeout(const millis_t ms) {
-    TERN(SCREENS_CAN_TIME_OUT, return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS, UNUSED(ms));
+    TERN(HAS_SCREEN_TIMEOUT, return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS, UNUSED(ms));
   }
 
   #if HAS_MARLINUI_MENU
@@ -596,11 +596,11 @@ public:
     #endif
 
     FORCE_INLINE static bool screen_is_sticky() {
-      return TERN1(SCREENS_CAN_TIME_OUT, defer_return_to_status);
+      return TERN1(HAS_SCREEN_TIMEOUT, defer_return_to_status);
     }
 
     FORCE_INLINE static void defer_status_screen(const bool defer=true) {
-      TERN(SCREENS_CAN_TIME_OUT, defer_return_to_status = defer, UNUSED(defer));
+      TERN(HAS_SCREEN_TIMEOUT, defer_return_to_status = defer, UNUSED(defer));
     }
 
     static void goto_previous_screen_no_defer() {
@@ -778,7 +778,7 @@ public:
 
 private:
 
-  #if SCREENS_CAN_TIME_OUT
+  #if HAS_SCREEN_TIMEOUT
     static millis_t return_to_status_ms;
     static bool defer_return_to_status;
   #else

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -61,7 +61,7 @@ typedef struct {
   screenFunc_t menu_function;     // The screen's function
   uint32_t encoder_position;      // The position of the encoder
   int8_t top_line, items;         // The amount of scroll, and the number of items
-  #if SCREENS_CAN_TIME_OUT
+  #if HAS_SCREEN_TIMEOUT
     bool sticky;                  // The screen is sticky
   #endif
 } menuPosition;
@@ -89,7 +89,7 @@ void MarlinUI::return_to_status() { goto_screen(status_screen); }
 
 void MarlinUI::push_current_screen() {
   if (screen_history_depth < COUNT(screen_history))
-    screen_history[screen_history_depth++] = { currentScreen, encoderPosition, encoderTopLine, screen_items OPTARG(SCREENS_CAN_TIME_OUT, screen_is_sticky()) };
+    screen_history[screen_history_depth++] = { currentScreen, encoderPosition, encoderTopLine, screen_items OPTARG(HAS_SCREEN_TIMEOUT, screen_is_sticky()) };
 }
 
 void MarlinUI::_goto_previous_screen(TERN_(TURBO_BACK_MENU_ITEM, const bool is_back/*=false*/)) {
@@ -102,7 +102,7 @@ void MarlinUI::_goto_previous_screen(TERN_(TURBO_BACK_MENU_ITEM, const bool is_b
       is_back ? 0 : sh.top_line,
       sh.items
     );
-    defer_status_screen(TERN_(SCREENS_CAN_TIME_OUT, sh.sticky));
+    defer_status_screen(TERN_(HAS_SCREEN_TIMEOUT, sh.sticky));
   }
   else
     return_to_status();


### PR DESCRIPTION
The FTDI display was using SCREENS_CAN_TIME_OUT to determine if a timeout was set, however this caused compile issues throughout the rest of the marlinUI code when it was force on around the marlinui check. In order to avoid kicking in the extra defines and use just the necessary value, changed the conditionals for the feature to just look for the time value to be non-0.