### PR TITLE
G30 Rework

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -307,9 +307,9 @@ typedef abce_float_t abce_pos_t;
 void toLogical(xy_pos_t &raw);
 void toLogical(xyz_pos_t &raw);
 void toLogical(xyze_pos_t &raw);
-void toNative(xy_pos_t &raw);
-void toNative(xyz_pos_t &raw);
-void toNative(xyze_pos_t &raw);
+void toNative(xy_pos_t &lpos);
+void toNative(xyz_pos_t &lpos);
+void toNative(xyze_pos_t &lpos);
 
 //
 // Paired XY coordinates, counters, flags, etc.

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -51,33 +51,23 @@
  *   E   Engage the probe for each probe (default 1)
  *   C   Enable probe temperature compensation (0 or 1, default 1)
  */
-void GcodeSuite::G30()
-{
+void GcodeSuite::G30() {
+
   #if HAS_MULTI_HOTEND
     const uint8_t old_tool_index = active_extruder;
     tool_change(0);
   #endif
 
-  const xy_pos_t pos = {parser.seenval('X') ? parser.value_linear_units()
-                        #if HAS_POSITION_SHIFT
-                          - position_shift.x
-                        #endif
-                        #if HAS_HOME_OFFSET
-                          - home_offset.x
-                        #endif
-                        : current_position.x,
-                        parser.seenval('Y') ? parser.value_linear_units()
-                        #if HAS_POSITION_SHIFT
-                          - position_shift.y
-                        #endif
-                        #if HAS_HOME_OFFSET
-                          - home_offset.y
-                        #endif
-                        : current_position.y};
+  const xy_pos_t pos = {
+    parser.seenval('X')
+      ? parser.value_linear_units() TERN_(HAS_POSITION_SHIFT, - position_shift.x) TERN_(HAS_HOME_OFFSET, - home_offset.x)
+      : current_position.x,
+    parser.seenval('Y')
+      ? parser.value_linear_units() TERN_(HAS_POSITION_SHIFT, - position_shift.y) TERN_(HAS_HOME_OFFSET, - home_offset.y)
+      : current_position.y
+  };
 
-
-  if (probe.can_reach(pos))
-  {
+  if (probe.can_reach(pos)) {
     // Disable leveling so the planner won't mess with us
     TERN_(HAS_LEVELING, set_bed_leveling_enabled(false));
 
@@ -90,7 +80,7 @@ void GcodeSuite::G30()
     const ProbePtRaise raise_after = parser.boolval('E', true) ? PROBE_PT_STOW : PROBE_PT_NONE;
 
     TERN_(HAS_PTC, ptc.set_enabled(!parser.seen('C') || parser.value_bool()));
-    const float measured_z = probe.probe_at_point(pos, raise_after, true, true);
+    const float measured_z = probe.probe_at_point(pos, raise_after, 1, true, true);
     TERN_(HAS_PTC, ptc.set_enabled(true));
     if (!isnan(measured_z)) {
       SERIAL_ECHOLNPGM("Bed X: ", pos.asLogical().x, " Y: ", pos.asLogical().y, " Z: ", measured_z);
@@ -112,13 +102,12 @@ void GcodeSuite::G30()
 
     report_current_position();
   }
-  #if ENABLED(DWIN_LCD_PROUI)
-    else
-    {
-        SERIAL_ECHOLNF(GET_EN_TEXT_F(MSG_ZPROBE_OUT));
-        LCD_MESSAGE(MSG_ZPROBE_OUT);
-    }
-  #endif
+  else {
+    #if ENABLED(DWIN_LCD_PROUI)
+      SERIAL_ECHOLNF(GET_EN_TEXT_F(MSG_ZPROBE_OUT));
+      LCD_MESSAGE(MSG_ZPROBE_OUT);
+    #endif
+  }
 
   // Restore the active tool
   TERN_(HAS_MULTI_HOTEND, tool_change(old_tool_index));

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -58,13 +58,10 @@ void GcodeSuite::G30() {
     tool_change(0);
   #endif
 
+  // Convert the given logical position to native position
   const xy_pos_t pos = {
-    parser.seenval('X')
-      ? parser.value_linear_units() TERN_(HAS_POSITION_SHIFT, - position_shift.x) TERN_(HAS_HOME_OFFSET, - home_offset.x)
-      : current_position.x,
-    parser.seenval('Y')
-      ? parser.value_linear_units() TERN_(HAS_POSITION_SHIFT, - position_shift.y) TERN_(HAS_HOME_OFFSET, - home_offset.y)
-      : current_position.y
+    parser.seenval('X') ? RAW_X_POSITION(parser.value_linear_units()) : current_position.x,
+    parser.seenval('Y') ? RAW_Y_POSITION(parser.value_linear_units()) : current_position.y
   };
 
   if (probe.can_reach(pos)) {

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -80,7 +80,7 @@ void GcodeSuite::G30() {
     const ProbePtRaise raise_after = parser.boolval('E', true) ? PROBE_PT_STOW : PROBE_PT_NONE;
 
     TERN_(HAS_PTC, ptc.set_enabled(!parser.seen('C') || parser.value_bool()));
-    const float measured_z = probe.probe_at_point(pos, raise_after, 1, true, true);
+    const float measured_z = probe.probe_at_point(pos, raise_after, 1);
     TERN_(HAS_PTC, ptc.set_enabled(true));
     if (!isnan(measured_z)) {
       SERIAL_ECHOLNPGM("Bed X: ", pos.asLogical().x, " Y: ", pos.asLogical().y, " Z: ", measured_z);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

G30 is all over the place. In rare occasions does a Z-Probe at a specified position.
For example:
- G0 X100 Y100; G30
- G30 X100 Y100

These two will not make a Z-Probe in the same position.
It's a whole other story if there's home offset and/or position shift (G92) is applied.

From my understanding G30 Xxxxx Yyyyy should do a probe where the nozzle would be in case of a G0 Xxxxx Yxxxx command and G30 should do a probe exactly where the nozzle is prior this command, all this regardless of home offset and/or position shift in use.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

- Z-Probe capability at a given coordinate (ex.: BL-Touch)

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

This PR makes G30 work as expected, doing Z-Probe at the same point on the bed where the nozzle is/would be.

### Related Issues

None reported, the bug was found during an attempt of adjusting the corners of the bed using G30.

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
