### PR TITLE
Fix progress percentage display on JyersUI

### DIFF
--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -752,7 +752,7 @@ void CrealityDWINClass::Draw_Print_Filename(const bool reset/*=false*/) {
 }
 
 void CrealityDWINClass::Draw_Print_ProgressBar() {
-  uint8_t printpercent = sdprint ? card.percentDone() : (ui._get_progress() / 100);
+  uint8_t printpercent = ui.get_progress_percent();
   DWIN_ICON_Show(ICON, ICON_Bar, 15, 93);
   DWIN_Draw_Rectangle(1, BarFill_Color, 16 + printpercent * 240 / 100, 93, 256, 113);
   DWIN_Draw_IntValue(true, true, 0, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_percent, Percent_Color), Color_Bg_Black, 3, 109, 133, printpercent);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

On latest `bugfix-2.1.x` branch the progress percentage isn't updated on Ender 3 V2 with DWIN running JyersUI. By looking at implementations for other LCD's I came up with this patch.

I've tested it on my Ender 3 V2 (BTT SKR mini E3 V2.0) in following configurations:

* SD print without M73 ✅
* SD print with M73 ✅ (starts with estimation, then switches to value from M73)
* Host print with M73 ✅
* Host print without M73 ❌ (stuck at 0%, as expected I guess)

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Ender 3 V2 with DWIN display.

### Benefits

<!-- What does this PR fix or improve? -->

Fixes progress percentage display on the LCD.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/9940575/Configuration.zip)

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
