### PR TITLE
🩹 Native types for RTS overloads

### DIFF
--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
@@ -92,7 +92,7 @@ namespace ExtUI {
     DWIN_SERIAL.begin(115200);
     rtscheck.recdat.head[0] = rtscheck.snddat.head[0] = FHONE;
     rtscheck.recdat.head[1] = rtscheck.snddat.head[1] = FHTWO;
-    memset(rtscheck.databuf, 0, sizeof(rtscheck.databuf));
+    ZERO(rtscheck.databuf);
 
     delay_ms(TERN(DWINOS_4, 1500, 500)); // Delay to allow screen startup
     SetTouchScreenConfiguration();
@@ -206,7 +206,7 @@ namespace ExtUI {
 
     if (waitway_lock > 100) {
       waitway_lock = 0;
-      waitway      = 0; // clear waitway if nothing is going on
+      waitway = 0; // clear waitway if nothing is going on
     }
 
     switch (waitway) {
@@ -416,7 +416,7 @@ namespace ExtUI {
   RTSSHOW::RTSSHOW() {
     recdat.head[0] = snddat.head[0] = FHONE;
     recdat.head[1] = snddat.head[1] = FHTWO;
-    memset(databuf, 0, sizeof(databuf));
+    ZERO(databuf);
   }
 
   int16_t RTSSHOW::RTS_RecData() {
@@ -494,8 +494,8 @@ namespace ExtUI {
     return -1;
   }
 
-  void RTSSHOW::RTS_SndData(void) {
-    if ((snddat.head[0] == FHONE) && (snddat.head[1] == FHTWO) && snddat.len >= 3) {
+  void RTSSHOW::RTS_SndData() {
+    if (snddat.head[0] == FHONE && snddat.head[1] == FHTWO && snddat.len >= 3) {
       databuf[0] = snddat.head[0];
       databuf[1] = snddat.head[1];
       databuf[2] = snddat.len;
@@ -527,7 +527,7 @@ namespace ExtUI {
       }
 
       memset(&snddat, 0, sizeof(snddat));
-      memset(databuf, 0, sizeof(databuf));
+      ZERO(databuf);
       snddat.head[0] = FHONE;
       snddat.head[1] = FHTWO;
     }
@@ -539,7 +539,6 @@ namespace ExtUI {
   }
 
   void RTSSHOW::RTS_SndData(const char *str, uint32_t addr, uint8_t cmd/*=VarAddr_W*/) {
-
     int16_t len = strlen(str);
     constexpr int16_t maxlen = SizeofDatabuf - 6;
     if (len > 0) {
@@ -556,25 +555,29 @@ namespace ExtUI {
         DWIN_SERIAL.write(databuf[i]);
         delay_us(1);
       }
-      memset(databuf, 0, sizeof(databuf));
+      ZERO(databuf);
     }
   }
 
-  void RTSSHOW::RTS_SndData(char c, uint32_t addr, uint8_t cmd/*=VarAddr_W*/) {
+  void RTSSHOW::RTS_SndData(const char c, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {
     snddat.command = cmd;
     snddat.addr    = addr;
-    snddat.data[0] = uint32_t(c);
-    snddat.data[0] = snddat.data[0] << 8;
+    snddat.data[0] = uint32_t(uint16_t(c) << 8);
     snddat.len     = 5;
     RTS_SndData();
   }
 
-  void RTSSHOW::RTS_SndData(uint8_t *str, uint32_t addr, uint8_t cmd) { RTS_SndData((char *)str, addr, cmd); }
-
-  void RTSSHOW::RTS_SndData(int16_t n, uint32_t addr, uint8_t cmd/*=VarAddr_W*/) {
+  void RTSSHOW::RTS_SndData(const int n, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {
     if (cmd == VarAddr_W) {
-      snddat.data[0] = n;
-      snddat.len = 5;
+      if ((unsigned int)n > 0xFFFF) {
+        snddat.data[0] = n >> 16;
+        snddat.data[1] = n & 0xFFFF;
+        snddat.len = 7;
+      }
+      else {
+        snddat.data[0] = n;
+        snddat.len = 5;
+      }
     }
     else if (cmd == RegAddr_W) {
       snddat.data[0] = n;
@@ -589,13 +592,7 @@ namespace ExtUI {
     RTS_SndData();
   }
 
-  void RTSSHOW::RTS_SndData(uint16_t n, uint32_t addr, uint8_t cmd) { RTS_SndData(int16_t(n), addr, cmd); }
-
-  void RTSSHOW::RTS_SndData(float n, uint32_t addr, uint8_t cmd) { RTS_SndData(int16_t(n), addr, cmd); }
-
-  void RTSSHOW::RTS_SndData(int32_t n, uint32_t addr, uint8_t cmd) { RTS_SndData(uint32_t(n), addr, cmd); }
-
-  void RTSSHOW::RTS_SndData(uint32_t n, uint32_t addr, uint8_t cmd/*=VarAddr_W*/) {
+  void RTSSHOW::RTS_SndData(const unsigned long n, uint32_t addr, uint8_t cmd/*=VarAddr_W*/) {
     if (cmd == VarAddr_W) {
       if (n > 0xFFFF) {
         snddat.data[0] = n >> 16;
@@ -632,11 +629,11 @@ namespace ExtUI {
       if (recdat.addr == Addrbuf[i]) {
         if (Addrbuf[i] == NzBdSet || Addrbuf[i] == NozzlePreheat || Addrbuf[i] == BedPreheat || Addrbuf[i] == Flowrate)
           Checkkey = ManualSetTemp;
-        else if (Addrbuf[i] >= Stopprint && Addrbuf[i] <= Resumeprint)
+        else if (WITHIN(Addrbuf[i], Stopprint, Resumeprint))
           Checkkey = PrintChoice;
-        else if (Addrbuf[i] >= AutoZero && Addrbuf[i] <= DisplayZaxis)
+        else if (WITHIN(Addrbuf[i], AutoZero, DisplayZaxis))
           Checkkey = XYZEaxis;
-        else if (Addrbuf[i] >= FilamentUnit1 && Addrbuf[i] <= FilamentUnit2)
+        else if (WITHIN(Addrbuf[i], FilamentUnit1, FilamentUnit2))
           Checkkey = Filament;
         else
           Checkkey = i;
@@ -1054,7 +1051,7 @@ namespace ExtUI {
         else if (recdat.data[0] == 2) { // Exchange filament
           InforShowStatus = true;
           TPShowStatus    = false;
-          memset(ChangeMaterialbuf, 0, sizeof(ChangeMaterialbuf));
+          ZERO(ChangeMaterialbuf);
           ChangeMaterialbuf[1] = ChangeMaterialbuf[0] = 10;
           RTS_SndData(10 * ChangeMaterialbuf[0], FilamentUnit1); // It's ChangeMaterialbuf for show,instead of current_position[E_AXIS] in them.
           RTS_SndData(10 * ChangeMaterialbuf[1], FilamentUnit2);

--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.h
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.h
@@ -223,19 +223,21 @@ namespace ExtUI {
     public:
       RTSSHOW();
       int16_t RTS_RecData();
-      void RTS_SDCardInit(void);
+      void RTS_SDCardInit();
       void RTS_SDCardUpate(bool, bool);
       int16_t RTS_CheckFilament(int16_t);
-      void RTS_SndData(void);
-      void RTS_SndData(const String &, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(const char[], uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(char, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(uint8_t*, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(int16_t, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(float, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(uint16_t, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(int32_t, uint32_t, uint8_t=VarAddr_W);
-      void RTS_SndData(uint32_t, uint32_t, uint8_t=VarAddr_W);
+      void RTS_SndData();
+      void RTS_SndData(const String&, const uint32_t, const uint8_t=VarAddr_W);
+      void RTS_SndData(const char[],  const uint32_t, const uint8_t=VarAddr_W);
+      void RTS_SndData(char,          const uint32_t, const uint8_t=VarAddr_W);
+      void RTS_SndData(int,           const uint32_t, const uint8_t=VarAddr_W);
+      void RTS_SndData(unsigned long, const uint32_t, const uint8_t=VarAddr_W);
+
+      void RTS_SndData(uint8_t * const str, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData((char *)str, addr, cmd); }
+      void RTS_SndData(const unsigned int n, uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData(int(n), addr, cmd); }
+      void RTS_SndData(const_float_t n, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData(int(n), addr, cmd); }
+      void RTS_SndData(const long n, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData((unsigned long)n, addr, cmd); }
+
       void RTS_SDcard_Stop();
       void RTS_HandleData();
       void RTS_Init();
@@ -281,7 +283,7 @@ namespace ExtUI {
     Filename = Filename_Value
   };
 
-  const uint32_t Addrbuf[] = {
+  const uint16_t Addrbuf[] = {
     0x1002, 0x1004, 0x1006, 0x1008, 0x100A, 0x100C,  0x1026, 0x1030, 0x1032, 0x1034, 0x103A,
     0x103E, 0x1040, 0x1044, 0x1046, 0x1048, 0x104A, 0x104C, 0x1054, 0x1056, 0x1058,
     0x105C, 0x105E, 0x105F, 0x1088, 0

--- a/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
@@ -322,7 +322,7 @@ int WifiSerial::read() {
   // if the head isn't ahead of the tail, we don't have any characters
   if (_serial.rx_head == _serial.rx_tail) return -1;
 
-  unsigned char c = _serial.rx_buff[_serial.rx_tail];
+  uint8_t c = _serial.rx_buff[_serial.rx_tail];
   _serial.rx_tail = (rx_buffer_index_t)(_serial.rx_tail + 1) % WIFI_RX_BUF_SIZE;
   return c;
 }


### PR DESCRIPTION
Followup to #25400, addressing #25429.

For the `RTS_SndData` overloads use native types to remove ambiguity related to bit-length types, since `int` and `long` are different sizes on AVR vs. ARM.