### PR TITLE
White-space fix for Marlin FW automated test shell scripts

### DIFF
--- a/buildroot/bin/run_tests
+++ b/buildroot/bin/run_tests
@@ -67,7 +67,7 @@ else
       printf "\033[0;32mMatching test \033[0m#$3\033[0;32m: '\033[0m$test_name\033[0;32m'\n"
     fi
   fi
-  $TESTS/$2 $1 $2 "$test_name"
+  "$TESTS/$2" $1 $2 "$test_name"
   if [[ $GIT_RESET_HARD == "true" ]]; then
     git reset --hard HEAD
   else


### PR DESCRIPTION
### Description

During local testing of mks_tinybee build test target using the test-single-ci Makefile target on Linux I found out that tests fail if the repository is placed under a path that contains whitespace. This is a potential reliability issue for the future. Thus I suggest to fix it.

### Benefits

More reliability for the Marlin FW building and testing workflows.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/25327
