### PR TITLE
add missing  FORCE_SOFT_SPI for MKS_MINI_12864 on skr v1.3 

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -423,6 +423,7 @@
         #define DOGLCD_A0            EXP1_07_PIN
         #define DOGLCD_SCK           EXP2_02_PIN
         #define DOGLCD_MOSI          EXP2_06_PIN
+        #define FORCE_SOFT_SPI
 
       #elif ENABLED(ENDER2_STOCKDISPLAY)
 


### PR DESCRIPTION
### Description

Bugfix 2.0.x brother PR to https://github.com/MarlinFirmware/Marlin/pull/24850

MKS_MINI_12864 on SKR v1.3 was found not to work.
https://github.com/MarlinFirmware/Marlin/issues/24848
This was traced back to PR https://github.com/MarlinFirmware/Marlin/pull/16349 accidently removing 
#define FORCE_SOFT_SPI when adding support for ENDER2_STOCKDISPLAY

### Requirements

MKS_MINI_12864 and BOARD_BTT_SKR_V1_3

### Benefits

Display works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24848
https://github.com/MarlinFirmware/Marlin/pull/16349 
https://github.com/MarlinFirmware/Marlin/pull/24850