### PR TITLE
Fix regression in FAST_PWM_FAN and TouchUI with NO_MOTION_BEFORE_HOMING

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -146,11 +146,11 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
       LIMIT(res_pc_temp, 1U, maxtop);
 
       // Calculate frequencies of test prescaler and resolution values
-      const uint32_t f_diff      = _MAX(f, f_desired) - _MIN(f, f_desired),
-                     f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
-                     f_fast_diff = _MAX(f_fast_temp, f_desired) - _MIN(f_fast_temp, f_desired),
-                     f_pc_temp   = (F_CPU) / (2 * p * res_pc_temp),
-                     f_pc_diff   = _MAX(f_pc_temp, f_desired) - _MIN(f_pc_temp, f_desired);
+      const int f_diff = ABS(f - int(f_desired)),
+                f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
+                f_fast_diff = ABS(f_fast_temp - int(f_desired)),
+                f_pc_temp = (F_CPU) / (2 * p * res_pc_temp),
+                f_pc_diff = ABS(f_pc_temp - int(f_desired));
 
       if (f_fast_diff < f_diff && f_fast_diff <= f_pc_diff) { // FAST values are closest to desired f
         // Set the Wave Generation Mode to FAST PWM

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -375,9 +375,9 @@ namespace ExtUI {
   bool canMove(const axis_t axis) {
     switch (axis) {
       #if IS_KINEMATIC || ENABLED(NO_MOTION_BEFORE_HOMING)
-        case X: return axis_should_home(X_AXIS);
-        OPTCODE(HAS_Y_AXIS, case Y: return axis_should_home(Y_AXIS))
-        OPTCODE(HAS_Z_AXIS, case Z: return axis_should_home(Z_AXIS))
+        case X: return !axis_should_home(X_AXIS);
+        OPTCODE(HAS_Y_AXIS, case Y: return !axis_should_home(Y_AXIS))
+        OPTCODE(HAS_Z_AXIS, case Z: return !axis_should_home(Z_AXIS))
       #else
         case X: case Y: case Z: return true;
       #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### 1) Touch UI error

This PR fixes an issue where when `NO_MOTION_BEFORE_HOMING` is enabled the touch UI allows the user to move the axis before homing, but grays out motion controls once the axis is homed. This is the exact opposite of the intended behavior.

### 2) Fast_PWM Regression

This PR fixes a regression that was introduced to `fast_pwm.cpp` in commit 07bffdf and subsequently incorrectly patched in 2cfde39. This appears to be caused by a change from signed to unsigned values in certain expressions that were computing absolute values. The symptom of this change is that fan PWM does not work when `FAST_PWM_FAN` is enabled and `FAST_PWM_FAN_FREQUENCY = 122`, as it is on LulzBot firmware.

#### History of changes:

Working code in commit 02b29c0:

```
void set_pwm_frequency(const pin_t pin, int f_desired) {
   ...
   const int f_temp_fast = (F_CPU) / (prescaler[i] * (1 + res_temp_fast)),
                f_temp_phase_correct = (F_CPU) / (2 * prescaler[i] * res_temp_phase_correct),
                f_diff = ABS(f - f_desired),
                f_fast_diff = ABS(f_temp_fast - f_desired),
                f_phase_diff = ABS(f_temp_phase_correct - f_desired);
    ...
}
```

Commit 07bffdf changed the signature of the function, which caused the computation of the absolute value to fail (due to an unsigned subtraction):

```
void set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
   ...
}
```

Commit 2cfde39 applied a patch, but testing revealed this still did not give the correct PWM behavior:

```
void set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
   ...
   const uint32_t f_diff      = _MAX(f, f_desired) - _MIN(f, f_desired),
                  f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
                  f_fast_diff = _MAX(f_fast_temp, f_desired) - _MIN(f_fast_temp, f_desired),
                  f_pc_temp   = (F_CPU) / (2 * p * res_pc_temp),
                  f_pc_diff   = _MAX(f_pc_temp, f_desired) - _MIN(f_pc_temp, f_desired);
}
```

This PR restores the use of the ABS function and adds a few int casts. This version allows PWM to work as intended and is, IMHO, more readable than the attempted patch:

```
void set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
   ...
   const int f_diff = ABS(f - int(f_desired)),
             f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
             f_fast_diff = ABS(f_fast_temp - int(f_desired)),
             f_pc_temp = (F_CPU) / (2 * p * res_pc_temp),
             f_pc_diff = ABS(f_pc_temp - int(f_desired));
   ...
}
```

### Benefits

1) This PR fixes the touch UI.
2) This PR fixes PWM fan control in certain configurations.

### Configurations

[MarlinConfig.zip](https://github.com/MarlinFirmware/Marlin/files/10051205/MarlinConfig.zip)

### Related Issues

[[BUG][TAZ6] PWM fan control not working in RC41+](https://github.com/drunken-octopus/drunken-octopus-marlin/issues/41)
