### PR TITLE
UBL (G29 J) bug fix

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -264,8 +264,8 @@ public:
         return UBL_Z_RAISE_WHEN_OFF_MESH;
     #endif
 
-    const uint8_t mx = _MIN(cx, (GRID_MAX_POINTS_X) - 2) + 1, my = _MIN(cy, (GRID_MAX_POINTS_Y) - 2) + 1,
-                  x0 = get_mesh_x(cx), x1 = get_mesh_x(cx + 1);
+    const uint8_t mx = _MIN(cx, (GRID_MAX_POINTS_X) - 2) + 1, my = _MIN(cy, (GRID_MAX_POINTS_Y) - 2) + 1;
+    const float x0 = get_mesh_x(cx), x1 = get_mesh_x(cx + 1);
     const float z1 = calc_z0(rx0, x0, z_values[cx][cy], x1, z_values[mx][cy]),
                 z2 = calc_z0(rx0, x0, z_values[cx][my], x1, z_values[mx][my]);
     float z0 = calc_z0(ry0, get_mesh_y(cy), z1, get_mesh_y(cy + 1), z2);

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -265,8 +265,8 @@ public:
     #endif
 
     const uint8_t mx = _MIN(cx, (GRID_MAX_POINTS_X) - 2) + 1, my = _MIN(cy, (GRID_MAX_POINTS_Y) - 2) + 1;
-    const float x0 = get_mesh_x(cx), x1 = get_mesh_x(cx + 1);
-    const float z1 = calc_z0(rx0, x0, z_values[cx][cy], x1, z_values[mx][cy]),
+    const float x0 = get_mesh_x(cx), x1 = get_mesh_x(cx + 1),
+                z1 = calc_z0(rx0, x0, z_values[cx][cy], x1, z_values[mx][cy]),
                 z2 = calc_z0(rx0, x0, z_values[cx][my], x1, z_values[mx][my]);
     float z0 = calc_z0(ry0, get_mesh_y(cy), z1, get_mesh_y(cy + 1), z2);
 


### PR DESCRIPTION
Corrects incorrect variable types in ubl.h that were causing UBL Mesh Leveling (G29 Jx) to tilt meshes incorrectly under certain circumstances. Also would have caused bed leveling in the planner to vastly over correct if printing at coordinates greater than 255mm on the x axis.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

In the function ```get_z_correction()``` in ubl.h, used in many places to interpolate the z height between mesh points, the x0 and x1 variables were initialized as ```const uint8_t```. These values correspond to the x coordinates of points on the mesh. If the coordinates were not whole numbers, they would be rounded down, leading to a slight error in the returned z height. Presumably this would still be usable, but is less than optimal. 

The primary issue appears when using a bed larger than 255mm in the X direction. This results in a rollover, and causes the required correction at points beyond this to be vastly overstated due to the way ```calc_z0()``` operates.

The offending variables have been corrected to ```const float```, presumably using ```const uint8_t``` was erroneous, as prior to this bug (appeared in version 2.0.9.4) the variables did not exist, the function that supplied (```static float get_mesh_x()```) them was used as an argument in their place.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Fixes UBL on printers larger than 255mm X axis.

<!-- What does this PR fix or improve? -->

### Related Issues

Fixes these issues:
https://github.com/MarlinFirmware/Marlin/issues/25192
https://github.com/MarlinFirmware/Marlin/issues/24665

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
