### PR TITLE
Support for TMC drivers with internal rSense

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2847,6 +2847,7 @@
     #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
     //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
     //#define X_HOLD_MULTIPLIER 0.5    // Enable to override 'HOLD_MULTIPLIER' for the X axis
+    //#define X_INTERNAL_RSENSE true   // Enable to if your controller doesnt have external RSENSE. The value in RSENSE is ignored
   #endif
 
   #if AXIS_IS_TMC(X2)
@@ -2857,6 +2858,7 @@
     #define X2_CHAIN_POS     -1
     //#define X2_INTERPOLATE true
     //#define X2_HOLD_MULTIPLIER 0.5
+    //#define X2_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Y)
@@ -2867,6 +2869,7 @@
     #define Y_CHAIN_POS      -1
     //#define Y_INTERPOLATE  true
     //#define Y_HOLD_MULTIPLIER 0.5
+    //#define Y_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Y2)
@@ -2877,6 +2880,7 @@
     #define Y2_CHAIN_POS     -1
     //#define Y2_INTERPOLATE true
     //#define Y2_HOLD_MULTIPLIER 0.5
+    //#define Y2_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Z)
@@ -2887,6 +2891,7 @@
     #define Z_CHAIN_POS      -1
     //#define Z_INTERPOLATE  true
     //#define Z_HOLD_MULTIPLIER 0.5
+    //#define Z_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Z2)
@@ -2897,6 +2902,7 @@
     #define Z2_CHAIN_POS     -1
     //#define Z2_INTERPOLATE true
     //#define Z2_HOLD_MULTIPLIER 0.5
+    //#define Z2_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Z3)
@@ -2907,6 +2913,7 @@
     #define Z3_CHAIN_POS     -1
     //#define Z3_INTERPOLATE true
     //#define Z3_HOLD_MULTIPLIER 0.5
+    //#define Z3_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(Z4)
@@ -2917,6 +2924,7 @@
     #define Z4_CHAIN_POS     -1
     //#define Z4_INTERPOLATE true
     //#define Z4_HOLD_MULTIPLIER 0.5
+    //#define Z4_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(I)
@@ -2927,6 +2935,7 @@
     #define I_CHAIN_POS     -1
     //#define I_INTERPOLATE  true
     //#define I_HOLD_MULTIPLIER 0.5
+    //#define I_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(J)
@@ -2937,6 +2946,7 @@
     #define J_CHAIN_POS     -1
     //#define J_INTERPOLATE  true
     //#define J_HOLD_MULTIPLIER 0.5
+    //#define J_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(K)
@@ -2947,6 +2957,7 @@
     #define K_CHAIN_POS     -1
     //#define K_INTERPOLATE  true
     //#define K_HOLD_MULTIPLIER 0.5
+    //#define K_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(U)
@@ -2957,6 +2968,7 @@
     #define U_CHAIN_POS     -1
     //#define U_INTERPOLATE  true
     //#define U_HOLD_MULTIPLIER 0.5
+    //#define U_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(V)
@@ -2967,6 +2979,7 @@
     #define V_CHAIN_POS     -1
     //#define V_INTERPOLATE  true
     //#define V_HOLD_MULTIPLIER 0.5
+    //#define V_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(W)
@@ -2977,6 +2990,7 @@
     #define W_CHAIN_POS     -1
     //#define W_INTERPOLATE  true
     //#define W_HOLD_MULTIPLIER 0.5
+    //#define W_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E0)
@@ -2986,6 +3000,7 @@
     #define E0_CHAIN_POS     -1
     //#define E0_INTERPOLATE true
     //#define E0_HOLD_MULTIPLIER 0.5
+    #define E0_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E1)
@@ -2995,6 +3010,7 @@
     #define E1_CHAIN_POS     -1
     //#define E1_INTERPOLATE true
     //#define E1_HOLD_MULTIPLIER 0.5
+    //#define E1_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E2)
@@ -3004,6 +3020,7 @@
     #define E2_CHAIN_POS     -1
     //#define E2_INTERPOLATE true
     //#define E2_HOLD_MULTIPLIER 0.5
+    //#define E2_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E3)
@@ -3013,6 +3030,7 @@
     #define E3_CHAIN_POS     -1
     //#define E3_INTERPOLATE true
     //#define E3_HOLD_MULTIPLIER 0.5
+    //#define E3_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E4)
@@ -3022,6 +3040,7 @@
     #define E4_CHAIN_POS     -1
     //#define E4_INTERPOLATE true
     //#define E4_HOLD_MULTIPLIER 0.5
+    //#define E4_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E5)
@@ -3031,6 +3050,7 @@
     #define E5_CHAIN_POS     -1
     //#define E5_INTERPOLATE true
     //#define E5_HOLD_MULTIPLIER 0.5
