### PR TITLE
[Feat/Fix] Toolchange evolution feature (Cleaner operation and more )

### DIFF
--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -163,7 +163,15 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
   inline void set_nozzle(measurements_t &m, const uint8_t extruder) {
     if (extruder != active_extruder) {
       park_above_object(m, CALIBRATION_MEASUREMENT_UNKNOWN);
-      tool_change(extruder);
+      #if ENABLED(CALIBRATION_TOOLCHANGE_FEATURE_DISABLED)
+        toolchange_settings_t tmp0 = {0};
+        REMEMBER(tmp, toolchange_settings);
+        toolchange_settings = tmp0;
+        tool_change(extruder);
+        RESTORE(tmp);
+      #else
+        tool_change(extruder);
+      #endif
     }
   }
 #endif

--- a/Marlin/src/gcode/config/M216.cpp
+++ b/Marlin/src/gcode/config/M216.cpp
@@ -1,0 +1,99 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)
+
+#include "../gcode.h"
+#include "../../module/tool_change.h"
+#include "../../MarlinCore.h" // for SP_X_STR, etc.
+
+/**
+ * M216 - Set Tool change Park parameters
+ *
+ *  // Tool change Park settings
+ *  P[linear]     0/1 Enable park
+ *  X[linear]     Park X
+ *  Y[linear]     Park Y
+ *  I[linear]     Park I (Requires NUM_AXES >= 4)
+ *  J[linear]     Park J (Requires NUM_AXES >= 5)
+ *  K[linear]     Park K (Requires NUM_AXES >= 6)
+ *  C[linear]     Park U (Requires NUM_AXES >= 7)
+ *  H[linear]     Park V (Requires NUM_AXES >= 8)
+ *  O[linear]     Park W (Requires NUM_AXES >= 9)
+ *
+ */
+void GcodeSuite::M216() {
+
+  if (parser.seenval('P')) { toolchange_settings.enable_park = parser.value_linear_units(); }
+  if (parser.seenval('X')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.x = constrain(v, X_MIN_POS, X_MAX_POS); }
+  #if HAS_Y_AXIS
+    if (parser.seenval('Y')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.y = constrain(v, Y_MIN_POS, Y_MAX_POS); }
+  #endif
+  #if HAS_I_AXIS
+    if (parser.seenval('I')) { const int16_t v = parser.TERN(AXIS4_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.i = constrain(v, I_MIN_POS, I_MAX_POS); }
+  #endif
+  #if HAS_J_AXIS
+    if (parser.seenval('J')) { const int16_t v = parser.TERN(AXIS5_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.j = constrain(v, J_MIN_POS, J_MAX_POS); }
+  #endif
+  #if HAS_K_AXIS
+    if (parser.seenval('K')) { const int16_t v = parser.TERN(AXIS6_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.k = constrain(v, K_MIN_POS, K_MAX_POS); }
+  #endif
+  #if HAS_U_AXIS
+    if (parser.seenval('C')) { const int16_t v = parser.TERN(AXIS7_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.u = constrain(v, U_MIN_POS, U_MAX_POS); }
+  #endif
+  #if HAS_V_AXIS
+    if (parser.seenval('H')) { const int16_t v = parser.TERN(AXIS8_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.v = constrain(v, V_MIN_POS, V_MAX_POS); }
+  #endif
+  #if HAS_W_AXIS
+    if (parser.seenval('O')) { const int16_t v = parser.TERN(AXIS9_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.w = constrain(v, W_MIN_POS, W_MAX_POS); }
+  #endif
+
+  M216_report();
+}
+
+void GcodeSuite::M216_report(const bool forReplay/*=true*/) {
+
+  SERIAL_ECHOPGM("  M216");
+
+  SERIAL_ECHOPGM(" P", LINEAR_UNIT(toolchange_settings.enable_park));
+  SERIAL_ECHOPGM_P(
+        SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x)
+    #if HAS_Y_AXIS
+      , SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y)
+    #endif
+    #if SECONDARY_AXES >= 1
+      , LIST_N(DOUBLE(SECONDARY_AXES)
+          , SP_I_STR,   I_AXIS_UNIT(toolchange_settings.change_point.i)
+          , SP_J_STR,   J_AXIS_UNIT(toolchange_settings.change_point.j)
+          , SP_K_STR,   K_AXIS_UNIT(toolchange_settings.change_point.k)
+          , SP_C_STR,   U_AXIS_UNIT(toolchange_settings.change_point.u)
+          , PSTR(" H"), V_AXIS_UNIT(toolchange_settings.change_point.v)
+          , PSTR(" O"), W_AXIS_UNIT(toolchange_settings.change_point.w)
+        )
+    #endif
+  );
+  SERIAL_EOL();
+}
+
+#endif // HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -37,33 +37,30 @@
  * M217 - Set toolchange parameters
  *
  *  // Tool change command
- *  Q           Prime active tool and exit
+ *  Q             Prime active tool and exit
+ *  C[extruder]   Reset specified (or active) extruder primed status (To prime on next T...)
  *
  *  // Tool change settings
  *  S[linear]     Swap length
  *  B[linear]     Extra Swap resume length
  *  E[linear]     Extra Prime length (as used by M217 Q)
- *  G[linear]     Cutting wipe retract length (<=100mm)
+ *  W[linear]     Cutting wipe retract length (<=100mm)
  *  R[linear/min] Retract speed
  *  U[linear/min] UnRetract speed
  *  P[linear/min] Prime speed
  *  V[linear]     0/1 Enable auto prime first extruder used
- *  W[linear]     0/1 Enable park & Z Raise
- *  X[linear]     Park X (Requires TOOLCHANGE_PARK)
- *  Y[linear]     Park Y (Requires TOOLCHANGE_PARK and NUM_AXES >= 2)
- *  I[linear]     Park I (Requires TOOLCHANGE_PARK and NUM_AXES >= 4)
- *  J[linear]     Park J (Requires TOOLCHANGE_PARK and NUM_AXES >= 5)
- *  K[linear]     Park K (Requires TOOLCHANGE_PARK and NUM_AXES >= 6)
- *  C[linear]     Park U (Requires TOOLCHANGE_PARK and NUM_AXES >= 7)
- *  H[linear]     Park V (Requires TOOLCHANGE_PARK and NUM_AXES >= 8)
- *  O[linear]     Park W (Requires TOOLCHANGE_PARK and NUM_AXES >= 9)
  *  Z[linear]     Z Raise
+ *  H[Linear]     0/1 Enable Smart cut wipe mode
+ *  N[Linear]     0/1 Enable Smart swap mode
+ *  O[linear]     0/1 Enable return to previous position
+ *
  *  F[speed]      Fan Speed 0-255
  *  D[seconds]    Fan time
  *
  * Tool migration settings
  *  A[0|1]      Enable auto-migration on runout
  *  L[index]    Last extruder to use for auto-migration
+ *  M[0|1]      Enable swap only migration (For primed extruder already swapped with no need to park/prime)
  *
  * Tool migration command
  *  T[index]    Migrate to next extruder or the given extruder
@@ -73,50 +70,32 @@ void GcodeSuite::M217() {
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
 
     static constexpr float max_extrude = TERN(PREVENT_LENGTHY_EXTRUDE, EXTRUDE_MAXLENGTH, 500);
-
-    if (parser.seen('Q')) { tool_change_prime(); return; }
-
+    if (parser.seen('C')) { const uint16_t v = parser.ushortval('C', active_extruder); extruder_was_primed.clear(constrain(v, 0, EXTRUDERS - 1)); }
+    if (parser.seen('Q')) {
+      extruder_was_primed.clear(active_extruder);
+      REMEMBER(tmp, enable_first_prime);
+      REMEMBER(tmp2, smart_recover.swap_mode);
+      enable_first_prime = true; smart_recover.swap_mode = false;
+      tool_change(active_extruder);
+      RESTORE(tmp);
+      RESTORE(tmp2);
+      return;
+    }
     if (parser.seenval('S')) { const float v = parser.value_linear_units(); toolchange_settings.swap_length = constrain(v, 0, max_extrude); }
     if (parser.seenval('B')) { const float v = parser.value_linear_units(); toolchange_settings.extra_resume = constrain(v, -10, 10); }
     if (parser.seenval('E')) { const float v = parser.value_linear_units(); toolchange_settings.extra_prime = constrain(v, 0, max_extrude); }
     if (parser.seenval('P')) { const int16_t v = parser.value_linear_units(); toolchange_settings.prime_speed = constrain(v, 10, 5400); }
-    if (parser.seenval('G')) { const int16_t v = parser.value_linear_units(); toolchange_settings.wipe_retract = constrain(v, 0, 100); }
+    if (parser.seenval('W')) { const int16_t v = parser.value_linear_units(); toolchange_settings.wipe_retract = constrain(v, 0, 100); }
     if (parser.seenval('R')) { const int16_t v = parser.value_linear_units(); toolchange_settings.retract_speed = constrain(v, 10, 5400); }
     if (parser.seenval('U')) { const int16_t v = parser.value_linear_units(); toolchange_settings.unretract_speed = constrain(v, 10, 5400); }
-    #if TOOLCHANGE_FS_FAN >= 0 && HAS_FAN
+    #if TOOLCHANGE_FS_FAN >= -1 && HAS_FAN
       if (parser.seenval('F')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_speed = constrain(v, 0, 255); }
-      if (parser.seenval('D')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_time = constrain(v, 1, 30); }
+      if (parser.seenval('D')) { const uint16_t v = parser.value_ushort(); toolchange_settings.fan_time = constrain(v, 0, 30); }
     #endif
-  #endif
-
-  #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
+    if (parser.seenval('O')) { toolchange_settings.no_return = parser.value_linear_units(); }
     if (parser.seenval('V')) { enable_first_prime = parser.value_linear_units(); }
-  #endif
-
-  #if ENABLED(TOOLCHANGE_PARK)
-    if (parser.seenval('W')) { toolchange_settings.enable_park = parser.value_linear_units(); }
-    if (parser.seenval('X')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.x = constrain(v, X_MIN_POS, X_MAX_POS); }
-    #if HAS_Y_AXIS
-      if (parser.seenval('Y')) { const int16_t v = parser.value_linear_units(); toolchange_settings.change_point.y = constrain(v, Y_MIN_POS, Y_MAX_POS); }
-    #endif
-    #if HAS_I_AXIS
-      if (parser.seenval('I')) { const int16_t v = parser.TERN(AXIS4_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.i = constrain(v, I_MIN_POS, I_MAX_POS); }
-    #endif
-    #if HAS_J_AXIS
-      if (parser.seenval('J')) { const int16_t v = parser.TERN(AXIS5_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.j = constrain(v, J_MIN_POS, J_MAX_POS); }
-    #endif
-    #if HAS_K_AXIS
-      if (parser.seenval('K')) { const int16_t v = parser.TERN(AXIS6_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.k = constrain(v, K_MIN_POS, K_MAX_POS); }
-    #endif
-    #if HAS_U_AXIS
-      if (parser.seenval('C')) { const int16_t v = parser.TERN(AXIS7_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.u = constrain(v, U_MIN_POS, U_MAX_POS); }
-    #endif
-    #if HAS_V_AXIS
-      if (parser.seenval('H')) { const int16_t v = parser.TERN(AXIS8_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.v = constrain(v, V_MIN_POS, V_MAX_POS); }
-    #endif
-    #if HAS_W_AXIS
-      if (parser.seenval('O')) { const int16_t v = parser.TERN(AXIS9_ROTATES, value_int, value_linear_units)(); toolchange_settings.change_point.w = constrain(v, W_MIN_POS, W_MAX_POS); }
-    #endif
+    if (parser.seenval('H')) { smart_recover.cut_wipe_mode = parser.value_linear_units(); }
+    if (parser.seenval('N')) { smart_recover.swap_mode = parser.value_linear_units(); }
   #endif
 
   #if HAS_Z_AXIS
@@ -136,6 +115,9 @@ void GcodeSuite::M217() {
 
     if (parser.seen('A'))       // Auto on/off
       migration.automode = parser.value_bool();
+
+    if (parser.seen('M'))       // Swap only mode on/off
+      migration.swap_only_mode = parser.value_bool();
 
     if (parser.seen('T')) {     // Migrate now
       if (parser.has_value()) {
@@ -166,47 +148,23 @@ void GcodeSuite::M217_report(const bool forReplay/*=true*/) {
   SERIAL_ECHOPGM("  M217");
 
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    SERIAL_ECHOPGM_P(
-      PSTR(" S"), LINEAR_UNIT(toolchange_settings.swap_length),
-        SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
-        SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
-        SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed),
-      PSTR(" G"), LINEAR_UNIT(toolchange_settings.wipe_retract),
-      PSTR(" R"), LINEAR_UNIT(toolchange_settings.retract_speed),
-      PSTR(" U"), LINEAR_UNIT(toolchange_settings.unretract_speed),
-      PSTR(" F"), toolchange_settings.fan_speed,
-      PSTR(" D"), toolchange_settings.fan_time
-    );
+    SERIAL_ECHOPGM(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPGM_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
+                     SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
+                     SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed));
+    SERIAL_ECHOPGM(" W", LINEAR_UNIT(toolchange_settings.wipe_retract),
+                   " R", LINEAR_UNIT(toolchange_settings.retract_speed),
+                   " U", LINEAR_UNIT(toolchange_settings.unretract_speed),
+                   " F", toolchange_settings.fan_speed,
+                   " D", toolchange_settings.fan_time);
 
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
       SERIAL_ECHOPGM(" A", migration.automode, " L", LINEAR_UNIT(migration.last));
     #endif
-
-    #if ENABLED(TOOLCHANGE_PARK)
-    {
-      SERIAL_ECHOPGM(" W", LINEAR_UNIT(toolchange_settings.enable_park));
-      SERIAL_ECHOPGM_P(
-            SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x)
-        #if HAS_Y_AXIS
-          , SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y)
-        #endif
-        #if SECONDARY_AXES >= 1
-          , LIST_N(DOUBLE(SECONDARY_AXES)
-              , SP_I_STR,   I_AXIS_UNIT(toolchange_settings.change_point.i)
-              , SP_J_STR,   J_AXIS_UNIT(toolchange_settings.change_point.j)
-              , SP_K_STR,   K_AXIS_UNIT(toolchange_settings.change_point.k)
-              , SP_C_STR,   U_AXIS_UNIT(toolchange_settings.change_point.u)
-              , PSTR(" H"), V_AXIS_UNIT(toolchange_settings.change_point.v)
-              , PSTR(" O"), W_AXIS_UNIT(toolchange_settings.change_point.w)
-            )
-        #endif
-      );
-    }
-    #endif
-
-    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-      SERIAL_ECHOPGM(" V", LINEAR_UNIT(enable_first_prime));
-    #endif
+    SERIAL_ECHOPGM(" O", LINEAR_UNIT(toolchange_settings.no_return));
+    SERIAL_ECHOPGM(" V", LINEAR_UNIT(enable_first_prime));
+    SERIAL_ECHOPGM(" N", LINEAR_UNIT(smart_recover.swap_mode));
+    SERIAL_ECHOPGM(" H", LINEAR_UNIT(smart_recover.cut_wipe_mode));
 
   #endif
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -739,8 +739,12 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 211: M211(); break;                                  // M211: Enable, Disable, and/or Report software endstops
       #endif
 
+      #if HAS_MULTI_EXTRUDER && ENABLED(TOOLCHANGE_PARK)
+        case 216: M216(); break;                                  // M216: Set toolchange park parameters
+      #endif
+
       #if HAS_MULTI_EXTRUDER
-        case 217: M217(); break;                                  // M217: Set filament swap parameters
+        case 217: M217(); break;                                  // M217: Set toolchange parameters
       #endif
 
       #if HAS_HOTEND_OFFSET

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -864,6 +864,10 @@ private:
   static void M211_report(const bool forReplay=true);
 
   #if HAS_MULTI_EXTRUDER
+    #if ENABLED(TOOLCHANGE_PARK)
+      static void M216();
+      static void M216_report(const bool forReplay=true);
+    #endif
     static void M217();
     static void M217_report(const bool forReplay=true);
   #endif

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -35,6 +35,11 @@
   #include "../../module/planner.h"
 #endif
 
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  #include "../../module/tool_change.h"
+  #include "../../module/planner.h"
+#endif
+
 extern xyze_pos_t destination;
 
 #if ENABLED(VARIABLE_G0_FEEDRATE)
@@ -105,6 +110,41 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
       }
 
     #endif // FWRETRACT
+
+    #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+      if (smart_recover.in_progress) {
+        // Cancel lower Z, if previous G0/G1 Zxxx before printing
+        if (parser.seen_test('Z') && smart_recover.z_raise) destination.z += smart_recover.z_raise;
+        // Extrusion detection
+        if (parser.seen_test('E') && parser.seen(STR_AXES_MAIN)) {
+          // Lower Z at first
+          if (smart_recover.z_raise) {
+            destination.z -= smart_recover.z_raise;
+            do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
+            planner.synchronize();
+            smart_recover.z_raise = 0;
+          }
+          // Restore previous settings
+          REMEMBER(smart_recover_tmp, toolchange_settings);
+          toolchange_settings = smart_recover.tool_settings;
+          // Recover
+          if (smart_recover.do_swap) {
+            extruder_prime();
+            extruder_cutting_recover(migration.in_progress? smart_recover.resume_e : 0);
+          }
+          if (smart_recover.do_cut_wipe) {
+            extruder_cutting_recover(migration.in_progress? smart_recover.resume_e : 0);
+          }
+          // Reset and restore
+          smart_recover.do_swap = smart_recover.do_cut_wipe = smart_recover.in_progress = false;
+          RESTORE(smart_recover_tmp);
+
+          #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
+            migration.in_progress = false;
+          #endif
+        }
+      }
+    #endif
 
     #if EITHER(IS_SCARA, POLAR)
       fast_move ? prepare_fast_move_to_destination() : prepare_line_to_destination();

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -254,12 +254,13 @@
 
 // Calibration codes only for non-core axes
 #if EITHER(BACKLASH_GCODE, CALIBRATION_GCODE)
-  #if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX)
+  #if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX) && DISABLED(CALIBRATION_ALLOW_CORE_AXES)
     #define CAN_CALIBRATE(A,B) (_AXIS(A) == B)
   #else
     #define CAN_CALIBRATE(A,B) true
   #endif
 #endif
+
 #define AXIS_CAN_CALIBRATE(A) CAN_CALIBRATE(A,NORMAL_AXIS)
 
 /**

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -126,7 +126,7 @@ void menu_advanced_settings();
       EDIT_ITEM_FAST(int4, MSG_SINGLENOZZLE_PRIME_SPEED, &toolchange_settings.prime_speed, 10, 5400);
       EDIT_ITEM_FAST(int4, MSG_SINGLENOZZLE_WIPE_RETRACT, &toolchange_settings.wipe_retract, 0, 100);
       EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_SPEED, &toolchange_settings.fan_speed, 0, 255);
-      EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_TIME, &toolchange_settings.fan_time, 1, 30);
+      EDIT_ITEM_FAST(uint8, MSG_SINGLENOZZLE_FAN_TIME, &toolchange_settings.fan_time, 0, 30);
     #endif
     EDIT_ITEM(float3, MSG_TOOL_CHANGE_ZLIFT, &toolchange_settings.z_raise, 0, 10);
     END_MENU();

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2973,6 +2973,7 @@ void MarlinSettings::reset() {
       toolchange_settings.wipe_retract    = TOOLCHANGE_FS_WIPE_RETRACT;
       toolchange_settings.fan_speed       = TOOLCHANGE_FS_FAN_SPEED;
       toolchange_settings.fan_time        = TOOLCHANGE_FS_FAN_TIME;
+      smart_recover                       = smart_recover_defaults;
     #endif
 
     #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
@@ -2985,6 +2986,7 @@ void MarlinSettings::reset() {
       toolchange_settings.change_point = tpxy;
     #endif
 
+    toolchange_settings.no_return = TERN0(TOOLCHANGE_NO_RETURN, true);
     toolchange_settings.z_raise = TOOLCHANGE_ZRAISE;
 
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -45,8 +45,14 @@
   migration_settings_t migration = migration_defaults;
 #endif
 
-#if ENABLED(TOOLCHANGE_FS_INIT_BEFORE_SWAP)
-  Flags<EXTRUDERS> toolchange_extruder_ready;
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  // Define any variables required
+  Flags<EXTRUDERS> extruder_did_first_prime;  // Extruders first priming status
+  Flags<EXTRUDERS> extruder_was_primed; // Extruders primed status
+  smart_recover_settings_t smart_recover = smart_recover_defaults;
+  #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
+    bool enable_first_prime; // As set by M217 V
+  #endif
 #endif
 
 #if EITHER(MAGNETIC_PARKING_EXTRUDER, TOOL_SENSOR) \
@@ -906,19 +912,12 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     #define FS_DEBUG(...) NOOP
   #endif
 
-  // Define any variables required
-  static Flags<EXTRUDERS> extruder_was_primed; // Extruders primed status
-
-  #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-    bool enable_first_prime; // As set by M217 V
-  #endif
-
   // Cool down with fan
   inline void filament_swap_cooling() {
-    #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-      thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = toolchange_settings.fan_speed;
+    #if HAS_FAN && defined(TOOLCHANGE_FS_FAN)
+      thermalManager.fan_speed[TOOLCHANGE_FS_FAN < 0 ? active_extruder : TOOLCHANGE_FS_FAN] = toolchange_settings.fan_speed;
       gcode.dwell(SEC_TO_MS(toolchange_settings.fan_time));
-      thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = FAN_OFF_PWM;
+      thermalManager.fan_speed[TOOLCHANGE_FS_FAN < 0 ? active_extruder : TOOLCHANGE_FS_FAN] = FAN_OFF_PWM;
     #endif
   }
 
@@ -946,7 +945,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
    */
   void extruder_cutting_recover(const_float_t e) {
     if (!too_cold(active_extruder)) {
-      const float dist = toolchange_settings.extra_resume + toolchange_settings.wipe_retract;
+      const float dist = toolchange_settings.extra_resume + (smart_recover.do_swap? 0 : toolchange_settings.wipe_retract);
       FS_DEBUG("Performing Cutting Recover | Distance: ", dist, " | Speed: ", MMM_TO_MMS(toolchange_settings.unretract_speed), "mm/s");
       unscaled_e_move(dist, MMM_TO_MMS(toolchange_settings.unretract_speed));
       planner.synchronize();
@@ -976,7 +975,6 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       /**
        * Perform first unretract movement at the slower Prime_Speed to avoid breakage on first prime
        */
-      static Flags<EXTRUDERS> extruder_did_first_prime;  // Extruders first priming status
       if (!extruder_did_first_prime[active_extruder]) {
         extruder_did_first_prime.set(active_extruder);   // Log first prime complete
         // new nozzle - prime at user-specified speed.
@@ -993,7 +991,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       FS_DEBUG("Loading Filament for T", active_extruder, " | Distance: ", toolchange_settings.swap_length, " | Speed: ", MMM_TO_MMS(fr), "mm/s");
       unscaled_e_move(toolchange_settings.swap_length, MMM_TO_MMS(fr)); // Prime (Unretract) filament by extruding equal to Swap Length (Unretract)
 
-      if (toolchange_settings.extra_prime > 0) {
+      if ((toolchange_settings.extra_prime > 0) && !smart_recover.do_swap) {
         FS_DEBUG("Performing Extra Priming for T", active_extruder, " | Distance: ", toolchange_settings.extra_prime, " | Speed: ", MMM_TO_MMS(toolchange_settings.prime_speed), "mm/s");
         unscaled_e_move(toolchange_settings.extra_prime, MMM_TO_MMS(toolchange_settings.prime_speed)); // Extra Prime Distance
       }
@@ -1011,90 +1009,31 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     // Cutting retraction
     #if TOOLCHANGE_FS_WIPE_RETRACT
-      FS_DEBUG("Performing Cutting Retraction | Distance: ", -toolchange_settings.wipe_retract, " | Speed: ", MMM_TO_MMS(toolchange_settings.retract_speed), "mm/s");
-      unscaled_e_move(-toolchange_settings.wipe_retract, MMM_TO_MMS(toolchange_settings.retract_speed));
+      FS_DEBUG("Performing Cutting Retraction | Distance: ", -(smart_recover.do_swap? 0 : toolchange_settings.wipe_retract), " | Speed: ", MMM_TO_MMS(toolchange_settings.retract_speed), "mm/s");
+      if(!smart_recover.do_swap)unscaled_e_move(-(toolchange_settings.wipe_retract), MMM_TO_MMS(toolchange_settings.retract_speed));
     #endif
 
     // Cool down with fan
-    filament_swap_cooling();
-
-  }
-
-  /**
-   * Sequence to Prime the currently selected extruder
-   * Raise Z, move the ToolChange_Park if enabled, prime the extruder, move back.
-   */
-  void tool_change_prime() {
-
-    FS_DEBUG(">>> tool_change_prime()");
-
-    if (!too_cold(active_extruder)) {
-      destination = current_position; // Remember the old position
-
-      const bool ok = TERN1(TOOLCHANGE_PARK, all_axes_homed() && toolchange_settings.enable_park);
-
-      #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-        // Store and stop fan. Restored on any exit.
-        REMEMBER(fan, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
-      #endif
-
-      // Z raise
-      if (ok) {
-        // Do a small lift to avoid the workpiece in the move back (below)
-        current_position.z += toolchange_settings.z_raise;
-        TERN_(HAS_SOFTWARE_ENDSTOPS, NOMORE(current_position.z, soft_endstop.max.z));
-        fast_line_to_current(Z_AXIS);
-        planner.synchronize();
-      }
-
-      // Park
-      #if ENABLED(TOOLCHANGE_PARK)
-        if (ok) {
-          IF_DISABLED(TOOLCHANGE_PARK_Y_ONLY, current_position.x = toolchange_settings.change_point.x);
-          IF_DISABLED(TOOLCHANGE_PARK_X_ONLY, current_position.y = toolchange_settings.change_point.y);
-          #if NONE(TOOLCHANGE_PARK_X_ONLY, TOOLCHANGE_PARK_Y_ONLY)
-            SECONDARY_AXIS_CODE(
-              current_position.i = toolchange_settings.change_point.i,
-              current_position.j = toolchange_settings.change_point.j,
-              current_position.k = toolchange_settings.change_point.k,
-              current_position.u = toolchange_settings.change_point.u,
-              current_position.v = toolchange_settings.change_point.v,
-              current_position.w = toolchange_settings.change_point.w
-            );
-          #endif
-          planner.buffer_line(current_position, MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE), active_extruder);
-          planner.synchronize();
-        }
-      #endif
-
-      extruder_prime();
-
-      // Move back
-      #if ENABLED(TOOLCHANGE_PARK)
-        if (ok) {
-          #if ENABLED(TOOLCHANGE_NO_RETURN)
-            const float temp = destination.z;
-            destination = current_position;
-            destination.z = temp;
-          #endif
-          prepare_internal_move_to_destination(TERN(TOOLCHANGE_NO_RETURN, planner.settings.max_feedrate_mm_s[Z_AXIS], MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE)));
-        }
-      #endif
-
-      extruder_cutting_recover(destination.e); // Cutting recover
-    }
-
-    FS_DEBUG("<<< tool_change_prime");
+    if(!smart_recover.do_swap) filament_swap_cooling();
 
   }
 
 #endif // TOOLCHANGE_FILAMENT_SWAP
+
+
 
 /**
  * Perform a tool-change, which may result in moving the
  * previous tool out of the way and the new tool into place.
  */
 void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
+
+  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+    if (smart_recover.do_swap || smart_recover.do_cut_wipe)   return invalid_extruder_error(new_tool);
+    // Remember extruder position
+    smart_recover.resume_e = current_position.e;
+    const bool smart_swap_allowed = extruder_was_primed[new_tool] && smart_recover.swap_mode;
+  #endif
 
   if (TERN0(MAGNETIC_SWITCHING_TOOLHEAD, new_tool == active_extruder))
     return;
@@ -1155,39 +1094,57 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     #endif
 
     const uint8_t old_tool = active_extruder;
-    const bool can_move_away = !no_move && !idex_full_control;
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       // Workaround for UBL mesh boundary, possibly?
       TEMPORARY_BED_LEVELING_STATE(false);
     #endif
 
-    // First tool priming. To prime again, reboot the machine. -- Should only occur for first T0 after powerup!
-    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-      if (enable_first_prime && old_tool == 0 && new_tool == 0 && !extruder_was_primed[0]) {
-        tool_change_prime();
-        TERN_(TOOLCHANGE_FS_INIT_BEFORE_SWAP, toolchange_extruder_ready.set(old_tool)); // Primed and initialized
-      }
+    // First tool priming. To prime again, use M217 Q. -- Should only occur for first Txxx after powerup!
+    #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+      const bool can_prime_tool = (!extruder_was_primed[new_tool] && enable_first_prime);
+      if (can_prime_tool) no_move = false;
     #endif
 
-    if (new_tool != old_tool || TERN0(PARKING_EXTRUDER, extruder_parked)) { // PARKING_EXTRUDER may need to attach old_tool when homing
+    const bool can_move_away = !no_move && !idex_full_control;
+
+    if (new_tool != old_tool || TERN0(PARKING_EXTRUDER, extruder_parked) || TERN0(TOOLCHANGE_FILAMENT_SWAP,can_prime_tool)) { // PARKING_EXTRUDER may need to attach old_tool when homing
       destination = current_position;
 
-      #if BOTH(TOOLCHANGE_FILAMENT_SWAP, HAS_FAN) && TOOLCHANGE_FS_FAN >= 0
+      #if HAS_FAN && defined(TOOLCHANGE_FS_FAN)
         // Store and stop fan. Restored on any exit.
-        REMEMBER(fan, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
+        REMEMBER(fan, thermalManager.fan_speed[TOOLCHANGE_FS_FAN < 0 ? active_extruder : TOOLCHANGE_FS_FAN], 0);
       #endif
 
-      // Z raise before retraction
-      #if ENABLED(TOOLCHANGE_ZRAISE_BEFORE_RETRACT) && DISABLED(SWITCHING_NOZZLE)
-        if (can_move_away && TERN1(TOOLCHANGE_PARK, toolchange_settings.enable_park)) {
+      auto toolchange_zraise = [] {
+        if (toolchange_settings.z_raise) {
+
+          // Save z_raise value
+          #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+            const float current_position_tmp = current_position.z + toolchange_settings.z_raise;
+            smart_recover.z_raise = toolchange_settings.z_raise;
+          #endif
+
           // Do a small lift to avoid the workpiece in the move back (below)
           current_position.z += toolchange_settings.z_raise;
           TERN_(HAS_SOFTWARE_ENDSTOPS, NOMORE(current_position.z, soft_endstop.max.z));
+
+          #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+            // z_raise limiter
+            if (current_position_tmp > current_position.z) {
+              smart_recover.z_raise -= (current_position_tmp - current_position.z);
+              LIMIT(smart_recover.z_raise, 0 , toolchange_settings.z_raise);
+            }
+          #endif
           fast_line_to_current(Z_AXIS);
-          planner.synchronize();
+          return true;
         }
-      #endif
+        return false;
+      };
+
+      // Z raise (before retraction)
+      if (TERN0(TOOLCHANGE_ZRAISE_BEFORE_RETRACT, can_move_away) && toolchange_zraise())
+        planner.synchronize();
 
       // Unload / Retract
       #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
@@ -1197,7 +1154,8 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             // If SingleNozzle setup is too cold, unable to perform tool_change.
             if (ENABLED(SINGLENOZZLE)) { active_extruder = new_tool; return; }
           }
-          else if (extruder_was_primed[old_tool]) {
+          // did_firt_prime added to allow M217Q of an already primed tool
+          else if (extruder_was_primed[old_tool] || extruder_did_first_prime[old_tool]) {
             // Retract the old extruder if it was previously primed
             // To-Do: Should SingleNozzle always retract?
             FS_DEBUG("Retracting Filament for T", old_tool, ". | Distance: ", toolchange_settings.swap_length, " | Speed: ", MMM_TO_MMS(toolchange_settings.retract_speed), "mm/s");
@@ -1223,18 +1181,13 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         #endif
       #endif
 
-      #if DISABLED(TOOLCHANGE_ZRAISE_BEFORE_RETRACT) && DISABLED(SWITCHING_NOZZLE)
-        if (can_move_away && TERN1(TOOLCHANGE_PARK, toolchange_settings.enable_park)) {
-          // Do a small lift to avoid the workpiece in the move back (below)
-          current_position.z += toolchange_settings.z_raise;
-          TERN_(HAS_SOFTWARE_ENDSTOPS, NOMORE(current_position.z, soft_endstop.max.z));
-          fast_line_to_current(Z_AXIS);
-        }
-      #endif
+      // Z raise (after retraction)
+      if (TERN(TOOLCHANGE_ZRAISE_BEFORE_RETRACT, false, can_move_away))
+        toolchange_zraise();
 
       // Toolchange park
-      #if ENABLED(TOOLCHANGE_PARK) && DISABLED(SWITCHING_NOZZLE)
-        if (can_move_away && toolchange_settings.enable_park) {
+      #if ENABLED(TOOLCHANGE_PARK)
+        if (can_move_away && toolchange_settings.enable_park && TERN1(TOOLCHANGE_FILAMENT_SWAP, !smart_swap_allowed)) {
           IF_DISABLED(TOOLCHANGE_PARK_Y_ONLY, current_position.x = toolchange_settings.change_point.x);
           IF_DISABLED(TOOLCHANGE_PARK_X_ONLY, current_position.y = toolchange_settings.change_point.y);
           #if NONE(TOOLCHANGE_PARK_X_ONLY, TOOLCHANGE_PARK_Y_ONLY)
@@ -1247,9 +1200,29 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
               current_position.w = toolchange_settings.change_point.w
             );
           #endif
+
+          #if HAS_HOTEND_OFFSET
+            //Apply XY correction to park the new tool at the exact park pos before tool changing
+            if(new_tool != old_tool ) {
+              xyz_pos_t park_diff = hotend_offset[new_tool] - hotend_offset[old_tool];
+              park_diff.z = 0; // No Z offset applied before tool changed
+              current_position -= park_diff;
+            }
+          #endif
+
           planner.buffer_line(current_position, MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE), old_tool);
           planner.synchronize();
         }
+      #endif
+
+      #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE) && HAS_MULTI_HOTEND
+         // Migrate the temperature to the new hotend
+         if(migration.in_progress && !extruder_was_primed[new_tool]){
+           thermalManager.setTargetHotend(thermalManager.degTargetHotend(old_tool), new_tool);
+           TERN_(AUTOTEMP, planner.autotemp_update());
+           thermalManager.set_heating_message(0);
+           thermalManager.wait_for_hotend(new_tool);
+         }
       #endif
 
       #if HAS_HOTEND_OFFSET
@@ -1316,7 +1289,22 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         #endif
 
         #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-          if (should_swap && !too_cold(active_extruder))
+          // Smart recover type :
+          // Swap(also travel retractation) mode for toolchanging inside bed
+          smart_recover.do_swap = smart_swap_allowed;
+          // Cut wipe(also travel retractation) for toolchanging in park/bucket
+          smart_recover.do_cut_wipe = !smart_recover.do_swap && smart_recover.cut_wipe_mode;
+          // Instant setting
+          smart_recover.in_progress = (smart_recover.do_swap || smart_recover.do_cut_wipe);
+
+          //Store toolchange_settings to finish recovery later
+          smart_recover.tool_settings = toolchange_settings;
+
+          // Z is raised until extrusion command appears
+          if (smart_recover.in_progress)
+            destination.z += smart_recover.z_raise;
+
+          if (should_swap && !too_cold(active_extruder) && !smart_recover.do_swap)
             extruder_prime(); // Prime selected Extruder
         #endif
 
@@ -1334,35 +1322,30 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
         // Should the nozzle move back to the old position?
         if (can_move_away) {
-          #if ENABLED(TOOLCHANGE_NO_RETURN)
-            // Just move back down
-            DEBUG_ECHOLNPGM("Move back Z only");
-
-            if (TERN1(TOOLCHANGE_PARK, toolchange_settings.enable_park))
-              do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
-
-          #else
-            // Move back to the original (or adjusted) position
+          // Force move back on migration
+          const bool move_back_ok = ( (!toolchange_settings.no_return && TERN1(TOOLCHANGE_FILAMENT_SWAP, !smart_recover.do_swap) ) || TERN0(TOOLCHANGE_MIGRATION_FEATURE, migration.in_progress) );
+          if (move_back_ok) {
             DEBUG_POS("Move back", destination);
-
-            #if ENABLED(TOOLCHANGE_PARK)
-              if (toolchange_settings.enable_park) do_blocking_move_to_xy_z(destination, destination.z, MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));
-            #else
-              do_blocking_move_to_xy(destination, planner.settings.max_feedrate_mm_s[X_AXIS]);
-              do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
-            #endif
-
-          #endif
+            const float back_fr = (
+              #if ENABLED(TOOLCHANGE_PARK)
+                toolchange_settings.enable_park? TOOLCHANGE_PARK_XY_FEEDRATE : planner.settings.max_feedrate_mm_s[X_AXIS]
+              #else
+                planner.settings.max_feedrate_mm_s[X_AXIS]
+              #endif
+            );
+            do_blocking_move_to_xy(destination,back_fr);
+          }
+          DEBUG_ECHOLNPGM("Move back Z");
+          if(TERN1(TOOLCHANGE_FILAMENT_SWAP, !smart_recover.in_progress)) do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
         }
-
         else DEBUG_ECHOLNPGM("Move back skipped");
 
         #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-          if (should_swap && !too_cold(active_extruder)) {
-            extruder_cutting_recover(0); // New extruder primed and set to 0
+          if (should_swap && !too_cold(active_extruder) && !smart_recover.in_progress) {
+             extruder_cutting_recover(0); // New extruder primed and set to previous
 
             // Restart Fan
-            #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
+            #if HAS_FAN && defined(TOOLCHANGE_FS_FAN)
               RESTORE(fan);
             #endif
           }
@@ -1372,9 +1355,11 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       }
 
       #if ENABLED(SWITCHING_NOZZLE)
-        // Move back down. (Including when the new tool is higher.)
-        if (!should_move)
-          do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
+      // Move back down. (Including when the new tool is higher.)
+      if (!should_move) {
+        if (TERN1(TOOLCHANGE_FILAMENT_SWAP, !smart_recover.in_progress)) do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
+      }
+
       #endif
 
       TERN_(SWITCHING_NOZZLE_TWO_SERVOS, lower_nozzle(new_tool));
@@ -1428,6 +1413,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
   #include "../core/debug_out.h"
 
   bool extruder_migration() {
+    if(migration.in_progress) return false;
 
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       if (thermalManager.targetTooColdToExtrude(active_extruder)) {
@@ -1445,7 +1431,6 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     }
 
     // Migrate to a target or the next extruder
-
     uint8_t migration_extruder = active_extruder;
 
     if (migration.target) {
@@ -1468,9 +1453,6 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     migration.in_progress = true; // Prevent runout script
     planner.synchronize();
 
-    // Remember position before migration
-    const float resume_current_e = current_position.e;
-
     // Migrate the flow
     planner.set_flow(migration_extruder, planner.flow_percentage[active_extruder]);
 
@@ -1479,19 +1461,57 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       fwretract.retracted.set(migration_extruder, fwretract.retracted[active_extruder]);
     #endif
 
-    // Migrate the temperature to the new hotend
-    #if HAS_MULTI_HOTEND
-      thermalManager.setTargetHotend(thermalManager.degTargetHotend(active_extruder), migration_extruder);
-      TERN_(AUTOTEMP, planner.autotemp_update());
-      thermalManager.set_heating_message(0);
-      thermalManager.wait_for_hotend(active_extruder);
-    #endif
-
     // Migrate Linear Advance K factor to the new extruder
     TERN_(LIN_ADVANCE, planner.extruder_advance_K[active_extruder] = planner.extruder_advance_K[migration_extruder]);
 
+    #if BOTH(TOOLCHANGE_MIGRATION_FEATURE,MIGRATION_OVERRIDE_TOOLCHANGE_SETTINGS)
+      REMEMBER(tmp_mig_override, toolchange_settings);
+      REMEMBER(tmp_mig_override2, smart_recover.swap_mode);
+      REMEMBER(tmp_mig_override3, smart_recover.cut_wipe_mode);
+
+      #if BOTH(TOOLCHANGE_MIGRATION_ALWAYS_PARK,TOOLCHANGE_PARK)
+        toolchange_settings.enable_park = true;
+      #endif
+      #ifdef MIGRATION_FS_EXTRA_PRIME
+        toolchange_settings.extra_prime = MIGRATION_FS_EXTRA_PRIME;
+      #endif
+      #ifdef MIGRATION_FS_WIPE_RETRACT
+        toolchange_settings.wipe_retract = MIGRATION_FS_WIPE_RETRACT;
+      #endif
+      #ifdef MIGRATION_FS_FAN_SPEED
+        toolchange_settings.fan_speed = MIGRATION_FS_FAN_SPEED;
+      #endif
+      #ifdef MIGRATION_FS_FAN_TIME
+        toolchange_settings.fan_time = MIGRATION_FS_FAN_TIME;
+      #endif
+      //Only cutting wipe used
+      smart_recover.swap_mode = false;
+
+      // Settings for swap only migration, keep current z_raise
+      if (migration.swap_only_mode && extruder_was_primed[migration_extruder]) {
+        smart_recover.swap_mode          = true;
+        smart_recover.cut_wipe_mode      = false;
+        toolchange_settings.extra_prime  = 0;
+        toolchange_settings.wipe_retract = 0;
+        toolchange_settings.fan_time     = 0;
+        TERN_(TOOLCHANGE_PARK, toolchange_settings.enable_park  = false);
+      }
+      else
+        #ifdef MIGRATION_ZRAISE
+          // Zraise for normal migration or current
+          toolchange_settings.z_raise = MIGRATION_ZRAISE;
+        #endif
+
+    #endif
+
     // Perform the tool change
     tool_change(migration_extruder);
+
+    #if BOTH(TOOLCHANGE_MIGRATION_FEATURE,MIGRATION_OVERRIDE_TOOLCHANGE_SETTINGS)
+      RESTORE(tmp_mig_override);
+      RESTORE(tmp_mig_override2);
+      RESTORE(tmp_mig_override3);
+    #endif
 
     // Retract if previously retracted
     #if ENABLED(FWRETRACT)
@@ -1503,9 +1523,10 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     if (EXTRUDERS < 2 || active_extruder >= EXTRUDERS - 2 || active_extruder == migration.last)
       migration.automode = false;
 
-    migration.in_progress = false;
+    //Migration finish now or later
+    migration.in_progress = smart_recover.in_progress;
 
-    current_position.e = resume_current_e;
+    current_position.e = smart_recover.resume_e;
 
     planner.synchronize();
     planner.set_e_position_mm(current_position.e); // New extruder primed and ready

--- a/Marlin/src/module/tool_change.h
+++ b/Marlin/src/module/tool_change.h
@@ -27,23 +27,29 @@
 
 #if HAS_MULTI_EXTRUDER
 
+  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+    // Define any variables required
+    extern Flags<EXTRUDERS> extruder_was_primed; // Extruders primed status
+  #endif
+
   typedef struct {
     #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
       float swap_length;            // M217 S
       float extra_prime;            // M217 E
       float extra_resume;           // M217 B
       int16_t prime_speed;          // M217 P
-      int16_t wipe_retract;         // M217 G
+      int16_t wipe_retract;         // M217 W
       int16_t retract_speed;        // M217 R
       int16_t unretract_speed;      // M217 U
       uint8_t fan_speed;            // M217 F
       uint8_t fan_time;             // M217 D
     #endif
     #if ENABLED(TOOLCHANGE_PARK)
-      bool enable_park;             // M217 W
-      xyz_pos_t change_point;       // M217 X Y I J K C H O
+      bool enable_park;             // M216 P
+      xyz_pos_t change_point;       // M216 X Y I J K C H O
     #endif
     float z_raise;                  // M217 Z
+    bool no_return;                 // M217 O
   } toolchange_settings_t;
 
   extern toolchange_settings_t toolchange_settings;
@@ -52,20 +58,47 @@
     extern bool enable_first_prime; // M217 V
   #endif
 
-  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    void tool_change_prime(); // Prime the currently selected extruder
-  #endif
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  typedef struct {
+    bool swap_mode,     // M217 N
+         cut_wipe_mode, // M217 H
+         do_swap,
+         do_cut_wipe,
+         in_progress;
+    float resume_e,
+          z_raise; // z_raise stored to avoid changing value by lcd between process
+    toolchange_settings_t tool_settings;
+    } smart_recover_settings_t;
 
-  #if ENABLED(TOOLCHANGE_FS_INIT_BEFORE_SWAP)
-    extern Flags<EXTRUDERS> toolchange_extruder_ready;
+    constexpr smart_recover_settings_t smart_recover_defaults = {
+      //swap_mode
+      TERN0(TOOLCHANGE_SMART_SWAP, true),
+      //cut_wipe_mode
+      TERN0(TOOLCHANGE_SMART_CUT_WIPE, true),
+      //do_swap
+      false,
+      //do_cut_wipe
+      false,
+      // in_progress
+      false,
+      //Resume E
+      0,
+      //z_raise
+      0
+    };
+
+    extern smart_recover_settings_t smart_recover;
+
   #endif
 
   #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
     typedef struct {
       uint8_t target, last;
-      bool automode, in_progress;
+      bool automode, swap_only_mode, in_progress;
     } migration_settings_t;
-    constexpr migration_settings_t migration_defaults = { 0, 0, false, false };
+    constexpr migration_settings_t migration_defaults = { 0, 0, false,
+                TERN0(TOOLCHANGE_MIGRATION_SWAP_ONLY_MODE, true),
+                false };
     extern migration_settings_t migration;
     bool extruder_migration();
   #endif
@@ -132,3 +165,11 @@
  * previous tool out of the way and the new tool into place.
  */
 void tool_change(const uint8_t tmp_extruder, bool no_move=false);
+
+/**
+ * Recover active extruder after toolchange
+ */
+#if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+  void extruder_prime();
+  void extruder_cutting_recover(const_float_t e);
+#endif


### PR DESCRIPTION
@thinkyhead :  Really a big job and usefull for marlin. Need intensive testing by the communauty

- **Toolchange evolution major features**
  - **Smart Recover implementation** : 
    - This feature is amazing, after a tool change, the new extruder recover **only** at the next printing command. Now, it waits the next G1 E..... The printing is cleaner, no leaks on travels to reach the prime tower or to come back of park. Works with swap and cutting wipe recover length. Easy operation , if target is already primed/swapped, then smart swap mode is turned on, and if the new tool not primed and make a priming sequence , than 'smart cut wipe ' is turned on. **_Can be totally disabled in cfg.adv_**
  - **Migration override toolchange settings+ always park option** : 
    - For many reasons, Migration must have this own settings, because use toolchange_settings that can be modified any time. Always park is made to force park, if park is disabled while printing if prime tower is used ' park is useless , but not for migration'. Migration is a priming sequence and must have priming settings and not ' toolchange floating settings'. **_Can be totally disabled in cfg.adv_**
   - **Migration swap only mode** :  
     - Option to play with colors like a piano,  now , if target extruder is already primed and swapped , a migration to this tool, will not use park and priming , a swap is made ' like a slicer should make ' and color is changed in one click. We can now change tools anytime during a print, and if extruder not primed , ' NORMAL migration is made , park+ priming' . (a simple toolchange cannot make this, totally impossible). **_Can be totally disabled in cfg.adv_**.
     
- **Toolchange evolution minor features**  
  - **Smart tool positionning** : 
     - Amazing too ! On toolchange, the old tool is parked, but useless, because only the new nozzle need to be a the park position, now is done, On toolchange , the new nozzle is parked correctly
  - **M216 implementation** :  Separation of toolchange M217 and toolchange "park" M216
  - **Add toolchange_setting.no_return** : Now possible to enable/disable 
  - **Add toolchange_settings.cutting_wipe** : Now possible to disable park and stop cutting wipe retract too.
  - **Toolchange active extruder Fan** : Fixes

  - **Code reduction/cleaning by deleting void toolchange_prime()** 
    - Explaination:  T0 when first used need toolchange_prime() , but T1 can first prime just with toolchange... It's an old code not updated , we can make a code reduction by deleting this function and make a special authorisation for T0 . But now all tools can be reprimed anytime , by M217 Q, for instant priming, or M217C for next call of the tool. Easy and no risk , because all the toolchange_prime() function have exactly the same cloned code in tool change
  - **Switching Nozzle Zraise feature** :  Lifting extruders use servos , but servos are too long for a z hop, this feature have been disabled because seems to be useless , but it's wrong, very usefull , to lift , to secure hotend offsets moves and more. Now possible!

- **Calibration**
  - **Calibration allowed for core axes ** : Now possible to have corexy system and make a nozzle calibration. CoreXy have been ejected for special reasons , but , works fine anyway. This option can be disabled if needed
  - **Calibration disable toolchange feature** : No prime , swap , zraise, fans, park when calibration change tool.



Code cleaning , bug , feature , hope you will agree

Thks


