### PR TITLE
Fix undefined MOVE_SERVO and use opwr instead of power

### DIFF
--- a/Marlin/src/feature/spindle_laser.cpp
+++ b/Marlin/src/feature/spindle_laser.cpp
@@ -141,7 +141,7 @@ void SpindleLaser::apply_power(const uint8_t opwr) {
       else
         ocr_off();
     #elif ENABLED(SPINDLE_SERVO)
-      MOVE_SERVO(SPINDLE_SERVO_NR, power);
+      servo[SPINDLE_SERVO_NR].move(opwr);
     #else
       WRITE(SPINDLE_LASER_ENA_PIN, enabled() ? SPINDLE_LASER_ACTIVE_STATE : !SPINDLE_LASER_ACTIVE_STATE);
       isReadyForUI = true;


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR fixes the following compile bug:

If you **enable** both, `SPINDLE_FEATURE` and `SPINDLE_SERVO`, but **disable** `SPINDLE_LASER_USE_PWM` in `Configuration_adv.h`, you get this error:
```
Marlin/src/feature/spindle_laser.cpp: In static member function 'static void SpindleLaser::apply_power(uint8_t)':
Marlin/src/feature/spindle_laser.cpp:144:7: error: 'MOVE_SERVO' was not declared in this scope
       MOVE_SERVO(SPINDLE_SERVO_NR, power);
       ^~~~~~~~~~
Marlin/src/feature/spindle_laser.cpp:144:7: note: suggested alternative: 'NUM_SERVOS'
       MOVE_SERVO(SPINDLE_SERVO_NR, power);
       ^~~~~~~~~~
       NUM_SERVOS
```
I'm not familiar with the history of the code base, but I assume that at some point the `MOVE_SERVO` macro did exist.
I replaced that macro with the way servos are moved in other parts of the code. Also, I don't think the servo should be moved to `power` here, but to `opwr` submitted as a parameter to the function. (The conditional branch for PWM does it too.)

### Requirements

In `Configuration_adv.h` **define**
* `SPINDLE_FEATURE` (line 3334)
* `SPINDLE_SERVO` (line 3360)

and **undefine**
* `SPINDLE_LASER_USE_PWM` (line 3339)

### Benefits

Marlin will not throw a compile error anymore if you have a spindle servo that you don't use with PWM.

### Configurations

See Requirements

### Related Issues

I couldn't find any related issues. (Which doesn't necessarily mean there aren't any; I just wasn't able to track them down.)
