### PR TITLE
Fix spurious "bad command"

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -260,7 +260,7 @@ bool unified_bed_leveling::sanity_check() {
    */
   void GcodeSuite::M1004() {
 
-    #define ALIGN_GCODE TERN(Z_STEPPER_AUTO_ALIGN, "G34", "")
+    #define ALIGN_GCODE TERN(Z_STEPPER_AUTO_ALIGN, "G34\n", "")
     #define PROBE_GCODE TERN(HAS_BED_PROBE, "G29P1\nG29P3", "G29P4R")
 
     #if HAS_HOTEND
@@ -280,7 +280,7 @@ bool unified_bed_leveling::sanity_check() {
     #endif
 
     process_subcommands_now(FPSTR(G28_STR));      // Home
-    process_subcommands_now(F(ALIGN_GCODE "\n"    // Align multi z axis if available
+    process_subcommands_now(F(ALIGN_GCODE         // Align multi z axis if available
                               PROBE_GCODE "\n"    // Build mesh with available hardware
                               "G29P3\nG29P3"));   // Ensure mesh is complete by running smart fill twice
 


### PR DESCRIPTION
From M1004 if Z_STEPPER_AUTO_ALIGN is not set.

### Description

Fix spurious

`Unknown command ""`

from `M1004` if `Z_STEPPER_AUTO_ALIGN` is not enabled.

The issue is that the trailing newline on line 283 of `Marlin/src/feature/bedlevel/ubl/ubl.cpp` is placed unconditionally even if `ALIGN_GCODE` is empty.

### Requirements

`AUTO_BED_LEVELING_UBL` enabled
`UBL_MESH_WIZARD` enabled
`Z_STEPPER_AUTO_ALIGN` disabled

### Benefits

Avoids a spurious `Unknown command ""` when running the UBL wizard if `Z_STEPPER_AUTO_ALIGN` is not enabled. This moves the newline to be conditional.

### Configurations

`AUTO_BED_LEVELING_UBL` enabled
`UBL_MESH_WIZARD` enabled
`Z_STEPPER_AUTO_ALIGN` disabled

### Related Issues

See https://discord.com/channels/461605380783472640/491105274464043026/1033906613473509486 reported on Discord.