+    //#define E5_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E6)
@@ -3040,6 +3060,7 @@
     #define E6_CHAIN_POS     -1
     //#define E6_INTERPOLATE true
     //#define E6_HOLD_MULTIPLIER 0.5
+    //#define E6_INTERNAL_RSENSE true
   #endif
 
   #if AXIS_IS_TMC(E7)
@@ -3049,6 +3070,7 @@
     #define E7_CHAIN_POS     -1
     //#define E7_INTERPOLATE true
     //#define E7_HOLD_MULTIPLIER 0.5
+    //#define E7_INTERNAL_RSENSE true
   #endif
 
   // @section tmc/spi

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2114,6 +2114,9 @@
     #ifndef X_INTERPOLATE
       #define X_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef X_INTERNAL_RSENSE
+      #define X_INTERNAL_RSENSE false
+    #endif
     #ifndef X_HOLD_MULTIPLIER
       #define X_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2131,6 +2134,9 @@
     #endif
     #ifndef X2_INTERPOLATE
       #define X2_INTERPOLATE X_INTERPOLATE
+    #endif
+    #ifndef X2_INTERNAL_RSENSE
+      #define X2_INTERNAL_RSENSE false
     #endif
     #ifndef X2_HOLD_MULTIPLIER
       #define X2_HOLD_MULTIPLIER X_HOLD_MULTIPLIER
@@ -2153,6 +2159,9 @@
     #ifndef Y_INTERPOLATE
       #define Y_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef Y_INTERNAL_RSENSE
+      #define Y_INTERNAL_RSENSE false
+    #endif
     #ifndef Y_HOLD_MULTIPLIER
       #define Y_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2169,6 +2178,9 @@
       #ifndef Y2_INTERPOLATE
         #define Y2_INTERPOLATE Y_INTERPOLATE
       #endif
+    #ifndef Y2_INTERNAL_RSENSE
+      #define Y2_INTERNAL_RSENSE false
+    #endif
       #ifndef Y2_HOLD_MULTIPLIER
         #define Y2_HOLD_MULTIPLIER Y_HOLD_MULTIPLIER
       #endif
@@ -2200,6 +2212,9 @@
     #ifndef Z_INTERPOLATE
       #define Z_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef Z_INTERNAL_RSENSE
+      #define Z_INTERNAL_RSENSE false
+    #endif
     #ifndef Z_HOLD_MULTIPLIER
       #define Z_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2215,6 +2230,9 @@
       #endif
       #ifndef Z2_INTERPOLATE
         #define Z2_INTERPOLATE Z_INTERPOLATE
+      #endif
+      #ifndef Z2_INTERNAL_RSENSE
+        #define Z2_INTERNAL_RSENSE false
       #endif
       #ifndef Z2_HOLD_MULTIPLIER
         #define Z2_HOLD_MULTIPLIER Z_HOLD_MULTIPLIER
@@ -2233,6 +2251,9 @@
       #ifndef Z3_INTERPOLATE
         #define Z3_INTERPOLATE Z_INTERPOLATE
       #endif
+      #ifndef Z3_INTERNAL_RSENSE
+        #define Z3_INTERNAL_RSENSE false
+      #endif
       #ifndef Z3_HOLD_MULTIPLIER
         #define Z3_HOLD_MULTIPLIER Z_HOLD_MULTIPLIER
       #endif
@@ -2249,6 +2270,9 @@
       #endif
       #ifndef Z4_INTERPOLATE
         #define Z4_INTERPOLATE Z_INTERPOLATE
+      #endif
+      #ifndef Z4_INTERNAL_RSENSE
+        #define Z4_INTERNAL_RSENSE false
       #endif
       #ifndef Z4_HOLD_MULTIPLIER
         #define Z4_HOLD_MULTIPLIER Z_HOLD_MULTIPLIER
@@ -2272,6 +2296,9 @@
     #ifndef I_INTERPOLATE
       #define I_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef I_INTERNAL_RSENSE
+      #define I_INTERNAL_RSENSE false
+    #endif
     #ifndef I_HOLD_MULTIPLIER
       #define I_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2292,6 +2319,9 @@
     #endif
     #ifndef J_INTERPOLATE
       #define J_INTERPOLATE INTERPOLATE
+    #endif
+    #ifndef J_INTERNAL_RSENSE
+      #define J_INTERNAL_RSENSE false
     #endif
     #ifndef J_HOLD_MULTIPLIER
       #define J_HOLD_MULTIPLIER HOLD_MULTIPLIER
@@ -2314,6 +2344,9 @@
     #ifndef K_INTERPOLATE
       #define K_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef K_INTERNAL_RSENSE
+      #define K_INTERNAL_RSENSE false
+    #endif
     #ifndef K_HOLD_MULTIPLIER
       #define K_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2334,6 +2367,9 @@
     #endif
     #ifndef U_INTERPOLATE
       #define U_INTERPOLATE INTERPOLATE
