### PR TITLE
LCD_BACKLIGHT_TIMEOUT support for neopixel LCDs.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3404,6 +3404,7 @@
   //#define NEOPIXEL_BKGD_INDEX_FIRST   0 // Index of the first background LED
   //#define NEOPIXEL_BKGD_INDEX_LAST    5 // Index of the last background LED
   //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 }  // R, G, B, W
+  //#define NEOPIXEL_BKGD_TIMEOUT_COLOR { 25, 25, 25, 0} // R, G, B, W
   //#define NEOPIXEL_BKGD_ALWAYS_ON       // Keep the backlight on when other NeoPixels are off
 #endif
 

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -53,7 +53,19 @@ Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIX
     constexpr uint8_t background_color[4] = NEOPIXEL_BKGD_COLOR;
     set_background_color(background_color);
   }
-
+  
+  #ifdef NEOPIXEL_BKGD_TIMEOUT_COLOR
+   void Marlin_NeoPixel::set_background_off() {
+      constexpr uint8_t background_color_off[4] = NEOPIXEL_BKGD_TIMEOUT_COLOR;
+      set_background_color(background_color_off);
+    }
+  #else
+    void Marlin_NeoPixel::set_background_off() {
+      constexpr uint8_t background_color_off[4] = { 0, 0, 0, 0};
+      set_background_color(background_color_off);
+    }
+  #endif
+   
 #endif
 
 void Marlin_NeoPixel::set_color(const uint32_t color) {

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -91,6 +91,11 @@ public:
     static void set_background_color(const uint8_t r, const uint8_t g, const uint8_t b, const uint8_t w);
     static void set_background_color(const uint8_t (&rgbw)[4]) { set_background_color(rgbw[0], rgbw[1], rgbw[2], rgbw[3]); }
     static void reset_background_color();
+    
+    #ifdef LCD_BACKLIGHT_TIMEOUT_MINS
+      static void set_background_off();
+    #endif
+
   #endif
 
   static void begin() {

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3237,8 +3237,16 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE, "Movement bounds (X_MIN_POS, X_MAX_POS
 #if LCD_BACKLIGHT_TIMEOUT_MINS
   #if !HAS_ENCODER_ACTION
     #error "LCD_BACKLIGHT_TIMEOUT_MINS requires an LCD with encoder or keypad."
-  #elif !PIN_EXISTS(LCD_BACKLIGHT)
-    #error "LCD_BACKLIGHT_TIMEOUT_MINS requires LCD_BACKLIGHT_PIN."
+  #elif ENABLED(NEOPIXEL_BKGD_INDEX_FIRST)
+    #if PIN_EXISTS(LCD_BACKLIGHT_PIN)
+      #error "LCD_BACKLIGHT_PIN and NEOPIXEL_BKGD_INDEX_FIRST are not supported at the same time."
+    #elif ENABLED(NEOPIXEL_BKGD_ALWAYS_ON)
+      #error "LCD_BACKLIGHT_TIMEOUT is not compatible with NEOPIXEL_BKGD_ALWAYS_ON."
+    #endif
+  #elif !PIN_EXISTS(LCD_BACKLIGHT_PIN)
+    #ifndef NEOPIXEL_BKGD_INDEX_FIRST
+      #error "LCD_BACKLIGHT_TIMEOUT_MINS requires either LCD_BACKLIGHT_PIN or NEOPIXEL_BKGD_INDEX_FIRST."
+    #endif
   #endif
 #endif
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -24,7 +24,7 @@
 
 #include "../MarlinCore.h" // for printingIsPaused
 
-#if LED_POWEROFF_TIMEOUT > 0 || BOTH(HAS_WIRED_LCD, PRINTER_EVENT_LEDS)
+#if LED_POWEROFF_TIMEOUT > 0 || BOTH(HAS_WIRED_LCD, PRINTER_EVENT_LEDS) || ENABLED(LCD_BACKLIGHT_TIMEOUT_MINS)
   #include "../feature/leds/leds.h"
 #endif
 
@@ -189,10 +189,22 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 
   uint8_t MarlinUI::backlight_timeout_minutes; // Initialized by settings.load()
   millis_t MarlinUI::backlight_off_ms = 0;
-  void MarlinUI::refresh_backlight_timeout() {
-    backlight_off_ms = backlight_timeout_minutes ? millis() + backlight_timeout_minutes * 60UL * 1000UL : 0;
-    WRITE(LCD_BACKLIGHT_PIN, HIGH);
-  }
+
+  #ifdef NEOPIXEL_BKGD_INDEX_FIRST
+
+    void MarlinUI::refresh_backlight_timeout() {
+      backlight_off_ms = backlight_timeout_minutes ? millis() + backlight_timeout_minutes * 60UL * 1000UL : 0;
+      neo.reset_background_color();
+      neo.show();
+    }
+  
+  #elif PIN_EXISTS(LCD_BACKLIGHT_PIN)
+
+      void MarlinUI::refresh_backlight_timeout() {
+      backlight_off_ms = backlight_timeout_minutes ? millis() + backlight_timeout_minutes * 60UL * 1000UL : 0;
+      WRITE(LCD_BACKLIGHT_PIN, HIGH);
+    }
+  #endif
 
 #elif HAS_DISPLAY_SLEEP
 
@@ -1196,10 +1208,18 @@ void MarlinUI::init() {
       #endif
 
       #if LCD_BACKLIGHT_TIMEOUT_MINS
-        if (backlight_off_ms && ELAPSED(ms, backlight_off_ms)) {
-          WRITE(LCD_BACKLIGHT_PIN, LOW); // Backlight off
-          backlight_off_ms = 0;
-        }
+        #ifdef NEOPIXEL_BKGD_INDEX_FIRST
+          if (backlight_off_ms && ELAPSED(ms, backlight_off_ms)) {
+           neo.set_background_off();  // Backlight off
+           neo.show();
+           backlight_off_ms = 0;
+          }
+        #elif PIN_EXISTS(LCD_BACKLIGHT_PIN)
+          if (backlight_off_ms && ELAPSED(ms, backlight_off_ms)) {
+            WRITE(LCD_BACKLIGHT_PIN, LOW); // Backlight off
+            backlight_off_ms = 0;
+          }
+        #endif
       #elif HAS_DISPLAY_SLEEP
         if (screen_timeout_millis && ELAPSED(ms, screen_timeout_millis))
           sleep_display();


### PR DESCRIPTION
### Description

- Added LCD_BACKLIGHT_TIMEOUT support for LCDs with neopixel backlight, like the Bigtreetech 12864, or Fysetch 12864 variants.
- User can define a custom timeouted neopixel color. If not defined, the default is {0,0,0,0}.

### Requirements

Any LCD with Neopixel backlight.

### Related Issues

#25406 
