### PR TITLE
Adding support for LCD for Melzi v4 to BTT SKR Mini E3

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -172,6 +172,26 @@
     #define LCD_PINS_ENABLE          EXP1_08_PIN
     #define LCD_PINS_D4              EXP1_06_PIN
 
+  #elif ENABLED(LCD_FOR_MELZI)
+
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! LCD for Melzi v4 display requires a custom cable. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
+   /*   ***** LCD for Melzi v4 needs a custom cable with reversed GND/5V pins; plugging in a standard cable may damage the board or LCD!
+    * 
+    * 1. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
+    * 2. Swap pin 4 on the Melzi LCD to pin 7 on the SKR Mini E3 EXP1 connector (pin 4 on the SKR is a reset and cannot be used)
+    */
+    #define BEEPER_PIN               EXP1_08_PIN
+    #define BTN_ENC                  EXP1_06_PIN
+
+    #define BTN_EN1                  EXP1_02_PIN
+    #define BTN_EN2                  EXP1_07_PIN
+
+    #define LCD_PINS_RS              EXP1_01_PIN
+    #define LCD_PINS_ENABLE          EXP1_03_PIN
+    #define LCD_PINS_D4              EXP1_05_PIN
+  
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
     #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
@@ -306,7 +326,7 @@
     #define FORCE_SOFT_SPI
 
   #else
-    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, TFTGLCD_PANEL_(SPI|I2C), FYSETC_MINI_12864_2_1, MKS_MINI_12864_V3, and BTT_MINI_12864_V1 are currently supported on the BIGTREE_SKR_MINI_E3."
+    #error "Only CR10_STOCKDISPLAY, LCD_FOR_MELZI, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, TFTGLCD_PANEL_(SPI|I2C), FYSETC_MINI_12864_2_1, MKS_MINI_12864_V3, and BTT_MINI_12864_V1 are currently supported on the BIGTREE_SKR_MINI_E3."
   #endif
 
 #endif // HAS_WIRED_LCD

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -163,8 +163,8 @@
   #if ENABLED(CR10_STOCKDISPLAY)
 
     #define BEEPER_PIN               EXP1_01_PIN
-    #define BTN_ENC                  EXP1_02_PIN
 
+    #define BTN_ENC                  EXP1_02_PIN
     #define BTN_EN1                  EXP1_03_PIN
     #define BTN_EN2                  EXP1_05_PIN
 
@@ -177,21 +177,22 @@
     #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
       #error "CAUTION! LCD for Melzi v4 display requires a custom cable. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
     #endif
-   /*   ***** LCD for Melzi v4 needs a custom cable with reversed GND/5V pins; plugging in a standard cable may damage the board or LCD!
-    * 
-    * 1. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
-    * 2. Swap pin 4 on the Melzi LCD to pin 7 on the SKR Mini E3 EXP1 connector (pin 4 on the SKR is a reset and cannot be used)
-    */
-    #define BEEPER_PIN               EXP1_08_PIN
-    #define BTN_ENC                  EXP1_06_PIN
 
+    /**
+     * LCD for Melzi v4 needs a custom cable with reversed GND/5V pins; plugging in a standard cable may damage the board or LCD!
+     *  1. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
+     *  2. Swap pin 4 on the Melzi LCD to pin 7 on the SKR Mini E3 EXP1 connector (pin 4 on the SKR is a reset and cannot be used)
+     */
+    #define BEEPER_PIN               EXP1_08_PIN
+
+    #define BTN_ENC                  EXP1_06_PIN
     #define BTN_EN1                  EXP1_02_PIN
     #define BTN_EN2                  EXP1_07_PIN
 
     #define LCD_PINS_RS              EXP1_01_PIN
     #define LCD_PINS_ENABLE          EXP1_03_PIN
     #define LCD_PINS_D4              EXP1_05_PIN
-  
+
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
     #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -181,7 +181,17 @@
     /**
      * LCD for Melzi v4 needs a custom cable with reversed GND/5V pins; plugging in a standard cable may damage the board or LCD!
      *  1. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
-     *  2. Swap pin 4 on the Melzi LCD to pin 7 on the SKR Mini E3 EXP1 connector (pin 4 on the SKR is a reset and cannot be used)
+     *  2. Swap pin 4 on the Melzi LCD to pin 7 on the SKR Mini E3 EXP1 connector (pin 4 on the SKR is a RESET and cannot be used)
+     *
+     *       LCD for Melzi V4         SKR Mini E3 V2.0
+     *            ------                   ------
+     *    LCD RS | 1  2 | EN1      LCD RS | 1  2 | EN1
+     *    LCD EN | 3  4 | EN2      LCD EN | 3  4 | OPEN (RESET)
+     *    LCD D4 | 5  6 | ENC      LCD D4 | 5  6 | ENC
+     *    E-Stop | 7  8 | BEEP        EN2 | 7  8 | BEEP
+     *        5V | 9 10 | GND         GND | 9 10 | 5V
+     *            ------                   ------
+     *             EXP1                     EXP1
      */
     #define BEEPER_PIN               EXP1_08_PIN
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This adds support to the BigTreeTech SKR Mini E3 for the "LCD for Melzi v4" screen and rotary knob as found on the Monoprice Maker Select v1.  It may be compatible with other printers that also feature the LCD for Melzi v4.

This LCD requires a custom cable, as 5V and GND are switched in the LCD connector relative to the SKR.  Thanks to [JacobIpsen](https://reprap.org/forum/profile.php?415,82589)'s work for figuring out most of the pinout on the LCD.  Pin 4 on the LCD should connect to pin 7 on the SKR (leaving SKR pin 4 open), and pins 10 and 9 should be swapped:

```
  /** LCD for Melzi V4  display pinout                         SKR Mini E3 V2.0 pinout
     *                   _____                                      _____
     *              GND |10 9 | 5V                              5V |10 9 | GND
     *             Buzz | 8 7 | e-Stop                        Buzz | 8 7 | Encoder ENC-EN2
     *  Encoder ENC     | 6 5 | Display D4         Encoder ENC     | 6 5 | Display D4
     *  Encoder ENC-EN2 | 4 3 | Display Enable        OPEN (reset) | 4 3 | Display Enable
     *  Encoder ENC-EN1 | 2 1 | Display RS         Encoder ENC-EN1 | 2 1 | Display RS
     *                   -----                                      -----
     *                    EXP1                                       EXP1
     */
```

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
This PR is specifically for the BigTreeTech SKR Mini E3 V2.0 and the LCD for Melzi v4.  It may be compatible with other SKR Mini variants and other Wanhao i3 clones.

A custom LCD cable is required.

### Benefits

<!-- What does this PR fix or improve? -->
Allows upgrade of the Monoprice Maker Select v1 to a new 32-bit control board.

### Configurations
[Configurations.zip](https://github.com/MarlinFirmware/Marlin/files/10541724/Configurations.zip)

Full working build for my Monoprice Maker Select v1 is [available here](https://github.com/kg333/Marlin/tree/kg333_skr_mini_e3_v2.0_monoprice), based on Marlin 2.1.2.

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
N/A
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
