### PR TITLE
Fix compilation errors for simulator with TFT screen

### DIFF
--- a/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
@@ -33,6 +33,7 @@
 #define DATASIZE_8BIT    8
 #define DATASIZE_16BIT   16
 #define TFT_IO_DRIVER TFT_SPI
+#define DMA_MAX_SIZE 65535
 
 #define DMA_MINC_ENABLE 1
 #define DMA_MINC_DISABLE 0
@@ -58,7 +59,9 @@ public:
   static void WriteData(uint16_t Data);
   static void WriteReg(uint16_t Reg);
 
+  static void WriteSequence_DMA(uint16_t *Data, uint16_t Count) { WriteSequence(Data, Count); }
+  static void WriteMultiple_DMA(uint16_t Color, uint16_t Count) { WriteMultiple(Color, Count); }
+
   static void WriteSequence(uint16_t *Data, uint16_t Count);
-  // static void WriteMultiple(uint16_t Color, uint16_t Count);
   static void WriteMultiple(uint16_t Color, uint32_t Count);
 };

--- a/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
@@ -31,11 +31,11 @@
 #endif
 
 #define DATASIZE_8BIT    8
-#define DATASIZE_16BIT   16
-#define TFT_IO_DRIVER TFT_SPI
-#define DMA_MAX_SIZE 65535
+#define DATASIZE_16BIT  16
+#define TFT_IO_DRIVER   TFT_SPI
+#define DMA_MAX_SIZE    0xFFFF
 
