### PR TITLE
Fixed typo in Marlin main README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Marlin is optimized to build with the **PlatformIO IDE** extension for **Visual 
 
 Marlin includes an abstraction layer to provide a common API for all the platforms it targets. This allows Marlin code to address the details of motion and user interface tasks at the lowest and highest levels with no system overhead, tying all events directly to the hardware clock.
 
-Every new HAL opens up a world of hardware. At this time we need HALs for RP2040 and the Duet3D family of boards. A HAL that wraps an RTOS is an interesting concept we would can explore. Did you know that Marlin includes a Simulator that can run on Windows, macOS, and Linux? Join the Discord to help move these sub-projects forward!
+Every new HAL opens up a world of hardware. At this time we need HALs for RP2040 and the Duet3D family of boards. A HAL that wraps an RTOS is an interesting concept that could be explored. Did you know that Marlin includes a Simulator that can run on Windows, macOS, and Linux? Join the Discord to help move these sub-projects forward!
 
 ## 8-Bit AVR Boards
 


### PR DESCRIPTION
HAL (Hardware Abstraction Layer) had a typo in the section talking about a HAL wrapping an RTOS.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
---
A screenshot of the typo:
<img width="869" alt="Screenshot 2023-02-15 at 4 06 26 PM" src="https://user-images.githubusercontent.com/47619990/219165149-602158d2-9b42-408d-9a52-7ee80862b7a7.png">


### Fix
---
The sentence has been reformatted to:
"A HAL that wraps an RTOS is an interesting concept that could be explored."
