### PR TITLE
Add support for BLTOUCH to Tronxy X5S-2e

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -23,7 +23,14 @@
 
 #define BOARD_INFO_NAME "Chitu3D V5"
 
-#define Z_STOP_PIN                          PA14    //Pintout [+12/24v | G | S]
-#define SERVO0_PIN                          PA13    //Z+ (behind FILAMENT) Pinout [+5v|G|S]
+//
+// Servos
+//
+#define SERVO0_PIN                          PA13  // Z+ (behind FILAMENT) Pinout [+5v|G|S]
+
+//
+// Limit Switches
+//
+#define Z_STOP_PIN                          PA14  // Pinout [+12/24v|G|S]
 
 #include "pins_CHITU3D_common.h"

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -23,6 +23,7 @@
 
 #define BOARD_INFO_NAME "Chitu3D V5"
 
-#define Z_STOP_PIN                          PA14
+#define Z_STOP_PIN                          PA14    //Pintout [+12/24v | G | S]
+#define SERVO0_PIN                          PA13    //Z+ (behind FILAMENT) Pinout [+5v|G|S]
 
 #include "pins_CHITU3D_common.h"


### PR DESCRIPTION
Add support for BLTOUCH to Tronxy X5S-2e

Existing header [Z+] was not defined. Pinout has +5v|G|S, Signal on PA13, perfect for BLTOUCH servo control. 

Updated pins definition. Tested on standard Tronxy X5S-2e; Chitu cxy-v5-180409 with STM32f1

Updated config.h and config_adv.h files to follow


### Requirements

No. 

### Benefits

Allows BLTouch if defined. Nill effect otherwise

### Configurations

See Marlin_Configuration pull request for required files (TBA)
