### PR TITLE
Add missed va_end in unwarm.cpp

### DIFF
--- a/Marlin/src/HAL/shared/backtrace/unwarm.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarm.cpp
@@ -33,8 +33,9 @@
 void UnwPrintf(const char *format, ...) {
   va_list args;
 
-  va_start( args, format );
-  vprintf(format, args );
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
 }
 #endif
 


### PR DESCRIPTION
I spot a missed va_end call. Here is the pull request about. I made no tests about it.