### PR TITLE
Fix Ultipanel-type displays on MKS mainboards

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -344,7 +344,7 @@
   #else
 
     #define LCD_PINS_D4              EXP1_05_PIN
-    #if ENABLED(ULTIPANEL)
+    #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN
       #define LCD_PINS_D6            EXP1_07_PIN
       #define LCD_PINS_D7            EXP1_08_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -361,7 +361,7 @@
   #else                                           // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP1_05_PIN
-    #if ENABLED(ULTIPANEL)
+    #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN
       #define LCD_PINS_D6            EXP1_07_PIN
       #define LCD_PINS_D7            EXP1_08_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -363,7 +363,7 @@
   #else                                           // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP1_05_PIN
-    #if ENABLED(ULTIPANEL)
+    #if IS_ULTIPANEL
       #define LCD_PINS_D5            EXP1_06_PIN
       #define LCD_PINS_D6            EXP1_07_PIN
       #define LCD_PINS_D7            EXP1_08_PIN


### PR DESCRIPTION
### Description

Pinmaps for several MKS boards use:
```h
#if ENABLED(ULTIPANEL)
  #define LCD_PINS_D5 EXAMPLE_PIN1
  #define LCD_PINS_D6 EXAMPLE_PIN2
  #define LCD_PINS_D7 EXAMPLE_PIN3
#endif
```
instead of:
```h
#if IS_ULTIPANEL
  #define LCD_PINS_D5 EXAMPLE_PIN1
  #define LCD_PINS_D6 EXAMPLE_PIN2
  #define LCD_PINS_D7 EXAMPLE_PIN3
#endif
```
like every other pinmap file. This causes pin mappings for `LCD_PINS_D5/6/7` to be incorrectly defined for every Ultipanel-type LCD except `ULTIPANEL`.

This PR changes `#if ENABLED(ULTIPANEL)` to `#if IS_ULTIPANEL`.

### Requirements
<!-- Does this PR require a specific board, LCD, etc.? -->

Any of the following boards:
- MKS Eagle
- MKS Monster 8 V1/V2
- MKS Robin Nano V3
- MKS Robin Pro V2

And any LCD that defines `IS_ULTIPANEL 1` in [Marlin/src/inc/Conditionals_LCD.h](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/Marlin/src/inc/Conditionals_LCD.h).


### Benefits
<!-- What does this PR fix or improve? -->

This PR fixes incorrect pin mappings for Ultipanel-type displays on several MKS mainboards.

### Configurations
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

Define one of the affected boards:
- `BOARD_MKS_EAGLE`
- `BOARD_MKS_ROBIN_PRO_V2`
- `BOARD_MKS_ROBIN_NANO_V3`
- `BOARD_MKS_ROBIN_NANO_V3_1`
- `BOARD_MKS_MONSTER8_V1`
- `BOARD_MKS_MONSTER8_V2`

Define any LCD that defines `IS_ULTIPANEL 1`. E.g. `REPRAP_DISCOUNT_SMART_CONTROLLER`.

I tested the change with an MKS Eagle and a RepRapDiscount Smart Controller.

### Related Issues
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

https://github.com/makerbase-mks/Mks-Robin-Nano-Marlin2.0-Firmware/issues/263