### PR TITLE
M306: Display MPC Autotune status (similar to c135db1c

### DIFF
--- a/Marlin/src/gcode/temp/M306.cpp
+++ b/Marlin/src/gcode/temp/M306.cpp
@@ -44,7 +44,7 @@
 
 void GcodeSuite::M306() {
   if (parser.seen_test('T')) {
-    ui.set_status(GET_TEXT(MSG_MPC_AUTOTUNE));
+    ui.set_status(GET_TEXT_F(MSG_MPC_AUTOTUNE));
     thermalManager.MPC_autotune();
     ui.reset_status();
     return;

--- a/Marlin/src/gcode/temp/M306.cpp
+++ b/Marlin/src/gcode/temp/M306.cpp
@@ -44,7 +44,7 @@
 
 void GcodeSuite::M306() {
   if (parser.seen_test('T')) {
-    ui.set_status(GET_TEXT_F(MSG_MPC_AUTOTUNE));
+    LCD_MESSAGE(MSG_MPC_AUTOTUNE);
     thermalManager.MPC_autotune();
     ui.reset_status();
     return;

--- a/Marlin/src/gcode/temp/M306.cpp
+++ b/Marlin/src/gcode/temp/M306.cpp
@@ -25,6 +25,7 @@
 #if ENABLED(MPCTEMP)
 
 #include "../gcode.h"
+#include "../../lcd/marlinui.h"
 #include "../../module/temperature.h"
 
 /**
@@ -42,7 +43,12 @@
  */
 
 void GcodeSuite::M306() {
-  if (parser.seen_test('T')) { thermalManager.MPC_autotune(); return; }
+  if (parser.seen_test('T')) {
+    ui.set_status(GET_TEXT(MSG_MPC_AUTOTUNE));
+    thermalManager.MPC_autotune();
+    ui.reset_status();
+    return;
+  }
 
   if (parser.seen("ACFPRH")) {
     const heater_id_t hid = (heater_id_t)parser.intval('E', 0);


### PR DESCRIPTION
### Description

When initiating MPC Autotuning, the printer start making movements, without the LCD telling what's going on.

### Requirements

An LCD is a requiment

### Benefits

With this commit, the LCD will have a status message that MPC Autotuning has been initiated.