### PR TITLE
E3V2/LCD: unify limits for feedrate, acc, jerk and steps

### DIFF
--- a/Marlin/src/lcd/e3v2/common/limits.h
+++ b/Marlin/src/lcd/e3v2/common/limits.h
@@ -1,0 +1,123 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/*****************************************************************************
+  * @file     lcd/e3v2/common/limits.h
+  * @brief    Limits for UI values
+  ****************************************************************************/
+
+#include "../../../inc/MarlinConfig.h"
+
+// If max edit values are not specified use default *DEFAULT_MAX_MULTIPLIER
+#define DEFAULT_MAX_MULTIPLIER 2
+
+/* feedrate limits */
+
+#define MIN_FEEDRATE_EDIT_VALUE 1
+
+constexpr float min_feedrate_edit_values[] = {
+  [X_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
+  [Y_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
+  [Z_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
+  [E_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
+};
+constexpr float default_max_feedrate[] = DEFAULT_MAX_FEEDRATE;
+constexpr float max_feedrate_edit_values[] =
+  #ifdef MAX_FEEDRATE_EDIT_VALUES
+    MAX_FEEDRATE_EDIT_VALUES
+  #else
+    {
+      [X_AXIS] = default_max_feedrate[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [Y_AXIS] = default_max_feedrate[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [Z_AXIS] = default_max_feedrate[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [E_AXIS] = default_max_feedrate[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
+    }
+  #endif
+;
+
+/* acceleration limits */
+
+#define MIN_ACCELERATION_EDIT_VALUE 1
+
+constexpr float min_acceleration_edit_values[] = {
+  [X_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
+  [Y_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
+  [Z_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
+  [E_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
+};
+constexpr float default_max_acceleration[] = DEFAULT_MAX_ACCELERATION;
+constexpr float max_acceleration_edit_values[] =
+  #ifdef MAX_ACCEL_EDIT_VALUES
+    MAX_ACCEL_EDIT_VALUES
+  #else
+    {
+      [X_AXIS] = default_max_acceleration[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [Y_AXIS] = default_max_acceleration[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [Z_AXIS] = default_max_acceleration[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
+      [E_AXIS] = default_max_acceleration[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
+    }
+  #endif
+;
+
+/* max jerk limits */
+
+#define MIN_JERK_EDIT_VALUE 0.1
+
+#if HAS_CLASSIC_JERK
+  constexpr float min_jerk_edit_values[] = {
+    [X_AXIS] = MIN_JERK_EDIT_VALUE,
+    [Y_AXIS] = MIN_JERK_EDIT_VALUE,
+    [Z_AXIS] = MIN_JERK_EDIT_VALUE,
+    [E_AXIS] = MIN_JERK_EDIT_VALUE,
+  };
+  constexpr float max_jerk_edit_values[] =
+    #ifdef MAX_JERK_EDIT_VALUES
+      MAX_JERK_EDIT_VALUES
+    #else
+      {
+        [X_AXIS] = DEFAULT_XJERK * DEFAULT_MAX_MULTIPLIER,
+        [Y_AXIS] = DEFAULT_YJERK * DEFAULT_MAX_MULTIPLIER,
+        [Z_AXIS] = DEFAULT_ZJERK * DEFAULT_MAX_MULTIPLIER,
+        [E_AXIS] = DEFAULT_EJERK * DEFAULT_MAX_MULTIPLIER,
+      }
+    #endif
+  ;
+#endif
+
+/* steps per mm limits */
+
+#define MIN_STEPS_EDIT_VALUE 1
+
+constexpr float min_steps_edit_values[] = {
+  [X_AXIS] = MIN_STEPS_EDIT_VALUE,
+  [Y_AXIS] = MIN_STEPS_EDIT_VALUE,
+  [Z_AXIS] = MIN_STEPS_EDIT_VALUE,
+  [E_AXIS] = MIN_STEPS_EDIT_VALUE,
+};
+constexpr float default_steps[] = DEFAULT_AXIS_STEPS_PER_UNIT;
+constexpr float max_steps_edit_values[] = {
+  [X_AXIS] = default_steps[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
+  [Y_AXIS] = default_steps[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
+  [Z_AXIS] = default_steps[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
+  [E_AXIS] = default_steps[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
+};

--- a/Marlin/src/lcd/e3v2/common/limits.h
+++ b/Marlin/src/lcd/e3v2/common/limits.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -22,102 +22,73 @@
 #pragma once
 
 /*****************************************************************************
-  * @file     lcd/e3v2/common/limits.h
-  * @brief    Limits for UI values
-  ****************************************************************************/
+ * @file     lcd/e3v2/common/limits.h
+ * @brief    Limits for UI values
+ ****************************************************************************/
 
 #include "../../../inc/MarlinConfig.h"
 
-// If max edit values are not specified use default *DEFAULT_MAX_MULTIPLIER
+// If max edit values are not specified use default * DEFAULT_MAX_MULTIPLIER
 #define DEFAULT_MAX_MULTIPLIER 2
 
-/* feedrate limits */
-
+//
+// Feedrate limits
+//
 #define MIN_FEEDRATE_EDIT_VALUE 1
 
-constexpr float min_feedrate_edit_values[] = {
-  [X_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
-  [Y_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
-  [Z_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
-  [E_AXIS] = MIN_FEEDRATE_EDIT_VALUE,
-};
-constexpr float default_max_feedrate[] = DEFAULT_MAX_FEEDRATE;
-constexpr float max_feedrate_edit_values[] =
-  #ifdef MAX_FEEDRATE_EDIT_VALUES
-    MAX_FEEDRATE_EDIT_VALUES
-  #else
-    {
-      [X_AXIS] = default_max_feedrate[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [Y_AXIS] = default_max_feedrate[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [Z_AXIS] = default_max_feedrate[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [E_AXIS] = default_max_feedrate[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
-    }
-  #endif
-;
+constexpr xyze_float_t min_feedrate_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_FEEDRATE_EDIT_VALUE),
+                       default_max_feedrate = DEFAULT_MAX_FEEDRATE,
+                       max_feedrate_edit_values =
+                         #ifdef MAX_FEEDRATE_EDIT_VALUES
+                           MAX_FEEDRATE_EDIT_VALUES
+                         #else
+                           default_max_feedrate * float(DEFAULT_MAX_MULTIPLIER)
+                         #endif
+                       ;
 
-/* acceleration limits */
-
+//
+// Acceleration limits
+//
 #define MIN_ACCELERATION_EDIT_VALUE 1
 
-constexpr float min_acceleration_edit_values[] = {
-  [X_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
-  [Y_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
-  [Z_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
-  [E_AXIS] = MIN_ACCELERATION_EDIT_VALUE,
-};
-constexpr float default_max_acceleration[] = DEFAULT_MAX_ACCELERATION;
-constexpr float max_acceleration_edit_values[] =
-  #ifdef MAX_ACCEL_EDIT_VALUES
-    MAX_ACCEL_EDIT_VALUES
-  #else
-    {
-      [X_AXIS] = default_max_acceleration[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [Y_AXIS] = default_max_acceleration[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [Z_AXIS] = default_max_acceleration[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
-      [E_AXIS] = default_max_acceleration[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
-    }
-  #endif
-;
+constexpr xyze_float_t min_acceleration_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_ACCELERATION_EDIT_VALUE),
+                       default_max_acceleration = DEFAULT_MAX_ACCELERATION,
+                       max_acceleration_edit_values =
+                        #ifdef MAX_ACCEL_EDIT_VALUES
+                          MAX_ACCEL_EDIT_VALUES
+                        #else
+                          default_max_acceleration * float(DEFAULT_MAX_MULTIPLIER)
+                        #endif
+                      ;
 
-/* max jerk limits */
-
+//
+// Max jerk limits
+//
 #define MIN_JERK_EDIT_VALUE 0.1
+#define DEFAULT_MAX_JERK_MULTIPLIER 2
 
 #if HAS_CLASSIC_JERK
-  constexpr float min_jerk_edit_values[] = {
-    [X_AXIS] = MIN_JERK_EDIT_VALUE,
-    [Y_AXIS] = MIN_JERK_EDIT_VALUE,
-    [Z_AXIS] = MIN_JERK_EDIT_VALUE,
-    [E_AXIS] = MIN_JERK_EDIT_VALUE,
-  };
-  constexpr float max_jerk_edit_values[] =
-    #ifdef MAX_JERK_EDIT_VALUES
-      MAX_JERK_EDIT_VALUES
-    #else
-      {
-        [X_AXIS] = DEFAULT_XJERK * DEFAULT_MAX_MULTIPLIER,
-        [Y_AXIS] = DEFAULT_YJERK * DEFAULT_MAX_MULTIPLIER,
-        [Z_AXIS] = DEFAULT_ZJERK * DEFAULT_MAX_MULTIPLIER,
-        [E_AXIS] = DEFAULT_EJERK * DEFAULT_MAX_MULTIPLIER,
-      }
-    #endif
-  ;
+  constexpr xyze_float_t min_jerk_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_JERK_EDIT_VALUE),
+                         default_jerk = LOGICAL_AXIS_ARRAY(
+                           DEFAULT_EJERK,
+                           DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK,
+                           DEFAULT_IJERK, DEFAULT_JJERK, DEFAULT_KJERK,
+                           DEFAULT_UJERK, DEFAULT_VJERK, DEFAULT_WJERK
+                         ),
+                         max_jerk_edit_values =
+                           #ifdef MAX_JERK_EDIT_VALUES
+                             MAX_JERK_EDIT_VALUES
+                           #else
+                             default_jerk * float(DEFAULT_MAX_JERK_MULTIPLIER)
+                           #endif
+                         ;
 #endif
 
-/* steps per mm limits */
-
+//
+// Steps per mm limits
+//
 #define MIN_STEPS_EDIT_VALUE 1
 
-constexpr float min_steps_edit_values[] = {
-  [X_AXIS] = MIN_STEPS_EDIT_VALUE,
-  [Y_AXIS] = MIN_STEPS_EDIT_VALUE,
-  [Z_AXIS] = MIN_STEPS_EDIT_VALUE,
-  [E_AXIS] = MIN_STEPS_EDIT_VALUE,
-};
-constexpr float default_steps[] = DEFAULT_AXIS_STEPS_PER_UNIT;
-constexpr float max_steps_edit_values[] = {
-  [X_AXIS] = default_steps[X_AXIS] * DEFAULT_MAX_MULTIPLIER,
-  [Y_AXIS] = default_steps[Y_AXIS] * DEFAULT_MAX_MULTIPLIER,
-  [Z_AXIS] = default_steps[Z_AXIS] * DEFAULT_MAX_MULTIPLIER,
-  [E_AXIS] = default_steps[E_AXIS] * DEFAULT_MAX_MULTIPLIER,
-};
+constexpr xyze_float_t min_steps_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_STEPS_EDIT_VALUE),
+                       default_steps = DEFAULT_AXIS_STEPS_PER_UNIT,
+                       max_steps_edit_values = default_steps * float(DEFAULT_MAX_MULTIPLIER);

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -101,12 +101,6 @@
 #define MIN_PRINT_SPEED  10
 #define MAX_PRINT_SPEED 999
 
-// Feedspeed limit (max feedspeed = DEFAULT_MAX_FEEDRATE * 2)
-#define MIN_MAXFEEDSPEED      1
-#define MIN_MAXACCELERATION   1
-#define MIN_MAXJERK           0.1
-#define MIN_STEP              1
-
 #define FEEDRATE_E      (60)
 
 // Minimum unit (0.1) : multiple (10)
@@ -180,13 +174,6 @@ uint8_t index_file     = MROWS,
         index_advset   = MROWS;
 
 bool dwin_abort_flag = false; // Flag to reset feedrate, return to Home
-
-constexpr float default_max_feedrate[]        = DEFAULT_MAX_FEEDRATE;
-constexpr float default_max_acceleration[]    = DEFAULT_MAX_ACCELERATION;
-
-#if HAS_CLASSIC_JERK
-  constexpr float default_max_jerk[]          = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
-#endif
 
 static uint8_t _card_percent = 0;
 static uint16_t _remain_time = 0;
@@ -1568,8 +1555,7 @@ void HMI_MaxFeedspeedXYZE() {
   }
   // MaxFeedspeed limit
   if (WITHIN(HMI_flag.feedspeed_axis, X_AXIS, LAST_AXIS))
-    NOMORE(HMI_ValueStruct.Max_Feedspeed, default_max_feedrate[HMI_flag.feedspeed_axis] * 2);
-  if (HMI_ValueStruct.Max_Feedspeed < MIN_MAXFEEDSPEED) HMI_ValueStruct.Max_Feedspeed = MIN_MAXFEEDSPEED;
+    LIMIT(HMI_ValueStruct.Max_Feedspeed, min_feedrate_edit_values[HMI_flag.feedspeed_axis], max_feedrate_edit_values[HMI_flag.feedspeed_axis]);
   // MaxFeedspeed value
   Draw_Edit_Integer4(select_speed.now, HMI_ValueStruct.Max_Feedspeed, true);
 }
@@ -1587,8 +1573,7 @@ void HMI_MaxAccelerationXYZE() {
   }
   // MaxAcceleration limit
   if (WITHIN(HMI_flag.acc_axis, X_AXIS, LAST_AXIS))
-    NOMORE(HMI_ValueStruct.Max_Acceleration, default_max_acceleration[HMI_flag.acc_axis] * 2);
-  if (HMI_ValueStruct.Max_Acceleration < MIN_MAXACCELERATION) HMI_ValueStruct.Max_Acceleration = MIN_MAXACCELERATION;
+    LIMIT(HMI_ValueStruct.Max_Acceleration, min_acceleration_edit_values[HMI_flag.acc_axis], max_acceleration_edit_values[HMI_flag.acc_axis]);
   // MaxAcceleration value
   Draw_Edit_Integer4(select_acc.now, HMI_ValueStruct.Max_Acceleration, true);
 }
@@ -1602,14 +1587,13 @@ void HMI_MaxAccelerationXYZE() {
       checkkey = MaxJerk;
       EncoderRate.enabled = false;
       if (WITHIN(HMI_flag.jerk_axis, X_AXIS, LAST_AXIS))
-        planner.set_max_jerk(HMI_flag.jerk_axis, HMI_ValueStruct.Max_Jerk_scaled / 10);
+        planner.set_max_jerk(HMI_flag.jerk_axis, HMI_ValueStruct.Max_Jerk_scaled / MINUNITMULT);
       Draw_Edit_Float3(select_jerk.now, HMI_ValueStruct.Max_Jerk_scaled);
       return;
     }
     // MaxJerk limit
     if (WITHIN(HMI_flag.jerk_axis, X_AXIS, LAST_AXIS))
-      NOMORE(HMI_ValueStruct.Max_Jerk_scaled, default_max_jerk[HMI_flag.jerk_axis] * 2 * MINUNITMULT);
-    NOLESS(HMI_ValueStruct.Max_Jerk_scaled, (MIN_MAXJERK) * MINUNITMULT);
+      LIMIT(HMI_ValueStruct.Max_Jerk_scaled, min_jerk_edit_values[HMI_flag.jerk_axis] * MINUNITMULT, max_jerk_edit_values[HMI_flag.jerk_axis] * MINUNITMULT);
     // MaxJerk value
     Draw_Edit_Float3(select_jerk.now, HMI_ValueStruct.Max_Jerk_scaled, true);
   }
@@ -1623,14 +1607,13 @@ void HMI_StepXYZE() {
     checkkey = Step;
     EncoderRate.enabled = false;
     if (WITHIN(HMI_flag.step_axis, X_AXIS, LAST_AXIS))
-      planner.settings.axis_steps_per_mm[HMI_flag.step_axis] = HMI_ValueStruct.Max_Step_scaled / 10;
+      planner.settings.axis_steps_per_mm[HMI_flag.step_axis] = HMI_ValueStruct.Max_Step_scaled / MINUNITMULT;
     Draw_Edit_Float3(select_step.now, HMI_ValueStruct.Max_Step_scaled);
     return;
   }
   // Step limit
   if (WITHIN(HMI_flag.step_axis, X_AXIS, LAST_AXIS))
-    NOMORE(HMI_ValueStruct.Max_Step_scaled, 999.9 * MINUNITMULT);
-  NOLESS(HMI_ValueStruct.Max_Step_scaled, MIN_STEP);
+    LIMIT(HMI_ValueStruct.Max_Step_scaled, min_steps_edit_values[HMI_flag.step_axis] * MINUNITMULT, max_steps_edit_values[HMI_flag.step_axis] * MINUNITMULT);
   // Step value
   Draw_Edit_Float3(select_step.now, HMI_ValueStruct.Max_Step_scaled, true);
 }

--- a/Marlin/src/lcd/e3v2/creality/dwin.h
+++ b/Marlin/src/lcd/e3v2/creality/dwin.h
@@ -27,6 +27,7 @@
 
 #include "dwin_lcd.h"
 #include "../common/encoder.h"
+#include "../common/limits.h"
 #include "../../../libs/BL24CXX.h"
 
 #include "../../../inc/MarlinConfigPre.h"

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -2370,7 +2370,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.max_feedrate_mm_s[X_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[X_AXIS], min_feedrate_edit_values[X_AXIS], max_feedrate_edit_values[X_AXIS], FEEDRATE_UNIT);
+              Modify_Value(planner.settings.max_feedrate_mm_s[X_AXIS], min_feedrate_edit_values.x, max_feedrate_edit_values.x, FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2381,7 +2381,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.max_feedrate_mm_s[Y_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[Y_AXIS], min_feedrate_edit_values[Y_AXIS], max_feedrate_edit_values[Y_AXIS], FEEDRATE_UNIT);
+              Modify_Value(planner.settings.max_feedrate_mm_s[Y_AXIS], min_feedrate_edit_values.y, max_feedrate_edit_values.y, FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2392,7 +2392,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.max_feedrate_mm_s[Z_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[Z_AXIS], min_feedrate_edit_values[Z_AXIS], max_feedrate_edit_values[Z_AXIS], FEEDRATE_UNIT);
+              Modify_Value(planner.settings.max_feedrate_mm_s[Z_AXIS], min_feedrate_edit_values.z, max_feedrate_edit_values.z, FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2403,7 +2403,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.max_feedrate_mm_s[E_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[E_AXIS], min_feedrate_edit_values[E_AXIS], max_feedrate_edit_values[E_AXIS], FEEDRATE_UNIT);
+              Modify_Value(planner.settings.max_feedrate_mm_s[E_AXIS], min_feedrate_edit_values.e, max_feedrate_edit_values.e, FEEDRATE_UNIT);
             break;
         #endif
       }
@@ -2431,7 +2431,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[X_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[X_AXIS], min_acceleration_edit_values[X_AXIS], max_acceleration_edit_values[X_AXIS], ACCELERATION_UNIT);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[X_AXIS], min_acceleration_edit_values.x, max_acceleration_edit_values.x, ACCELERATION_UNIT);
           break;
         case ACCEL_Y:
           if (draw) {
@@ -2439,7 +2439,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], min_acceleration_edit_values[Y_AXIS], max_acceleration_edit_values[Y_AXIS], ACCELERATION_UNIT);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], min_acceleration_edit_values.y, max_acceleration_edit_values.y, ACCELERATION_UNIT);
           break;
         case ACCEL_Z:
           if (draw) {
@@ -2447,7 +2447,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], min_acceleration_edit_values[Z_AXIS], max_acceleration_edit_values[Z_AXIS], ACCELERATION_UNIT);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], min_acceleration_edit_values.z, max_acceleration_edit_values.z, ACCELERATION_UNIT);
           break;
         #if HAS_HOTEND
           case ACCEL_E:
@@ -2456,7 +2456,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.max_acceleration_mm_per_s2[E_AXIS], row, false, ACCELERATION_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_acceleration_mm_per_s2[E_AXIS], min_acceleration_edit_values[E_AXIS], max_acceleration_edit_values[E_AXIS], ACCELERATION_UNIT);
+              Modify_Value(planner.settings.max_acceleration_mm_per_s2[E_AXIS], min_acceleration_edit_values.e, max_acceleration_edit_values.e, ACCELERATION_UNIT);
             break;
         #endif
       }
@@ -2478,30 +2478,36 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
             else
               Draw_Menu(Motion, MOTION_JERK);
             break;
-          case JERK_X:
-            if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkX, F("X Axis"));
-              Draw_Float(planner.max_jerk.x, row, false, JERK_UNIT);
-            }
-            else
-              Modify_Value(planner.max_jerk.x, min_jerk_edit_values[X_AXIS], max_jerk_edit_values[X_AXIS], JERK_UNIT);
-            break;
-          case JERK_Y:
-            if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkY, F("Y Axis"));
-              Draw_Float(planner.max_jerk.y, row, false, JERK_UNIT);
-            }
-            else
-              Modify_Value(planner.max_jerk.y, min_jerk_edit_values[Y_AXIS], max_jerk_edit_values[Y_AXIS], JERK_UNIT);
-            break;
-          case JERK_Z:
-            if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, F("Z Axis"));
-              Draw_Float(planner.max_jerk.z, row, false, JERK_UNIT);
-            }
-            else
-              Modify_Value(planner.max_jerk.z, min_jerk_edit_values[Z_AXIS], max_jerk_edit_values[Z_AXIS], JERK_UNIT);
-            break;
+          #if HAS_X_AXIS
+            case JERK_X:
+              if (draw) {
+                Draw_Menu_Item(row, ICON_MaxSpeedJerkX, F("X Axis"));
+                Draw_Float(planner.max_jerk.x, row, false, JERK_UNIT);
+              }
+              else
+                Modify_Value(planner.max_jerk.x, min_jerk_edit_values.x, max_jerk_edit_values.x, JERK_UNIT);
+              break;
+          #endif
+          #if HAS_Y_AXIS
+            case JERK_Y:
+              if (draw) {
+                Draw_Menu_Item(row, ICON_MaxSpeedJerkY, F("Y Axis"));
+                Draw_Float(planner.max_jerk.y, row, false, JERK_UNIT);
+              }
+              else
+                Modify_Value(planner.max_jerk.y, min_jerk_edit_values.y, max_jerk_edit_values.y, JERK_UNIT);
+              break;
+          #endif
+          #if HAS_Z_AXIS
+            case JERK_Z:
+              if (draw) {
+                Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, F("Z Axis"));
+                Draw_Float(planner.max_jerk.z, row, false, JERK_UNIT);
+              }
+              else
+                Modify_Value(planner.max_jerk.z, min_jerk_edit_values.z, max_jerk_edit_values.z, JERK_UNIT);
+              break;
+          #endif
           #if HAS_HOTEND
             case JERK_E:
               if (draw) {
@@ -2509,7 +2515,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
                 Draw_Float(planner.max_jerk.e, row, false, JERK_UNIT);
               }
               else
-                Modify_Value(planner.max_jerk.e, min_jerk_edit_values[E_AXIS], max_jerk_edit_values[E_AXIS], JERK_UNIT);
+                Modify_Value(planner.max_jerk.e, min_jerk_edit_values.e, max_jerk_edit_values.e, JERK_UNIT);
               break;
           #endif
         }
@@ -2530,31 +2536,37 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
             Draw_Menu_Item(row, ICON_Back, F("Back"));
           else
             Draw_Menu(Motion, MOTION_STEPS);
-          break;
-        case STEPS_X:
-          if (draw) {
-            Draw_Menu_Item(row, ICON_StepX, F("X Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[X_AXIS], row, false, STEPS_UNIT);
-          }
-          else
-            Modify_Value(planner.settings.axis_steps_per_mm[X_AXIS], min_steps_edit_values[X_AXIS], max_steps_edit_values[X_AXIS], STEPS_UNIT);
-          break;
-        case STEPS_Y:
-          if (draw) {
-            Draw_Menu_Item(row, ICON_StepY, F("Y Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[Y_AXIS], row, false, STEPS_UNIT);
-          }
-          else
-            Modify_Value(planner.settings.axis_steps_per_mm[Y_AXIS], min_steps_edit_values[Y_AXIS], max_steps_edit_values[Y_AXIS], STEPS_UNIT);
-          break;
-        case STEPS_Z:
-          if (draw) {
-            Draw_Menu_Item(row, ICON_StepZ, F("Z Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[Z_AXIS], row, false, STEPS_UNIT);
-          }
-          else
-            Modify_Value(planner.settings.axis_steps_per_mm[Z_AXIS], min_steps_edit_values[Z_AXIS], max_steps_edit_values[Z_AXIS], STEPS_UNIT);
-          break;
+            break;
+        #if HAS_X_AXIS
+          case STEPS_X:
+            if (draw) {
+              Draw_Menu_Item(row, ICON_StepX, F("X Axis"));
+              Draw_Float(planner.settings.axis_steps_per_mm[X_AXIS], row, false, STEPS_UNIT);
+            }
+            else
+              Modify_Value(planner.settings.axis_steps_per_mm[X_AXIS], min_steps_edit_values.x, max_steps_edit_values.x, STEPS_UNIT);
+            break;
+        #endif
+        #if HAS_Y_AXIS
+          case STEPS_Y:
+            if (draw) {
+              Draw_Menu_Item(row, ICON_StepY, F("Y Axis"));
+              Draw_Float(planner.settings.axis_steps_per_mm[Y_AXIS], row, false, STEPS_UNIT);
+            }
+            else
+              Modify_Value(planner.settings.axis_steps_per_mm[Y_AXIS], min_steps_edit_values.y, max_steps_edit_values.y, STEPS_UNIT);
+            break;
+        #endif
+        #if HAS_Z_AXIS
+          case STEPS_Z:
+            if (draw) {
+              Draw_Menu_Item(row, ICON_StepZ, F("Z Axis"));
+              Draw_Float(planner.settings.axis_steps_per_mm[Z_AXIS], row, false, STEPS_UNIT);
+            }
+            else
+              Modify_Value(planner.settings.axis_steps_per_mm[Z_AXIS], min_steps_edit_values.z, max_steps_edit_values.z, STEPS_UNIT);
+            break;
+        #endif
         #if HAS_HOTEND
           case STEPS_E:
             if (draw) {
@@ -2562,7 +2574,7 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
               Draw_Float(planner.settings.axis_steps_per_mm[E_AXIS], row, false, STEPS_UNIT);
             }
             else
-              Modify_Value(planner.settings.axis_steps_per_mm[E_AXIS], min_steps_edit_values[E_AXIS], max_steps_edit_values[E_AXIS], STEPS_UNIT);
+              Modify_Value(planner.settings.axis_steps_per_mm[E_AXIS], min_steps_edit_values.e, max_steps_edit_values.e, STEPS_UNIT);
             break;
         #endif
       }

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -127,6 +127,11 @@
   #define MIN_BED_TEMP  0
 #endif
 
+#define FEEDRATE_UNIT 1
+#define ACCELERATION_UNIT 1
+#define JERK_UNIT 10
+#define STEPS_UNIT 10
+
 /**
  * Custom menu items with jyersLCD
  */
@@ -154,13 +159,6 @@ constexpr uint16_t TROWS = 6, MROWS = TROWS - 1,
                    MENU_CHR_W = 8, MENU_CHR_H = 16, STAT_CHR_W = 10;
 
 #define MBASE(L) (49 + MLINE * (L))
-
-constexpr float default_max_feedrate[]        = DEFAULT_MAX_FEEDRATE;
-constexpr float default_max_acceleration[]    = DEFAULT_MAX_ACCELERATION;
-constexpr float default_steps[]               = DEFAULT_AXIS_STEPS_PER_UNIT;
-#if HAS_CLASSIC_JERK
-  constexpr float default_max_jerk[]            = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
-#endif
 
 enum SelectItem : uint8_t {
   PAGE_PRINT = 0,
@@ -2369,10 +2367,10 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
           case SPEED_X:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedX, F("X Axis"));
-              Draw_Float(planner.settings.max_feedrate_mm_s[X_AXIS], row, false, 1);
+              Draw_Float(planner.settings.max_feedrate_mm_s[X_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[X_AXIS], 0, default_max_feedrate[X_AXIS] * 2, 1);
+              Modify_Value(planner.settings.max_feedrate_mm_s[X_AXIS], min_feedrate_edit_values[X_AXIS], max_feedrate_edit_values[X_AXIS], FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2380,10 +2378,10 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
           case SPEED_Y:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedY, F("Y Axis"));
-              Draw_Float(planner.settings.max_feedrate_mm_s[Y_AXIS], row, false, 1);
+              Draw_Float(planner.settings.max_feedrate_mm_s[Y_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[Y_AXIS], 0, default_max_feedrate[Y_AXIS] * 2, 1);
+              Modify_Value(planner.settings.max_feedrate_mm_s[Y_AXIS], min_feedrate_edit_values[Y_AXIS], max_feedrate_edit_values[Y_AXIS], FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2391,10 +2389,10 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
           case SPEED_Z:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedZ, F("Z Axis"));
-              Draw_Float(planner.settings.max_feedrate_mm_s[Z_AXIS], row, false, 1);
+              Draw_Float(planner.settings.max_feedrate_mm_s[Z_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[Z_AXIS], 0, default_max_feedrate[Z_AXIS] * 2, 1);
+              Modify_Value(planner.settings.max_feedrate_mm_s[Z_AXIS], min_feedrate_edit_values[Z_AXIS], max_feedrate_edit_values[Z_AXIS], FEEDRATE_UNIT);
             break;
         #endif
 
@@ -2402,10 +2400,10 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
           case SPEED_E:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedE, F("Extruder"));
-              Draw_Float(planner.settings.max_feedrate_mm_s[E_AXIS], row, false, 1);
+              Draw_Float(planner.settings.max_feedrate_mm_s[E_AXIS], row, false, FEEDRATE_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_feedrate_mm_s[E_AXIS], 0, default_max_feedrate[E_AXIS] * 2, 1);
+              Modify_Value(planner.settings.max_feedrate_mm_s[E_AXIS], min_feedrate_edit_values[E_AXIS], max_feedrate_edit_values[E_AXIS], FEEDRATE_UNIT);
             break;
         #endif
       }
@@ -2430,35 +2428,35 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
         case ACCEL_X:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxAccX, F("X Axis"));
-            Draw_Float(planner.settings.max_acceleration_mm_per_s2[X_AXIS], row, false, 1);
+            Draw_Float(planner.settings.max_acceleration_mm_per_s2[X_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[X_AXIS], 0, default_max_acceleration[X_AXIS] * 2, 1);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[X_AXIS], min_acceleration_edit_values[X_AXIS], max_acceleration_edit_values[X_AXIS], ACCELERATION_UNIT);
           break;
         case ACCEL_Y:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxAccY, F("Y Axis"));
-            Draw_Float(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], row, false, 1);
+            Draw_Float(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], 0, default_max_acceleration[Y_AXIS] * 2, 1);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], min_acceleration_edit_values[Y_AXIS], max_acceleration_edit_values[Y_AXIS], ACCELERATION_UNIT);
           break;
         case ACCEL_Z:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxAccZ, F("Z Axis"));
-            Draw_Float(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], row, false, 1);
+            Draw_Float(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], row, false, ACCELERATION_UNIT);
           }
           else
-            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], 0, default_max_acceleration[Z_AXIS] * 2, 1);
+            Modify_Value(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], min_acceleration_edit_values[Z_AXIS], max_acceleration_edit_values[Z_AXIS], ACCELERATION_UNIT);
           break;
         #if HAS_HOTEND
           case ACCEL_E:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxAccE, F("Extruder"));
-              Draw_Float(planner.settings.max_acceleration_mm_per_s2[E_AXIS], row, false, 1);
+              Draw_Float(planner.settings.max_acceleration_mm_per_s2[E_AXIS], row, false, ACCELERATION_UNIT);
             }
             else
-              Modify_Value(planner.settings.max_acceleration_mm_per_s2[E_AXIS], 0, default_max_acceleration[E_AXIS] * 2, 1);
+              Modify_Value(planner.settings.max_acceleration_mm_per_s2[E_AXIS], min_acceleration_edit_values[E_AXIS], max_acceleration_edit_values[E_AXIS], ACCELERATION_UNIT);
             break;
         #endif
       }
@@ -2483,35 +2481,35 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
           case JERK_X:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedJerkX, F("X Axis"));
