### PR TITLE
🧑‍💻 Width/Magnitude-based types

### DIFF
--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -34,6 +34,7 @@
 #include <WString.h>
 
 #include "../../inc/MarlinConfigPre.h"
+#include "../../core/types.h"
 #include "../../core/serial_hook.h"
 
 #ifndef SERIAL_PORT
@@ -138,10 +139,6 @@
 
   #define BYTE 0
 
-  // Templated type selector
-  template<bool b, typename T, typename F> struct TypeSelector { typedef T type;} ;
-  template<typename T, typename F> struct TypeSelector<false, T, F> { typedef F type; };
-
   template<typename Cfg>
   class MarlinSerial {
   protected:
@@ -164,7 +161,7 @@
     static constexpr B_U2Xx<Cfg::PORT>   B_U2X   = 0;
 
     // Base size of type on buffer size
-    typedef typename TypeSelector<(Cfg::RX_SIZE>256), uint16_t, uint8_t>::type ring_buffer_pos_t;
+    typedef uvalue_t(Cfg::RX_SIZE - 1) ring_buffer_pos_t;
 
     struct ring_buffer_r {
       volatile ring_buffer_pos_t head, tail;

--- a/Marlin/src/HAL/DUE/MarlinSerial.h
+++ b/Marlin/src/HAL/DUE/MarlinSerial.h
@@ -30,6 +30,7 @@
 #include <WString.h>
 
 #include "../../inc/MarlinConfigPre.h"
+#include "../../core/types.h"
 #include "../../core/serial_hook.h"
 
 // Define constants and variables for buffering incoming serial data.  We're
@@ -52,10 +53,6 @@
 //  #error "TX_BUFFER_SIZE must be 0, a power of 2 greater than 1, and no greater than 256."
 //#endif
 
-// Templated type selector
-template<bool b, typename T, typename F> struct TypeSelector { typedef T type;} ;
-template<typename T, typename F> struct TypeSelector<false, T, F> { typedef F type; };
-
 // Templated structure wrapper
 template<typename S, unsigned int addr> struct StructWrapper {
   constexpr StructWrapper(int) {}
@@ -76,7 +73,7 @@ protected:
   static constexpr int HWUART_IRQ_ID = IRQ_IDS[Cfg::PORT];
 
   // Base size of type on buffer size
-  typedef typename TypeSelector<(Cfg::RX_SIZE>256), uint16_t, uint8_t>::type ring_buffer_pos_t;
+  typedef uvalue_t(Cfg::RX_SIZE - 1) ring_buffer_pos_t;
 
   struct ring_buffer_r {
     volatile ring_buffer_pos_t head, tail;

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -38,12 +38,12 @@ void safe_delay(millis_t ms);           // Delay ensuring that temperatures are 
   // 16x16 bit arrays
   template <int W, int H>
   struct FlagBits {
-    typename IF<(W>8), uint16_t, uint8_t>::type bits[H];
-    void fill()                                   { memset(bits, 0xFF, sizeof(bits)); }
-    void reset()                                  { memset(bits, 0x00, sizeof(bits)); }
-    void unmark(const uint8_t x, const uint8_t y) { CBI(bits[y], x); }
-    void mark(const uint8_t x, const uint8_t y)   { SBI(bits[y], x); }
-    bool marked(const uint8_t x, const uint8_t y) { return TEST(bits[y], x); }
+    bits_t(W) flags[H];
+    void fill()                                   { memset(flags, 0xFF, sizeof(flags)); }
+    void reset()                                  { memset(flags, 0x00, sizeof(flags)); }
+    void unmark(const uint8_t x, const uint8_t y) { CBI(flags[y], x); }
+    void mark(const uint8_t x, const uint8_t y)   { SBI(flags[y], x); }
+    bool marked(const uint8_t x, const uint8_t y) { return TEST(flags[y], x); }
     inline void unmark(const xy_int8_t &xy)       { unmark(xy.x, xy.y); }
     inline void mark(const xy_int8_t &xy)         { mark(xy.x, xy.y); }
     inline bool marked(const xy_int8_t &xy)       { return marked(xy.x, xy.y); }

--- a/Marlin/src/feature/direct_stepping.h
+++ b/Marlin/src/feature/direct_stepping.h
@@ -80,9 +80,6 @@ namespace DirectStepping {
     static void set_page_state(const page_idx_t page_idx, const PageState page_state);
   };
 
-  template<bool b, typename T, typename F> struct TypeSelector { typedef T type;} ;
-  template<typename T, typename F> struct TypeSelector<false, T, F> { typedef F type; };
-
   template <int num_pages, int num_axes, int bits_segment, bool dir, int segments>
   struct config_t {
     static constexpr char CONTROL_CHAR  = '!';
@@ -98,8 +95,8 @@ namespace DirectStepping {
     static constexpr int TOTAL_STEPS    = SEGMENT_STEPS * SEGMENTS;
     static constexpr int PAGE_SIZE      = (AXIS_COUNT * BITS_SEGMENT * SEGMENTS) / 8;
 
-    typedef typename TypeSelector<(PAGE_SIZE>256), uint16_t, uint8_t>::type write_byte_idx_t;
-    typedef typename TypeSelector<(PAGE_COUNT>256), uint16_t, uint8_t>::type page_idx_t;
+    typedef uvalue_t(PAGE_SIZE - 1) write_byte_idx_t;
+    typedef uvalue_t(PAGE_COUNT - 1) page_idx_t;
   };
 
   template <uint8_t num_pages>

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -66,7 +66,7 @@
 // Types
 // ------------------------
 
-typedef IF<(TERN0(NEOPIXEL_LED, NEOPIXEL_PIXELS > 127)), int16_t, int8_t>::type pixel_index_t;
+typedef value_t(TERN0(NEOPIXEL_LED, NEOPIXEL_PIXELS)) pixel_index_t;
 
 // ------------------------
 // Classes

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -471,7 +471,7 @@ void Max7219::register_setup() {
     constexpr millis_t pattern_delay = 4;
 
     int8_t spiralx, spiraly, spiral_dir;
-    IF<(MAX7219_LEDS > 255), uint16_t, uint8_t>::type spiral_count;
+    uvalue_t(MAX7219_LEDS) spiral_count;
 
     void Max7219::test_pattern() {
       constexpr int8_t way[][2] = { { 1, 0 }, { 0, 1 }, { -1, 0 }, { 0, -1 } };

--- a/Marlin/src/feature/spindle_laser_types.h
+++ b/Marlin/src/feature/spindle_laser_types.h
@@ -57,7 +57,7 @@
   #endif
 #endif
 
-typedef IF<(SPEED_POWER_MAX > 255), uint16_t, uint8_t>::type cutter_cpower_t;
+typedef uvalue_t(SPEED_POWER_MAX) cutter_cpower_t;
 
 #if CUTTER_UNIT_IS(RPM) && SPEED_POWER_MAX > 255
   typedef uint16_t cutter_power_t;

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -96,9 +96,10 @@
     DRAWBIT_HOTEND,
     DRAWBIT_BED = HOTENDS,
     DRAWBIT_CHAMBER,
-    DRAWBIT_CUTTER
+    DRAWBIT_CUTTER,
+    DRAWBIT_COUNT
   };
-  IF<(DRAWBIT_CUTTER > 7), uint16_t, uint8_t>::type draw_bits;
+  bits_t(DRAWBIT_COUNT) draw_bits;
 #endif
 
 #if ANIM_HOTEND

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -368,8 +368,8 @@ void DGUSScreenHandlerMKS::EEPROM_CTRL(DGUS_VP_Variable &var, void *val_ptr) {
 }
 
 void DGUSScreenHandlerMKS::Z_offset_select(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t z_value = BE16_P(val_ptr);
-  switch (z_value) {
+  const uint16_t z = BE16_P(val_ptr);
+  switch (z) {
     case 0: Z_distance = 0.01; break;
     case 1: Z_distance = 0.1; break;
     case 2: Z_distance = 0.5; break;
@@ -477,7 +477,7 @@ void DGUSScreenHandlerMKS::MeshLevelDistanceConfig(DGUS_VP_Variable &var, void *
 
 void DGUSScreenHandlerMKS::MeshLevel(DGUS_VP_Variable &var, void *val_ptr) {
   #if ENABLED(MESH_BED_LEVELING)
-    const uint16_t mesh_value = BE16_P(val_ptr);
+    const uint16_t mesh_val = BE16_P(val_ptr);
     // static uint8_t a_first_level = 1;
     char cmd_buf[30];
     float offset = mesh_adj_distance;
@@ -485,7 +485,7 @@ void DGUSScreenHandlerMKS::MeshLevel(DGUS_VP_Variable &var, void *val_ptr) {
 
     if (!queue.ring_buffer.empty()) return;
 
-    switch (mesh_value) {
+    switch (mesh_val) {
       case 0:
         offset = mesh_adj_distance;
         integer = offset; // get int
@@ -575,20 +575,19 @@ void DGUSScreenHandlerMKS::SD_FileBack(DGUS_VP_Variable&, void*) {
 }
 
 void DGUSScreenHandlerMKS::LCD_BLK_Adjust(DGUS_VP_Variable &var, void *val_ptr) {
-
-  const uint16_t lcd_value = BE16_P(val_ptr);
-  lcd_default_light = constrain(lcd_value, 10, 100);
+  const uint16_t lcd_val = BE16_P(val_ptr);
+  lcd_default_light = constrain(lcd_val, 10, 100);
 
   const uint16_t lcd_data[2] = { lcd_default_light, lcd_default_light };
   dgusdisplay.WriteVariable(0x0082, &lcd_data, 5, true);
 }
 
 void DGUSScreenHandlerMKS::ManualAssistLeveling(DGUS_VP_Variable &var, void *val_ptr) {
-  const int16_t point_value = BE16_P(val_ptr);
+  const int16_t point_val = BE16_P(val_ptr);
 
   // Insist on leveling first time at this screen
   static bool first_level_flag = false;
-  if (!first_level_flag || point_value == 0x0001) {
+  if (!first_level_flag || point_val == 0x0001) {
     queue.enqueue_now_P(G28_STR);
     first_level_flag = true;
   }
@@ -601,10 +600,10 @@ void DGUSScreenHandlerMKS::ManualAssistLeveling(DGUS_VP_Variable &var, void *val
     queue.enqueue_one_now(buf_level);
   };
 
-  if (WITHIN(point_value, 0x0001, 0x0005))
+  if (WITHIN(point_val, 0x0001, 0x0005))
     queue.enqueue_now(F("G1Z10"));
 
-  switch (point_value) {
+  switch (point_val) {
     case 0x0001:
       enqueue_corner_move(X_MIN_POS + ABS(mks_corner_offsets[0].x),
                           Y_MIN_POS + ABS(mks_corner_offsets[0].y), level_speed);
@@ -628,7 +627,7 @@ void DGUSScreenHandlerMKS::ManualAssistLeveling(DGUS_VP_Variable &var, void *val
       break;
   }
 
-  if (WITHIN(point_value, 0x0002, 0x0005)) {
+  if (WITHIN(point_val, 0x0002, 0x0005)) {
     //queue.enqueue_now(F("G28Z"));
     queue.enqueue_now(F("G1Z-10"));
   }
@@ -638,14 +637,14 @@ void DGUSScreenHandlerMKS::ManualAssistLeveling(DGUS_VP_Variable &var, void *val
 #define mks_max(a, b) ((a) > (b)) ? (a) : (b)
 void DGUSScreenHandlerMKS::TMC_ChangeConfig(DGUS_VP_Variable &var, void *val_ptr) {
   #if EITHER(HAS_TRINAMIC_CONFIG, HAS_STEALTHCHOP)
-    const uint16_t tmc_value = BE16_P(val_ptr);
+    const uint16_t tmc_val = BE16_P(val_ptr);
   #endif
 
   switch (var.VP) {
     case VP_TMC_X_STEP:
       #if USE_SENSORLESS
         #if X_HAS_STEALTHCHOP
-          stepperX.homing_threshold(mks_min(tmc_value, 255));
+          stepperX.homing_threshold(mks_min(tmc_val, 255));
           settings.save();
           //tmc_step.x = stepperX.homing_threshold();
         #endif
@@ -654,7 +653,7 @@ void DGUSScreenHandlerMKS::TMC_ChangeConfig(DGUS_VP_Variable &var, void *val_ptr
     case VP_TMC_Y_STEP:
       #if USE_SENSORLESS
         #if Y_HAS_STEALTHCHOP
-          stepperY.homing_threshold(mks_min(tmc_value, 255));
+          stepperY.homing_threshold(mks_min(tmc_val, 255));
           settings.save();
           //tmc_step.y = stepperY.homing_threshold();
         #endif
@@ -663,7 +662,7 @@ void DGUSScreenHandlerMKS::TMC_ChangeConfig(DGUS_VP_Variable &var, void *val_ptr
     case VP_TMC_Z_STEP:
       #if USE_SENSORLESS
         #if Z_HAS_STEALTHCHOP
-          stepperZ.homing_threshold(mks_min(tmc_value, 255));
+          stepperZ.homing_threshold(mks_min(tmc_val, 255));
           settings.save();
           //tmc_step.z = stepperZ.homing_threshold();
         #endif
@@ -671,49 +670,49 @@ void DGUSScreenHandlerMKS::TMC_ChangeConfig(DGUS_VP_Variable &var, void *val_ptr
       break;
     case VP_TMC_X_Current:
       #if AXIS_IS_TMC(X)
-        stepperX.rms_current(tmc_value);
+        stepperX.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_X1_Current:
       #if AXIS_IS_TMC(X2)
-        stepperX2.rms_current(tmc_value);
+        stepperX2.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_Y_Current:
       #if AXIS_IS_TMC(Y)
-        stepperY.rms_current(tmc_value);
+        stepperY.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_Y1_Current:
       #if AXIS_IS_TMC(X2)
-        stepperY2.rms_current(tmc_value);
+        stepperY2.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_Z_Current:
       #if AXIS_IS_TMC(Z)
-        stepperZ.rms_current(tmc_value);
+        stepperZ.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_Z1_Current:
       #if AXIS_IS_TMC(Z2)
-        stepperZ2.rms_current(tmc_value);
+        stepperZ2.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_E0_Current:
       #if AXIS_IS_TMC(E0)
-        stepperE0.rms_current(tmc_value);
+        stepperE0.rms_current(tmc_val);
         settings.save();
       #endif
       break;
     case VP_TMC_E1_Current:
       #if AXIS_IS_TMC(E1)
-        stepperE1.rms_current(tmc_value);
+        stepperE1.rms_current(tmc_val);
         settings.save();
       #endif
       break;
@@ -849,29 +848,29 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
 }
 
 void DGUSScreenHandlerMKS::GetParkPos(DGUS_VP_Variable &var, void *val_ptr) {
-  const int16_t value_pos = BE16_P(val_ptr);
+  const int16_t pos = BE16_P(val_ptr);
 
   switch (var.VP) {
-    case VP_X_PARK_POS: mks_park_pos.x = value_pos; break;
-    case VP_Y_PARK_POS: mks_park_pos.y = value_pos; break;
-    case VP_Z_PARK_POS: mks_park_pos.z = value_pos; break;
+    case VP_X_PARK_POS: mks_park_pos.x = pos; break;
+    case VP_Y_PARK_POS: mks_park_pos.y = pos; break;
+    case VP_Z_PARK_POS: mks_park_pos.z = pos; break;
     default: break;
   }
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 void DGUSScreenHandlerMKS::HandleChangeLevelPoint(DGUS_VP_Variable &var, void *val_ptr) {
-  const int16_t value_raw = BE16_P(val_ptr);
+  const int16_t raw = BE16_P(val_ptr);
 
-  *(int16_t*)var.memadr = value_raw;
+  *(int16_t*)var.memadr = raw;
 
   settings.save();
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 void DGUSScreenHandlerMKS::HandleStepPerMMChanged(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_raw = BE16_P(val_ptr);
-  const float value = (float)value_raw;
+  const uint16_t raw = BE16_P(val_ptr);
+  const float value = (float)raw;
 
   ExtUI::axis_t axis;
   switch (var.VP) {
@@ -886,8 +885,8 @@ void DGUSScreenHandlerMKS::HandleStepPerMMChanged(DGUS_VP_Variable &var, void *v
 }
 
 void DGUSScreenHandlerMKS::HandleStepPerMMExtruderChanged(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_raw = BE16_P(val_ptr);
-  const float value = (float)value_raw;
+  const uint16_t raw = BE16_P(val_ptr);
+  const float value = (float)raw;
 
   ExtUI::extruder_t extruder;
   switch (var.VP) {
@@ -905,8 +904,8 @@ void DGUSScreenHandlerMKS::HandleStepPerMMExtruderChanged(DGUS_VP_Variable &var,
 }
 
 void DGUSScreenHandlerMKS::HandleMaxSpeedChange(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_raw = BE16_P(val_ptr);
-  const float value = (float)value_raw;
+  const uint16_t raw = BE16_P(val_ptr);
+  const float value = (float)raw;
 
   ExtUI::axis_t axis;
   switch (var.VP) {
@@ -921,8 +920,8 @@ void DGUSScreenHandlerMKS::HandleMaxSpeedChange(DGUS_VP_Variable &var, void *val
 }
 
 void DGUSScreenHandlerMKS::HandleExtruderMaxSpeedChange(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_raw = BE16_P(val_ptr);
-  const float value = (float)value_raw;
+  const uint16_t raw = BE16_P(val_ptr);
+  const float value = (float)raw;
 
   ExtUI::extruder_t extruder;
   switch (var.VP) {
@@ -940,8 +939,8 @@ void DGUSScreenHandlerMKS::HandleExtruderMaxSpeedChange(DGUS_VP_Variable &var, v
 }
 
 void DGUSScreenHandlerMKS::HandleMaxAccChange(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_raw = BE16_P(val_ptr);
-  const float value = (float)value_raw;
+  const uint16_t raw = BE16_P(val_ptr);
+  const float value = (float)raw;
 
   ExtUI::axis_t axis;
   switch (var.VP) {
@@ -956,8 +955,8 @@ void DGUSScreenHandlerMKS::HandleMaxAccChange(DGUS_VP_Variable &var, void *val_p
 }
 
 void DGUSScreenHandlerMKS::HandleExtruderAccChange(DGUS_VP_Variable &var, void *val_ptr) {
-  uint16_t value_raw = BE16_P(val_ptr);
-  float value = (float)value_raw;
+  uint16_t raw = BE16_P(val_ptr);
+  float value = (float)raw;
   ExtUI::extruder_t extruder;
   switch (var.VP) {
     default: return;
@@ -974,33 +973,33 @@ void DGUSScreenHandlerMKS::HandleExtruderAccChange(DGUS_VP_Variable &var, void *
 }
 
 void DGUSScreenHandlerMKS::HandleTravelAccChange(DGUS_VP_Variable &var, void *val_ptr) {
-  uint16_t value_travel = BE16_P(val_ptr);
-  planner.settings.travel_acceleration = (float)value_travel;
+  uint16_t travel = BE16_P(val_ptr);
+  planner.settings.travel_acceleration = (float)travel;
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 void DGUSScreenHandlerMKS::HandleFeedRateMinChange(DGUS_VP_Variable &var, void *val_ptr) {
-  uint16_t value_t = BE16_P(val_ptr);
-  planner.settings.min_feedrate_mm_s = (float)value_t;
+  uint16_t t = BE16_P(val_ptr);
+  planner.settings.min_feedrate_mm_s = (float)t;
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 void DGUSScreenHandlerMKS::HandleMin_T_F(DGUS_VP_Variable &var, void *val_ptr) {
-  uint16_t value_t_f = BE16_P(val_ptr);
-  planner.settings.min_travel_feedrate_mm_s = (float)value_t_f;
+  uint16_t t_f = BE16_P(val_ptr);
+  planner.settings.min_travel_feedrate_mm_s = (float)t_f;
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 void DGUSScreenHandlerMKS::HandleAccChange(DGUS_VP_Variable &var, void *val_ptr) {
-  uint16_t value_acc = BE16_P(val_ptr);
-  planner.settings.acceleration = (float)value_acc;
+  uint16_t acc = BE16_P(val_ptr);
+  planner.settings.acceleration = (float)acc;
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   void DGUSScreenHandlerMKS::HandleGetExMinTemp(DGUS_VP_Variable &var, void *val_ptr) {
-    const uint16_t value_ex_min_temp = BE16_P(val_ptr);
-    thermalManager.extrude_min_temp = value_ex_min_temp;
+    const uint16_t ex_min_temp = BE16_P(val_ptr);
+    thermalManager.extrude_min_temp = ex_min_temp;
     skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
   }
 #endif
@@ -1080,8 +1079,8 @@ void DGUSScreenHandlerMKS::HandleAccChange(DGUS_VP_Variable &var, void *val_ptr)
 #endif // BABYSTEPPING
 
 void DGUSScreenHandlerMKS::GetManualFilament(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_len = BE16_P(val_ptr);
-  const float value = (float)value_len;
+  const uint16_t len = BE16_P(val_ptr);
+  const float value = (float)len;
 
   distanceFilament = value;
 
@@ -1089,8 +1088,8 @@ void DGUSScreenHandlerMKS::GetManualFilament(DGUS_VP_Variable &var, void *val_pt
 }
 
 void DGUSScreenHandlerMKS::GetManualFilamentSpeed(DGUS_VP_Variable &var, void *val_ptr) {
-  const uint16_t value_len = BE16_P(val_ptr);
-  filamentSpeed_mm_s = value_len;
+  const uint16_t len = BE16_P(val_ptr);
+  filamentSpeed_mm_s = len;
 
   skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -115,7 +115,7 @@ enum EndstopEnum : char {
 class Endstops {
   public:
 
-    typedef IF<(NUM_ENDSTOP_STATES > 8), uint16_t, uint8_t>::type endstop_mask_t;
+    typedef bits_t(NUM_ENDSTOP_STATES) endstop_mask_t;
 
     #if ENABLED(X_DUAL_ENDSTOPS)
       static float x2_endstop_adj;

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -411,10 +411,10 @@ void restore_feedrate_and_scaling();
 /**
  * Homing and Trusted Axes
  */
-typedef IF<(NUM_AXES > 8), uint16_t, uint8_t>::type main_axes_bits_t;
+typedef bits_t(NUM_AXES) main_axes_bits_t;
 constexpr main_axes_bits_t main_axes_mask = _BV(NUM_AXES) - 1;
 
-typedef IF<(NUM_AXES + EXTRUDERS > 8), uint16_t, uint8_t>::type e_axis_bits_t;
+typedef bits_t(NUM_AXES + EXTRUDERS) e_axis_bits_t;
 constexpr e_axis_bits_t e_axis_mask = (_BV(EXTRUDERS) - 1) << NUM_AXES;
 
 void set_axis_is_at_home(const AxisEnum axis);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -216,7 +216,7 @@ xyze_float_t Planner::previous_speed;
 float Planner::previous_nominal_speed;
 
 #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
-  last_move_t Planner::g_uc_extruder_last_move[E_STEPPERS] = { 0 };
+  last_move_t Planner::extruder_last_move[E_STEPPERS] = { 0 };
 #endif
 
 #ifdef XY_FREQUENCY_LIMIT
@@ -2280,7 +2280,7 @@ bool Planner::_populate_block(
 
         // Count down all steppers that were recently moved
         LOOP_L_N(i, E_STEPPERS)
-          if (g_uc_extruder_last_move[i]) g_uc_extruder_last_move[i]--;
+          if (extruder_last_move[i]) extruder_last_move[i]--;
 
         // Switching Extruder uses one E stepper motor per two nozzles
         #define E_STEPPER_INDEX(E) TERN(SWITCHING_EXTRUDER, (E) / 2, E)
@@ -2289,12 +2289,12 @@ bool Planner::_populate_block(
         #define _IS_DUPE(N) TERN0(HAS_DUPLICATION_MODE, (extruder_duplication_enabled && TERN1(MULTI_NOZZLE_DUPLICATION, TEST(duplication_e_mask, N))))
 
         #define ENABLE_ONE_E(N) do{ \
-          if (N == E_STEPPER_INDEX(extruder) || _IS_DUPE(N)) {    /* N is 'extruder', or N is duplicating */ \
-            stepper.ENABLE_EXTRUDER(N);                           /* Enable the relevant E stepper... */ \
-            g_uc_extruder_last_move[N] = (BLOCK_BUFFER_SIZE) * 2; /* ...and reset its counter */ \
+          if (N == E_STEPPER_INDEX(extruder) || _IS_DUPE(N)) {  /* N is 'extruder', or N is duplicating */ \
+            stepper.ENABLE_EXTRUDER(N);                         /* Enable the relevant E stepper... */ \
+            extruder_last_move[N] = (BLOCK_BUFFER_SIZE) * 2;    /* ...and reset its counter */ \
           } \
-          else if (!g_uc_extruder_last_move[N])                   /* Counter expired since last E stepper enable */ \
-            stepper.DISABLE_EXTRUDER(N);                          /* Disable the E stepper */ \
+          else if (!extruder_last_move[N])                      /* Counter expired since last E stepper enable */ \
+            stepper.DISABLE_EXTRUDER(N);                        /* Disable the E stepper */ \
         }while(0);
 
       #else

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -353,7 +353,7 @@ typedef struct {
 #endif
 
 #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
-  typedef IF<(BLOCK_BUFFER_SIZE > 64), uint16_t, uint8_t>::type last_move_t;
+  typedef uvalue_t(BLOCK_BUFFER_SIZE * 2) last_move_t;
 #endif
 
 #if ENABLED(ARC_SUPPORT)
@@ -535,7 +535,7 @@ class Planner {
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
       // Counters to manage disabling inactive extruder steppers
-      static last_move_t g_uc_extruder_last_move[E_STEPPERS];
+      static last_move_t extruder_last_move[E_STEPPERS];
     #endif
 
     #if HAS_WIRED_LCD

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -263,11 +263,7 @@
 #define MIN_STEP_ISR_FREQUENCY (MAX_STEP_ISR_FREQUENCY_1X / 2)
 
 #define ENABLE_COUNT (NUM_AXES + E_STEPPERS)
-#if ENABLE_COUNT > 16
-  typedef uint32_t ena_mask_t;
-#else
-  typedef IF<(ENABLE_COUNT > 8), uint16_t, uint8_t>::type ena_mask_t;
-#endif
+typedef bits_t(ENABLE_COUNT) ena_mask_t;
 
 // Axis flags type, for enabled state or other simple state
 typedef struct {
@@ -358,7 +354,7 @@ constexpr ena_mask_t enable_overlap[] = {
   constexpr uint16_t shaping_min_freq = SHAPING_MIN_FREQ,
                      shaping_echoes = max_step_rate / shaping_min_freq / 2 + 3;
 
-  typedef IF<ENABLED(__AVR__), uint16_t, uint32_t>::type shaping_time_t;
+  typedef hal_timer_t shaping_time_t;
   enum shaping_echo_t { ECHO_NONE = 0, ECHO_FWD = 1, ECHO_BWD = 2 };
   struct shaping_echo_axis_t {
     TERN_(INPUT_SHAPING_X, shaping_echo_t x:2);


### PR DESCRIPTION
Shorthand macros to define minimal-sized types based on the number of bits or max value needed.

`bits_t(W)` : Provide an unsigned type to fit W bits.
`uvalue_t(V)` : Provide an unsigned value to hold values up to V.
`value_t(V) ` : Provide a signed value to hold values up to V.