### PR TITLE
DEL - Sort file names in reverse order

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1611,6 +1611,7 @@
 
   // SD Card Sorting options
   #if ENABLED(SDCARD_SORT_ALPHA)
+    #define SDSORT_REVERSE     false  // Sort file names in reverse order
     #define SDSORT_LIMIT       40     // Maximum number of sorted items (10-256). Costs 27 bytes each.
     #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
     #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 G-code.

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1182,9 +1182,17 @@ void CardReader::cdroot() {
 
             // Compare names from the array or just the two buffered names
             #if ENABLED(SDSORT_USES_RAM)
-              #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) > 0)
+              #if ENABLED(SDSORT_REVERSE)
+                #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) < 0)
+              #else
+                #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) > 0)
+              #endif
             #else
-              #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) > 0)
+              #if ENABLED(SDSORT_REVERSE)
+                #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) < 0)
+              #else
+                #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) > 0)
+              #endif    
             #endif
 
             #if HAS_FOLDER_SORTING

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1182,17 +1182,9 @@ void CardReader::cdroot() {
 
             // Compare names from the array or just the two buffered names
             #if ENABLED(SDSORT_USES_RAM)
-              #if ENABLED(SDSORT_REVERSE)
-                #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) < 0)
-              #else
-                #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) > 0)
-              #endif
+              #define _SORT_CMP_NODIR() (strcasecmp(sortnames[o1], sortnames[o2]) TERN(SDSORT_REVERSE, <, >) 0)
             #else
-              #if ENABLED(SDSORT_REVERSE)
-                #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) < 0)
-              #else
-                #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) > 0)
-              #endif    
+              #define _SORT_CMP_NODIR() (strcasecmp(name1, name2) TERN(SDSORT_REVERSE, <, >) 0)
             #endif
 
             #if HAS_FOLDER_SORTING


### PR DESCRIPTION
Implementation of #24937

Currently files could be sorted by name, with option recent FAT entry first. So it could be difficult find new file.

Some slicers (at least Prusa) allows add date/time at the file name beginning like 202221028-174608. Reverse sort puts new file at the list top.