-#define DMA_MINC_ENABLE 1
+#define DMA_MINC_ENABLE  1
 #define DMA_MINC_DISABLE 0
 
 class TFT_SPI {

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1549,29 +1549,8 @@
   #endif
 #endif
 
-// Set TFT_COLOR_UI_PORTRAIT flag, if needed
-#if defined(TFT_ROTATION) && (HAS_SPI_TFT || HAS_FSMC_TFT || HAS_LTDC_TFT)
-  #define _CMP_TFT_ROTATE_90   90
-  #define _CMP_TFT_ROTATE_270 270
-  #define _CMP_TFT_ROTATE_90_MIRROR_X   90
-  #define _CMP_TFT_ROTATE_90_MIRROR_Y   90
-  #define _CMP_TFT_ROTATE_270_MIRROR_X 270
-  #define _CMP_TFT_ROTATE_270_MIRROR_Y 270
-  #define _ISROT(N) || (_CAT(_CMP_, TFT_ROTATION) == N)
-  #define ISROT(V...) (0 MAP(_ISROT, V))
-
-  #if ISROT(90, 270)
-    #define TFT_COLOR_UI_PORTRAIT 1
-  #endif
-
-  #undef _CMP_TFT_ROTATE_90
-  #undef _CMP_TFT_ROTATE_270
-  #undef _CMP_TFT_ROTATE_90_MIRROR_X
-  #undef _CMP_TFT_ROTATE_90_MIRROR_Y
-  #undef _CMP_TFT_ROTATE_270_MIRROR_X
-  #undef _CMP_TFT_ROTATE_270_MIRROR_Y
-  #undef _ISROT
-  #undef ISROT
+#if ANY(HAS_SPI_TFT, HAS_FSMC_TFT, HAS_LTDC_TFT)
+  #include "../lcd/tft_io/tft_orientation.h"
 #endif
 
 #if ENABLED(TFT_RES_320x240)

--- a/Marlin/src/lcd/tft_io/tft_io.h
+++ b/Marlin/src/lcd/tft_io/tft_io.h
@@ -34,65 +34,10 @@
 #endif
 
 #ifndef DMA_MAX_SIZE
-  #error "MAX_DMA_SIZE is not configured for this platform."
+  #error "DMA_MAX_SIZE is not configured for this platform."
 #endif
 
-#define TFT_EXCHANGE_XY _BV32(1)
-#define TFT_INVERT_X    _BV32(2)
-#define TFT_INVERT_Y    _BV32(3)
-
-#define TFT_NO_ROTATION           (0x00)
-#define TFT_ROTATE_90             (TFT_EXCHANGE_XY | TFT_INVERT_X)
-#define TFT_ROTATE_180            (TFT_INVERT_X    | TFT_INVERT_Y)
-#define TFT_ROTATE_270            (TFT_EXCHANGE_XY | TFT_INVERT_Y)
-
-#define TFT_MIRROR_X              (TFT_INVERT_Y)
-#define TFT_MIRROR_Y              (TFT_INVERT_X)
-
-#define TFT_ROTATE_90_MIRROR_X    (TFT_ROTATE_90 ^ TFT_MIRROR_X)
-#define TFT_ROTATE_90_MIRROR_Y    (TFT_ROTATE_90 ^ TFT_MIRROR_Y)
-
-#define TFT_ROTATE_180_MIRROR_X   (TFT_ROTATE_180 ^ TFT_MIRROR_X)
-#define TFT_ROTATE_180_MIRROR_Y   (TFT_ROTATE_180 ^ TFT_MIRROR_Y)
-
-#define TFT_ROTATE_270_MIRROR_X   (TFT_ROTATE_270 ^ TFT_MIRROR_X)
-#define TFT_ROTATE_270_MIRROR_Y   (TFT_ROTATE_270 ^ TFT_MIRROR_Y)
-
-// TFT_ROTATION is user configurable
-#ifndef TFT_ROTATION
-  #define TFT_ROTATION TFT_NO_ROTATION
-#endif
-
-// TFT_ORIENTATION is the "sum" of TFT_DEFAULT_ORIENTATION plus user TFT_ROTATION
-#define TFT_ORIENTATION ((TFT_DEFAULT_ORIENTATION) ^ (TFT_ROTATION))
-
-#define TFT_COLOR_RGB   _BV32(3)
-#define TFT_COLOR_BGR   _BV32(4)
-
-// Each TFT Driver is responsible for its default color mode.
-// #ifndef TFT_COLOR
-//   #define TFT_COLOR   TFT_COLOR_RGB
-// #endif
-
-#define TOUCH_ORIENTATION_NONE  0
-#define TOUCH_LANDSCAPE         1
-#define TOUCH_PORTRAIT          2
-
-#ifndef TOUCH_CALIBRATION_X
-  #define TOUCH_CALIBRATION_X   0
-#endif
-#ifndef TOUCH_CALIBRATION_Y
-  #define TOUCH_CALIBRATION_Y   0
-#endif
-#ifndef TOUCH_OFFSET_X
-  #define TOUCH_OFFSET_X        0
-#endif
-#ifndef TOUCH_OFFSET_Y
-  #define TOUCH_OFFSET_Y        0
-#endif
-#ifndef TOUCH_ORIENTATION
-  #define TOUCH_ORIENTATION     TOUCH_LANDSCAPE
-#endif
+#include "tft_orientation.h"
 
 #ifndef TFT_DRIVER
   #define TFT_DRIVER    AUTO

--- a/Marlin/src/lcd/tft_io/tft_orientation.h
+++ b/Marlin/src/lcd/tft_io/tft_orientation.h
@@ -1,0 +1,85 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define TFT_EXCHANGE_XY _BV32(1)
+#define TFT_INVERT_X    _BV32(2)
+#define TFT_INVERT_Y    _BV32(3)
+
+#define TFT_NO_ROTATION           (0x00)
+#define TFT_ROTATE_90             (TFT_EXCHANGE_XY | TFT_INVERT_X)
+#define TFT_ROTATE_180            (TFT_INVERT_X    | TFT_INVERT_Y)
+#define TFT_ROTATE_270            (TFT_EXCHANGE_XY | TFT_INVERT_Y)
+
+#define TFT_MIRROR_X              (TFT_INVERT_Y)
+#define TFT_MIRROR_Y              (TFT_INVERT_X)
+
+#define TFT_ROTATE_90_MIRROR_X    (TFT_ROTATE_90 ^ TFT_MIRROR_X)
+#define TFT_ROTATE_90_MIRROR_Y    (TFT_ROTATE_90 ^ TFT_MIRROR_Y)
+
+#define TFT_ROTATE_180_MIRROR_X   (TFT_ROTATE_180 ^ TFT_MIRROR_X)
+#define TFT_ROTATE_180_MIRROR_Y   (TFT_ROTATE_180 ^ TFT_MIRROR_Y)
+
+#define TFT_ROTATE_270_MIRROR_X   (TFT_ROTATE_270 ^ TFT_MIRROR_X)
+#define TFT_ROTATE_270_MIRROR_Y   (TFT_ROTATE_270 ^ TFT_MIRROR_Y)
+
+// TFT_ROTATION is user configurable
+#ifndef TFT_ROTATION
+  #define TFT_ROTATION TFT_NO_ROTATION
+#endif
+
+// TFT_ORIENTATION is the "sum" of TFT_DEFAULT_ORIENTATION plus user TFT_ROTATION
+#define TFT_ORIENTATION ((TFT_DEFAULT_ORIENTATION) ^ (TFT_ROTATION))
+
+// Set TFT_COLOR_UI_PORTRAIT flag, if needed
+#if ((TFT_ORIENTATION) & TFT_EXCHANGE_XY) == 0
+  #define TFT_COLOR_UI_PORTRAIT 1
+#endif
+
+#define TFT_COLOR_RGB   _BV32(3)
+#define TFT_COLOR_BGR   _BV32(4)
+
+// Each TFT Driver is responsible for its default color mode.
+// #ifndef TFT_COLOR
+//   #define TFT_COLOR   TFT_COLOR_RGB
+// #endif
+
+#define TOUCH_ORIENTATION_NONE  0
+#define TOUCH_LANDSCAPE         1
+#define TOUCH_PORTRAIT          2
+
+#ifndef TOUCH_CALIBRATION_X
+  #define TOUCH_CALIBRATION_X   0
+#endif
+#ifndef TOUCH_CALIBRATION_Y
+  #define TOUCH_CALIBRATION_Y   0
+#endif
+#ifndef TOUCH_OFFSET_X
+  #define TOUCH_OFFSET_X        0
+#endif
+#ifndef TOUCH_OFFSET_Y
+  #define TOUCH_OFFSET_Y        0
+#endif
+#ifndef TOUCH_ORIENTATION
+  #define TOUCH_ORIENTATION     TOUCH_LANDSCAPE
+#endif
+


### PR DESCRIPTION
### Description

Fix compilation errors for simulator with TFT_COLOR_UI caused by https://github.com/MarlinFirmware/Marlin/pull/24980
Improved portrait mode detection for 320x240 screen, https://github.com/MarlinFirmware/Marlin/pull/25253 is now obsolete

![240x320](https://user-images.githubusercontent.com/9879021/214398226-d0e4ab8d-31ba-4c62-a52d-cb1ae21c8998.png)


### Requirements

Simulator with TFT_COLOR_UI
or
Any 320x240 TFT screen with TFT_COLOR_UI in portrait mode

