### PR TITLE
Resend death loop on high latency connection

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2405,6 +2405,21 @@
   //#define SERIAL_XON_XOFF
 #endif
 
+/**
+ * Line Number Error Handler
+ * 
+ * Add function to delay resend requests for line number 
+ * errors, for Hosts that send N# line number with GCode.
+ * Prevents resend cycles causing stuttering and failure
+ * on systems with latency between Host and Printer.
+ * eg. Octoprint through ESP8266(WIFI) pass-through
+*/
+#define RESEND_HANDLER
+#if ENABLED(RESEND_HANDLER)
+  #define RESEND_HANDLER_DROP_GCODE 1   //Number of GCode lines to drop before resend request sent to Host. Octprint>>ESP3D; Min 5
+  //#define RESEND_HANDLER_NOTICE       //Send additional details to host terminal
+#endif
+
 #if ENABLED(SDSUPPORT)
   // Enable this option to collect and display the maximum
   // RX queue usage after transferring a file to SD.

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -101,6 +101,21 @@ public:
   };
 
   /**
+   * Resend handler to deal with Host>>Printer latency
+  */
+  #if ENABLED(RESEND_HANDLER)
+    struct ResendCtrl {
+      long last_error_N = 0; //Record the last requested resend line number
+      uint8_t ignore_resend_count = 0;
+      const uint8_t ignore_resend_max = RESEND_HANDLER_DROP_GCODE; //Number of resends requests deleted //LH this can be constant
+    };
+
+    static ResendCtrl resend_ctrl; //resend ctrl variables
+
+    static void ln_num_error_notice(const serial_index_t serial_ind, const long host_gcode_N);
+  #endif
+
+  /**
    * The ring buffer of commands
    */
   static RingBuffer ring_buffer;


### PR DESCRIPTION
Related to streaming GCode from Host to Printer.
Experiencing poor error handling on a connection with relatively high latency compared to typical connections.

Existing Resend method; clears RX_Buffer, sends request for resend and eventually processing the next line into RX_Buffer, expecting it to be the requested resent line. If the line is not the resent line, it triggers another resend request.

It appears the latency in the connection is effectively creating a buffer that neither the host or printer can control/clear. These lines in-flight are received by the printer in place of the expected resend line. Triggering the additional resend request. When the resent line is received with duplicates, a resend is requested for the Next line. The process repeats, effectively crippling useful Gcode lines being sent to the printer, resulting in depleted command and planner buffers, with stuttering, pimples, etc.

Example pattern:

2022-10-27 16:44:14,405 - Send: N90 [#USER Input error line]
        2022-10-27 16:44:14,426 - Send: N1231 G1 F3022.7 X168.509 Y68.782*84
        2022-10-27 16:44:14,451 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1230
        2022-10-27 16:44:14,455 -   Recv: Resend: 1231
        2022-10-27 16:44:14,461 -   Recv: ok
        2022-10-27 16:44:14,464 - Send: N1231 G1 F3022.7 X168.509 Y68.782*84
        2022-10-27 16:44:14,473 -   Recv: ok N1231 P18 B31
        2022-10-27 16:44:14,485 - Send: N1232 G1 F3038.0 X166.868 Y66.256*93
        2022-10-27 16:44:14,511 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1231
        2022-10-27 16:44:14,517 -   Recv: Resend: 1232
        2022-10-27 16:44:14,523 -   Recv: ok
        2022-10-27 16:44:14,527 - Send: N1232 G1 F3038.0 X166.868 Y66.256*93
        2022-10-27 16:44:14,537 -   Recv: ok N1232 P21 B31
        2022-10-27 16:44:14,554 - Send: N1233 G1 F3045.7 X165.139 Y63.803*80
        2022-10-27 16:44:14,575 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1232
        2022-10-27 16:44:14,580 -   Recv: Resend: 1233
        2022-10-27 16:44:14,585 -   Recv: ok
        2022-10-27 16:44:14,588 - Send: N1233 G1 F3045.7 X165.139 Y63.803*80
        2022-10-27 16:44:14,597 -   Recv: ok N1233 P23 B31
        2022-10-27 16:44:14,608 - Send: N1234 G1 F3038.0 X164.231 Y62.612*95
        2022-10-27 16:44:14,633 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1233
        2022-10-27 16:44:14,638 -   Recv: Resend: 1234
        2022-10-27 16:44:14,643 -   Recv: ok
        2022-10-27 16:44:14,648 - Send: N1234 G1 F3038.0 X164.231 Y62.612*95
        2022-10-27 16:44:14,656 -   Recv: ok N1234 P27 B31
        2022-10-27 16:44:14,670 - Send: N1235 G1 F3022.7 X163.323 Y61.42*103
        2022-10-27 16:44:14,690 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1234
        2022-10-27 16:44:14,695 - Recv: Resend: 1235
        2022-10-27 16:44:14,700 -   Recv: ok
        2022-10-27 16:44:14,703 - Send: N1235 G1 F3022.7 X163.323 Y61.42*103
        2022-10-27 16:44:14,712 -   Recv: ok N1235 P29 B31
        2022-10-27 16:44:14,725 - Send: N1236 G1 F3030.3 X162.366 Y60.259*90
        2022-10-27 16:44:14,749 -   Recv: Error:Line Number is not Last Line Number+1, Last Line: 1235
        2022-10-27 16:44:14,754 -   Recv: Resend: 1236
        2022-10-27 16:44:14,757 -   Recv: ok

Repeats until Octoprint triggers cancellation from excessive resend ratio. If you're lucky it may clear itself during the stuttering, or just keep struggling through. 


Current printer setup:
Octoprint [raspberry pi3]
  >>(wifi)>>
ESP3D [esp8266]
  >>(serial)>>
Marlin [STM32F1 printer control board]



-->

### Requirements

Nil requirements. Disabled RESEND_HANDLER in Configuration_adv.h will result in existing resend method. Default enabled with low gcode line drop value, as may be beneficial to others printing direct through Octoprint, etc. Negligible effect on gcode streaming if one resend is dropped.

### Benefits

Enable printing via WIFI without fear of a resend loop

### Configurations

Nill

### Related Issues

Bug fix request not opened
