### PR TITLE
Support Dual SPI endstops on X and Y

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -1339,6 +1339,12 @@ void Endstops::update() {
         SBI(live_state, X_ENDSTOP);
         hit = true;
       }
+      #if ENABLED(X_DUAL_ENDSTOPS)
+	      if (tmc_spi_homing.x && (stepperX2.test_stall_status())) {
+          SBI(live_state, X2_ENDSTOP);
+          hit = true;
+        }
+      #endif
     #endif
     #if Y_SPI_SENSORLESS
       if (tmc_spi_homing.y && (stepperY.test_stall_status()
@@ -1351,6 +1357,12 @@ void Endstops::update() {
         SBI(live_state, Y_ENDSTOP);
         hit = true;
       }
+      #if ENABLED(Y_DUAL_ENDSTOPS)
+	      if (tmc_spi_homing.y && (stepperY2.test_stall_status())) {
+          SBI(live_state, Y2_ENDSTOP);
+          hit = true;
+        }
+      #endif
     #endif
     #if Z_SPI_SENSORLESS
       if (tmc_spi_homing.z && (stepperZ.test_stall_status()
@@ -1416,6 +1428,12 @@ void Endstops::update() {
     TERN_(U_SPI_SENSORLESS, CBI(live_state, U_ENDSTOP));
     TERN_(V_SPI_SENSORLESS, CBI(live_state, V_ENDSTOP));
     TERN_(W_SPI_SENSORLESS, CBI(live_state, W_ENDSTOP));
+    #if ENABLED(X_DUAL_ENDSTOPS)
+      TERN_(X_SPI_SENSORLESS, CBI(live_state, X2_ENDSTOP));
+    #endif
+    #if ENABLED(Y_DUAL_ENDSTOPS)
+      TERN_(Y_SPI_SENSORLESS, CBI(live_state, Y2_ENDSTOP));
+    #endif
   }
 
 #endif // SPI_ENDSTOPS

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -1330,87 +1330,54 @@ void Endstops::update() {
     bool hit = false;
     #if X_SPI_SENSORLESS
       if (tmc_spi_homing.x && (stepperX.test_stall_status()
-        #if ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX) && Y_SPI_SENSORLESS
+        #if Y_SPI_SENSORLESS && ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
           || stepperY.test_stall_status()
-        #elif CORE_IS_XZ && Z_SPI_SENSORLESS
+        #elif Z_SPI_SENSORLESS && CORE_IS_XZ
           || stepperZ.test_stall_status()
         #endif
-      )) {
-        SBI(live_state, X_ENDSTOP);
-        hit = true;
-      }
+      )) { SBI(live_state, X_ENDSTOP); hit = true; }
       #if ENABLED(X_DUAL_ENDSTOPS)
-	      if (tmc_spi_homing.x && (stepperX2.test_stall_status())) {
-          SBI(live_state, X2_ENDSTOP);
-          hit = true;
-        }
+	      if (tmc_spi_homing.x && stepperX2.test_stall_status()) { SBI(live_state, X2_ENDSTOP); hit = true; }
       #endif
     #endif
     #if Y_SPI_SENSORLESS
       if (tmc_spi_homing.y && (stepperY.test_stall_status()
-        #if ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX) && X_SPI_SENSORLESS
+        #if X_SPI_SENSORLESS && ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
           || stepperX.test_stall_status()
-        #elif CORE_IS_YZ && Z_SPI_SENSORLESS
+        #elif Z_SPI_SENSORLESS && CORE_IS_YZ
           || stepperZ.test_stall_status()
         #endif
-      )) {
-        SBI(live_state, Y_ENDSTOP);
-        hit = true;
-      }
+      )) { SBI(live_state, Y_ENDSTOP); hit = true; }
       #if ENABLED(Y_DUAL_ENDSTOPS)
-	      if (tmc_spi_homing.y && (stepperY2.test_stall_status())) {
-          SBI(live_state, Y2_ENDSTOP);
-          hit = true;
-        }
+	      if (tmc_spi_homing.y && stepperY2.test_stall_status()) { SBI(live_state, Y2_ENDSTOP); hit = true; }
       #endif
     #endif
     #if Z_SPI_SENSORLESS
       if (tmc_spi_homing.z && (stepperZ.test_stall_status()
-        #if CORE_IS_XZ && X_SPI_SENSORLESS
+        #if X_SPI_SENSORLESS && CORE_IS_XZ
           || stepperX.test_stall_status()
-        #elif CORE_IS_YZ && Y_SPI_SENSORLESS
+        #elif Y_SPI_SENSORLESS && CORE_IS_YZ
           || stepperY.test_stall_status()
         #endif
-      )) {
-        SBI(live_state, Z_ENDSTOP);
-        hit = true;
-      }
+      )) { SBI(live_state, Z_ENDSTOP); hit = true; }
     #endif
     #if I_SPI_SENSORLESS
