### PR TITLE
🔧 Sanity Check Custom Menu

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3797,6 +3797,10 @@ static_assert(_PLUS_TEST(4), "HOMING_FEEDRATE_MM_M values must be positive.");
   #error "LED_CONTROL_MENU requires an LCD controller that implements the menu."
 #endif
 
+#if ENABLED(CUSTOM_MENU_MAIN) && NONE(HAS_MARLINUI_MENU, TOUCH_UI_FTDI_EVE, TFT_LVGL_UI)
+  #error "CUSTOM_MENU_MAIN requires an LCD controller that implements the menu."
+#endif
+
 #if ENABLED(CASE_LIGHT_USE_NEOPIXEL) && DISABLED(NEOPIXEL_LED)
   #error "CASE_LIGHT_USE_NEOPIXEL requires NEOPIXEL_LED."
 #endif


### PR DESCRIPTION
### Description

`CUSTOM_MENU_MAIN` is not compatible with all LCD controllers, so add a sanity check.

I searched for `CUSTOM_MENU_MAIN` & `MAIN_MENU_ITEM`, so I hope I caught all UIs that utilize this menu.

_Note: `DWIN_CREALITY_LCD_JYERSUI` uses `CUSTOM_MENU_CONFIG` instead of `CUSTOM_MENU_MAIN`, so that isn't checked here and will still work._

### Requirements

`CUSTOM_MENU_MAIN`

### Benefits

Users will be alerted to an incompatible configuration.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/25077
- https://github.com/MarlinFirmware/MarlinDocumentation/pull/476