### PR TITLE
[Feat/Fix] Toolchange evolution feature

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1204,6 +1204,8 @@
 
   //#define CALIBRATION_SCRIPT_PRE  "M117 Starting Auto-Calibration\nT0\nG28\nG12\nM117 Calibrating..."
   //#define CALIBRATION_SCRIPT_POST "M500\nM117 Calibration data saved"
+  //#define CALIBRATION_ALLOW_XY_IS_CORE  // Backlash & calibration allowed for CORE X/Y axis
+  //#define CALIBRATION_TOOLCHANGE_FEATURE_DISABLED // Disable prime, swap, moves and park during calibration
 
   #define CALIBRATION_MEASUREMENT_RESOLUTION     0.01 // mm
 
@@ -2529,7 +2531,7 @@
   // Z raise distance for tool-change, as needed for some extruders
   #define TOOLCHANGE_ZRAISE                 2 // (mm)
   //#define TOOLCHANGE_ZRAISE_BEFORE_RETRACT  // Apply raise before swap retraction (if enabled)
-  //#define TOOLCHANGE_NO_RETURN              // Never return to previous position on tool-change
+	//#define TOOLCHANGE_NO_RETURN              //  M216 R 0/1: Never return to previous position on tool-change
   #if ENABLED(TOOLCHANGE_NO_RETURN)
     //#define EVENT_GCODE_AFTER_TOOLCHANGE "G12X"   // Extra G-code to run after tool-change
   #endif
@@ -2560,10 +2562,10 @@
     #define TOOLCHANGE_FS_RETRACT_SPEED   (50*60) // (mm/min) (Unloading)
     #define TOOLCHANGE_FS_UNRETRACT_SPEED (25*60) // (mm/min) (On SINGLENOZZLE or Bowden loading must be slowed down)
 
-    // Longer prime to clean out a SINGLENOZZLE
+    // Longer prime to clean out
     #define TOOLCHANGE_FS_EXTRA_PRIME          0  // (mm) Extra priming length
     #define TOOLCHANGE_FS_PRIME_SPEED    (4.6*60) // (mm/min) Extra priming feedrate
-    #define TOOLCHANGE_FS_WIPE_RETRACT         0  // (mm) Cutting retraction out of park, for less stringing, better wipe, etc. Adjust with LCD or M217 G.
+    #define TOOLCHANGE_FS_WIPE_RETRACT         0  // (mm) Cutting retraction out of park, for less stringing, better wipe, etc. Adjust with LCD or M217 W.
 
     // Cool after prime to reduce stringing
     #define TOOLCHANGE_FS_FAN                 -1  // Fan index or -1 to skip
@@ -2574,13 +2576,37 @@
     //#define TOOLCHANGE_FS_SLOW_FIRST_PRIME
 
     /**
-     * Prime T0 the first time T0 is sent to the printer:
+     * Prime Txxx the first time Txxx is sent to the printer:
      *  [ Power-On -> T0 { Activate & Prime T0 } -> T1 { Retract T0, Activate & Prime T1 } ]
      * If disabled, no priming on T0 until switching back to T0 from another extruder:
      *  [ Power-On -> T0 { T0 Activated } -> T1 { Activate & Prime T1 } -> T0 { Retract T1, Activate & Prime T0 } ]
      * Enable with M217 V1 before printing to avoid unwanted priming on host connect.
+     * To avoid unwanted priming, value not stored, must be applied on printing file.
+     * Note: M217 Q, prime tool without resuming position. Can only be used for starting, not during printing
      */
     //#define TOOLCHANGE_FS_PRIME_FIRST_USED
