### PR TITLE
patch move_extruder_servo for SWITCHING_EXTRUDER

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -115,7 +115,7 @@
 
   void move_extruder_servo(const uint8_t e) {
     planner.synchronize();
-    if ((EXTRUDERS & 1) && e < EXTRUDERS - 1) {
+    if (e < EXTRUDERS) {
       servo[_SERVO_NR(e)].move(servo_angles[_SERVO_NR(e)][e & 1]);
       safe_delay(500);
     }


### PR DESCRIPTION
### Description

Issue https://github.com/MarlinFirmware/Marlin/issues/24904 showed an issue with the servo not moving as expected.

After a bit of debugging found that (EXTRUDERS & 1)  fails for 0 and all even numbered extruders
The  SWITCHING_EXTRUDER has 2  or more even numbered extruders, This example with 2 extruders fails to enter the loop and servos are not moved into position.

Perhaps this has meant to check for a even number of extruders?

T1 was also ignored due to the EXTRUDERS - 1

I'm not sure why this code was here as it is and would definitely like this patch reviewed by someone more familiar with this section of the code.

### Requirements

SWITCHING_EXTRUDER and an even number of EXTRUDERS

### Benefits

Servo moves as expected on init, T0 and T1

### Configurations
https://github.com/MarlinFirmware/Marlin/files/9826532/updated.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24904