### PR TITLE
Increase SCURVE cycle count for unoptimized cortex-m0

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -76,19 +76,11 @@
   #define TIMER_READ_ADD_AND_STORE_CYCLES 34UL
 
   // The base ISR takes 792 cycles
-  #ifdef STM32G0B1xx
-    #define ISR_BASE_CYCLES  928UL
-  #else
-    #define ISR_BASE_CYCLES  792UL
-  #endif
+  #define ISR_BASE_CYCLES  792UL
 
   // Linear advance base time is 64 cycles
   #if ENABLED(LIN_ADVANCE)
-    #ifdef STM32G0B1xx
-      #define ISR_LA_BASE_CYCLES 200UL
-    #else
-      #define ISR_LA_BASE_CYCLES 64UL
-    #endif
+    #define ISR_LA_BASE_CYCLES 64UL
   #else
     #define ISR_LA_BASE_CYCLES 0UL
   #endif
@@ -96,7 +88,7 @@
   // S curve interpolation adds 40 cycles
   #if ENABLED(S_CURVE_ACCELERATION)
     #ifdef STM32G0B1xx
-      #define ISR_S_CURVE_CYCLES 544UL
+      #define ISR_S_CURVE_CYCLES 500UL
     #else
       #define ISR_S_CURVE_CYCLES 40UL
     #endif

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -76,7 +76,7 @@
   #define TIMER_READ_ADD_AND_STORE_CYCLES 34UL
 
   // The base ISR takes 792 cycles
-  #if defined(STM32G0B1xx)
+  #ifdef STM32G0B1xx
     #define ISR_BASE_CYCLES  928UL
   #else
     #define ISR_BASE_CYCLES  792UL
@@ -84,7 +84,7 @@
 
   // Linear advance base time is 64 cycles
   #if ENABLED(LIN_ADVANCE)
-    #if defined(STM32G0B1xx)
+    #ifdef STM32G0B1xx
       #define ISR_LA_BASE_CYCLES 200UL
     #else
       #define ISR_LA_BASE_CYCLES 64UL
@@ -95,7 +95,7 @@
 
   // S curve interpolation adds 40 cycles
   #if ENABLED(S_CURVE_ACCELERATION)
-    #if defined(STM32G0B1xx)
+    #ifdef STM32G0B1xx
       #define ISR_S_CURVE_CYCLES 544UL
     #else
       #define ISR_S_CURVE_CYCLES 40UL

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -76,18 +76,30 @@
   #define TIMER_READ_ADD_AND_STORE_CYCLES 34UL
 
   // The base ISR takes 792 cycles
-  #define ISR_BASE_CYCLES  792UL
+  #if defined(STM32G0B1xx)
+    #define ISR_BASE_CYCLES  928UL
+  #else
+    #define ISR_BASE_CYCLES  792UL
+  #endif
 
   // Linear advance base time is 64 cycles
   #if ENABLED(LIN_ADVANCE)
-    #define ISR_LA_BASE_CYCLES 64UL
+    #if defined(STM32G0B1xx)
+      #define ISR_LA_BASE_CYCLES 200UL
+    #else
+      #define ISR_LA_BASE_CYCLES 64UL
+    #endif
   #else
     #define ISR_LA_BASE_CYCLES 0UL
   #endif
 
   // S curve interpolation adds 40 cycles
   #if ENABLED(S_CURVE_ACCELERATION)
-    #define ISR_S_CURVE_CYCLES 40UL
+    #if defined(STM32G0B1xx)
+      #define ISR_S_CURVE_CYCLES 544UL
+    #else
+      #define ISR_S_CURVE_CYCLES 40UL
+    #endif
   #else
     #define ISR_S_CURVE_CYCLES 0UL
   #endif


### PR DESCRIPTION
Cortex-M0 doesn't have 32bitx32bit=64bit multiplication instructions and can not use optimized path.

Increasing to actual cycle count of 500 to hopefully improve stability of board as well as a form of documentation that people should consider disabling SCURVE feqature until the code is optimized for cortex-m0;

### Description

I came across the fact that SCURVE cycle counts are greatly undercounted for cortex-m0 while looking into a couple of issues that could be triggered by stepper ISR running to much and that I didn't see on my Creality V422 board.

One main difference between my two boards is the STM32G0 used by SKR Mini E3 V3 disables SCURVE optimization.  So I disassembled the code and I see it's taking 500 cycles instead of 40 cycles (gcc uses a badly optimized 64bitx64bit=64bit function that takes 52 cycles each time a multiplication is done).

I think a somewhat easy future modification would be to use a macro to patch in the 32bitx32bit=64bit instructions using widely available examples (https://github.com/gcc-mirror/gcc/blob/master/include/longlong.h#L249 ).  That version of optimized code would run on cortex-m0 and should reduce it to less than 200 cycles and then be pretty close to AVR cycles at higher accuracy.

I also did a test compile on simulator_macos_debug; which also falls back to C++ code; and I see its well optimized at under 40 cycles.  So I wrote the check so that simulators will still use 40 cycle estimates.

I'm attaching the disassembled eval_bezier_curve() function and I've prefixed each line with cycle counts.

[s_curve.zip](https://github.com/MarlinFirmware/Marlin/files/9925325/s_curve.zip)

### Requirements

SKR Mini E3 V3.0 or other 32-bit board with cortex-m0.

### Benefits

Possibly more stable board when under heavy loads.

### Configurations

Enable S_CURVE_ACCELERATION

### Related Issues

#24927 