+
+	 /**
+    * M217 N 0/1 Recover new tool just before printing.(Clean travel without leaks)
+    * Usefull with prime tower. On tool change the new tool stay swapped, travel over the object to prime tower position and print
+    * Or to play easily with colors in real time as you want.
+    * Cutting wipe + park are disabled when active.
+    * Migration disable this, only when priming with park
+    * M217 Q 'priming' disable this feature during process.
+    * Prime tool if not primed before.
+    * Disable toolchange if not recovered before.
+    * For better results, adjust resume length in negative and swap during infills printing.
+    */
+		//#define TOOLCHANGE_SMART_SWAP
+
+  	/**
+		* M217 H 0/1 Cutting wipe/travel Recover new tool just before printing.(Clean travel without leaks)
+    * Usefull for travelling after toolchange or to cut filament after priming with cooling and resume print cleaner.
+    * Disabled when TOOLCHANGE_SMART_SWAP enabled.
+    * Disable toolchange if not recovered before.
+    * M217 Q 'priming' can be used but not repeated if no printing command to recover.
+		*/
+    //#define TOOLCHANGE_SMART_CUT_WIPE
 
     /**
      * Tool Change Migration
@@ -2594,11 +2620,28 @@
      */
     #define TOOLCHANGE_MIGRATION_FEATURE
 
+    #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
+      //Override toolchange settings (To use prime tower(toolchange inside bed) with Migration outside)
+      #define MIGRATION_OVERRIDE_TOOLCHANGE_SETTINGS
+      #if ENABLED(MIGRATION_OVERRIDE_TOOLCHANGE_SETTINGS)
+        #define MIGRATION_ZRAISE                  5 // (mm)
+
+        // Longer prime to clean out
+        #define MIGRATION_FS_EXTRA_PRIME         50  // (mm) Extra priming length
+        #define MIGRATION_FS_WIPE_RETRACT        10  // (mm) Retract before cooling for less stringing, better wipe, etc.
+        // Cool after prime to reduce stringing
+        #ifdef TOOLCHANGE_FS_FAN
+          #define MIGRATION_FS_FAN_SPEED        255  // 0-255
+          #define MIGRATION_FS_FAN_TIME          10  // (seconds)
+        #endif
+      #endif // MIGRATION_OVERRIDE_TOOLCHANGE_SETTINGS
+    #endif //ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
   #endif
 
   /**
    * Position to park head during tool change.
    * Doesn't apply to SWITCHING_TOOLHEAD, DUAL_X_CARRIAGE, or PARKING_EXTRUDER
+   * M216 Gcodes (See m216.cpp for settings documentation)
    */
   //#define TOOLCHANGE_PARK
   #if ENABLED(TOOLCHANGE_PARK)
@@ -2606,6 +2649,16 @@
     #define TOOLCHANGE_PARK_XY_FEEDRATE 6000  // (mm/min)
     //#define TOOLCHANGE_PARK_X_ONLY          // X axis only move
     //#define TOOLCHANGE_PARK_Y_ONLY          // Y axis only move
+    #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
+      // Force park on normal mode migration
+      #define TOOLCHANGE_MIGRATION_ALWAYS_PARK
+
+      // Disable park & priming if target extruder already primed and swapped
+      // For playing easily with colors in realtime between primed extruders
+      // If not primed, make a normal migration
+      // M217 M[0/1]
+      #define TOOLCHANGE_MIGRATION_SWAP_ONLY_MODE
+    #endif
   #endif
 #endif // HAS_MULTI_EXTRUDER
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -163,7 +163,15 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
   inline void set_nozzle(measurements_t &m, const uint8_t extruder) {
     if (extruder != active_extruder) {
       park_above_object(m, CALIBRATION_MEASUREMENT_UNKNOWN);
-      tool_change(extruder);
+      #if ENABLED(CALIBRATION_TOOLCHANGE_FEATURE_DISABLED)
+        toolchange_settings_t tmp0 = {0};
+        REMEMBER(tmp, toolchange_settings);
+        toolchange_settings = tmp0;
+        tool_change(extruder);
+        RESTORE(tmp);
+      #else
+        tool_change(extruder);
+      #endif
     }
   }
 #endif
