### PR TITLE
config.ini fetch examples fix

### DIFF
--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -5,7 +5,7 @@
 import re, shutil, configparser
 from pathlib import Path
 
-verbose = 0
+verbose = 2
 def blab(str,level=1):
     if verbose >= level: print(f"[config] {str}")
 
@@ -85,13 +85,12 @@ def apply_opt(name, val, conf=None):
 # Return True if any files were fetched.
 def fetch_example(url):
     if url.endswith("/"): url = url[:-1]
-    if url.startswith('http'):
-        url = url.replace("%", "%25").replace(" ", "%20")
-    else:
+    if not url.startswith('http'):
         brch = "bugfix-2.1.x"
-        if '@' in path: path, brch = map(str.strip, path.split('@'))
+        if '@' in url: url, brch = map(str.strip, url.split('@'))
         url = f"https://raw.githubusercontent.com/MarlinFirmware/Configurations/{brch}/config/{url}"
-
+    url = url.replace("%", "%25").replace(" ", "%20")
+ 
     # Find a suitable fetch command
     if shutil.which("curl") is not None:
         fetch = "curl -L -s -S -f -o"

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -5,7 +5,7 @@
 import re, shutil, configparser
 from pathlib import Path
 
-verbose = 2
+verbose = 0
 def blab(str,level=1):
     if verbose >= level: print(f"[config] {str}")
 


### PR DESCRIPTION
### Description

Using config.ini to fetch example configurations was failing for two reasons:

1. in configuration.py, the function fetch_example had an undefined and unnecessary variable called "path". It should be "url"
2. in the same function, only some URLs would be properly escaped for spaces and percent signs. 


### Requirements

This PR does not require a specific board, only a config.ini file with `ini_use_config` contains a URL or `example/...'

### Benefits

Enables examples configurations to be fetched so that config.ini can only contain overrides from defaults.

### Configurations


### Related Issues