-              Draw_Float(planner.max_jerk.x, row, false, 10);
+              Draw_Float(planner.max_jerk.x, row, false, JERK_UNIT);
             }
             else
-              Modify_Value(planner.max_jerk.x, 0, default_max_jerk[X_AXIS] * 2, 10);
+              Modify_Value(planner.max_jerk.x, min_jerk_edit_values[X_AXIS], max_jerk_edit_values[X_AXIS], JERK_UNIT);
             break;
           case JERK_Y:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedJerkY, F("Y Axis"));
-              Draw_Float(planner.max_jerk.y, row, false, 10);
+              Draw_Float(planner.max_jerk.y, row, false, JERK_UNIT);
             }
             else
-              Modify_Value(planner.max_jerk.y, 0, default_max_jerk[Y_AXIS] * 2, 10);
+              Modify_Value(planner.max_jerk.y, min_jerk_edit_values[Y_AXIS], max_jerk_edit_values[Y_AXIS], JERK_UNIT);
             break;
           case JERK_Z:
             if (draw) {
               Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, F("Z Axis"));
-              Draw_Float(planner.max_jerk.z, row, false, 10);
+              Draw_Float(planner.max_jerk.z, row, false, JERK_UNIT);
             }
             else
-              Modify_Value(planner.max_jerk.z, 0, default_max_jerk[Z_AXIS] * 2, 10);
+              Modify_Value(planner.max_jerk.z, min_jerk_edit_values[Z_AXIS], max_jerk_edit_values[Z_AXIS], JERK_UNIT);
             break;
           #if HAS_HOTEND
             case JERK_E:
               if (draw) {
                 Draw_Menu_Item(row, ICON_MaxSpeedJerkE, F("Extruder"));
-                Draw_Float(planner.max_jerk.e, row, false, 10);
+                Draw_Float(planner.max_jerk.e, row, false, JERK_UNIT);
               }
               else
