### PR TITLE
allow for max endstops on BOARD_MKS_MONSTER8_V2

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
@@ -26,7 +26,9 @@
 //
 // Limit Switches
 //
+#define X_MIN_PIN                           PA14
 #define X_MAX_PIN                           PA13
+#define Y_MIN_PIN                           PA15
 #define Y_MAX_PIN                           PC5
 
 //

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -58,6 +58,6 @@
   #define WIFI_RESET_PIN PD14 // MKS ESP WIFI RESET PIN
 #endif
 
-#define NEOPIXEL_PIN                        PC5
+#define NEOPIXEL_PIN                       PC5
 
 #include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -24,6 +24,12 @@
 #define BOARD_INFO_NAME "MKS Monster8 V2"
 
 //
+// Limit Switches
+//
+#define X_STOP_PIN                          PA14
+#define Y_STOP_PIN                          PA15
+
+//
 // Steppers
 //
 #define E4_ENABLE_PIN                       PB6   // Driver7
@@ -52,6 +58,6 @@
   #define WIFI_RESET_PIN PD14 // MKS ESP WIFI RESET PIN
 #endif
 
-#define NEOPIXEL_PIN                         PC5
+#define NEOPIXEL_PIN                        PC5
 
 #include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -64,8 +64,16 @@
 #define E4_DIAG_PIN                         -1    // Driver7 diag signal is not connected
 
 // Limit Switches for endstops
-#define X_MIN_PIN                           PA14
-#define Y_MIN_PIN                           PA15
+#ifdef X_MAX_PIN
+  #define X_MIN_PIN                         PA14
+#else
+  #define X_STOP_PIN                        PA14
+#endif
+#ifdef Y_MAX_PIN
+  #define Y_MIN_PIN                         PA15
+#else
+  #define Y_STOP_PIN                        PA15
+#endif
 #define Z_MIN_PIN                           PB13
 #define Z_MAX_PIN                           PB12
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -64,16 +64,6 @@
 #define E4_DIAG_PIN                         -1    // Driver7 diag signal is not connected
 
 // Limit Switches for endstops
-#ifdef X_MAX_PIN
-  #define X_MIN_PIN                         PA14
-#else
-  #define X_STOP_PIN                        PA14
-#endif
-#ifdef Y_MAX_PIN
-  #define Y_MIN_PIN                         PA15
-#else
-  #define Y_STOP_PIN                        PA15
-#endif
 #define Z_MIN_PIN                           PB13
 #define Z_MAX_PIN                           PB12
 


### PR DESCRIPTION
### Description

A user on Discord wanted to use max endstops on their BOARD_MKS_MONSTER8_V2
Attempting to do so errors with the error (X|Y)_MAX_PIN was not declared in this scope.

The issue

BOARD_MKS_MONSTER8_V1 and BOARD_MKS_MONSTER8_V2 both use pins_MKS_MONSTER8_common.h

BOARD_MKS_MONSTER8_V1 is set correctly
```
X_MIN_PIN PA14    from  pins_MKS_MONSTER8_common.h
X_MAX_PIN PA13    from  pins_MKS_MONSTER8_V1.h
Y_MIN_PIN PA15    from  pins_MKS_MONSTER8_common.h
Y_MAX_PIN PC5     from  pins_MKS_MONSTER8_V1.h
Z_MIN_PIN PB13    from  pins_MKS_MONSTER8_common.h
Z_MAX_PIN PB12    from  pins_MKS_MONSTER8_common.h
```
and BOARD_MKS_MONSTER8_V2 is set to 
```
X_MIN_PIN PA14   from  pins_MKS_MONSTER8_common.h
Y_MIN_PIN PA15   from  pins_MKS_MONSTER8_common.h
Z_MIN_PIN PB13   from  pins_MKS_MONSTER8_common.h
Z_MAX_PIN PB12   from  pins_MKS_MONSTER8_common.h
```
But when there is only MIN pins STOP pins should used. So they can be reallocated as MAX pins if that is the users requirements

removed X_MIN_PIN and Y_MIN_PIN from pins_MKS_MONSTER8_common 
Added to pins_MKS_MONSTER8_V1
Added STOP pins to pins_MKS_MONSTER8_V2

Updated results: 

BOARD_MKS_MONSTER8_V1 
```
X_MIN_PIN PA14    from  pins_MKS_MONSTER8_V1.h
X_MAX_PIN PA13    from  pins_MKS_MONSTER8_V1.h
Y_MIN_PIN PA15    from  pins_MKS_MONSTER8_V1.h
Y_MAX_PIN PC5     from  pins_MKS_MONSTER8_V1.h
Z_MIN_PIN PB13    from  pins_MKS_MONSTER8_common.h
Z_MAX_PIN PB12    from  pins_MKS_MONSTER8_common.h
```
BOARD_MKS_MONSTER8_V2 
```
X_STOP_PIN PA14  from  pins_MKS_MONSTER8_V2.h
Y_STOP_PIN PA15  from  pins_MKS_MONSTER8_V2.h
Z_MIN_PIN PB13   from  pins_MKS_MONSTER8_common.h
Z_MAX_PIN PB12   from  pins_MKS_MONSTER8_common.h
```
Which allows users to  reallocate as max or min endstop as needed

### Requirements

BOARD_MKS_MONSTER8_V2
#define X_HOME_DIR 1 with #define USE_XMAX_PLUG
and/or 
#define Y_HOME_DIR 1 with #define USE_YMAX_PLUG

### Benefits

Compiles and works as expected
