### PR TITLE
Fix Stuck Print Abort Menu

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1630,7 +1630,7 @@ void MarlinUI::init() {
     #ifdef ACTION_ON_CANCEL
       hostui.cancel();
     #endif
-    IF_DISABLED(SDSUPPORT, print_job_timer.stop());
+    print_job_timer.stop();
     TERN_(HOST_PROMPT_SUPPORT, hostui.prompt_open(PROMPT_INFO, F("UI Aborted"), FPSTR(DISMISS_STR)));
     LCD_MESSAGE(MSG_PRINT_ABORTED);
     TERN_(HAS_MARLINUI_MENU, return_to_status());


### PR DESCRIPTION
When the print job timer has been started, the Abort menu is brought up. If SD printing is active, but the timer is left active, such as the case from a disconnected host (eg Raspberry Pi lost power and suddenly disconnected) the print job timer is left running. The local abort will not stop the print job timer if SD printing is enabled. This removes that check so everything that can set busy will be cleared, not leaving the menu stuck until you either reconnect a host terminal or power cycle.