-      if (tmc_spi_homing.i && stepperI.test_stall_status()) {
-        SBI(live_state, I_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.i && stepperI.test_stall_status()) { SBI(live_state, I_ENDSTOP); hit = true; }
     #endif
     #if J_SPI_SENSORLESS
-      if (tmc_spi_homing.j && stepperJ.test_stall_status()) {
-        SBI(live_state, J_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.j && stepperJ.test_stall_status()) { SBI(live_state, J_ENDSTOP); hit = true; }
     #endif
     #if K_SPI_SENSORLESS
-      if (tmc_spi_homing.k && stepperK.test_stall_status()) {
-        SBI(live_state, K_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.k && stepperK.test_stall_status()) { SBI(live_state, K_ENDSTOP); hit = true; }
     #endif
     #if U_SPI_SENSORLESS
-      if (tmc_spi_homing.u && stepperU.test_stall_status()) {
-        SBI(live_state, U_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.u && stepperU.test_stall_status()) { SBI(live_state, U_ENDSTOP); hit = true; }
     #endif
     #if V_SPI_SENSORLESS
-      if (tmc_spi_homing.v && stepperV.test_stall_status()) {
-        SBI(live_state, V_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.v && stepperV.test_stall_status()) { SBI(live_state, V_ENDSTOP); hit = true; }
     #endif
     #if W_SPI_SENSORLESS
-      if (tmc_spi_homing.w && stepperW.test_stall_status()) {
-        SBI(live_state, W_ENDSTOP);
-        hit = true;
-      }
+      if (tmc_spi_homing.w && stepperW.test_stall_status()) { SBI(live_state, W_ENDSTOP); hit = true; }
     #endif
 
     if (TERN0(ENDSTOP_INTERRUPTS_FEATURE, hit)) update();
@@ -1420,7 +1387,13 @@ void Endstops::update() {
 
   void Endstops::clear_endstop_state() {
     TERN_(X_SPI_SENSORLESS, CBI(live_state, X_ENDSTOP));
+    #if BOTH(X_SPI_SENSORLESS, X_DUAL_ENDSTOPS)
+      CBI(live_state, X2_ENDSTOP);
+    #endif
     TERN_(Y_SPI_SENSORLESS, CBI(live_state, Y_ENDSTOP));
+    #if BOTH(Y_SPI_SENSORLESS, Y_DUAL_ENDSTOPS)
+      CBI(live_state, Y2_ENDSTOP);
+    #endif
     TERN_(Z_SPI_SENSORLESS, CBI(live_state, Z_ENDSTOP));
     TERN_(I_SPI_SENSORLESS, CBI(live_state, I_ENDSTOP));
     TERN_(J_SPI_SENSORLESS, CBI(live_state, J_ENDSTOP));
@@ -1428,12 +1401,6 @@ void Endstops::update() {
     TERN_(U_SPI_SENSORLESS, CBI(live_state, U_ENDSTOP));
     TERN_(V_SPI_SENSORLESS, CBI(live_state, V_ENDSTOP));
     TERN_(W_SPI_SENSORLESS, CBI(live_state, W_ENDSTOP));
-    #if ENABLED(X_DUAL_ENDSTOPS)
-      TERN_(X_SPI_SENSORLESS, CBI(live_state, X2_ENDSTOP));
-    #endif
-    #if ENABLED(Y_DUAL_ENDSTOPS)
-      TERN_(Y_SPI_SENSORLESS, CBI(live_state, Y2_ENDSTOP));
-    #endif
   }
 
 #endif // SPI_ENDSTOPS

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -85,9 +85,15 @@ enum EndstopEnum : char {
   // Endstops can be either MIN or MAX but not both
   #if HAS_X_MIN || HAS_X_MAX
     , X_ENDSTOP = TERN(X_HOME_TO_MAX, X_MAX, X_MIN)
+    #if ENABLED(X_DUAL_ENDSTOPS)
+	  , X2_ENDSTOP = TERN(X_HOME_TO_MAX, X2_MAX, X2_MIN)
+    #endif
   #endif
   #if HAS_Y_MIN || HAS_Y_MAX
     , Y_ENDSTOP = TERN(Y_HOME_TO_MAX, Y_MAX, Y_MIN)
+    #if ENABLED(Y_DUAL_ENDSTOPS)
+      , Y2_ENDSTOP = TERN(Y_HOME_TO_MAX, Y2_MAX, Y2_MIN)
+    #endif
   #endif
   #if HAS_Z_MIN || HAS_Z_MAX || HOMING_Z_WITH_PROBE
     , Z_ENDSTOP = TERN(Z_HOME_TO_MAX, Z_MAX, TERN(HOMING_Z_WITH_PROBE, Z_MIN_PROBE, Z_MIN))

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -86,7 +86,7 @@ enum EndstopEnum : char {
   #if HAS_X_MIN || HAS_X_MAX
     , X_ENDSTOP = TERN(X_HOME_TO_MAX, X_MAX, X_MIN)
     #if ENABLED(X_DUAL_ENDSTOPS)
-	  , X2_ENDSTOP = TERN(X_HOME_TO_MAX, X2_MAX, X2_MIN)
+	    , X2_ENDSTOP = TERN(X_HOME_TO_MAX, X2_MAX, X2_MIN)
     #endif
   #endif
   #if HAS_Y_MIN || HAS_Y_MAX


### PR DESCRIPTION
### Description

If you are using X_DUAL_ENDSTOPS and/or Y_DUAL_ENDSTOPS together with SPI_ENDSTOPS and SENSORLESS_HOMING, homing fails. This PR adds support for this scenario.

### Requirements

You need TMC drivers that support sensorless homing and SPI endstops (TMC2130 or TMC5160).

### Benefits

Supports dual sensorless endstops on X and/or Y together with SPI endstops.

### Configurations
[configurations.zip](https://github.com/MarlinFirmware/Marlin/files/10716188/configurations.zip)

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24155