### PR TITLE
Update Simulator Linux instructions

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -26,6 +26,7 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/LINUX>
 # Native Simulation
 # Builds with a small subset of available features
 # Required system libraries: SDL2, SDL2-net, OpenGL, GLM
+#   sudo apt-get install python3-venv build-essential libsdl2-dev libsdl2-net-dev libglm-dev
 # See https://docs.platformio.org/en/latest/platforms/native.html for more information
 #
 # Tested with Linux (Mint 20) : gcc [9.3.0, 10.2.0]: libsdl2-dev[2.0.10], libsdl2-net-dev[2.0.1], libglm-dev[0.9.9.7, 0.9.9.8]


### PR DESCRIPTION
### Description

This adds a cut and paste line for dependances on Linux.  Some people commented that they forget them.  This also prevents the error:

```
/bin/sh: 1: CC: not found
Error: Failed to parse Marlin features. See previous error messages.
```

Tested on a fresh Ubuntu install