### PR TITLE
🐛 Ender 3v2 DWIN MarlinUI Fixup

### DIFF
--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -234,7 +234,7 @@ void DWIN_Frame_AreaMove(uint8_t mode, uint8_t dir, uint16_t dis,
 //  *string: The string
 //  rlimit: To limit the drawn string length
 void DWIN_Draw_String(bool bShow, uint8_t size, uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, const char * const string, uint16_t rlimit/*=0xFFFF*/) {
-  #if NONE(DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
+  #if NONE(DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI, IS_DWIN_MARLINUI)
     DWIN_Draw_Rectangle(1, bColor, x, y, x + (fontWidth(size) * strlen_P(string)), y + fontHeight(size));
   #endif
   constexpr uint8_t widthAdjust = 0;

--- a/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
@@ -453,7 +453,7 @@ void MarlinUI::draw_status_screen() {
         DWIN_Draw_String(
           false, font16x32, Percent_Color, Color_Bg_Black,
           pb_left + (pb_width - dwin_string.length * 16) / 2,
-          (pb_top + (pb_height - 32) / 2) - 1,
+          pb_top + (pb_height - 32) / 2 - 1,
           S(dwin_string.string())
         );
       #endif

--- a/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
@@ -453,7 +453,7 @@ void MarlinUI::draw_status_screen() {
         DWIN_Draw_String(
           false, font16x32, Percent_Color, Color_Bg_Black,
           pb_left + (pb_width - dwin_string.length * 16) / 2,
-          pb_top + (pb_height - 32) / 2,
+          (pb_top + (pb_height - 32) / 2) - 1,
           S(dwin_string.string())
         );
       #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This fixes a few visual artifacts that occur on the Ender 3 v2 DWIN with MarlinUI. Most notably, many text labels are drawn incorrectly with a background when they shouldn't be. This is most noticeable on confirmation screens.

Additionally, bumped the progress % shown up by 1 pixel. This puts it completely inside the progress bar in horizontal mode so that there are no artifacts left over when the progress text changes.

A side note: drawing a background rectangle in `DWIN_Draw_String` is probably being done because the CrealityUI or others assumes that `bShow` is always true instead of actually passing true when needed. 

### Requirements

An Ender 3 v2 DWIN with MarlinUI.

### Benefits

Fixes visual artifacts in MarlinUI on this LCD.

### Configurations

[ender3v2_octopus.zip](https://github.com/MarlinFirmware/Marlin/files/9997519/ender3v2_octopus.zip)

### Related Issues

None
