### PR TITLE
fix: MarlinUI XYZ border on status screen not displaying correctly

### DIFF
--- a/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
@@ -315,7 +315,7 @@ void MarlinUI::draw_status_screen() {
     // Draw a frame around the x/y/z values
     DWIN_Draw_Rectangle(0, Select_Color,
       #if ENABLED(DWIN_MARLINUI_PORTRAIT)
-        0, 193, LCD_PIXEL_WIDTH, 260
+        0, 193, LCD_PIXEL_WIDTH - 1, 260
       #else
         0, 115, LCD_PIXEL_WIDTH - 1, 152
       #endif


### PR DESCRIPTION
### Description

This PR fixes the blue border around the XYZ coordinates on the Status screen of MarlinUI on Ender-3 V2 / S1 style displays.

### Requirements

Ender-3 V2 / S1 family printer with DWIN / "DWIN-like" (clones with the same protocol) 272x480 knob display.

### Benefits

The border around the current printhead coordinates is now drawn correctly.

This issue isn't reproducible on original DWIN displays due to what seems to be automatic correction of invalid rectangle coordinates - on clones, the problem became apparent (observed on a DACAI unit).

### Configurations

N/A

### Related Issues

N/A
