### PR TITLE
fix warning with DISTINCT_E_FACTORS in settings.cpp

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3271,7 +3271,7 @@ void MarlinSettings::reset() {
     #if ENABLED(DISTINCT_E_FACTORS)
       constexpr float linAdvanceK[] = ADVANCE_K;
       EXTRUDER_LOOP() {
-        const float a = linAdvanceK[_MAX((uint8_t)e, COUNT(linAdvanceK) - 1)];
+        const float a = linAdvanceK[_MAX(uint8_t(e), COUNT(linAdvanceK) - 1)];
         planner.extruder_advance_K[e] = a;
         TERN_(ADVANCE_K_EXTRA, other_extruder_advance_K[e] = a);
       }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3271,7 +3271,7 @@ void MarlinSettings::reset() {
     #if ENABLED(DISTINCT_E_FACTORS)
       constexpr float linAdvanceK[] = ADVANCE_K;
       EXTRUDER_LOOP() {
-        const float a = linAdvanceK[_MAX(e, COUNT(linAdvanceK) - 1)];
+        const float a = linAdvanceK[_MAX((uint8_t)e, COUNT(linAdvanceK) - 1)];
         planner.extruder_advance_K[e] = a;
         TERN_(ADVANCE_K_EXTRA, other_extruder_advance_K[e] = a);
       }


### PR DESCRIPTION
### Description

Warning
```
In file included from Marlin/src/module/../inc/MarlinConfigPre.h:37,
                 from Marlin/src/module/../inc/MarlinConfig.h:28,
                 from Marlin/src/module/settings.h:28,
                 from Marlin/src/module/settings.cpp:46:
Marlin/src/module/../inc/../core/macros.h: In instantiation of 'constexpr decltype ((lhs + rhs)) _MAX(L, R) [with L = signed char; R = unsigned int; decltype ((lhs + rhs)) = unsigned int]':
Marlin/src/module/settings.cpp:3274:67:   required from here
Marlin/src/module/../inc/../core/macros.h:436:20: warning: comparison of integer expressions of different signedness: 'const signed char' and 'const unsigned int' [-Wsign-compare]
  436 |         return lhs > rhs ? lhs : rhs;

```

### Requirements

LIN_ADVANCE
DISTINCT_E_FACTORS

### Benefits

Warning is gone

### Configurations

From 25148 but with user errors corrected. 
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/10299359/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25148