### PR TITLE
fix issue with menu_ubl.cpp with no FAN_PIN

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -144,7 +144,6 @@ jobs:
     - name: Install PlatformIO
       run: |
         pip install -U platformio
-        pio upgrade --dev
         pio pkg update --global
 
     - name: Run ${{ matrix.test-platform }} Tests

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -144,6 +144,7 @@ jobs:
     - name: Install PlatformIO
       run: |
         pip install -U platformio
+        pio upgrade --dev
         pio pkg update --global
 
     - name: Run ${{ matrix.test-platform }} Tests

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -35,6 +35,9 @@
 #include "../../module/planner.h"
 #include "../../module/settings.h"
 #include "../../feature/bedlevel/bedlevel.h"
+#if HAS_HOTEND
+  #include "../../module/temperature.h"
+#endif
 
 static int16_t ubl_storage_slot = 0,
                custom_hotend_temp = 150,


### PR DESCRIPTION
### Description

When AUTO_BED_LEVELING_UBL is enabled with a MENU but the FAN_PIN has been disabled 
eg #define FAN_PIN -1
Marlin fails to compile

```CPP
"Marlin/src/lcd/menu/menu_ubl.cpp:131:87: error: 'thermalManager' was not declared in this scope
     EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, EXTRUDE_MINTEMP, thermalManager.hotend_max_target(0));"

```
The issue is that menu_ubl.cpp relies on menu_item.h to include temperature.h
But menu_item only includes temperature.h if HAS_FAN is defined.

menu_ubl.cpp now includes temperature.h if HAS_HOTEND is true.

### Requirements

#define FAN_PIN -1
#define FIX_MOUNTED_PROBE  // any probe really, this is just simplest
#define AUTO_BED_LEVELING_UBL
#define Z_SAFE_HOMING  // requirement when homing with a probe 
#define EEPROM_SETTINGS // requirement of UBL
#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER // Any display that uses marlin menu.

### Benefits

Compiles as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25017
