### PR TITLE
Small Linear Advance fixes

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1869,7 +1869,6 @@ void Stepper::pulse_phase_isr() {
             // don't actually step here, but do subtract movements steps
             // from the linear advance step count
             step_needed.e = false;
-            count_position.e -= count_direction.e;
             la_advance_steps--;
           }
         #endif


### PR DESCRIPTION
### Description

#### Fix 1: E stepper position count
#24951 moved the increment of `count_position.*` to `PULSE_START()` from `PULSE_PREP()`. This caused a bug for linear advance which decrements `count_position.e` to undo the increment. However the linear advance logic also prevents `PULSE_START()` from doing anything so `count_position.e` is now being decremented when it should not be.

The behaviour is trivial to demonstrate:
```
M900 K0.2
G0 X0
G92 E0
G1 X1 E1
M114 D
```

The latter should report that a `Diff:` of zero (or very close to zero) between the stepper's position and the planner's position. But instead it reports a negative number. (Note `M114_DETAIL` is needed for `M114 D`).

#### Fix 2: stationary E stepper during deceleration

During the deceleration ramp there can be a moment where the LA de-retraction rate exactly balances the E feed rate from the g-code. This case was originally handled in  #24533 and then accidentally removed in commit [d97e6cd](https://github.com/MarlinFirmware/Marlin/pull/24533/commits/d97e6cd34a96715111a2c48e414bfc9f8fd7c80f).

### Requirements

Any machine using linear advance.

### Benefits

- Correct position counting for E.
- Correct handling of the potential E pause during the deceleration ramp.

### Configurations

Enable `LIN_ADVANCE` and set a K factor other than zero.

### Related Issues


