### PR TITLE
COLOR_UI: restore display sleep timeout and setting

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -196,12 +196,11 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 
   uint8_t MarlinUI::sleep_timeout_minutes; // Initialized by settings.load()
   millis_t MarlinUI::screen_timeout_millis = 0;
-  #if DISABLED(TFT_COLOR_UI)
-    void MarlinUI::refresh_screen_timeout() {
-      screen_timeout_millis = sleep_timeout_minutes ? millis() + sleep_timeout_minutes * 60UL * 1000UL : 0;
-      sleep_display(false);
-    }
-  #endif
+  void MarlinUI::refresh_screen_timeout() {
+    screen_timeout_millis = sleep_timeout_minutes ? millis() + sleep_timeout_minutes * 60UL * 1000UL : 0;
+    sleep_display(false);
+  }
+
 #endif
 
 void MarlinUI::init() {
@@ -1071,7 +1070,7 @@ void MarlinUI::init() {
 
           #if LCD_BACKLIGHT_TIMEOUT_MINS
             refresh_backlight_timeout();
-          #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
+          #elif HAS_DISPLAY_SLEEP
             refresh_screen_timeout();
           #endif
 
@@ -1184,9 +1183,9 @@ void MarlinUI::init() {
           WRITE(LCD_BACKLIGHT_PIN, LOW); // Backlight off
           backlight_off_ms = 0;
         }
-      #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
+      #elif HAS_DISPLAY_SLEEP
         if (screen_timeout_millis && ELAPSED(ms, screen_timeout_millis))
-          sleep_display(true);
+          sleep_display();
       #endif
 
       // Change state of drawing flag between screen updates

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -201,6 +201,10 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
     sleep_display(false);
   }
 
+  #if !HAS_TOUCH_SLEEP && !HAS_MARLINUI_U8GLIB // without DOGM (COLOR_UI)
+    void MarlinUI::sleep_display(const bool sleep) {} // if unimplemented
+  #endif
+
 #endif
 
 void MarlinUI::init() {
@@ -730,6 +734,11 @@ void MarlinUI::init() {
     void MarlinUI::wakeup_screen() {
       TERN(HAS_TOUCH_BUTTONS, touchBt.wakeUp(), touch.wakeUp());
     }
+    #if HAS_DISPLAY_SLEEP && !HAS_MARLINUI_U8GLIB // without DOGM (COLOR_UI)
+      void MarlinUI::sleep_display(const bool sleep) {
+        if (!sleep) wakeup_screen(); // relay extra wake up events
+      }
+    #endif
   #endif
 
   void MarlinUI::quick_feedback(const bool clear_buttons/*=true*/) {

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -550,7 +550,7 @@ void menu_configuration() {
   //
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     EDIT_ITEM(uint8, MSG_SCREEN_TIMEOUT, &ui.backlight_timeout_minutes, ui.backlight_timeout_min, ui.backlight_timeout_max, ui.refresh_backlight_timeout);
-  #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
+  #elif HAS_DISPLAY_SLEEP
     EDIT_ITEM(uint8, MSG_SCREEN_TIMEOUT, &ui.sleep_timeout_minutes, ui.sleep_timeout_min, ui.sleep_timeout_max, ui.refresh_screen_timeout);
   #endif
 

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -43,7 +43,7 @@ int16_t Touch::x, Touch::y;
 touch_control_t Touch::controls[];
 touch_control_t *Touch::current_control;
 uint16_t Touch::controls_count;
-millis_t Touch::last_touch_ms = 0,
+millis_t Touch::next_touch_ms = 0,
          Touch::time_to_hold,
          Touch::repeat_delay,
          Touch::touch_time;
@@ -83,8 +83,8 @@ void Touch::idle() {
 
   // Return if Touch::idle is called within the same millisecond
   const millis_t now = millis();
-  if (last_touch_ms >= now) return;
-  last_touch_ms = now;
+  if (now <= next_touch_ms) return;
+  next_touch_ms = now;
 
   if (get_point(&_x, &_y)) {
     #if HAS_RESUME_CONTINUE
@@ -97,18 +97,18 @@ void Touch::idle() {
       }
     #endif
 
-    ui.reset_status_timeout(last_touch_ms);
+    ui.reset_status_timeout(now);
 
     if (touch_time) {
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-        if (touch_control_type == NONE && ELAPSED(last_touch_ms, touch_time + TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS) && ui.on_status_screen())
+        if (touch_control_type == NONE && ELAPSED(now, touch_time + TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS) && ui.on_status_screen())
           ui.goto_screen(touch_screen_calibration);
       #endif
       return;
     }
 
-    if (time_to_hold == 0) time_to_hold = last_touch_ms + MINIMUM_HOLD_TIME;
-    if (PENDING(last_touch_ms, time_to_hold)) return;
+    if (time_to_hold == 0) time_to_hold = now + MINIMUM_HOLD_TIME;
+    if (PENDING(now, time_to_hold)) return;
 
     if (x != 0 && y != 0) {
       if (current_control) {
@@ -133,7 +133,7 @@ void Touch::idle() {
       }
 
       if (!current_control)
-        touch_time = last_touch_ms;
+        touch_time = now;
     }
     x = _x;
     y = _y;
@@ -252,8 +252,8 @@ void Touch::touch(touch_control_t *control) {
 void Touch::hold(touch_control_t *control, millis_t delay) {
   current_control = control;
   if (delay) {
-    repeat_delay = delay > MIN_REPEAT_DELAY ? delay : MIN_REPEAT_DELAY;
-    time_to_hold = last_touch_ms + repeat_delay;
+    repeat_delay = _MAX(delay, MIN_REPEAT_DELAY);
+    time_to_hold = next_touch_ms + repeat_delay;
   }
   ui.refresh();
 }
@@ -301,7 +301,7 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
-      last_touch_ms = millis() + 100;
+      next_touch_ms = millis() + 100;
       safe_delay(20);
     }
     next_sleep_ms = millis() + SEC_TO_MS(ui.sleep_timeout_minutes * 60);

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -83,7 +83,7 @@ void Touch::idle() {
 
   // Return if Touch::idle is called within the same millisecond
   const millis_t now = millis();
-  if (last_touch_ms == now) return;
+  if (last_touch_ms >= now) return;
   last_touch_ms = now;
 
   if (get_point(&_x, &_y)) {
@@ -301,6 +301,8 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
+      last_touch_ms = millis() + 100;
+      safe_delay(20);
     }
     next_sleep_ms = millis() + SEC_TO_MS(ui.sleep_timeout_minutes * 60);
   }

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -103,7 +103,7 @@ class Touch {
     static touch_control_t *current_control;
     static uint16_t controls_count;
 
-    static millis_t last_touch_ms, time_to_hold, repeat_delay, touch_time;
+    static millis_t next_touch_ms, time_to_hold, repeat_delay, touch_time;
     static TouchControlType touch_control_type;
 
     static bool get_point(int16_t *x, int16_t *y);

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3232,7 +3232,7 @@ void MarlinSettings::reset() {
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     ui.backlight_timeout_minutes = LCD_BACKLIGHT_TIMEOUT_MINS;
   #elif HAS_DISPLAY_SLEEP
-    ui.sleep_timeout_minutes = DISPLAY_SLEEP_MINUTES;
+    ui.sleep_timeout_minutes = TERN(TOUCH_SCREEN, TOUCH_IDLE_SLEEP_MINS, DISPLAY_SLEEP_MINUTES);
   #endif
 
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -658,7 +658,7 @@ void MarlinSettings::postprocess() {
 
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     ui.refresh_backlight_timeout();
-  #elif HAS_DISPLAY_SLEEP && DISABLED(TFT_COLOR_UI)
+  #elif HAS_DISPLAY_SLEEP
     ui.refresh_screen_timeout();
   #endif
 }
@@ -3232,7 +3232,7 @@ void MarlinSettings::reset() {
   #if LCD_BACKLIGHT_TIMEOUT_MINS
     ui.backlight_timeout_minutes = LCD_BACKLIGHT_TIMEOUT_MINS;
   #elif HAS_DISPLAY_SLEEP
-    ui.sleep_timeout_minutes = TERN(TOUCH_SCREEN, TOUCH_IDLE_SLEEP_MINS, DISPLAY_SLEEP_MINUTES);
+    ui.sleep_timeout_minutes = DISPLAY_SLEEP_MINUTES;
   #endif
 
   //


### PR DESCRIPTION
May relay some extra events to wake up the display (encoder or such)

This also keep the eeprom setting for the timeout delay (and menu to edit it)

Cases tested for now: COLOR_UI + Touchscreen TFT with a backlight pin (longer3D board) on STM32 (with pwm pin) and F1 (maple) platforms