### PR TITLE
Fix first neopixel strip behaviour at startup

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -108,7 +108,7 @@ void Marlin_NeoPixel::init() {
   set_color(adaneo1.Color
     TERN(LED_USER_PRESET_STARTUP,
       (LED_USER_PRESET_RED, LED_USER_PRESET_GREEN, LED_USER_PRESET_BLUE, LED_USER_PRESET_WHITE),
-      (255, 255, 255, 255))
+      (0, 0, 0, 0))
   );
 }
 


### PR DESCRIPTION
### Description

#23938 changed behaviour of first neopixel strip at startup when `LED_USER_PRESET_STARTUP` is disabled, switching from `(0, 0, 0, 0)` (led off) to `(255, 255, 255, 255)` (all led on in first strip).

This leads to two weird behaviour described in #25199

- Inconsistent behaviour between first and second nepixel strips when both `LED_USER_PRESET_STARTUP` and `NEO2_USER_PRESET_STARTUP` are disabled, first strip being lit at startup while second strip stay off
- Inconsistent Ligths menu entry with first led strip state, led strip being on while menu thinking it's off

This PR revert default for first strip to `(0, 0, 0, 0)` (led off) when `LED_USER_PRESET_STARTUP` is disabled, fixing these two issues.

### Requirements

At least one Neopixel led strip

### Benefits

Bug fixed

### Configurations

```cpp
// Support for Adafruit NeoPixel LED driver
#define NEOPIXEL_LED
#if ENABLED(NEOPIXEL_LED)
  #define NEOPIXEL_TYPE           NEO_GRB // NEO_GRBW, NEO_RGBW, NEO_GRB, NEO_RBG, etc.
                                          // See https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.h
  //#define NEOPIXEL_PIN                4 // LED driving pin
  #define NEOPIXEL2_TYPE          NEO_GRB
  //#define NEOPIXEL2_PIN               5
  #define NEOPIXEL_PIXELS              15 // Number of LEDs in the strip. (Longest strip when NEOPIXEL2_SEPARATE is disabled.)
  //#define NEOPIXEL_IS_SEQUENTIAL        // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
  #define NEOPIXEL_BRIGHTNESS         127 // Initial brightness (0-255)
  //#define NEOPIXEL_STARTUP_TEST         // Cycle through colors at startup

  // Support for second Adafruit NeoPixel LED driver controlled with M150 S1 ...
  #define NEOPIXEL2_SEPARATE
  #if ENABLED(NEOPIXEL2_SEPARATE)
    #define NEOPIXEL2_PIXELS            3 // Number of LEDs in the second strip
    #define NEOPIXEL2_BRIGHTNESS      127 // Initial brightness (0-255)
    //#define NEOPIXEL2_STARTUP_TEST        // Cycle through colors at startup
    #define NEOPIXEL_M150_DEFAULT       0 // Default strip for M150 without 'S'. Use -1 to set all by default.
  #else
    //#define NEOPIXEL2_INSERIES          // Default behavior is NeoPixel 2 in parallel
  #endif

  // Use some of the NeoPixel LEDs for static (background) lighting
  //#define NEOPIXEL_BKGD_INDEX_FIRST   0 // Index of the first background LED
  //#define NEOPIXEL_BKGD_INDEX_LAST    5 // Index of the last background LED
  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 }  // R, G, B, W
  //#define NEOPIXEL_BKGD_ALWAYS_ON       // Keep the backlight on when other NeoPixels are off
#endif
```

```cpp
  /**
   * LED Control Menu
   * Add LED Control to the LCD menu
   */
  #define LED_CONTROL_MENU
  #if ENABLED(LED_CONTROL_MENU)
    #define LED_COLOR_PRESETS                 // Enable the Preset Color menu option
    #define NEO2_COLOR_PRESETS                // Enable a second NeoPixel Preset Color menu option
    #if ENABLED(LED_COLOR_PRESETS)
      #define LED_USER_PRESET_RED        255  // User defined RED value
      #define LED_USER_PRESET_GREEN      255  // User defined GREEN value
      #define LED_USER_PRESET_BLUE       255  // User defined BLUE value
      #define LED_USER_PRESET_WHITE      255  // User defined WHITE value
      #define LED_USER_PRESET_BRIGHTNESS 127  // User defined intensity
      //#define LED_USER_PRESET_STARTUP       // Have the printer display the user preset color on startup
    #endif
    #if ENABLED(NEO2_COLOR_PRESETS)
      #define NEO2_USER_PRESET_RED        255 // User defined RED value
      #define NEO2_USER_PRESET_GREEN      255 // User defined GREEN value
      #define NEO2_USER_PRESET_BLUE       255 // User defined BLUE value
      #define NEO2_USER_PRESET_WHITE      255 // User defined WHITE value
      #define NEO2_USER_PRESET_BRIGHTNESS 127 // User defined intensity
      #define NEO2_USER_PRESET_STARTUP        // Have the printer display the user preset color on startup for the second strip
    #endif
  #endif
```

### Related Issues

Fixes #25199

