### PR TITLE
Fixed compilation error in marlinui.cpp for Overlord configuration

### DIFF
--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -34,10 +34,6 @@
   #include "blinkm.h"
 #endif
 
-#if ENABLED(PCA9632)
-  #include "pca9632.h"
-#endif
-
 #if ENABLED(PCA9533)
   #include "pca9533.h"
 #endif

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -30,14 +30,6 @@
 
 #include "leds.h"
 
-#if ENABLED(BLINKM)
-  #include "blinkm.h"
-#endif
-
-#if ENABLED(PCA9533)
-  #include "pca9533.h"
-#endif
-
 #if EITHER(CASE_LIGHT_USE_RGB_LED, CASE_LIGHT_USE_NEOPIXEL)
   #include "../../feature/caselight.h"
 #endif

--- a/Marlin/src/feature/leds/leds.h
+++ b/Marlin/src/feature/leds/leds.h
@@ -40,10 +40,8 @@
   #undef _NEOPIXEL_INCLUDE_
 #endif
 
-#if HAS_COLOR_LEDS
-  #if ENABLED(PCA9632)
-    #include "pca9632.h"
-  #endif
+#if ENABLED(PCA9632)
+  #include "pca9632.h"
 #endif
 
 /**

--- a/Marlin/src/feature/leds/leds.h
+++ b/Marlin/src/feature/leds/leds.h
@@ -40,6 +40,14 @@
   #undef _NEOPIXEL_INCLUDE_
 #endif
 
+#if ENABLED(BLINKM)
+  #include "blinkm.h"
+#endif
+
+#if ENABLED(PCA9533)
+  #include "pca9533.h"
+#endif
+
 #if ENABLED(PCA9632)
   #include "pca9632.h"
 #endif

--- a/Marlin/src/feature/leds/leds.h
+++ b/Marlin/src/feature/leds/leds.h
@@ -40,6 +40,12 @@
   #undef _NEOPIXEL_INCLUDE_
 #endif
 
+#if HAS_COLOR_LEDS
+  #if ENABLED(PCA9632)
+    #include "pca9632.h"
+  #endif
+#endif
+
 /**
  * LEDcolor type for use with leds.set_color
  */


### PR DESCRIPTION
### Description
This moves the inclusion of the PCA9632.h header file to the leds.h header file, rather than the leds.cpp file. This makes it so that when PCA9632 and PCA9632_BUZZER are enabled, the definition is available for marlinui.cpp to use it after including leds.h.

### Requirements

The only requirements for replicating this seem to be enabling OVERLORD_OLED and PCA9632 in Configuration.h.

### Benefits

This allows compilation to succeed when building the latest marlin for the Overlord Pro.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/9899525/Configuration.zip)

### Related Issues

This fixes a bug, but does not have an issue associated with it.