-                Modify_Value(planner.max_jerk.e, 0, default_max_jerk[E_AXIS] * 2, 10);
+                Modify_Value(planner.max_jerk.e, min_jerk_edit_values[E_AXIS], max_jerk_edit_values[E_AXIS], JERK_UNIT);
               break;
           #endif
         }
@@ -2536,35 +2534,35 @@ void CrealityDWINClass::Menu_Item_Handler(const uint8_t menu, const uint8_t item
         case STEPS_X:
           if (draw) {
             Draw_Menu_Item(row, ICON_StepX, F("X Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[X_AXIS], row, false, 10);
+            Draw_Float(planner.settings.axis_steps_per_mm[X_AXIS], row, false, STEPS_UNIT);
           }
           else
-            Modify_Value(planner.settings.axis_steps_per_mm[X_AXIS], 0, default_steps[X_AXIS] * 2, 10);
+            Modify_Value(planner.settings.axis_steps_per_mm[X_AXIS], min_steps_edit_values[X_AXIS], max_steps_edit_values[X_AXIS], STEPS_UNIT);
           break;
         case STEPS_Y:
           if (draw) {
             Draw_Menu_Item(row, ICON_StepY, F("Y Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[Y_AXIS], row, false, 10);
+            Draw_Float(planner.settings.axis_steps_per_mm[Y_AXIS], row, false, STEPS_UNIT);
           }
           else
-            Modify_Value(planner.settings.axis_steps_per_mm[Y_AXIS], 0, default_steps[Y_AXIS] * 2, 10);
+            Modify_Value(planner.settings.axis_steps_per_mm[Y_AXIS], min_steps_edit_values[Y_AXIS], max_steps_edit_values[Y_AXIS], STEPS_UNIT);
           break;
         case STEPS_Z:
           if (draw) {
             Draw_Menu_Item(row, ICON_StepZ, F("Z Axis"));
-            Draw_Float(planner.settings.axis_steps_per_mm[Z_AXIS], row, false, 10);
+            Draw_Float(planner.settings.axis_steps_per_mm[Z_AXIS], row, false, STEPS_UNIT);
           }
           else
-            Modify_Value(planner.settings.axis_steps_per_mm[Z_AXIS], 0, default_steps[Z_AXIS] * 2, 10);
+            Modify_Value(planner.settings.axis_steps_per_mm[Z_AXIS], min_steps_edit_values[Z_AXIS], max_steps_edit_values[Z_AXIS], STEPS_UNIT);
           break;
         #if HAS_HOTEND
           case STEPS_E:
             if (draw) {
               Draw_Menu_Item(row, ICON_StepE, F("Extruder"));
-              Draw_Float(planner.settings.axis_steps_per_mm[E_AXIS], row, false, 10);
+              Draw_Float(planner.settings.axis_steps_per_mm[E_AXIS], row, false, STEPS_UNIT);
             }
             else
-              Modify_Value(planner.settings.axis_steps_per_mm[E_AXIS], 0, 1000, 10);
+              Modify_Value(planner.settings.axis_steps_per_mm[E_AXIS], min_steps_edit_values[E_AXIS], max_steps_edit_values[E_AXIS], STEPS_UNIT);
             break;
         #endif
       }

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.h
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.h
@@ -30,6 +30,7 @@
 #include "../common/dwin_font.h"
 #include "../common/dwin_color.h"
 #include "../common/encoder.h"
+#include "../common/limits.h"
 #include "../../../libs/BL24CXX.h"
 
 #include "../../../inc/MarlinConfigPre.h"

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -188,38 +188,6 @@ typedef struct {
 } select_t;
 select_t select_page{0}, select_print{0};
 
-constexpr float max_feedrate_edit_values[] =
-  #ifdef MAX_FEEDRATE_EDIT_VALUES
-    MAX_FEEDRATE_EDIT_VALUES
-  #else
-    { 1000, 1000, 10, 50 }
-  #endif
-;
-
-constexpr float max_acceleration_edit_values[] =
-  #ifdef MAX_ACCEL_EDIT_VALUES
-    MAX_ACCEL_EDIT_VALUES
-  #else
-    { 1000, 1000, 200, 2000 }
-  #endif
-;
-
-#if HAS_CLASSIC_JERK
-  constexpr float max_jerk_edit_values[] =
-    #ifdef MAX_JERK_EDIT_VALUES
-      MAX_JERK_EDIT_VALUES
-    #else
-      { DEFAULT_XJERK * 2, DEFAULT_YJERK * 2, DEFAULT_ZJERK * 2, DEFAULT_EJERK * 2 }
-    #endif
-  ;
-#endif
-
-static uint8_t _percent_done = 0;
-static uint32_t _remain_time = 0;
-
-// Additional Aux Host Support
-static bool sdprint = false;
-
 #if HAS_HOTEND
   float last_E = 0;
   #define E_MIN_POS (last_E - (EXTRUDE_MAXLENGTH))
@@ -1300,8 +1268,8 @@ void EachMomentUpdate() {
       if (card.isPrinting() && !HMI_flag.percent_flag) {
         uint8_t percentDone = card.percentDone();
         if (_percent_done != percentDone) { // print percent
-            _percent_done = percentDone;
-            Draw_Print_ProgressBar();
+          _percent_done = percentDone;
+          Draw_Print_ProgressBar();
         }
 
         // Estimate remaining time every 20 seconds
@@ -2536,36 +2504,60 @@ void TramC () { Tram(4); }
 #endif
 
 void ApplyMaxSpeed() { planner.set_max_feedrate(HMI_value.axis, MenuData.Value / MINUNITMULT); }
-void SetMaxSpeedX() { HMI_value.axis = X_AXIS, SetFloatOnClick(min_feedrate_edit_values[X_AXIS], max_feedrate_edit_values[X_AXIS], UNITFDIGITS, planner.settings.max_feedrate_mm_s[X_AXIS], ApplyMaxSpeed); }
-void SetMaxSpeedY() { HMI_value.axis = Y_AXIS, SetFloatOnClick(min_feedrate_edit_values[Y_AXIS], max_feedrate_edit_values[Y_AXIS], UNITFDIGITS, planner.settings.max_feedrate_mm_s[Y_AXIS], ApplyMaxSpeed); }
-void SetMaxSpeedZ() { HMI_value.axis = Z_AXIS, SetFloatOnClick(min_feedrate_edit_values[Z_AXIS], max_feedrate_edit_values[Z_AXIS], UNITFDIGITS, planner.settings.max_feedrate_mm_s[Z_AXIS], ApplyMaxSpeed); }
+#if HAS_X_AXIS
+  void SetMaxSpeedX() { HMI_value.axis = X_AXIS, SetFloatOnClick(min_feedrate_edit_values.x, max_feedrate_edit_values.x, UNITFDIGITS, planner.settings.max_feedrate_mm_s[X_AXIS], ApplyMaxSpeed); }
+#endif
+#if HAS_Y_AXIS
+  void SetMaxSpeedY() { HMI_value.axis = Y_AXIS, SetFloatOnClick(min_feedrate_edit_values.y, max_feedrate_edit_values.y, UNITFDIGITS, planner.settings.max_feedrate_mm_s[Y_AXIS], ApplyMaxSpeed); }
+#endif
+#if HAS_Z_AXIS
+  void SetMaxSpeedZ() { HMI_value.axis = Z_AXIS, SetFloatOnClick(min_feedrate_edit_values.z, max_feedrate_edit_values.z, UNITFDIGITS, planner.settings.max_feedrate_mm_s[Z_AXIS], ApplyMaxSpeed); }
+#endif
 #if HAS_HOTEND
-  void SetMaxSpeedE() { HMI_value.axis = E_AXIS; SetFloatOnClick(min_feedrate_edit_values[E_AXIS], max_feedrate_edit_values[E_AXIS], UNITFDIGITS, planner.settings.max_feedrate_mm_s[E_AXIS], ApplyMaxSpeed); }
+  void SetMaxSpeedE() { HMI_value.axis = E_AXIS; SetFloatOnClick(min_feedrate_edit_values.e, max_feedrate_edit_values.e, UNITFDIGITS, planner.settings.max_feedrate_mm_s[E_AXIS], ApplyMaxSpeed); }
 #endif
 
 void ApplyMaxAccel() { planner.set_max_acceleration(HMI_value.axis, MenuData.Value); }
-void SetMaxAccelX() { HMI_value.axis = X_AXIS, SetIntOnClick(min_acceleration_edit_values[X_AXIS], max_acceleration_edit_values[X_AXIS], planner.settings.max_acceleration_mm_per_s2[X_AXIS], ApplyMaxAccel); }
-void SetMaxAccelY() { HMI_value.axis = Y_AXIS, SetIntOnClick(min_acceleration_edit_values[Y_AXIS], max_acceleration_edit_values[Y_AXIS], planner.settings.max_acceleration_mm_per_s2[Y_AXIS], ApplyMaxAccel); }
-void SetMaxAccelZ() { HMI_value.axis = Z_AXIS, SetIntOnClick(min_acceleration_edit_values[Z_AXIS], max_acceleration_edit_values[Z_AXIS], planner.settings.max_acceleration_mm_per_s2[Z_AXIS], ApplyMaxAccel); }
+#if HAS_X_AXIS
+  void SetMaxAccelX() { HMI_value.axis = X_AXIS, SetIntOnClick(min_acceleration_edit_values.x, max_acceleration_edit_values.x, planner.settings.max_acceleration_mm_per_s2[X_AXIS], ApplyMaxAccel); }
+#endif
+#if HAS_Y_AXIS
+  void SetMaxAccelY() { HMI_value.axis = Y_AXIS, SetIntOnClick(min_acceleration_edit_values.y, max_acceleration_edit_values.y, planner.settings.max_acceleration_mm_per_s2[Y_AXIS], ApplyMaxAccel); }
+#endif
+#if HAS_Z_AXIS
+  void SetMaxAccelZ() { HMI_value.axis = Z_AXIS, SetIntOnClick(min_acceleration_edit_values.z, max_acceleration_edit_values.z, planner.settings.max_acceleration_mm_per_s2[Z_AXIS], ApplyMaxAccel); }
+#endif
 #if HAS_HOTEND
-  void SetMaxAccelE() { HMI_value.axis = E_AXIS; SetIntOnClick(min_acceleration_edit_values[E_AXIS], max_acceleration_edit_values[E_AXIS], planner.settings.max_acceleration_mm_per_s2[E_AXIS], ApplyMaxAccel); }
+  void SetMaxAccelE() { HMI_value.axis = E_AXIS; SetIntOnClick(min_acceleration_edit_values.e, max_acceleration_edit_values.e, planner.settings.max_acceleration_mm_per_s2[E_AXIS], ApplyMaxAccel); }
 #endif
 
 #if HAS_CLASSIC_JERK
   void ApplyMaxJerk() { planner.set_max_jerk(HMI_value.axis, MenuData.Value / MINUNITMULT); }
-  void SetMaxJerkX() { HMI_value.axis = X_AXIS, SetFloatOnClick(min_jerk_edit_values[X_AXIS], max_jerk_edit_values[X_AXIS], UNITFDIGITS, planner.max_jerk.x, ApplyMaxJerk); }
-  void SetMaxJerkY() { HMI_value.axis = Y_AXIS, SetFloatOnClick(min_jerk_edit_values[Y_AXIS], max_jerk_edit_values[Y_AXIS], UNITFDIGITS, planner.max_jerk.y, ApplyMaxJerk); }
-  void SetMaxJerkZ() { HMI_value.axis = Z_AXIS, SetFloatOnClick(min_jerk_edit_values[Z_AXIS], max_jerk_edit_values[Z_AXIS], UNITFDIGITS, planner.max_jerk.z, ApplyMaxJerk); }
+  #if HAS_X_AXIS
+    void SetMaxJerkX() { HMI_value.axis = X_AXIS, SetFloatOnClick(min_jerk_edit_values.x, max_jerk_edit_values.x, UNITFDIGITS, planner.max_jerk.x, ApplyMaxJerk); }
+  #endif
+  #if HAS_Y_AXIS
+    void SetMaxJerkY() { HMI_value.axis = Y_AXIS, SetFloatOnClick(min_jerk_edit_values.y, max_jerk_edit_values.y, UNITFDIGITS, planner.max_jerk.y, ApplyMaxJerk); }
+  #endif
+  #if HAS_Z_AXIS
+    void SetMaxJerkZ() { HMI_value.axis = Z_AXIS, SetFloatOnClick(min_jerk_edit_values.z, max_jerk_edit_values.z, UNITFDIGITS, planner.max_jerk.z, ApplyMaxJerk); }
+  #endif
   #if HAS_HOTEND
-    void SetMaxJerkE() { HMI_value.axis = E_AXIS; SetFloatOnClick(min_jerk_edit_values[E_AXIS], max_jerk_edit_values[E_AXIS], UNITFDIGITS, planner.max_jerk.e, ApplyMaxJerk); }
+    void SetMaxJerkE() { HMI_value.axis = E_AXIS; SetFloatOnClick(min_jerk_edit_values.e, max_jerk_edit_values.e, UNITFDIGITS, planner.max_jerk.e, ApplyMaxJerk); }
   #endif
 #endif
 
-void SetStepsX() { HMI_value.axis = X_AXIS, SetPFloatOnClick( min_steps_edit_values[X_AXIS], max_steps_edit_values[X_AXIS], UNITFDIGITS); }
-void SetStepsY() { HMI_value.axis = Y_AXIS, SetPFloatOnClick( min_steps_edit_values[Y_AXIS], max_steps_edit_values[Y_AXIS], UNITFDIGITS); }
-void SetStepsZ() { HMI_value.axis = Z_AXIS, SetPFloatOnClick( min_steps_edit_values[Z_AXIS], max_steps_edit_values[Z_AXIS], UNITFDIGITS); }
+#if HAS_X_AXIS
+  void SetStepsX() { HMI_value.axis = X_AXIS, SetPFloatOnClick( min_steps_edit_values.x, max_steps_edit_values.x, UNITFDIGITS); }
+#endif
+#if HAS_Y_AXIS
+  void SetStepsY() { HMI_value.axis = Y_AXIS, SetPFloatOnClick( min_steps_edit_values.y, max_steps_edit_values.y, UNITFDIGITS); }
+#endif
+#if HAS_Z_AXIS
+  void SetStepsZ() { HMI_value.axis = Z_AXIS, SetPFloatOnClick( min_steps_edit_values.z, max_steps_edit_values.z, UNITFDIGITS); }
+#endif
 #if HAS_HOTEND
-  void SetStepsE() { HMI_value.axis = E_AXIS; SetPFloatOnClick( min_steps_edit_values[E_AXIS], max_steps_edit_values[E_AXIS], UNITFDIGITS); }
+  void SetStepsE() { HMI_value.axis = E_AXIS; SetPFloatOnClick( min_steps_edit_values.e, max_steps_edit_values.e, UNITFDIGITS); }
   #if ENABLED(PIDTEMP)
     void SetHotendPidT() { SetPIntOnClick(MIN_ETEMP, MAX_ETEMP); }
   #endif
@@ -2815,29 +2807,35 @@ void onDrawSpeed(MenuItemClass* menuitem, int8_t line) {
   onDrawSubMenu(menuitem, line);
 }
 
-void onDrawMaxSpeedX(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 228, 147);
-    DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 58, MBASE(line));     // X
+#if HAS_X_AXIS
+  void onDrawMaxSpeedX(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 228, 147);
+      DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 58, MBASE(line));   // X
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
-void onDrawMaxSpeedY(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 228, 147);
-    DWIN_Frame_AreaCopy(1, 1, 150, 7, 160, LBLX + 58, MBASE(line));         // Y
+#if HAS_Y_AXIS
+  void onDrawMaxSpeedY(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 228, 147);
+      DWIN_Frame_AreaCopy(1, 1, 150, 7, 160, LBLX + 58, MBASE(line));       // Y
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
-void onDrawMaxSpeedZ(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 228, 147);
-    DWIN_Frame_AreaCopy(1, 9, 150, 16, 160, LBLX + 58, MBASE(line) + 3);    // Z
+#if HAS_Z_AXIS
+  void onDrawMaxSpeedZ(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 228, 147);
+      DWIN_Frame_AreaCopy(1, 9, 150, 16, 160, LBLX + 58, MBASE(line) + 3);  // Z
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
 #if HAS_HOTEND
   void onDrawMaxSpeedE(MenuItemClass* menuitem, int8_t line) {
@@ -2857,32 +2855,38 @@ void onDrawAcc(MenuItemClass* menuitem, int8_t line) {
   onDrawSubMenu(menuitem, line);
 }
 
-void onDrawMaxAccelX(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 200, 147);
-    DWIN_Frame_AreaCopy(1, 28,  149,  69, 161, LBLX + 27, MBASE(line));
-    DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 71, MBASE(line));     // X
+#if HAS_X_AXIS
+  void onDrawMaxAccelX(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 200, 147);
+      DWIN_Frame_AreaCopy(1, 28,  149,  69, 161, LBLX + 27, MBASE(line));
+      DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 71, MBASE(line));   // X
+    }
+    onDrawPInt32Menu(menuitem, line);
   }
-  onDrawPInt32Menu(menuitem, line);
-}
+#endif
 
