### PR TITLE
+ set z-stop pin for Chitu board CXY-V6-191017

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -27,6 +27,8 @@
 #define Z2_STEP_PIN                         PF5
 #define Z2_DIR_PIN                          PF1
 
+#define Z_STOP_PIN                          PA14
+
 #ifndef FIL_RUNOUT2_PIN
   #define FIL_RUNOUT2_PIN                   PF13
 #endif


### PR DESCRIPTION
### Description

Small patch to get z-stop connector working on Chitu board CXY-V6-191017 with STM32F103 CPU.
It's old revision of this board, later one uses STM32F446Z CPU and marked as CXY-V6-191121
Can be found on some old models of Tronxy printers.

### Requirements

Yes, it's for specific board.

### Benefits

working z endstop, obviously

### Configurations

I'm going to publish config for tronxy d01 in near time, and post link here asap.

### Related Issues

it's bugfix.

### Links

https://tronxy.fandom.com/wiki/TronXY_Mainboard_Documentation#TronXY_CXY-V6
https://aliexpress.ru/item/1005002510308738.html still on sale as spare part (see item specification)
