### PR TITLE
Fix MSG_MOVE_N_MM substitution

### DIFF
--- a/Marlin/src/lcd/language/language_el.h
+++ b/Marlin/src/lcd/language/language_el.h
@@ -95,7 +95,7 @@ namespace Language_el {
   LSTR MSG_MOVE_N                         = _UxGT("Μετακίνηση @");
   LSTR MSG_MOVE_E                         = _UxGT("Εξωθητής");
   LSTR MSG_MOVE_EN                        = _UxGT("Εξωθητής *");
-  LSTR MSG_MOVE_N_MM                      = _UxGT("Μετακίνηση %s μμ");
+  LSTR MSG_MOVE_N_MM                      = _UxGT("Μετακίνηση $μμ");
   LSTR MSG_MOVE_01MM                      = _UxGT("Μετακίνηση 0,1 μμ");
   LSTR MSG_MOVE_1MM                       = _UxGT("Μετακίνηση 1 μμ");
   LSTR MSG_MOVE_10MM                      = _UxGT("Μετακίνηση 10 μμ");

--- a/Marlin/src/lcd/language/language_el_gr.h
+++ b/Marlin/src/lcd/language/language_el_gr.h
@@ -84,7 +84,7 @@ namespace Language_el_gr {
   LSTR MSG_MOVE_N                         = _UxGT("Μετακίνηση @");
   LSTR MSG_MOVE_E                         = _UxGT("Εξωθητήρας");
   LSTR MSG_MOVE_EN                        = _UxGT("Εξωθητήρας *");
-  LSTR MSG_MOVE_N_MM                      = _UxGT("Μετακίνηση %s μμ");
+  LSTR MSG_MOVE_N_MM                      = _UxGT("Μετακίνηση $μμ");
   LSTR MSG_MOVE_01MM                      = _UxGT("Μετακίνηση 0,1 μμ");
   LSTR MSG_MOVE_1MM                       = _UxGT("Μετακίνηση 1 μμ");
   LSTR MSG_MOVE_10MM                      = _UxGT("Μετακίνηση 10 μμ");

--- a/Marlin/src/lcd/language/language_ru.h
+++ b/Marlin/src/lcd/language/language_ru.h
@@ -336,7 +336,7 @@ namespace Language_ru {
   LSTR MSG_MOVE_E                           = _UxGT("Экструдер");
   LSTR MSG_MOVE_EN                          = _UxGT("Экструдер *");
   LSTR MSG_HOTEND_TOO_COLD                  = _UxGT("Сопло не нагрето");
-  LSTR MSG_MOVE_N_MM                        = _UxGT("Движение %sмм");
+  LSTR MSG_MOVE_N_MM                        = _UxGT("Движение $мм");
   LSTR MSG_MOVE_01MM                        = _UxGT("Движение 0.1мм");
   LSTR MSG_MOVE_1MM                         = _UxGT("Движение 1мм");
   LSTR MSG_MOVE_10MM                        = _UxGT("Движение 10мм");

--- a/Marlin/src/lcd/language/language_uk.h
+++ b/Marlin/src/lcd/language/language_uk.h
@@ -337,7 +337,7 @@ namespace Language_uk {
   LSTR MSG_MOVE_E                           = _UxGT("Екструдер");
   LSTR MSG_MOVE_EN                          = _UxGT("Екструдер *");
   LSTR MSG_HOTEND_TOO_COLD                  = _UxGT("Сопло дуже холодне");
-  LSTR MSG_MOVE_N_MM                        = _UxGT("Рух %sмм");
+  LSTR MSG_MOVE_N_MM                        = _UxGT("Рух $мм");
   LSTR MSG_MOVE_01MM                        = _UxGT("Рух 0.1мм");
   LSTR MSG_MOVE_1MM                         = _UxGT("Рух 1мм");
   LSTR MSG_MOVE_10MM                        = _UxGT("Рух 10мм");


### PR DESCRIPTION
### Description

Issue 25039 reported that %s was incorrectly used in the following strings

language_el.h
LSTR MSG_MOVE_N_MM = _UxGT("Μετακίνηση %s μμ");
language_el_gr.h
LSTR MSG_MOVE_N_MM = _UxGT("Μετακίνηση %s μμ");
language_ru.h
LSTR MSG_MOVE_N_MM = _UxGT("Движение %sмм");
language_uk.h
LSTR MSG_MOVE_N_MM = _UxGT("Рух %sмм");

Should be using $ instead

### Benefits

$ is substituted with numbers as expected 

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/25039