### PR TITLE
🩹 Fix Sidewinder X2 pinout

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
+++ b/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
@@ -81,9 +81,9 @@
 #define E0_DIR_PIN                          PA6
 #define E0_ENABLE_PIN                       PC4
 
-#define E1_STEP_PIN                         PA4
-#define E1_DIR_PIN                          PA3
-#define E1_ENABLE_PIN                       PA5
+#define Z2_STEP_PIN                         PA4
+#define Z2_DIR_PIN                          PA3
+#define Z2_ENABLE_PIN                       PA5
 
 //
 // Temperature Sensors


### PR DESCRIPTION
### Description

Compiling Marlin for a sidewinder X2 produced warnings and fixing the pinout definition fixed it.
This printer have a single extruder but dual Z axis/motors.


Someone produced a documentation of the board pin assignment https://i.redd.it/h87re4wrbrd91.png which confirms those pins are the second Z motor pins.

### Requirements

Some Sidewinder using a RUBY board.

### Benefits

Fixes compilation warnings (I didn't check if the motor was in use without this change).

### Configurations

[used_x2_config.zip](https://github.com/MarlinFirmware/Marlin/files/10044386/used_x2_config.zip)


### Related Issues

I didn't enter a bug for that.