-void onDrawMaxAccelY(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 200, 147);
-    DWIN_Frame_AreaCopy(1, 28, 149,  69, 161, LBLX + 27, MBASE(line));
-    DWIN_Frame_AreaCopy(1,  1, 150,   7, 160, LBLX + 71, MBASE(line));      // Y
+#if HAS_Y_AXIS
+  void onDrawMaxAccelY(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 200, 147);
+      DWIN_Frame_AreaCopy(1, 28, 149,  69, 161, LBLX + 27, MBASE(line));
+      DWIN_Frame_AreaCopy(1,  1, 150,   7, 160, LBLX + 71, MBASE(line));    // Y
+    }
+    onDrawPInt32Menu(menuitem, line);
   }
-  onDrawPInt32Menu(menuitem, line);
-}
+#endif
 
-void onDrawMaxAccelZ(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 173, 133, 200, 147);
-    DWIN_Frame_AreaCopy(1, 28, 149,  69, 161, LBLX + 27, MBASE(line));
-    DWIN_Frame_AreaCopy(1,  9, 150,  16, 160, LBLX + 71, MBASE(line));      // Z
+#if HAS_Z_AXIS
+  void onDrawMaxAccelZ(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 173, 133, 200, 147);
+      DWIN_Frame_AreaCopy(1, 28, 149,  69, 161, LBLX + 27, MBASE(line));
+      DWIN_Frame_AreaCopy(1,  9, 150,  16, 160, LBLX + 71, MBASE(line));    // Z
+    }
+    onDrawPInt32Menu(menuitem, line);
   }
