### PR TITLE
remove use of pow call in M605, causes a rounding error

### DIFF
--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -169,7 +169,7 @@
     if (parser.seen("EPS")) {
       planner.synchronize();
       if (parser.seenval('P')) duplication_e_mask = parser.value_int();   // Set the mask directly
-      else if (parser.seenval('E')) duplication_e_mask = pow(2, parser.value_int() + 1) - 1; // Set the mask by E index
+      else if (parser.seenval('E')) duplication_e_mask = _BV(parser.value_int() + 1) - 1; // Set the mask by E index
       ena = (2 == parser.intval('S', extruder_duplication_enabled ? 2 : 0));
       set_duplication_enabled(ena && (duplication_e_mask >= 3));
     }


### PR DESCRIPTION
### Description

pow() returns a float and the conversion to a uint8_t  has rounding issues on 8 bit avr

I added some temporary debugging to diagnose this issue in Marlin/src/gcode/control/M605.cpp

```CPP
      else if (parser.seenval('E')) {
        // original code used
        duplication_e_mask = pow(2, parser.value_int() + 1) - 1;  

        // alternative code that does not use floats
        //duplication_e_mask = _BV(parser.value_int()+1) -1;

        SERIAL_ECHOLNPGM("parser.value_int: ",parser.value_int());
        SERIAL_ECHOLNPGM("pow(2, parser.value_int() + 1) - 1: ",pow(2, parser.value_int() + 1) - 1);
        SERIAL_ECHOLNPGM("_BV(parser.value_int()+1) -1: ",_BV(parser.value_int()+1) -1);
        SERIAL_ECHOLNPGM("duplication_e_mask: ",duplication_e_mask);
      }
```

When  using  original  duplication_e_mask = pow(2, parser.value_int() + 1) - 1;  

```
Send: M605 S2 E2
Received:
> parser.value_int: 2
> pow(2, parser.value_int() + 1) - 1: 7.00           <---- is a float
> _BV(parser.value_int()+1) -1: 7                    <---- is a int (not used in this case)
> duplication_e_mask: 6                              <---- converted float is incorrect
> echo:Duplication mode: ON ( 1 2 )                  <---- incorrect due to conversion issue
```

When  using  new duplication_e_mask = _BV(parser.value_int()+1) -1; 

```
Send: M605 S2 E2   
Received:
> parser.value_int: 2
> pow(2, parser.value_int() + 1) - 1: 7.00           <---- is a float (not used in his case)
> _BV(parser.value_int()+1) -1: 7                    <---- is a int
> duplication_e_mask: 7                              <---- converted into to uint8_t is correct
> echo:Duplication mode: ON ( 0 1 2 )                <---- correct result
```

### Requirements

3 extruders
#define MULTI_NOZZLE_DUPLICATION

I used a ramps and configured it for 3 extruders (using X as E2, X pins where remapped to unused io pins)
Tested all E stepper moved as one as expected 
 
### Benefits

With MULTI_NOZZLE_DUPLICATION M605 E parameter works as expected

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/10341305/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25179

