### PR TITLE
Fix incorrect sanity check of ADVANCE_K when DISTINCT_E_FACTORS is en…

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1340,7 +1340,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if ENABLED(LIN_ADVANCE)
   #if DISTINCT_E > 1
     constexpr float lak[] = ADVANCE_K;
-    static_assert(COUNT(lak) < DISTINCT_E, "The ADVANCE_K array has too many elements (i.e., more than " STRINGIFY(DISTINCT_E) ").");
+    static_assert(COUNT(lak) <= DISTINCT_E, "The ADVANCE_K array has too many elements (i.e., more than " STRINGIFY(DISTINCT_E) ").");
     #define _LIN_ASSERT(N) static_assert(N >= COUNT(lak) || WITHIN(lak[N], 0, 10), "ADVANCE_K values must be from 0 to 10 (Changed in LIN_ADVANCE v1.5, Marlin 1.1.9).");
     REPEAT(DISTINCT_E, _LIN_ASSERT)
     #undef _LIN_ASSERT


### PR DESCRIPTION

### Description

When DISTINCT_E_FACTORS is enabled and EXTRUDERS is 2, ADVANCE_K should have two elements. However, the sanity check is failing because the static_assert is incorrect (even though the text description is correct)

