### PR TITLE
Suppress warning in touch.cpp

### DIFF
--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -252,7 +252,7 @@ void Touch::touch(touch_control_t *control) {
 void Touch::hold(touch_control_t *control, millis_t delay) {
   current_control = control;
   if (delay) {
-    repeat_delay = _MAX(delay, MIN_REPEAT_DELAY);
+    repeat_delay = _MAX(delay, uint32_t(MIN_REPEAT_DELAY));
     time_to_hold = next_touch_ms + repeat_delay;
   }
   ui.refresh();


### PR DESCRIPTION
### Description

Touch.cpp gives a warning.

In file included from Marlin\src\lcd\tft\../../inc/MarlinConfigPre.h:37, from Marlin\src\lcd\tft\../../inc/MarlinConfig.h:28, from Marlin\src\lcd\tft\touch.cpp:23: Marlin\src\lcd\tft\../../inc/../core/macros.h: In instantiation of 'constexpr decltype ((lhs + rhs)) _MAX(L, R) [with L = long unsigned int; R = int; decltype ((lhs + rhs)) = long unsigned int]': Marlin\src\lcd\tft\touch.cpp:255:24: required from here Marlin\src\lcd\tft\../../inc/../core/macros.h:436:20: warning: comparison of integer expressions of different signedness: 'const long unsigned int' and 'const int' [-Wsign-compare] 436 | return lhs > rhs ? lhs : rhs; | ~~~~^~~~~

Fixes this warning

### Requirements

A display that uses a touch interface controlled by marlin

### Benefits

Warning removed

### Configurations

https://github.com/MarlinFirmware/Marlin/files/10241389/Configuration.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25100