### PR TITLE
Generalize Configurations URL (2.1.x)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,3 +1,3 @@
 # Where have all the configurations gone?
 
-## https://github.com/MarlinFirmware/Configurations/archive/release-2.1.zip
+## https://github.com/MarlinFirmware/Configurations


### PR DESCRIPTION
### Description

This URL frequently points to the wrong version/tag, so use top-level Configurations URL instead.