### PR TITLE
Fixed sanity check errors for k8400 config with bl touch

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1808,7 +1808,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
       #error "BLTOUCH requires DEACTIVATE_SERVOS_AFTER_MOVE to be to disabled. Please update your Configuration.h file."
     #endif
 
-    #if HAS_INVERTED_PROBE
+    #if ENABLED(INVERTED_PROBE_STATE)
       #if !Z_MIN_PROBE_ENDSTOP_INVERTING
         #error "BLTOUCH requires Z_MIN_PROBE_ENDSTOP_INVERTING set to true."
       #endif
@@ -1816,7 +1816,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
       #error "BLTOUCH requires Z_MIN_PROBE_ENDSTOP_INVERTING set to false."
     #endif
     #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-      #if HAS_INVERTED_PROBE
+      #if ENABLED(INVERTED_PROBE_STATE)
         #if !Z_MIN_ENDSTOP_INVERTING
           #error "BLTOUCH requires Z_MIN_ENDSTOP_INVERTING set to true."
         #endif
@@ -1848,7 +1848,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #elif !HAS_RESUME_CONTINUE
       #error "TOUCH_MI_PROBE currently requires an LCD controller or EMERGENCY_PARSER."
     #endif
-    #if HAS_INVERTED_PROBE
+    #if ENABLED(INVERTED_PROBE_STATE)
       #if !Z_MIN_PROBE_ENDSTOP_INVERTING
         #error "TOUCH_MI_PROBE requires Z_MIN_PROBE_ENDSTOP_INVERTING set to true."
       #endif
@@ -1856,7 +1856,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
       #error "TOUCH_MI_PROBE requires Z_MIN_PROBE_ENDSTOP_INVERTING set to false."
     #endif
     #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-      #if HAS_INVERTED_PROBE
+      #if ENABLED(INVERTED_PROBE_STATE)
         #if !Z_MIN_ENDSTOP_INVERTING
           #error "TOUCH_MI_PROBE requires Z_MIN_ENDSTOP_INVERTING set to true."
         #endif

--- a/Marlin/src/pins/ramps/pins_K8400.h
+++ b/Marlin/src/pins/ramps/pins_K8400.h
@@ -51,7 +51,7 @@
 #define Y_STOP_PIN                            14
 
 #if EITHER(BLTOUCH, TOUCH_MI_PROBE)
-  #define HAS_INVERTED_PROBE
+#define HAS_INVERTED_PROBE true
 #endif
 
 #include "pins_3DRAG.h" // ... RAMPS

--- a/Marlin/src/pins/ramps/pins_K8400.h
+++ b/Marlin/src/pins/ramps/pins_K8400.h
@@ -51,7 +51,7 @@
 #define Y_STOP_PIN                            14
 
 #if EITHER(BLTOUCH, TOUCH_MI_PROBE)
-#define HAS_INVERTED_PROBE true
+  #define INVERTED_PROBE_STATE
 #endif
 
 #include "pins_3DRAG.h" // ... RAMPS


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

According to this pull request #25085 a sanity check has been added for HAS_INVERTED_PROBE. But in the pins_K8400.h file it is just defined not defined with true creating compilation errors.

### Requirements

Vertex K8400 board. Changes can be tested without it.

### Benefits

Fixes compilation errors when using bl touch on a k8400 board.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/10497266/Configuration.zip)

