### PR TITLE
Fix missing )

### DIFF
--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -112,7 +112,7 @@ void GcodeSuite::M48() {
     set_bed_leveling_enabled(false);
   #endif
 
-  TERN_(HAS_PTC, ptc.set_enabled(parser.boolval('C', true));
+  TERN_(HAS_PTC, ptc.set_enabled(parser.boolval('C', true)));
 
   // Work with reasonable feedrates
   remember_feedrate_scaling_off();


### PR DESCRIPTION
This PR fixes a typo introduced by commit [3ba9387](https://github.com/MarlinFirmware/Marlin/commit/3ba9387479b115e7e21f33b3cd2d3e153209520e).
