### PR TITLE
[FIX] Fix preheating time

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2317,8 +2317,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
   #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED < 5
     #error "Thermistor 66 requires MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED ≥ 5."
-  #elif MILLISECONDS_PREHEAT_TIME < 30000
-    #error "Thermistor 66 requires MILLISECONDS_PREHEAT_TIME ≥ 30000."
+  #elif MILLISECONDS_PREHEAT_TIME < 15000
+    #error "Thermistor 66 requires MILLISECONDS_PREHEAT_TIME ≥ 15000."
   #endif
   #undef _BAD_MINTEMP
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2318,7 +2318,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED < 5
     #error "Thermistor 66 requires MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED ≥ 5."
   #elif MILLISECONDS_PREHEAT_TIME < 15000
-    #error "Thermistor 66 requires MILLISECONDS_PREHEAT_TIME ≥ 15000."
+    #error "Thermistor 66 requires MILLISECONDS_PREHEAT_TIME ≥ 15000, but 30000 or higher is recommended."
   #endif
   #undef _BAD_MINTEMP
 #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2406,16 +2406,15 @@ void Temperature::updateTemperaturesFromRawValues() {
       if ((neg && r < temp_range[e].raw_max) || (pos && r > temp_range[e].raw_max))
         max_temp_error((heater_id_t)e);
 
+      /**
+      // DEBUG PREHEATING TIME
+      SERIAL_ECHOLNPGM("\nExtruder = ", e, " Preheat On/Off = ", is_preheating(e));
+      const float test_is_preheating = (preheat_end_time[HOTEND_INDEX] - millis()) * 0.001f;
+      if (test_is_preheating < 31) SERIAL_ECHOLNPGM("Extruder = ", e, " Preheat remaining time = ", test_is_preheating, "s", "\n");
+      //*/
+
       const bool heater_on = temp_hotend[e].target > 0;
-
-      /*
-      //DEBUG PREHEATING TIME
-      SERIAL_ECHOLNPGM("\nExtruder = ", e ," Preheating On/Off = ",is_preheating(e));
-      const float test_is_preheating = (preheat_end_time[HOTEND_INDEX] - millis()) / 1000;
-      if (test_is_preheating < 31) SERIAL_ECHOLNPGM("Extruder = ", e ," Preheating remaining time = ", test_is_preheating , "s", "\n");
-      */
-
-      if (!is_preheating(e) && (heater_on && ((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min)))) {
+      if (heater_on && !is_preheating(e) && ((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min))) {
         if (TERN1(MULTI_MAX_CONSECUTIVE_LOW_TEMP_ERR, ++consecutive_low_temperature_error[e] >= MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED))
           min_temp_error((heater_id_t)e);
       }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2407,7 +2407,15 @@ void Temperature::updateTemperaturesFromRawValues() {
         max_temp_error((heater_id_t)e);
 
       const bool heater_on = temp_hotend[e].target > 0;
-      if (heater_on && ((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min))) {
+
+      /*
+      //DEBUG PREHEATING TIME
+      SERIAL_ECHOLNPGM("\nExtruder = ", e ," Preheating On/Off = ",is_preheating(e));
+      const float test_is_preheating = (preheat_end_time[HOTEND_INDEX] - millis()) / 1000;
+      if (test_is_preheating < 31) SERIAL_ECHOLNPGM("Extruder = ", e ," Preheating remaining time = ", test_is_preheating , "s", "\n");
+      */
+
+      if (!is_preheating(e) && (heater_on && ((neg && r > temp_range[e].raw_min) || (pos && r < temp_range[e].raw_min)))) {
         if (TERN1(MULTI_MAX_CONSECUTIVE_LOW_TEMP_ERR, ++consecutive_low_temperature_error[e] >= MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED))
           min_temp_error((heater_id_t)e);
       }


### PR DESCRIPTION
Repair hotend preating :
Min temp related issue
Preheating not working , need to be fixed (works in 1.1,  'is_preheating' variable is the mintemp detection , but not in 2.0)
Manufacturer requirements are too dangerous, now possible to reduce preheating time to 15s ' minimum'

Thks