### PR TITLE
Fix compile error without PREVENT_COLD_EXTRUSION

### DIFF
--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -47,7 +47,7 @@ void GcodeSuite::M145() {
     preheat_t &mat = ui.material_preset[material];
     #if HAS_HOTEND
       if (parser.seenval('H'))
-        mat.hotend_temp = constrain(parser.value_int(), thermalManager.extrude_min_temp, thermalManager.hotend_max_target(0));
+        mat.hotend_temp = constrain(parser.value_int(), TERN0(PREVENT_COLD_EXTRUSION, thermalManager.extrude_min_temp), thermalManager.hotend_max_target(0));
     #endif
     #if HAS_HEATED_BED
       if (parser.seenval('B'))


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Compiling failed when `PREVENT_COLD_EXTRUSION` was disabled, because M145 tried to access the non-existing `thermalManager.extrude_min_temp`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