+    #endif
+    #ifndef U_INTERNAL_RSENSE
+      #define U_INTERNAL_RSENSE false
     #endif
     #ifndef U_HOLD_MULTIPLIER
       #define U_HOLD_MULTIPLIER HOLD_MULTIPLIER
@@ -2356,6 +2392,9 @@
     #ifndef V_INTERPOLATE
       #define V_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef V_INTERNAL_RSENSE
+      #define V_INTERNAL_RSENSE false
+    #endif
     #ifndef V_HOLD_MULTIPLIER
       #define V_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2377,6 +2416,9 @@
     #ifndef W_INTERPOLATE
       #define W_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef W_INTERNAL_RSENSE
+      #define W_INTERNAL_RSENSE false
+    #endif
     #ifndef W_HOLD_MULTIPLIER
       #define W_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2392,6 +2434,9 @@
     #ifndef E0_INTERPOLATE
       #define E0_INTERPOLATE INTERPOLATE
     #endif
+    #ifndef E0_INTERNAL_RSENSE
+      #define E0_INTERNAL_RSENSE false
+    #endif
     #ifndef E0_HOLD_MULTIPLIER
       #define E0_HOLD_MULTIPLIER HOLD_MULTIPLIER
     #endif
@@ -2405,6 +2450,9 @@
     #endif
     #ifndef E1_INTERPOLATE
       #define E1_INTERPOLATE E0_INTERPOLATE
+    #endif
+    #ifndef E1_INTERNAL_RSENSE
+      #define E1_INTERNAL_RSENSE false
     #endif
     #ifndef E1_HOLD_MULTIPLIER
       #define E1_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
@@ -2420,6 +2468,9 @@
     #ifndef E2_INTERPOLATE
       #define E2_INTERPOLATE E0_INTERPOLATE
     #endif
+    #ifndef E2_INTERNAL_RSENSE
+      #define E2_INTERNAL_RSENSE false
+    #endif
     #ifndef E2_HOLD_MULTIPLIER
       #define E2_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
     #endif
@@ -2433,6 +2484,9 @@
     #endif
     #ifndef E3_INTERPOLATE
       #define E3_INTERPOLATE E0_INTERPOLATE
+    #endif
+    #ifndef E3_INTERNAL_RSENSE
+      #define E3_INTERNAL_RSENSE false
     #endif
     #ifndef E3_HOLD_MULTIPLIER
       #define E3_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
@@ -2448,6 +2502,9 @@
     #ifndef E4_INTERPOLATE
       #define E4_INTERPOLATE E0_INTERPOLATE
     #endif
+    #ifndef E4_INTERNAL_RSENSE
+      #define E4_INTERNAL_RSENSE false
+    #endif
     #ifndef E4_HOLD_MULTIPLIER
       #define E4_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
     #endif
@@ -2461,6 +2518,9 @@
     #endif
     #ifndef E5_INTERPOLATE
       #define E5_INTERPOLATE E0_INTERPOLATE
+    #endif
+    #ifndef E5_INTERNAL_RSENSE
+      #define E5_INTERNAL_RSENSE false
     #endif
     #ifndef E5_HOLD_MULTIPLIER
       #define E5_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
@@ -2476,6 +2536,9 @@
     #ifndef E6_INTERPOLATE
       #define E6_INTERPOLATE E0_INTERPOLATE
     #endif
+    #ifndef E6_INTERNAL_RSENSE
+      #define E6_INTERNAL_RSENSE false
+    #endif
     #ifndef E6_HOLD_MULTIPLIER
       #define E6_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER
     #endif
@@ -2489,6 +2552,9 @@
     #endif
     #ifndef E7_INTERPOLATE
       #define E7_INTERPOLATE E0_INTERPOLATE
+    #endif
+    #ifndef E7_INTERNAL_RSENSE
+      #define E7_INTERNAL_RSENSE false
     #endif
     #ifndef E7_HOLD_MULTIPLIER
       #define E7_HOLD_MULTIPLIER E0_HOLD_MULTIPLIER

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -688,6 +688,7 @@ enum StealthIndex : uint8_t {
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
+    st.internal_Rsense(internalrsense);
     st.rms_current(mA, hold_multiplier);
     st.microsteps(microsteps);
     st.iholddelay(10);
@@ -728,7 +729,6 @@ enum StealthIndex : uint8_t {
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
-    st.internal_Rsense(internalrsense);
 
     st.internal_Rsense(internalrsense);
     st.rms_current(mA, hold_multiplier);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

"*_INTERNAL_RSENSE" Definition added to Configuration_adv to allow the use of internal rSense resistors on TMC drivers that support the feature. Required for control boards that don't use external sense resistors

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

A control board with no external Rsense resistor(s), and a TMC driver that has the internal_Rsense feature

### Benefits

<!-- What does this PR fix or improve? -->

Adds support for control boards that do not use external Rsense resistors, with Trinamic control chips that support the feature

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
