### PR TITLE
Reintroduce IS_MELZI define so LCDs work correctly on Melzi boards

### DIFF
--- a/Marlin/src/pins/sanguino/pins_MELZI.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI.h
@@ -29,6 +29,8 @@
   #define BOARD_INFO_NAME "Melzi"
 #endif
 
+#define IS_MELZI 1
+
 #ifndef FAN_PIN
   #define FAN_PIN                              4
 #endif


### PR DESCRIPTION
### Description

When compiling Marlin for a Melzi board and there is an LCD configured, the pins are undefined after commit 9949672f1d303d786e20cd053701fcd5c61de736

I think this was a simple mistake when copy/pasting the `FAN_PIN` definition.

Also fixes 

### Requirements

It requires a Melzi board and an LCD

### Benefits

This enables LCDs again on Melzi boards

### Configurations

N/A

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/25189