-  onDrawPInt32Menu(menuitem, line);
-}
+#endif
 
 #if HAS_HOTEND
   void onDrawMaxAccelE(MenuItemClass* menuitem, int8_t line) {
@@ -2906,35 +2910,41 @@ void onDrawMaxAccelZ(MenuItemClass* menuitem, int8_t line) {
     onDrawSubMenu(menuitem, line);
   }
 
-  void onDrawMaxJerkX(MenuItemClass* menuitem, int8_t line) {
-    if (HMI_IsChinese()) {
-      menuitem->SetFrame(1, 173, 133, 200, 147);
-      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
-      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
-      DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 83, MBASE(line));
+  #if HAS_X_AXIS
+    void onDrawMaxJerkX(MenuItemClass* menuitem, int8_t line) {
+      if (HMI_IsChinese()) {
+        menuitem->SetFrame(1, 173, 133, 200, 147);
+        DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
+        DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
+        DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 83, MBASE(line));
+      }
+      onDrawPFloatMenu(menuitem, line);
     }
-    onDrawPFloatMenu(menuitem, line);
-  }
+  #endif
 
-  void onDrawMaxJerkY(MenuItemClass* menuitem, int8_t line) {
-    if (HMI_IsChinese()) {
-      menuitem->SetFrame(1, 173, 133, 200, 147);
-      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
-      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
-      DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 83, MBASE(line));
+  #if HAS_Y_AXIS
+    void onDrawMaxJerkY(MenuItemClass* menuitem, int8_t line) {
+      if (HMI_IsChinese()) {
+        menuitem->SetFrame(1, 173, 133, 200, 147);
+        DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
+        DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
+        DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 83, MBASE(line));
+      }
+      onDrawPFloatMenu(menuitem, line);
     }
