### PR TITLE
Fix LCD_HEIGHT for TFT Color UI

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1641,9 +1641,11 @@
   #define HAS_UI_1024x600 1
 #endif
 #if ANY(HAS_UI_320x240, HAS_UI_480x320, HAS_UI_480x272)
-  #define LCD_HEIGHT TERN(TOUCH_SCREEN, 6, 7)   // Fewer lines with touch buttons onscreen
-#elif HAS_UI_240x320
-  #define LCD_HEIGHT TERN(TOUCH_SCREEN, 8, 6)   // Fewer lines with touch buttons onscreen
+  #if ENABLED(TFT_COLOR_UI_PORTRAIT)
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 6, 7) // Fewer lines with touch buttons onscreen
+  #else
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 8, 9) // Fewer lines with touch buttons onscreen
+  #endif
 #elif HAS_UI_1024x600
   #define LCD_HEIGHT TERN(TOUCH_SCREEN, 12, 13) // Fewer lines with touch buttons onscreen
 #endif


### PR DESCRIPTION
HAS_UI_240x320 -> TFT_COLOR_UI_PORTRAIT

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Changed HAS_UI_240x320 to TFT_COLOR_UI_PORTRAIT. Fix lines count for portrait orientation.
<!--
Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
Any 320x240 TFT screen with TFT_COLOR_UI in portrait mode
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
#25207 
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