@@ -268,10 +276,10 @@ inline void probe_side(measurements_t &m, const float uncertainty, const side_t 
   #define _PCASE(N) _ACASE(N, N##MINIMUM, N##MAXIMUM)
 
   switch (side) {
-    #if AXIS_CAN_CALIBRATE(X)
+    #if HAS_X_AXIS && ( AXIS_CAN_CALIBRATE(X) || ENABLED(CALIBRATION_ALLOW_XY_IS_CORE))
       _ACASE(X, RIGHT, LEFT);
     #endif
-    #if HAS_Y_AXIS && AXIS_CAN_CALIBRATE(Y)
+    #if HAS_Y_AXIS && ( AXIS_CAN_CALIBRATE(Y) || ENABLED(CALIBRATION_ALLOW_XY_IS_CORE))
       _ACASE(Y, BACK, FRONT);
     #endif
     #if HAS_Z_AXIS && AXIS_CAN_CALIBRATE(Z)

--- a/Marlin/src/gcode/config/M216.cpp
+++ b/Marlin/src/gcode/config/M216.cpp
@@ -1,0 +1,98 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)
+
+#include "../gcode.h"
+#include "../../module/tool_change.h"
+#include "../../MarlinCore.h" // for SP_X_STR, etc.
+
+/**
+ * M216 - Set Tool change Park parameters
+ *
+ *  // Tool change Park settings
+ *  P[linear]     0/1 Enable park
+ *  X[linear]     Park X
+ *  Y[linear]     Park Y
+ *  I[linear]     Park I (Requires NUM_AXES >= 4)
+ *  J[linear]     Park J (Requires NUM_AXES >= 5)
+ *  K[linear]     Park K (Requires NUM_AXES >= 6)
+ *  C[linear]     Park U (Requires NUM_AXES >= 7)
+ *  H[linear]     Park V (Requires NUM_AXES >= 8)
+ *  O[linear]     Park W (Requires NUM_AXES >= 9)
+ *
+ */
+void GcodeSuite::M216() {
+
+  if (parser.seenval('P')) { toolchange_settings.enable_park = parser.value_linear_units(); }
+  if (parser.seenval('X')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.x = constrain(v, X_MIN_POS, X_MAX_POS); }
+  #if HAS_Y_AXIS
+    if (parser.seenval('Y')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.y = constrain(v, Y_MIN_POS, Y_MAX_POS); }
+  #endif
+  #if HAS_I_AXIS
+    if (parser.seenval('I')) { const int16_t v = parser.TERN(AXIS4_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.i = constrain(v, I_MIN_POS, I_MAX_POS); }
+  #endif
+  #if HAS_J_AXIS
+    if (parser.seenval('J')) { const int16_t v = parser.TERN(AXIS5_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.j = constrain(v, J_MIN_POS, J_MAX_POS); }
+  #endif
+  #if HAS_K_AXIS
+    if (parser.seenval('K')) { const int16_t v = parser.TERN(AXIS6_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.k = constrain(v, K_MIN_POS, K_MAX_POS); }
+  #endif
+  #if HAS_U_AXIS
+    if (parser.seenval('C')) { const int16_t v = parser.TERN(AXIS7_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.u = constrain(v, U_MIN_POS, U_MAX_POS); }
+  #endif
+  #if HAS_V_AXIS
+    if (parser.seenval('H')) { const int16_t v = parser.TERN(AXIS8_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.v = constrain(v, V_MIN_POS, V_MAX_POS); }
+  #endif
+  #if HAS_W_AXIS
+    if (parser.seenval('O')) { const int16_t v = parser.TERN(AXIS9_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.w = constrain(v, W_MIN_POS, W_MAX_POS); }
+  #endif
+
+  M216_report();
+}
+
+void GcodeSuite::M216_report(const bool forReplay/*=true*/) {
+
+  SERIAL_ECHOPGM("  M216");
+
+  SERIAL_ECHOPGM(" P", LINEAR_UNIT(toolchange_settings.enable_park));
+  SERIAL_ECHOPGM_P(
+        SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x)
+    #if HAS_Y_AXIS
+      , SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y)
+    #endif
+    #if SECONDARY_AXES >= 1
+      , LIST_N(DOUBLE(SECONDARY_AXES)
+          , SP_I_STR,   I_AXIS_UNIT(toolchange_settings.change_point.i)
+          , SP_J_STR,   J_AXIS_UNIT(toolchange_settings.change_point.j)
+          , SP_K_STR,   K_AXIS_UNIT(toolchange_settings.change_point.k)
+          , SP_C_STR,   U_AXIS_UNIT(toolchange_settings.change_point.u)
+          , PSTR(" H"), V_AXIS_UNIT(toolchange_settings.change_point.v)
+          , PSTR(" O"), W_AXIS_UNIT(toolchange_settings.change_point.w)
+        )
+    #endif
+  );
+}
+
+#endif // HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -37,33 +37,30 @@
  * M217 - Set toolchange parameters
  *
  *  // Tool change command
- *  Q           Prime active tool and exit
+ *  Q             Prime active tool and exit
+ *  C[extruder]   Reset specified (or active) extruder primed status (To prime on next T...)
  *
  *  // Tool change settings
  *  S[linear]     Swap length
  *  B[linear]     Extra Swap resume length
  *  E[linear]     Extra Prime length (as used by M217 Q)
- *  G[linear]     Cutting wipe retract length (<=100mm)
+ *  W[linear]     Cutting wipe retract length (<=100mm)
  *  R[linear/min] Retract speed
  *  U[linear/min] UnRetract speed
  *  P[linear/min] Prime speed
  *  V[linear]     0/1 Enable auto prime first extruder used
- *  W[linear]     0/1 Enable park & Z Raise
- *  X[linear]     Park X (Requires TOOLCHANGE_PARK)
- *  Y[linear]     Park Y (Requires TOOLCHANGE_PARK and NUM_AXES >= 2)
- *  I[linear]     Park I (Requires TOOLCHANGE_PARK and NUM_AXES >= 4)
- *  J[linear]     Park J (Requires TOOLCHANGE_PARK and NUM_AXES >= 5)
- *  K[linear]     Park K (Requires TOOLCHANGE_PARK and NUM_AXES >= 6)
- *  C[linear]     Park U (Requires TOOLCHANGE_PARK and NUM_AXES >= 7)
- *  H[linear]     Park V (Requires TOOLCHANGE_PARK and NUM_AXES >= 8)
- *  O[linear]     Park W (Requires TOOLCHANGE_PARK and NUM_AXES >= 9)
  *  Z[linear]     Z Raise
+ *  H[Linear]     0/1 Enable Smart cut wipe mode
+ *  N[Linear]     0/1 Enable Smart swap mode
+ *  O[linear]     0/1 Enable return to previous position
+ *
  *  F[speed]      Fan Speed 0-255
  *  D[seconds]    Fan time
  *
  * Tool migration settings
  *  A[0|1]      Enable auto-migration on runout
  *  L[index]    Last extruder to use for auto-migration
+ *  M[0|1]      Enable swap only migration (For primed extruder already swapped with no need to park/prime)
  *
  * Tool migration command
  *  T[index]    Migrate to next extruder or the given extruder
@@ -73,50 +70,32 @@ void GcodeSuite::M217() {
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
 
     static constexpr float max_extrude = TERN(PREVENT_LENGTHY_EXTRUDE, EXTRUDE_MAXLENGTH, 500);
-
-    if (parser.seen('Q')) { tool_change_prime(); return; }
-
+    if (parser.seen('C')) { const uint16_t v = parser.ushortval('C', active_extruder); extruder_was_primed.clear(constrain(v, 0, EXTRUDERS - 1)); }
+    if (parser.seen('Q')) {
+      extruder_was_primed.clear(active_extruder);
+      REMEMBER(tmp, enable_first_prime);
+      REMEMBER(tmp2, smart_recover.swap_mode);
+      enable_first_prime = true; smart_recover.swap_mode = false;
+      tool_change(active_extruder);
+      RESTORE(tmp);
+      RESTORE(tmp2);
+      return;
+    }
     if (parser.seenval('S')) { const float v = parser.value_linear_units(); toolchange_settings.swap_length = constrain(v, 0, max_extrude); }
     if (parser.seenval('B')) { const float v = parser.value_linear_units(); toolchange_settings.extra_resume = constrain(v, -10, 10); }
     if (parser.seenval('E')) { const float v = parser.value_linear_units(); toolchange_settings.extra_prime = constrain(v, 0, max_extrude); }
     if (parser.seenval('P')) { const int16_t v = parser.value_linear_units(); toolchange_settings.prime_speed = constrain(v, 10, 5400); }
-    if (parser.seenval('G')) { const int16_t v = parser.value_linear_units(); toolchange_settings.wipe_retract = constrain(v, 0, 100); }
+    if (parser.seenval('W')) { const int16_t v = parser.value_linear_units(); toolchange_settings.wipe_retract = constrain(v, 0, 100); }
     if (parser.seenval('R')) { const int16_t v = parser.value_linear_units(); toolchange_settings.retract_speed = constrain(v, 10, 5400); }
     if (parser.seenval('U')) { const int16_t v = parser.value_linear_units(); toolchange_settings.unretract_speed = constrain(v, 10, 5400); }
-    #if TOOLCHANGE_FS_FAN >= 0 && HAS_FAN
+    #if TOOLCHANGE_FS_FAN >= -1 && HAS_FAN
       if (parser.seenval('F')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_speed = constrain(v, 0, 255); }
-      if (parser.seenval('D')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_time = constrain(v, 1, 30); }
+      if (parser.seenval('D')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_time = constrain(v, 0, 30); }
     #endif
-  #endif
-
-  #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
+    if (parser.seenval('O')) { toolchange_settings.no_return = parser.value_linear_units(); }
     if (parser.seenval('V')) { enable_first_prime = parser.value_linear_units(); }
-  #endif
-
-  #if ENABLED(TOOLCHANGE_PARK)
-    if (parser.seenval('W')) { toolchange_settings.enable_park = parser.value_linear_units(); }
-    if (parser.seenval('X')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.x = constrain(v, X_MIN_POS, X_MAX_POS); }
-    #if HAS_Y_AXIS
-      if (parser.seenval('Y')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.y = constrain(v, Y_MIN_POS, Y_MAX_POS); }
-    #endif
-    #if HAS_I_AXIS
-      if (parser.seenval('I')) { const int16_t v = parser.TERN(AXIS4_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.i = constrain(v, I_MIN_POS, I_MAX_POS); }
-    #endif
-    #if HAS_J_AXIS
-      if (parser.seenval('J')) { const int16_t v = parser.TERN(AXIS5_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.j = constrain(v, J_MIN_POS, J_MAX_POS); }
-    #endif
-    #if HAS_K_AXIS
-      if (parser.seenval('K')) { const int16_t v = parser.TERN(AXIS6_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.k = constrain(v, K_MIN_POS, K_MAX_POS); }
-    #endif
-    #if HAS_U_AXIS
-      if (parser.seenval('C')) { const int16_t v = parser.TERN(AXIS7_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.u = constrain(v, U_MIN_POS, U_MAX_POS); }
-    #endif
-    #if HAS_V_AXIS
-      if (parser.seenval('H')) { const int16_t v = parser.TERN(AXIS8_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.v = constrain(v, V_MIN_POS, V_MAX_POS); }
-    #endif
-    #if HAS_W_AXIS
-      if (parser.seenval('O')) { const int16_t v = parser.TERN(AXIS9_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.w = constrain(v, W_MIN_POS, W_MAX_POS); }
-    #endif
+    if (parser.seenval('H')) { smart_recover.cut_wipe_mode = parser.value_linear_units(); }
+    if (parser.seenval('N')) { smart_recover.swap_mode = parser.value_linear_units(); }
   #endif
 
   #if HAS_Z_AXIS
@@ -136,6 +115,9 @@ void GcodeSuite::M217() {
 
     if (parser.seen('A'))       // Auto on/off
       migration.automode = parser.value_bool();
+
+    if (parser.seen('M'))       // Swap only mode on/off
+      migration.swap_only_mode = parser.value_bool();
 
     if (parser.seen('T')) {     // Migrate now
       if (parser.has_value()) {
@@ -166,47 +148,23 @@ void GcodeSuite::M217_report(const bool forReplay/*=true*/) {
   SERIAL_ECHOPGM("  M217");
 
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    SERIAL_ECHOPGM_P(
-      PSTR(" S"), LINEAR_UNIT(toolchange_settings.swap_length),
-        SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
-        SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
-        SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed),
-      PSTR(" G"), LINEAR_UNIT(toolchange_settings.wipe_retract),
-      PSTR(" R"), LINEAR_UNIT(toolchange_settings.retract_speed),
-      PSTR(" U"), LINEAR_UNIT(toolchange_settings.unretract_speed),
-      PSTR(" F"), toolchange_settings.fan_speed,
-      PSTR(" D"), toolchange_settings.fan_time
-    );
+    SERIAL_ECHOPGM(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPGM_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
+                     SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
+                     SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed));
+    SERIAL_ECHOPGM(" W", LINEAR_UNIT(toolchange_settings.wipe_retract),
+                   " R", LINEAR_UNIT(toolchange_settings.retract_speed),
+                   " U", LINEAR_UNIT(toolchange_settings.unretract_speed),
+                   " F", toolchange_settings.fan_speed,
+                   " D", toolchange_settings.fan_time);
 
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
       SERIAL_ECHOPGM(" A", migration.automode, " L", LINEAR_UNIT(migration.last));
     #endif
-
-    #if ENABLED(TOOLCHANGE_PARK)
-    {
-      SERIAL_ECHOPGM(" W", LINEAR_UNIT(toolchange_settings.enable_park));
-      SERIAL_ECHOPGM_P(
-            SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x)
-        #if HAS_Y_AXIS
-          , SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y)
-        #endif
-        #if SECONDARY_AXES >= 1
-          , LIST_N(DOUBLE(SECONDARY_AXES)
-              , SP_I_STR,   I_AXIS_UNIT(toolchange_settings.change_point.i)
-              , SP_J_STR,   J_AXIS_UNIT(toolchange_settings.change_point.j)
-              , SP_K_STR,   K_AXIS_UNIT(toolchange_settings.change_point.k)
-              , SP_C_STR,   U_AXIS_UNIT(toolchange_settings.change_point.u)
-              , PSTR(" H"), V_AXIS_UNIT(toolchange_settings.change_point.v)
-              , PSTR(" O"), W_AXIS_UNIT(toolchange_settings.change_point.w)
-            )
-        #endif
-      );
-    }
-    #endif
-
-    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-      SERIAL_ECHOPGM(" V", LINEAR_UNIT(enable_first_prime));
-    #endif
+    SERIAL_ECHOPGM(" O", LINEAR_UNIT(toolchange_settings.no_return));
+    SERIAL_ECHOPGM(" V", LINEAR_UNIT(enable_first_prime));
+    SERIAL_ECHOPGM(" N", LINEAR_UNIT(smart_recover.swap_mode));
+    SERIAL_ECHOPGM(" H", LINEAR_UNIT(smart_recover.cut_wipe_mode));
 
   #endif
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -739,8 +739,12 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 211: M211(); break;                                  // M211: Enable, Disable, and/or Report software endstops
       #endif
 
+      #if HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)
+        case 216: M216(); break;                                  // M216: Set toolchange park parameters
+      #endif
+
       #if HAS_MULTI_EXTRUDER
-        case 217: M217(); break;                                  // M217: Set filament swap parameters
+        case 217: M217(); break;                                  // M217: Set toolchange parameters
       #endif
 
       #if HAS_HOTEND_OFFSET

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -864,6 +864,10 @@ private:
   static void M211_report(const bool forReplay=true);
 
   #if HAS_MULTI_EXTRUDER
+    #if ENABLED(TOOLCHANGE_PARK)
+      static void M216();
+      static void M216_report(const bool forReplay=true);
+    #endif
     static void M217();
     static void M217_report(const bool forReplay=true);
   #endif

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -35,6 +35,11 @@
   #include "../../module/planner.h"
 #endif
 
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  #include "../../module/tool_change.h"
+  #include "../../module/planner.h"
+#endif
+
 extern xyze_pos_t destination;
 
 #if ENABLED(VARIABLE_G0_FEEDRATE)
@@ -105,6 +110,41 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
       }
 
     #endif // FWRETRACT
+
+    #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+      if (smart_recover.in_progress) {
+        // Cancel lower Z, if previous G0/G1 before printing
+        if (parser.seen_test('Z') && smart_recover.z_raise) destination.z += smart_recover.z_raise;
+        // Extrusion detection
+        if (parser.seen_test('E') && parser.seen(STR_AXES_MAIN)) {
+          // Lower Z at first
+          if (smart_recover.z_raise) {
+            destination.z -= smart_recover.z_raise;
+            do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
+            planner.synchronize();
+            smart_recover.z_raise = 0;
+          }
+          // Restore previous settings
+          REMEMBER(smart_recover_tmp, toolchange_settings);
+          toolchange_settings = smart_recover.tool_settings;
+          // Recover
+          if (smart_recover.do_swap) {
+            extruder_prime();
+            extruder_cutting_recover(migration.in_progress? smart_recover.resume_e : 0);
+          }
+          if (smart_recover.do_cut_wipe) {
+            extruder_cutting_recover(migration.in_progress? smart_recover.resume_e : 0);
+          }
+          // Reset and restore
+          smart_recover.do_swap = smart_recover.do_cut_wipe = smart_recover.in_progress = false;
+          RESTORE(smart_recover_tmp);
+          
+          #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
+            migration.in_progress = false;
+          #endif
+        }
+      }
+    #endif
 
     #if IS_SCARA
       fast_move ? prepare_fast_move_to_destination() : prepare_line_to_destination();

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -126,7 +126,7 @@ void menu_advanced_settings();
       EDIT_ITEM_FAST(int4, MSG_SINGLENOZZLE_PRIME_SPEED, &toolchange_settings.prime_speed, 10, 5400);
       EDIT_ITEM_FAST(int4, MSG_SINGLENOZZLE_WIPE_RETRACT, &toolchange_settings.wipe_retract, 0, 100);
       EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_SPEED, &toolchange_settings.fan_speed, 0, 255);
-      EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_TIME, &toolchange_settings.fan_time, 1, 30);
+      EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_TIME, &toolchange_settings.fan_time, 0, 30);
     #endif
     EDIT_ITEM(float3, MSG_TOOL_CHANGE_ZLIFT, &toolchange_settings.z_raise, 0, 10);
     END_MENU();

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2940,6 +2940,7 @@ void MarlinSettings::reset() {
       toolchange_settings.wipe_retract    = TOOLCHANGE_FS_WIPE_RETRACT;
       toolchange_settings.fan_speed       = TOOLCHANGE_FS_FAN_SPEED;
       toolchange_settings.fan_time        = TOOLCHANGE_FS_FAN_TIME;
+      smart_recover                       = smart_recover_defaults;
     #endif
 
     #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
@@ -2952,6 +2953,7 @@ void MarlinSettings::reset() {
       toolchange_settings.change_point = tpxy;
     #endif
 
+    toolchange_settings.no_return = TERN0(TOOLCHANGE_NO_RETURN, true);
     toolchange_settings.z_raise = TOOLCHANGE_ZRAISE;
 
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)

--- a/Marlin/src/module/tool_change.h
+++ b/Marlin/src/module/tool_change.h
@@ -27,23 +27,29 @@
 
 #if HAS_MULTI_EXTRUDER
 
+  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+    // Define any variables required
+    extern Flags<EXTRUDERS> extruder_was_primed; // Extruders primed status
+  #endif
+
   typedef struct {
     #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
       float swap_length;            // M217 S
       float extra_prime;            // M217 E
       float extra_resume;           // M217 B
       int16_t prime_speed;          // M217 P
-      int16_t wipe_retract;         // M217 G
+      int16_t wipe_retract;         // M217 W
       int16_t retract_speed;        // M217 R
       int16_t unretract_speed;      // M217 U
       uint8_t fan_speed;            // M217 F
       uint8_t fan_time;             // M217 D
     #endif
     #if ENABLED(TOOLCHANGE_PARK)
-      bool enable_park;             // M217 W
-      xyz_pos_t change_point;       // M217 X Y I J K C H O
+      bool enable_park;             // M216 P
+      xyz_pos_t change_point;       // M216 X Y I J K C H O
     #endif
     float z_raise;                  // M217 Z
+    bool no_return;                 // M217 O
   } toolchange_settings_t;
 
   extern toolchange_settings_t toolchange_settings;
@@ -52,20 +58,47 @@
     extern bool enable_first_prime; // M217 V
   #endif
 
-  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    void tool_change_prime(); // Prime the currently selected extruder
-  #endif
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  typedef struct {
+    bool swap_mode,     // M217 N
+         cut_wipe_mode, // M217 H
+         do_swap,
+         do_cut_wipe,
+         in_progress;
+    float resume_e,
+          z_raise; // z_raise stored to avoid changing value by lcd between process
+    toolchange_settings_t tool_settings;
+    } smart_recover_settings_t;
 
-  #if ENABLED(TOOLCHANGE_FS_INIT_BEFORE_SWAP)
-    extern Flags<EXTRUDERS> toolchange_extruder_ready;
+    constexpr smart_recover_settings_t smart_recover_defaults = {
+      //swap_mode
+      TERN0(TOOLCHANGE_SMART_SWAP, true),
+      //cut_wipe_mode
+      TERN0(TOOLCHANGE_SMART_CUT_WIPE, true),
+      //do_swap
+      false,
+      //do_cut_wipe
+      false,
+      // in_progress
+      false,
+      //Resume E
+      0,
+      //z_raise
+      0
+    };
+
+    extern smart_recover_settings_t smart_recover;
+
   #endif
 
   #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
     typedef struct {
       uint8_t target, last;
-      bool automode, in_progress;
+      bool automode, swap_only_mode, in_progress;
     } migration_settings_t;
-    constexpr migration_settings_t migration_defaults = { 0, 0, false, false };
+    constexpr migration_settings_t migration_defaults = { 0, 0, false,
+                TERN0(TOOLCHANGE_MIGRATION_SWAP_ONLY_MODE, true),
+                false };
     extern migration_settings_t migration;
     bool extruder_migration();
   #endif
@@ -132,3 +165,11 @@
  * previous tool out of the way and the new tool into place.
  */
 void tool_change(const uint8_t tmp_extruder, bool no_move=false);
+
+/**
+ * Recover active extruder after toolchange
+ */
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  void extruder_prime();
+  void extruder_cutting_recover(const_float_t e);
+#endif


### PR DESCRIPTION
@thinkyhead :  Really a big job and usefull for marlin. Need intensive testing by the communauty

- **Toolchange evolution major features**
  - **Smart Recover implementation** : 
    - This feature is amazing, the extruder recover only at the next printing command. Before this, the extruders recovered immediatly after toolchange, now, it waits the next G1 E.... to recover. The printing is cleaner. Two options : Smart swap that is made for prime tower, the old tool retract, the new tool stay swapped for travelling , travel to prime tower , swap & recover on it. 'Before ' , recover immediatly and leaks during travel to prime tower. Second option is cut_wipe , that is the same method but, for park, for ex , go to park cut_wipe retractation, travel and wait G1E... to recover. A big job , many hours of testing , must be in marlin. **_These two options can be enabled together_** , swap_mode disable cut_wipe_mode, but not if migration to park, these options can fully cohabit. 
  - **Migration override toolchange settings+ always park option** : 
    - For many reasons, Migration must have this own settings, because use toolchange_settings that can be modified any time. Always park is made to force park, if park is disabled while printing if prime tower is used ' park is useless , but not for migration'. Migration is a priming sequence and must have priming settings and not ' toolchange floating settings'
   - **Migration swap only mode** :  
     -   Option to play with colors like a piano,  now , if target extruder is already primed and swapped , a migration to this tool, will not use park and priming , a swap is made ' like a slicer should make ' and color is changed in one click. We can now change tools anytime during a print, and if extruder not primed , ' NORMAL migration is made , park+ priming' . (a simple toolchange cannot make this, totally impossible)

- **Toolchange evolution minor features**
  - **M216 implementation** :  Separation of toolchange M217 and toolchange "park" M216
  - **Add toolchange_setting.no_return** : Now possible to enable/disable 
  - **Add toolchange_settings.cutting_wipe** : Now possible to disable park and stop cutting wipe retract too.
  - **Toolchange active extruder Fan** : Fixes

  - **Code reduction/cleaning by deleting void toolchange_prime()** 
    - Explaination:  T0 when first used need toolchange_prime() , but T1 can first prime just with toolchange... It's an old code not updated , we can make a code reduction by deleting this function and make a special authorisation for T0 . Easy and no risk , because all the toolchange_prime() function have exactly the same cloned code in tool change
  - **Switching Nozzle Zraise feature** :  Lifting extruders use servos , but servos are too long for a z hop, this feature have been disabled because seems to be useless , but it's wrong, very usefull , to lift , to secure hotend offsets moves and more. Now possible!

- **Calibration**
  - **Calibration allowed for CORE XY or others** : Now possible to have corexy system and make a nozzle calibration. CoreXy have been ejected for special reasons , but , works fine anyway. This option can be disabled if needed
  - **Calibration disable toolchange feature** : No prime , swap , zraise, fans, park when calibration change tool.



Code cleaning , bug , feature , hope you will agree

Thks