-    onDrawPFloatMenu(menuitem, line);
-  }
+  #endif
 
-  void onDrawMaxJerkZ(MenuItemClass* menuitem, int8_t line) {
-    if (HMI_IsChinese()) {
-      menuitem->SetFrame(1, 173, 133, 200, 147);
-      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
-      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
-      DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 83, MBASE(line));
+  #if HAS_Z_AXIS
+    void onDrawMaxJerkZ(MenuItemClass* menuitem, int8_t line) {
+      if (HMI_IsChinese()) {
+        menuitem->SetFrame(1, 173, 133, 200, 147);
+        DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(line));
+        DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(line));
+        DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 83, MBASE(line));
+      }
+      onDrawPFloatMenu(menuitem, line);
     }
-    onDrawPFloatMenu(menuitem, line);
-  }
+  #endif
 
   #if HAS_HOTEND
 
@@ -2952,29 +2962,35 @@ void onDrawMaxAccelZ(MenuItemClass* menuitem, int8_t line) {
 
 #endif // HAS_CLASSIC_JERK
 
-void onDrawStepsX(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 153, 148, 194, 161);
-    DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 44, MBASE(line));      // X
+#if HAS_X_AXIS
+  void onDrawStepsX(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 153, 148, 194, 161);
+      DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 44, MBASE(line));      // X
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
-void onDrawStepsY(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 153, 148, 194, 161);
-    DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 44, MBASE(line));      // Y
+#if HAS_Y_AXIS
+  void onDrawStepsY(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 153, 148, 194, 161);
+      DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 44, MBASE(line));      // Y
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
-void onDrawStepsZ(MenuItemClass* menuitem, int8_t line) {
-  if (HMI_IsChinese()) {
-    menuitem->SetFrame(1, 153, 148, 194, 161);
-    DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 44, MBASE(line));      // Z
+#if HAS_Z_AXIS
+  void onDrawStepsZ(MenuItemClass* menuitem, int8_t line) {
+    if (HMI_IsChinese()) {
+      menuitem->SetFrame(1, 153, 148, 194, 161);
+      DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 44, MBASE(line));      // Z
+    }
+    onDrawPFloatMenu(menuitem, line);
   }
