### PR TITLE
fix AVR PWM, follow up to 25005

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -146,11 +146,11 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
       LIMIT(res_pc_temp, 1U, maxtop);
 
       // Calculate frequencies of test prescaler and resolution values
-      const uint32_t f_diff = ABS(f - int(f_desired)),
-                     f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
-                     f_fast_diff = ABS(f_fast_temp - int(f_desired)),
-                     f_pc_temp = (F_CPU) / (2 * p * res_pc_temp),
-                     f_pc_diff = ABS(f_pc_temp - int(f_desired));
+      const uint16_t f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
+                     f_pc_temp   = (F_CPU) / (2 * p * res_pc_temp);
+      const int      f_diff      = _MAX(f, f_desired) - _MIN(f, f_desired),
+                     f_fast_diff = _MAX(f_fast_temp, f_desired) - _MIN(f_fast_temp, f_desired),
+                     f_pc_diff   = _MAX(f_pc_temp, f_desired) - _MIN(f_pc_temp, f_desired);
 
       if (f_fast_diff < f_diff && f_fast_diff <= f_pc_diff) { // FAST values are closest to desired f
         // Set the Wave Generation Mode to FAST PWM

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -146,11 +146,11 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
       LIMIT(res_pc_temp, 1U, maxtop);
 
       // Calculate frequencies of test prescaler and resolution values
-      const int f_diff = ABS(f - int(f_desired)),
-                f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
-                f_fast_diff = ABS(f_fast_temp - int(f_desired)),
-                f_pc_temp = (F_CPU) / (2 * p * res_pc_temp),
-                f_pc_diff = ABS(f_pc_temp - int(f_desired));
+      const uint32_t f_diff = ABS(f - int(f_desired)),
+                     f_fast_temp = (F_CPU) / (p * (1 + res_fast_temp)),
+                     f_fast_diff = ABS(f_fast_temp - int(f_desired)),
+                     f_pc_temp = (F_CPU) / (2 * p * res_pc_temp),
+                     f_pc_diff = ABS(f_pc_temp - int(f_desired));
 
       if (f_fast_diff < f_diff && f_fast_diff <= f_pc_diff) { // FAST values are closest to desired f
         // Set the Wave Generation Mode to FAST PWM


### PR DESCRIPTION
### Description

Issue https://github.com/MarlinFirmware/Marlin/issues/25018 reported that simple PWM of LEDS was no longer working on AVR  (only full on works, or its off) 

Git bisect shows it stopped working with https://github.com/MarlinFirmware/Marlin/commit/e3e07354d5ff98293f87d532fdd1c384d8e0b2e2

Current code only works is you have FAST_PWM_FAN enabled.

Corrected a few variable types. It now works as expected with and without FAST_PWM_FAN

### Requirements

An eg only.
Stock config + 
#define RGBW_LED
#define RGB_LED_R_PIN 5
#define RGB_LED_G_PIN 4
#define RGB_LED_B_PIN 6
#define RGB_LED_W_PIN 44

### Benefits

M150 PWM of these LED pins work again
M106 with and without FAST_PWM_FAN and FAST_PWM_FAN_FREQUENCY 122 works as expected

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/25018
https://github.com/MarlinFirmware/Marlin/pull/25005