### PR TITLE
Minor flash memory optimization in `edit_screen()`

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -117,8 +117,7 @@ void MenuEditItemBase::edit_screen(strfunc_t strfunc, loadfunc_t loadfunc) {
   // Reset repeat_delay for Touch Buttons
   TERN_(HAS_TOUCH_BUTTONS, ui.repeat_delay = BUTTON_DELAY_EDIT);
   // Constrain ui.encoderPosition to 0 ... maxEditValue (calculated in encoder steps)
-  if (int32_t(ui.encoderPosition) < 0) ui.encoderPosition = 0;
-  if (int32_t(ui.encoderPosition) > maxEditValue) ui.encoderPosition = maxEditValue;
+  ui.encoderPosition = constrain(int32_t(ui.encoderPosition), 0, maxEditValue);
   // If drawing is flagged then redraw the (whole) edit screen
   if (ui.should_draw())
     draw_edit_screen(strfunc(ui.encoderPosition + minEditValue));


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

If the first if-statement `int32_t(ui.encoderPosition) < 0` is true, then there is no need to check the 2nd if-statement `int32_t(ui.encoderPosition) > maxEditValue`. Using `constrain()` makes the code a little bit cleaner, I see its used a bit throughout the Marlin codebase so I think it's fine to use here :) 

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

No specific requirements.

### Benefits

<!-- What does this PR fix or improve? -->
This PR reduces code size a little bit in `edit_screen()`
On the Rambo target, changes save 26 bytes of flash memory.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
