### PR TITLE
fix: Glitchy submenu when conditionally rendering menu options with Lambdas

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -243,10 +243,8 @@ void menu_main() {
   START_MENU();
   BACK_ITEM(MSG_INFO_SCREEN);
 
-  #if ENABLED(SDSUPPORT)
-    #if !defined(MEDIA_MENU_AT_TOP) && !HAS_ENCODER_WHEEL
-      #define MEDIA_MENU_AT_TOP
-    #endif
+  #if ENABLED(SDSUPPORT) && !defined(MEDIA_MENU_AT_TOP) && !HAS_ENCODER_WHEEL
+    #define MEDIA_MENU_AT_TOP
   #endif
 
   if (busy) {

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -274,6 +274,7 @@ void menu_main() {
   }
   else {
     #if BOTH(SDSUPPORT, MEDIA_MENU_AT_TOP)
+      // BEGIN MEDIA MENU
       #if ENABLED(MENU_ADDAUTOSTART)
         ACTION_ITEM(MSG_RUN_AUTO_FILES, card.autofile_begin); // Run Auto Files
       #endif
@@ -302,6 +303,7 @@ void menu_main() {
           GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21"));          // M21 Attach Media
         #endif
       }
+      // END MEDIA MENU
     #endif
 
     if (TERN0(MACHINE_CAN_PAUSE, printingIsPaused()))
@@ -381,6 +383,7 @@ void menu_main() {
   #endif
 
   #if ENABLED(SDSUPPORT) && DISABLED(MEDIA_MENU_AT_TOP)
+    // BEGIN MEDIA MENU
     #if ENABLED(MENU_ADDAUTOSTART)
       ACTION_ITEM(MSG_RUN_AUTO_FILES, card.autofile_begin); // Run Auto Files
     #endif
@@ -409,6 +412,7 @@ void menu_main() {
         GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21"));          // M21 Attach Media
       #endif
     }
+    // END MEDIA MENU
   #endif
 
   #if HAS_SERVICE_INTERVALS

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -274,7 +274,6 @@ void menu_main() {
   }
   else {
     #if BOTH(SDSUPPORT, MEDIA_MENU_AT_TOP)
-      // Render sdcard menu items; will return at label
       #if ENABLED(MENU_ADDAUTOSTART)
         ACTION_ITEM(MSG_RUN_AUTO_FILES, card.autofile_begin); // Run Auto Files
       #endif
@@ -382,7 +381,6 @@ void menu_main() {
   #endif
 
   #if ENABLED(SDSUPPORT) && DISABLED(MEDIA_MENU_AT_TOP)
-    // Render sdcard menu items; will return at label
     #if ENABLED(MENU_ADDAUTOSTART)
       ACTION_ITEM(MSG_RUN_AUTO_FILES, card.autofile_begin); // Run Auto Files
     #endif

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -233,10 +233,6 @@ void menu_configuration();
 #endif
 
 void menu_main() {
-  #if ENABLED(SDSUPPORT) && !defined(MEDIA_MENU_AT_TOP) && !HAS_ENCODER_WHEEL
-    #define MEDIA_MENU_AT_TOP
-  #endif
-
   const bool busy = printingIsActive()
     #if ENABLED(SDSUPPORT)
       , card_detected = card.isMounted()
@@ -246,6 +242,12 @@ void menu_main() {
 
   START_MENU();
   BACK_ITEM(MSG_INFO_SCREEN);
+
+  #if ENABLED(SDSUPPORT)
+    #if !defined(MEDIA_MENU_AT_TOP) && !HAS_ENCODER_WHEEL
+      #define MEDIA_MENU_AT_TOP
+    #endif
+  #endif
 
   if (busy) {
     #if MACHINE_CAN_PAUSE


### PR DESCRIPTION
### Description

This PR aims to fix a bug that's demonstrated at the following link: [https://photos.app.goo.gl/mXc8ag5s1qpeD4t39](https://photos.app.goo.gl/mXc8ag5s1qpeD4t39)

**The issue**

In order to support `MEDIA_MENU_AT_TOP` (that is, SD card options pushed to the top of the screen instead of further down), `menu_main.cpp` implements an sd card options rendering routine in the form of a `[&]{ ... }` lambda expression with reference captures. The _issue_ is the fact that due to the way the menu is implemented, rendering submenu items inside lambda expressions _corrupts_ the menu when you enter it.

To be more exact, when a submenu item is being rendered from within a lambda expression, entering it will cause the menu system to glitch, redrawing all items under the currently selected submenu, duplicating the first item underneath onto the currently selected submenu, and then draw the submenu itself on the screen. The reason only the items below are redrawn in this glitch is because when the menu system iterates over the currently selected item, it will clear the screen, so all artifacts that can appear here are the next menu items, not the previous.

This appears to be caused by some variables not updating correctly (`should_draw` maybe?) when lambda expressions are used, causing the previous menu to keep redrawing after `goto_screen` is called.

The problem can be induced manually, for example, by converting any submenu rendering into a lamba expression. If we were to remove the call to the Filament Change option and redefine it near the top of the main menu as:

```C++
  START_MENU();
  BACK_ITEM(MSG_INFO_SCREEN);

  auto filament_change_lambda = [&] {
    SUBMENU(MSG_FILAMENTCHANGE, menu_change_filament);
  };

  filament_change_lambda();
```

If we entered this submenu, the screen would glitch as described above, redrawing the entire main menu options underneath the one that was just accessed, and then drawing the filament change menu over the now-corrupted screen.

**The solution**

I was unable to determine whether the way C++ handles lambda closures is the issue, or if there is an underlying bug in the Marlin menu system that makes this happen.

What I do know is the menu system was designed to involve direct invocations of the menu rendering "hooks" inside the menu loop macros directly.

In order to still support `MEDIA_MENU_AT_TOP`, and being required to not use lambda expressions, I refactored the conditional sdcard menu rendering code using `goto` statements. This might indeed feel too _bare metal_ to some, and as such, suggestions for alternative fixes to this bug are most welcome - if anyone has any insights, I'd be happy to hear them. Ideally, the issue would be fixed from within the menu system itself, which would allow us to use lambdas again.

### Requirements

The issue does not relate to any specific board. The only requirement is an LCD capable of displaying the native Marlin UI, with enough vertical space.
In this case, the issue has been observed on an Ender-3 V2 / S1 screen. Both portrait and landscape have enough space for the problem to become apparent.

It is worth noting that under the right conditions (`MEDIA_MENU_AT_TOP`, only 1 file on the card), this issue can be repro'd on an 128x64 LCD as well, as the menu options under the media options would redraw on the entire screen while the card content would only draw on 2 lines.

### Benefits

This PR offers a fix for the sdcard menu glitch caused above, by refactoring the media menu options rendering to run directly inside the menu loop, just like all other menus.

### Configurations

N/A

### Related Issues

N/A
