### PR TITLE
Add option for swapping Z1 and Z2 pinouts.

### DIFF
--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -88,6 +88,11 @@
     #ifndef FIL_RUNOUT_PIN
       #define FIL_RUNOUT_PIN                  33
     #endif
+    #define HEATER_BED_PIN          MOSFET_B_PIN  // HEATER1
+  #else
+    #ifndef FIL_RUNOUT_PIN
+      #define FIL_RUNOUT_PIN                  19
+    #endif
   #endif
 
   #if EITHER(TRIGORILLA_MAPPING_CHIRON, SWAP_TRIGORILLA_Z_MOTOR_PINS)
@@ -102,17 +107,8 @@
     #define Z2_DIR_PIN                        48
     #define Z2_ENABLE_PIN                     62
     #define Z2_CS_PIN                         40
-
-  #endif
-
-    #define HEATER_BED_PIN          MOSFET_B_PIN  // HEATER1
-  #else
-    #ifndef FIL_RUNOUT_PIN
-      #define FIL_RUNOUT_PIN                  19
-    #endif
   #endif
 #endif
-
 #if EITHER(ANYCUBIC_LCD_CHIRON, ANYCUBIC_LCD_I3MEGA)
   #define BEEPER_PIN                          31
   #define SD_DETECT_PIN                       49

--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -88,8 +88,11 @@
     #ifndef FIL_RUNOUT_PIN
       #define FIL_RUNOUT_PIN                  33
     #endif
+  #endif
 
+  #if EITHER(TRIGORILLA_MAPPING_CHIRON, SWAP_TRIGORILLA_Z_MOTOR_PINS)
     // Chiron swaps the Z stepper connections
+    // as do some Anycubic i3 MEGAs
     #define Z_STEP_PIN                        36
     #define Z_DIR_PIN                         34
     #define Z_ENABLE_PIN                      30
@@ -99,6 +102,8 @@
     #define Z2_DIR_PIN                        48
     #define Z2_ENABLE_PIN                     62
     #define Z2_CS_PIN                         40
+
+  #endif
 
     #define HEATER_BED_PIN          MOSFET_B_PIN  // HEATER1
   #else

--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -95,9 +95,8 @@
     #endif
   #endif
 
-  #if EITHER(TRIGORILLA_MAPPING_CHIRON, SWAP_TRIGORILLA_Z_MOTOR_PINS)
-    // Chiron swaps the Z stepper connections
-    // as do some Anycubic i3 MEGAs
+  #if EITHER(TRIGORILLA_MAPPING_CHIRON, SWAP_Z_MOTORS)
+    // Chiron and some Anycubic i3 MEGAs swap Z steppers
     #define Z_STEP_PIN                        36
     #define Z_DIR_PIN                         34
     #define Z_ENABLE_PIN                      30
@@ -109,6 +108,7 @@
     #define Z2_CS_PIN                         40
   #endif
 #endif
+
 #if EITHER(ANYCUBIC_LCD_CHIRON, ANYCUBIC_LCD_I3MEGA)
   #define BEEPER_PIN                          31
   #define SD_DETECT_PIN                       49


### PR DESCRIPTION
### Description

Some Anycubic i3 mega. have the z access wiring swapped. This change adds an option to select this for i3 MEGA

### Requirements

AnyCubic i3 MEGA with revered factory wiring.

### Benefits

Adds software configurable option

### Configurations

refer linked PR: https://github.com/MarlinFirmware/Configurations/pull/854

### Related Issues

-nil-
