### PR TITLE
remove env:mega1280 from MIGHTYBOARD_REVE

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -234,7 +234,7 @@
 #elif MB(CNCONTROLS_15)
   #include "mega/pins_CNCONTROLS_15.h"          // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
 #elif MB(MIGHTYBOARD_REVE)
-  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280 env:MightyBoard1280 env:MightyBoard2560
+  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega2560, ATmega1280                 env:mega2560ext env:MightyBoard1280 env:MightyBoard2560
 #elif MB(CHEAPTRONIC)
   #include "mega/pins_CHEAPTRONIC.h"            // ATmega2560                             env:mega2560
 #elif MB(CHEAPTRONIC_V2)


### PR DESCRIPTION
### Description

The mega1280 environment does not work with a atmega1280 based MIGHTYBOARD_REVE 
Solution:  Remove the env:mega1280 from the list of valid environments.
It builds but due to environment differences does not work. 
Most obvious issue Hotend E0 does not heat up. 

### Requirements

MIGHTYBOARD_REVE with atmega1280 MPU

### Benefits

Works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25078