### PR TITLE
update VIKI2 SPI pins on Re-ARM

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -354,8 +354,8 @@
   #if EITHER(VIKI2, miniVIKI)
     #define DOGLCD_CS                      P0_16  // (16)
     #define DOGLCD_A0                      P2_06  // (59) J3-8 & AUX-2
-    #define DOGLCD_SCK                SD_SCK_PIN
-    #define DOGLCD_MOSI              SD_MOSI_PIN
+    #define DOGLCD_SCK                     P0_15  // (52) (SCK)  J3-9 & AUX-3
+    #define DOGLCD_MOSI                    P0_18  // (51) (MOSI) J3-10 & AUX-3
 
     #define STAT_LED_BLUE_PIN              P0_26  // (63)  may change if cable changes
     #define STAT_LED_RED_PIN               P1_21  // ( 6)  may change if cable changes


### PR DESCRIPTION
### Description

SPI pins used for VIKI2 on Re-ARM uses SD CLK and SD MOSI, this works when SD_CONNECTION_IS(LCD), but stops the LCD working when SD_CONNECTION_IS(ONBOARD).

The LCD SPI pins should not be tied to the SD SPI pins. 

Updated Pin to be independent of SD SPI pins.

### Requirements

Re-ARM
VIKI2 LCD
SDCARD_CONNECTION ONBOARD

### Benefits

VIKI2 LCD with SDCARD_CONNECTION ONBOARD or SDCARD_CONNECTION LCD works as expected

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/25410