### PR TITLE
Define Anet ET4 SD SS Pin

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_ANET_ET4.h
+++ b/Marlin/src/pins/stm32f4/pins_ANET_ET4.h
@@ -206,6 +206,7 @@
   #if DISABLED(SDIO_SUPPORT)
     #define SOFTWARE_SPI
     #define SDSS                            PC11
+    #define SD_SS_PIN                       SDSS
     #define SD_SCK_PIN                      PC12
     #define SD_MISO_PIN                     PC8
     #define SD_MOSI_PIN                     PD2


### PR DESCRIPTION
### Description

From https://github.com/davidtgbe/Marlin/issues/33:

> There is no explicit define for `SD_SS_PIN` in file `pins_ANET_ET4.h`, so it is assigned the value `PIN_SPI_SS` in file `Marlin\src\HAL\STM32\spi_pins.h` , and `PIN_SPI_SS` is assigned to `PA4` in file `buildroot\share\PlatformIO\variants\MARLIN_F4x7Vx\variant.h `.

> When function spiBegin(void) from file `Marlin\src\HAL\STM32\HAL_SPI.cpp` is called (when accesing SD card), the pin `PA4` is written with a 1.

> But this pin is the BED thermistor pin, so it should never be written, only read.

### Requirements

Anet ET4/ET5 series printer

### Benefits

BED thermistor pin won't be written to while accessing the SD card.

### Configurations

Any ET4/ET5 series config from the [Configurations repo](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Anet).

### Related Issues

- https://github.com/davidtgbe/Marlin/issues/33