-  onDrawPFloatMenu(menuitem, line);
-}
+#endif
 
 #if HAS_HOTEND
 
@@ -2995,10 +3011,7 @@ void onDrawStepsZ(MenuItemClass* menuitem, int8_t line) {
 // Menu Creation and Drawing functions ======================================================
 
 frame_rect_t selrect(frame_rect_t) {
-  if (HMI_IsChinese())
-    return {133, 1, 28, 13};
-  else
-    return{0};
+  return HMI_IsChinese() ? frame_rect_t({ 133, 1, 28, 13 }) : frame_rect_t({ 0 });
 }
 
 void Draw_Prepare_Menu() {
@@ -3146,9 +3159,15 @@ void Draw_Move_Menu() {
   if (SET_MENU_R(MoveMenu, selrect({192, 1, 42, 14}), MSG_MOVE_AXIS, 6)) {
     BACK_ITEM(Draw_Prepare_Menu);
     EDIT_ITEM(ICON_Axis, MSG_LIVE_MOVE, onDrawChkbMenu, SetLiveMove, &EnableLiveMove);
-    EDIT_ITEM(ICON_MoveX, MSG_MOVE_X, onDrawMoveX, SetMoveX, &current_position.x);
-    EDIT_ITEM(ICON_MoveY, MSG_MOVE_Y, onDrawMoveY, SetMoveY, &current_position.y);
-    EDIT_ITEM(ICON_MoveZ, MSG_MOVE_Z, onDrawMoveZ, SetMoveZ, &current_position.z);
+    #if HAS_X_AXIS
+      EDIT_ITEM(ICON_MoveX, MSG_MOVE_X, onDrawMoveX, SetMoveX, &current_position.x);
+    #endif
+    #if HAS_Y_AXIS
+      EDIT_ITEM(ICON_MoveY, MSG_MOVE_Y, onDrawMoveY, SetMoveY, &current_position.y);
+    #endif
+    #if HAS_Z_AXIS
+      EDIT_ITEM(ICON_MoveZ, MSG_MOVE_Z, onDrawMoveZ, SetMoveZ, &current_position.z);
+    #endif
     #if HAS_HOTEND
       gcode.process_subcommands_now(F("G92E0"));  // reset extruder position
       EDIT_ITEM(ICON_Extruder, MSG_MOVE_E, onDrawMoveE, SetMoveE, &current_position.e);
@@ -3164,9 +3183,15 @@ void Draw_Move_Menu() {
     checkkey = Menu;
     if (SET_MENU(HomeOffMenu, MSG_SET_HOME_OFFSETS, 4)) {
       BACK_ITEM(Draw_PhySet_Menu);
-      EDIT_ITEM(ICON_HomeOffsetX, MSG_HOME_OFFSET_X, onDrawPFloatMenu, SetHomeOffsetX, &home_offset.x);
-      EDIT_ITEM(ICON_HomeOffsetY, MSG_HOME_OFFSET_Y, onDrawPFloatMenu, SetHomeOffsetY, &home_offset.y);
-      EDIT_ITEM(ICON_HomeOffsetZ, MSG_HOME_OFFSET_Z, onDrawPFloatMenu, SetHomeOffsetZ, &home_offset.z);
+      #if HAS_X_AXIS
+        EDIT_ITEM(ICON_HomeOffsetX, MSG_HOME_OFFSET_X, onDrawPFloatMenu, SetHomeOffsetX, &home_offset.x);
+      #endif
+      #if HAS_Y_AXIS
+        EDIT_ITEM(ICON_HomeOffsetY, MSG_HOME_OFFSET_Y, onDrawPFloatMenu, SetHomeOffsetY, &home_offset.y);
+      #endif
+      #if HAS_Z_AXIS
+        EDIT_ITEM(ICON_HomeOffsetZ, MSG_HOME_OFFSET_Z, onDrawPFloatMenu, SetHomeOffsetZ, &home_offset.z);
+      #endif
     }
     UpdateMenu(HomeOffMenu);
   }
@@ -3179,9 +3204,15 @@ void Draw_Move_Menu() {
     checkkey = Menu;
     if (SET_MENU(ProbeSetMenu, MSG_ZPROBE_SETTINGS, 9)) {
       BACK_ITEM(Draw_AdvancedSettings_Menu);
-      EDIT_ITEM(ICON_ProbeOffsetX, MSG_ZPROBE_XOFFSET, onDrawPFloatMenu, SetProbeOffsetX, &probe.offset.x);
-      EDIT_ITEM(ICON_ProbeOffsetY, MSG_ZPROBE_YOFFSET, onDrawPFloatMenu, SetProbeOffsetY, &probe.offset.y);
-      EDIT_ITEM(ICON_ProbeOffsetZ, MSG_ZPROBE_ZOFFSET, onDrawPFloat2Menu, SetProbeOffsetZ, &probe.offset.z);
+      #if HAS_X_AXIS
+        EDIT_ITEM(ICON_ProbeOffsetX, MSG_ZPROBE_XOFFSET, onDrawPFloatMenu, SetProbeOffsetX, &probe.offset.x);
+      #endif
+      #if HAS_Y_AXIS
+        EDIT_ITEM(ICON_ProbeOffsetY, MSG_ZPROBE_YOFFSET, onDrawPFloatMenu, SetProbeOffsetY, &probe.offset.y);
+      #endif
+      #if HAS_Z_AXIS
+        EDIT_ITEM(ICON_ProbeOffsetZ, MSG_ZPROBE_ZOFFSET, onDrawPFloat2Menu, SetProbeOffsetZ, &probe.offset.z);
+      #endif
       #if ENABLED(BLTOUCH)
         MENU_ITEM(ICON_ProbeStow, MSG_MANUAL_STOW, onDrawMenuItem, ProbeStow);
         MENU_ITEM(ICON_ProbeDeploy, MSG_MANUAL_DEPLOY, onDrawMenuItem, ProbeDeploy);
@@ -3430,7 +3461,7 @@ void Draw_Motion_Menu() {
 
   #define _Preheat_Menu(N) \
     void Draw_Preheat## N ##_Menu() { \
-      HMI_value.Select = N-1; \
+      HMI_value.Select = (N) - 1; \
       Draw_Preheat_Menu(SET_MENU(PreheatMenu, MSG_PREHEAT_## N ##_SETTINGS, 5)); \
     }
   REPEAT_1(PREHEAT_COUNT, _Preheat_Menu)
@@ -3462,9 +3493,15 @@ void Draw_MaxSpeed_Menu() {
   checkkey = Menu;
   if (SET_MENU_R(MaxSpeedMenu, selrect({1, 16, 28, 13}), MSG_MAX_SPEED, 5)) {
     BACK_ITEM(Draw_Motion_Menu);
-    EDIT_ITEM(ICON_MaxSpeedX, MSG_VMAX_A, onDrawMaxSpeedX, SetMaxSpeedX, &planner.settings.max_feedrate_mm_s[X_AXIS]);
-    EDIT_ITEM(ICON_MaxSpeedY, MSG_VMAX_B, onDrawMaxSpeedY, SetMaxSpeedY, &planner.settings.max_feedrate_mm_s[Y_AXIS]);
-    EDIT_ITEM(ICON_MaxSpeedZ, MSG_VMAX_C, onDrawMaxSpeedZ, SetMaxSpeedZ, &planner.settings.max_feedrate_mm_s[Z_AXIS]);
+    #if HAS_X_AXIS
+      EDIT_ITEM(ICON_MaxSpeedX, MSG_VMAX_A, onDrawMaxSpeedX, SetMaxSpeedX, &planner.settings.max_feedrate_mm_s[X_AXIS]);
+    #endif
+    #if HAS_Y_AXIS
+      EDIT_ITEM(ICON_MaxSpeedY, MSG_VMAX_B, onDrawMaxSpeedY, SetMaxSpeedY, &planner.settings.max_feedrate_mm_s[Y_AXIS]);
+    #endif
+    #if HAS_Z_AXIS
+      EDIT_ITEM(ICON_MaxSpeedZ, MSG_VMAX_C, onDrawMaxSpeedZ, SetMaxSpeedZ, &planner.settings.max_feedrate_mm_s[Z_AXIS]);
+    #endif
     #if HAS_HOTEND
       EDIT_ITEM(ICON_MaxSpeedE, MSG_VMAX_E, onDrawMaxSpeedE, SetMaxSpeedE, &planner.settings.max_feedrate_mm_s[E_AXIS]);
     #endif
@@ -3476,9 +3513,15 @@ void Draw_MaxAccel_Menu() {
   checkkey = Menu;
   if (SET_MENU_R(MaxAccelMenu, selrect({1, 16, 28, 13}), MSG_AMAX_EN, 5)) {
     BACK_ITEM(Draw_Motion_Menu);
-    EDIT_ITEM(ICON_MaxAccX, MSG_AMAX_A, onDrawMaxAccelX, SetMaxAccelX, &planner.settings.max_acceleration_mm_per_s2[X_AXIS]);
-    EDIT_ITEM(ICON_MaxAccY, MSG_AMAX_B, onDrawMaxAccelY, SetMaxAccelY, &planner.settings.max_acceleration_mm_per_s2[Y_AXIS]);
-    EDIT_ITEM(ICON_MaxAccZ, MSG_AMAX_C, onDrawMaxAccelZ, SetMaxAccelZ, &planner.settings.max_acceleration_mm_per_s2[Z_AXIS]);
+    #if HAS_X_AXIS
+      EDIT_ITEM(ICON_MaxAccX, MSG_AMAX_A, onDrawMaxAccelX, SetMaxAccelX, &planner.settings.max_acceleration_mm_per_s2[X_AXIS]);
+    #endif
+    #if HAS_Y_AXIS
+      EDIT_ITEM(ICON_MaxAccY, MSG_AMAX_B, onDrawMaxAccelY, SetMaxAccelY, &planner.settings.max_acceleration_mm_per_s2[Y_AXIS]);
+    #endif
+    #if HAS_Z_AXIS
+      EDIT_ITEM(ICON_MaxAccZ, MSG_AMAX_C, onDrawMaxAccelZ, SetMaxAccelZ, &planner.settings.max_acceleration_mm_per_s2[Z_AXIS]);
+    #endif
     #if HAS_HOTEND
       EDIT_ITEM(ICON_MaxAccE, MSG_AMAX_E, onDrawMaxAccelE, SetMaxAccelE, &planner.settings.max_acceleration_mm_per_s2[E_AXIS]);
     #endif
@@ -3492,9 +3535,15 @@ void Draw_MaxAccel_Menu() {
     checkkey = Menu;
     if (SET_MENU_R(MaxJerkMenu, selrect({1, 16, 28, 13}), MSG_JERK, 5)) {
       BACK_ITEM(Draw_Motion_Menu);
-      EDIT_ITEM(ICON_MaxSpeedJerkX, MSG_VA_JERK, onDrawMaxJerkX, SetMaxJerkX, &planner.max_jerk.x);
-      EDIT_ITEM(ICON_MaxSpeedJerkY, MSG_VB_JERK, onDrawMaxJerkY, SetMaxJerkY, &planner.max_jerk.y);
-      EDIT_ITEM(ICON_MaxSpeedJerkZ, MSG_VC_JERK, onDrawMaxJerkZ, SetMaxJerkZ, &planner.max_jerk.z);
+      #if HAS_X_AXIS
+        EDIT_ITEM(ICON_MaxSpeedJerkX, MSG_VA_JERK, onDrawMaxJerkX, SetMaxJerkX, &planner.max_jerk.x);
+      #endif
+      #if HAS_Y_AXIS
+        EDIT_ITEM(ICON_MaxSpeedJerkY, MSG_VB_JERK, onDrawMaxJerkY, SetMaxJerkY, &planner.max_jerk.y);
+      #endif
+      #if HAS_Z_AXIS
+        EDIT_ITEM(ICON_MaxSpeedJerkZ, MSG_VC_JERK, onDrawMaxJerkZ, SetMaxJerkZ, &planner.max_jerk.z);
+      #endif
       #if HAS_HOTEND
         EDIT_ITEM(ICON_MaxSpeedJerkE, MSG_VE_JERK, onDrawMaxJerkE, SetMaxJerkE, &planner.max_jerk.e);
       #endif
@@ -3508,9 +3557,15 @@ void Draw_Steps_Menu() {
   checkkey = Menu;
   if (SET_MENU_R(StepsMenu, selrect({1, 16, 28, 13}), MSG_STEPS_PER_MM, 5)) {
     BACK_ITEM(Draw_Motion_Menu);
-    EDIT_ITEM(ICON_StepX, MSG_A_STEPS, onDrawStepsX, SetStepsX, &planner.settings.axis_steps_per_mm[X_AXIS]);
-    EDIT_ITEM(ICON_StepY, MSG_B_STEPS, onDrawStepsY, SetStepsY, &planner.settings.axis_steps_per_mm[Y_AXIS]);
-    EDIT_ITEM(ICON_StepZ, MSG_C_STEPS, onDrawStepsZ, SetStepsZ, &planner.settings.axis_steps_per_mm[Z_AXIS]);
+    #if HAS_X_AXIS
+      EDIT_ITEM(ICON_StepX, MSG_A_STEPS, onDrawStepsX, SetStepsX, &planner.settings.axis_steps_per_mm[X_AXIS]);
+    #endif
+    #if HAS_Y_AXIS
+      EDIT_ITEM(ICON_StepY, MSG_B_STEPS, onDrawStepsY, SetStepsY, &planner.settings.axis_steps_per_mm[Y_AXIS]);
+    #endif
+    #if HAS_Z_AXIS
+      EDIT_ITEM(ICON_StepZ, MSG_C_STEPS, onDrawStepsZ, SetStepsZ, &planner.settings.axis_steps_per_mm[Z_AXIS]);
+    #endif
     #if HAS_HOTEND
       EDIT_ITEM(ICON_StepE, MSG_E_STEPS, onDrawStepsE, SetStepsE, &planner.settings.axis_steps_per_mm[E_AXIS]);
     #endif
@@ -3623,9 +3678,15 @@ void Draw_Steps_Menu() {
     if (SET_MENU(HomingMenu, MSG_HOMING, 6)) {
       BACK_ITEM(Draw_Prepare_Menu);
       MENU_ITEM(ICON_Homing, MSG_AUTO_HOME, onDrawMenuItem, AutoHome);
-      MENU_ITEM(ICON_HomeX, MSG_AUTO_HOME_X, onDrawMenuItem, HomeX);
-      MENU_ITEM(ICON_HomeY, MSG_AUTO_HOME_Y, onDrawMenuItem, HomeY);
-      MENU_ITEM(ICON_HomeZ, MSG_AUTO_HOME_Z, onDrawMenuItem, HomeZ);
+      #if HAS_X_AXIS
+        MENU_ITEM(ICON_HomeX, MSG_AUTO_HOME_X, onDrawMenuItem, HomeX);
+      #endif
+      #if HAS_Y_AXIS
+        MENU_ITEM(ICON_HomeY, MSG_AUTO_HOME_Y, onDrawMenuItem, HomeY);
+      #endif
+      #if HAS_Z_AXIS
+        MENU_ITEM(ICON_HomeZ, MSG_AUTO_HOME_Z, onDrawMenuItem, HomeZ);
+      #endif
       #if ENABLED(MESH_BED_LEVELING)
         EDIT_ITEM(ICON_ZAfterHome, MSG_Z_AFTER_HOME, onDrawPInt8Menu, SetZAfterHoming, &HMI_data.z_after_homing);
       #endif

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -33,6 +33,7 @@
 #include "dwin_defines.h"
 #include "dwinui.h"
 #include "../common/encoder.h"
+#include "../common/limits.h"
 #include "../../../libs/BL24CXX.h"
 
 #if EITHER(BABYSTEPPING, HAS_BED_PROBE)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Currently neither Creality's default, JyersUI nor ProUI LCD drivers use max values for acceleration, steps and jerk as documented in `Configuration.h`.

Each driver has a different way of dealing with limits which makes it hard to update. In this patch I've unified acceleration, feedrate, jerk and steps/mm limits into one file and implemented it in JyersUI, ProUI and Creality's default UI drivers.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Ender-3 V2 with DWIN display.

### Benefits

<!-- What does this PR fix or improve? -->

The UI limits for acceleration, feedrate, jerk and steps/mm will now observe documentation from `Configuration.h`.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

Any configuration for E3V2 with any of `DWIN_CREALITY_LCD`, `DWIN_LCD_PROUI` or `DWIN_CREALITY_LCD_JYERSUI` enabled.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

None
