### PR TITLE
Update renamed.ini nano_35 to nano35

### DIFF
--- a/ini/renamed.ini
+++ b/ini/renamed.ini
@@ -57,10 +57,10 @@ extends = renamed
 # Renamed to STM32F103VE_GTM32_maple
 extends = renamed
 
-[env:mks_robin_nano_35]
+[env:mks_robin_nano35]
 # Renamed to mks_robin_nano_v1v2
 extends = renamed
 
-[env:mks_robin_nano_35_maple]
+[env:mks_robin_nano35_maple]
 # Renamed to mks_robin_nano_v1v2_maple
 extends = renamed


### PR DESCRIPTION
```
env:mks_robin_nano_35       -> env:mks_robin_nano35
env:mks_robin_nano_35_maple -> env:mks_robin_nano35_maple 
```
nano_35 never existed, is a typo

### Description

Fixing a typo
