### PR TITLE
Fix "Extra Tokens" Flash EEPROM Leveling Warning

### DIFF
--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -221,7 +221,7 @@ bool PersistentStore::access_finish() {
 
       return success;
 
-    #else
+    #else // !FLASH_EEPROM_LEVELING
 
       // The following was written for the STM32F4 but may work with other MCUs as well.
       // Most STM32F4 flash does not allow reading from flash during erase operations.

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -221,7 +221,7 @@ bool PersistentStore::access_finish() {
 
       return success;
 
-    #else !FLASH_EEPROM_LEVELING
+    #else
 
       // The following was written for the STM32F4 but may work with other MCUs as well.
       // Most STM32F4 flash does not allow reading from flash during erase operations.


### PR DESCRIPTION
### Description

Drop the `!FLASH_EEPROM_LEVELING` after the `else` in `eeprom_flash.cpp` to remove the `extra tokens at end of #else directive` warning.

### Related Issues

- Source of warning: https://github.com/MarlinFirmware/Marlin/commit/e298266eff9a53dd0bdddf5488135681d09baa77