### PR TITLE
Fix TOUCH_SCREEN_CALIBRATION Invalid First Point

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -492,6 +492,7 @@ void lv_encoder_pin_init() {
 }
 
 #if 1 // HAS_ENCODER_ACTION
+
   void lv_update_encoder() {
     static uint32_t encoder_time1;
     uint32_t tmpTime, diffTime = 0;
@@ -552,7 +553,7 @@ void lv_encoder_pin_init() {
 
       #endif // HAS_ENCODER_WHEEL
 
-    } // next_button_update_ms
+    } // encoder_time1
   }
 
 #endif // HAS_ENCODER_ACTION

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -152,7 +152,7 @@ void Touch::touch(touch_control_t *control) {
       case CALIBRATE:
         if (touch_calibration.handleTouch(x, y)) ui.refresh();
         break;
-    #endif // TOUCH_SCREEN_CALIBRATION
+    #endif
 
     case MENU_SCREEN: ui.goto_screen((screenFunc_t)control->data); break;
     case BACK: ui.goto_previous_screen(); break;

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -92,6 +92,13 @@ void TouchCalibration::validate_calibration() {
 bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
   static millis_t next_button_update_ms = 0;
   const millis_t now = millis();
+
+  // Avoid registering first touch point as top-left corner when initiating touch calibration since user is touching TFT
+  if (next_button_update_ms == 0) {
+    next_button_update_ms = now + BUTTON_DELAY_MENU;
+    return true;
+  }
+
   if (PENDING(now, next_button_update_ms)) return false;
   next_button_update_ms = now + BUTTON_DELAY_MENU;
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -41,7 +41,7 @@ touch_calibration_t TouchCalibration::calibration;
 calibrationState TouchCalibration::calibration_state = CALIBRATION_NONE;
 touch_calibration_point_t TouchCalibration::calibration_points[4];
 uint8_t TouchCalibration::failed_count;
-millis_t TouchCalibration::next_button_update_ms; // = 0;
+millis_t TouchCalibration::next_touch_update_ms; // = 0;
 
 void TouchCalibration::validate_calibration() {
   #define VALIDATE_PRECISION(XY, A, B) validate_precision_##XY(CALIBRATION_##A, CALIBRATION_##B)
@@ -91,16 +91,10 @@ void TouchCalibration::validate_calibration() {
 }
 
 bool TouchCalibration::handleTouch(const uint16_t x, const uint16_t y) {
-  const millis_t now = millis(), next_ms = next_button_update_ms;
+  const millis_t now = millis();
 
-  if (next_ms && PENDING(now, next_ms)) return false;
-  next_button_update_ms = now + BUTTON_DELAY_MENU;
-
-  // Ignore the first touch because it was probably the one that entered the screen
-  if (!next_ms) {
-    next_button_update_ms += 500;
-    return true;
-  }
+  if (next_touch_update_ms && PENDING(now, next_touch_update_ms)) return false;
+  next_touch_update_ms = now + BUTTON_DELAY_MENU;
 
   if (calibration_state < CALIBRATION_SUCCESS) {
     calibration_points[calibration_state].raw_x = x;

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -57,7 +57,7 @@ class TouchCalibration {
 public:
   static calibrationState calibration_state;
   static touch_calibration_point_t calibration_points[4];
-  static millis_t next_button_update_ms;
+  static millis_t next_touch_update_ms;
 
   static bool validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
   static bool validate_precision_x(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_x, calibration_points[b].raw_x); }
@@ -70,7 +70,7 @@ public:
   static bool need_calibration() { return !calibration.offset_x && !calibration.offset_y && !calibration.x && !calibration.y; }
 
   static calibrationState calibration_start() {
-    next_button_update_ms = 0;
+    next_touch_update_ms = millis() + 750UL;
     calibration = { 0, 0, 0, 0, TOUCH_ORIENTATION_NONE };
     calibration_state = CALIBRATION_TOP_LEFT;
     calibration_points[CALIBRATION_TOP_LEFT].x = 30;

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -57,6 +57,7 @@ class TouchCalibration {
 public:
   static calibrationState calibration_state;
   static touch_calibration_point_t calibration_points[4];
+  static millis_t next_button_update_ms;
 
   static bool validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
   static bool validate_precision_x(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_x, calibration_points[b].raw_x); }
@@ -64,11 +65,12 @@ public:
   static void validate_calibration();
 
   static touch_calibration_t calibration;
-  static uint8_t             failed_count;
+  static uint8_t failed_count;
   static void calibration_reset() { calibration = { TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION }; }
   static bool need_calibration() { return !calibration.offset_x && !calibration.offset_y && !calibration.x && !calibration.y; }
 
   static calibrationState calibration_start() {
+    next_button_update_ms = 0;
     calibration = { 0, 0, 0, 0, TOUCH_ORIENTATION_NONE };
     calibration_state = CALIBRATION_TOP_LEFT;
     calibration_points[CALIBRATION_TOP_LEFT].x = 30;
@@ -89,7 +91,7 @@ public:
     return !need_calibration();
   }
 
-  static bool handleTouch(uint16_t x, uint16_t y);
+  static bool handleTouch(const uint16_t x, const uint16_t y);
 };
 
 extern TouchCalibration touch_calibration;

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -91,7 +91,7 @@ uint8_t TouchButtons::read_buttons() {
         y = uint16_t((uint32_t(y) * TOUCH_CALIBRATION_Y) >> 16) + TOUCH_OFFSET_Y;
       #endif
     #elif ENABLED(TFT_TOUCH_DEVICE_GT911)
-      bool is_touched = (TOUCH_ORIENTATION == TOUCH_PORTRAIT ? touchIO.getPoint(&y, &x) : touchIO.getPoint(&x, &y));
+      const bool is_touched = (TOUCH_ORIENTATION == TOUCH_PORTRAIT ? touchIO.getPoint(&y, &x) : touchIO.getPoint(&x, &y));
       if (!is_touched) return 0;
     #endif
 


### PR DESCRIPTION
### Description

Avoid registering first touch point as top-left corner when initiating touch calibration since user is touching TFT.

h/t to @larik008 for the fix.

### Requirements

Any Marlin-managed TFT with `TOUCH_SCREEN` & `TOUCH_SCREEN_CALIBRATION`.

### Benefits

Touch screen calibration will work correctly.

### Configurations

- [/config/examples/Anet/ET5X/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Anet/ET5X)
- [/config/examples/BIQU/B1 SE Plus/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/BIQU/B1%20SE%20Plus)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/21860
