### PR TITLE
Update status_screen_DOGM.cpp

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -508,7 +508,7 @@ void MarlinUI::draw_status_screen() {
 
   const bool show_e_total = TERN0(LCD_SHOW_E_TOTAL, printingIsActive());
 
-  static u8g_uint_t progress_bar_solid_width = 0;
+  //static u8g_uint_t progress_bar_solid_width = 0;
 
   // At the first page, generate new display values
   if (first_page) {


### PR DESCRIPTION
### Description

I've commented out the line  (511) in Marlin>src>lcd>dogm>status_screen_DOGM.cpp

static u8g_uint_t progress_bar_solid_width = 0;

### Requirements

DOGM LCD

### Benefits

Fixes warning at compile time:

Marlin\src\lcd\dogm\status_screen_DOGM.cpp: In static member function 'static void MarlinUI::draw_status_screen()': Marlin\src\lcd\dogm\status_screen_DOGM.cpp:511:21: warning: unused variable 'progress_bar_solid_width' [-Wunused-variable]
  511 |   static u8g_uint_t progress_bar_solid_width = 0;
--------------------------^------------------------------
Marlin\src\lcd\dogm\status_screen_DOGM.cpp: At global scope:
Marlin\src\lcd\dogm\status_screen_DOGM.cpp:511:21: warning: 'progress_bar_solid_width' defined but not used [-Wunused-variable]

### Related Issues

Unknown/haven't searched.
I was going through making a configuration of 2.1.2 for Ender 3 Pro and was faced with the above error.
Decided to dive into the source and fix the issue myself. I used a comment instead of deleting the line, as I have no idea if it was planned to be used or depreciated.