### PR TITLE
Fix TMC5160 overcurrent bug with input shaping

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -144,7 +144,6 @@ jobs:
     - name: Install PlatformIO
       run: |
         pip install -U platformio
-        pio upgrade --dev
         pio pkg update --global
 
     - name: Run ${{ matrix.test-platform }} Tests

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1679,12 +1679,14 @@ void Stepper::pulse_phase_isr() {
     // the TMC2208 / TMC2225 shutdown bug (#16076), add a half step hysteresis
     // in each direction. This results in the position being off by half an
     // average half step during travel but correct at the end of each segment.
-    #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE)
+    #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE) || \
+        AXIS_DRIVER_TYPE_X(TMC5160) || AXIS_DRIVER_TYPE_X(TMC5160_STANDALONE)
       #define HYSTERESIS_X 64
     #else
       #define HYSTERESIS_X 0
     #endif
-    #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE)
+    #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE) || \
+        AXIS_DRIVER_TYPE_Y(TMC5160) || AXIS_DRIVER_TYPE_Y(TMC5160_STANDALONE)
       #define HYSTERESIS_Y 64
     #else
       #define HYSTERESIS_Y 0


### PR DESCRIPTION
### Description

TMC5160 has the same problem as TMC2208 and TMC2225 with uneven pulse trains. This applies the same fix to the 5160 drivers.

### Requirements

TMC5160 drivers.

### Benefits

Drivers don't shut down when using input shaping.

### Related Issues

[See conversation in #24797](https://github.com/MarlinFirmware/Marlin/pull/24797#issuecomment-1335942508)
