### PR TITLE
EZBoard V2 - AutoFan Issue - Fix Compile Issues from 2.1.2 Update

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
@@ -174,12 +174,6 @@
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN           AUTO_FAN_PIN
 #endif
-#ifndef E1_AUTO_FAN_PIN
-  #define E1_AUTO_FAN_PIN           AUTO_FAN_PIN
-#endif
-#ifndef E2_AUTO_FAN_PIN
-  #define E2_AUTO_FAN_PIN           AUTO_FAN_PIN
-#endif
 
 //
 // SD Card


### PR DESCRIPTION
### Description

At some point, someone added E1 and E2 autofan lines to our board config and this makes the compile fail because of the auto fan pins being the same. This is a single extruder board so there is no reason to have E1 and E2 autofan pins defined in the pins file ever.
