### PR TITLE
more IA_CREALITY fixes, Followup to #25440

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3061,8 +3061,8 @@
 #if DGUS_UI_IS(MKS)
   #define USE_MKS_GREEN_UI
 #elif DGUS_UI_IS(IA_CREALITY)
-  //#define LCD_SCREEN_ROTATE 90 // Portrait Mode or 800x480 displays
-  //#define LCD_LONG_BOOT
+  //#define LCD_SCREEN_ROTATE 90          // Portrait Mode or 800x480 displays
+  //#define IA_CREALITY_BOOT_DELAY 1500   // (ms)
 #endif
 
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3062,6 +3062,7 @@
   #define USE_MKS_GREEN_UI
 #elif DGUS_UI_IS(IA_CREALITY)
   //#define LCD_SCREEN_ROTATE 90 // Portrait Mode or 800x480 displays
+  //#define LCD_LONG_BOOT
 #endif
 
 //

--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
@@ -94,7 +94,7 @@ namespace ExtUI {
     rtscheck.recdat.head[1] = rtscheck.snddat.head[1] = FHTWO;
     ZERO(rtscheck.databuf);
 
-    delay_ms(TERN(DWINOS_4, 1500, 500)); // Delay to allow screen startup
+    delay_ms(TERN(LCD_LONG_BOOT, 1500, 500)); // Delay to allow screen startup
     SetTouchScreenConfiguration();
     rtscheck.RTS_SndData(StartSoundSet, SoundAddr);
     delay_ms(400); // Delay to allow screen to configure

--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
@@ -87,6 +87,9 @@ namespace ExtUI {
   #ifndef CUSTOM_MACHINE_NAME
     #define CUSTOM_MACHINE_NAME MACHINE_NAME
   #endif
+  #ifndef IA_CREALITY_BOOT_DELAY
+    #define IA_CREALITY_BOOT_DELAY 500
+  #endif
 
   void onStartup() {
     DWIN_SERIAL.begin(115200);
@@ -94,7 +97,7 @@ namespace ExtUI {
     rtscheck.recdat.head[1] = rtscheck.snddat.head[1] = FHTWO;
     ZERO(rtscheck.databuf);
 
-    delay_ms(TERN(LCD_LONG_BOOT, 1500, 500)); // Delay to allow screen startup
+    delay_ms(IA_CREALITY_BOOT_DELAY); // Delay to allow screen startup
     SetTouchScreenConfiguration();
     rtscheck.RTS_SndData(StartSoundSet, SoundAddr);
     delay_ms(400); // Delay to allow screen to configure

--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.cpp
@@ -314,31 +314,31 @@ namespace ExtUI {
       else
         rtscheck.RTS_SndData(2, DisplayStandbyEnableIndicator);
 
-      rtscheck.RTS_SndData(uint16_t(getAxisSteps_per_mm(X))  * 10, StepMM_X);
-      rtscheck.RTS_SndData(uint16_t(getAxisSteps_per_mm(Y))  * 10, StepMM_Y);
-      rtscheck.RTS_SndData(uint16_t(getAxisSteps_per_mm(Z))  * 10, StepMM_Z);
-      rtscheck.RTS_SndData(uint16_t(getAxisSteps_per_mm(E0)) * 10, StepMM_E);
+      rtscheck.RTS_SndData(getAxisSteps_per_mm(X)  * 10, StepMM_X);
+      rtscheck.RTS_SndData(getAxisSteps_per_mm(Y)  * 10, StepMM_Y);
+      rtscheck.RTS_SndData(getAxisSteps_per_mm(Z)  * 10, StepMM_Z);
+      rtscheck.RTS_SndData(getAxisSteps_per_mm(E0) * 10, StepMM_E);
 
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxAcceleration_mm_s2(X)) / 100, Accel_X);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxAcceleration_mm_s2(Y)) / 100, Accel_Y);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxAcceleration_mm_s2(Z)) /  10, Accel_Z);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxAcceleration_mm_s2(E0)),      Accel_E);
+      rtscheck.RTS_SndData(getAxisMaxAcceleration_mm_s2(X) / 100, Accel_X);
+      rtscheck.RTS_SndData(getAxisMaxAcceleration_mm_s2(Y) / 100, Accel_Y);
+      rtscheck.RTS_SndData(getAxisMaxAcceleration_mm_s2(Z) /  10, Accel_Z);
+      rtscheck.RTS_SndData(getAxisMaxAcceleration_mm_s2(E0),      Accel_E);
 
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxFeedrate_mm_s(X)),  Feed_X);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxFeedrate_mm_s(Y)),  Feed_Y);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxFeedrate_mm_s(Z)),  Feed_Z);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxFeedrate_mm_s(E0)), Feed_E);
+      rtscheck.RTS_SndData(getAxisMaxFeedrate_mm_s(X),  Feed_X);
+      rtscheck.RTS_SndData(getAxisMaxFeedrate_mm_s(Y),  Feed_Y);
+      rtscheck.RTS_SndData(getAxisMaxFeedrate_mm_s(Z),  Feed_Z);
+      rtscheck.RTS_SndData(getAxisMaxFeedrate_mm_s(E0), Feed_E);
 
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxJerk_mm_s(X))  * 100, Jerk_X);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxJerk_mm_s(Y))  * 100, Jerk_Y);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxJerk_mm_s(Z))  * 100, Jerk_Z);
-      rtscheck.RTS_SndData(uint16_t(getAxisMaxJerk_mm_s(E0)) * 100, Jerk_E);
+      rtscheck.RTS_SndData(getAxisMaxJerk_mm_s(X) * 100, Jerk_X);
+      rtscheck.RTS_SndData(getAxisMaxJerk_mm_s(Y) * 100, Jerk_Y);
+      rtscheck.RTS_SndData(getAxisMaxJerk_mm_s(Z) * 100, Jerk_Z);
+      rtscheck.RTS_SndData(getAxisMaxJerk_mm_s(E0) * 100, Jerk_E);
 
       #if HAS_HOTEND_OFFSET
-        rtscheck.RTS_SndData(uint16_t(getNozzleOffset_mm(X, E1)) * 10, T2Offset_X);
-        rtscheck.RTS_SndData(uint16_t(getNozzleOffset_mm(Y, E1)) * 10, T2Offset_Y);
-        rtscheck.RTS_SndData(uint16_t(getNozzleOffset_mm(Z, E1)) * 10, T2Offset_Z);
-        rtscheck.RTS_SndData(uint16_t(getAxisSteps_per_mm(E1))   * 10, T2StepMM_E);
+        rtscheck.RTS_SndData(getNozzleOffset_mm(X, E1) * 10, T2Offset_X);
+        rtscheck.RTS_SndData(getNozzleOffset_mm(Y, E1) * 10, T2Offset_Y);
+        rtscheck.RTS_SndData(getNozzleOffset_mm(Z, E1) * 10, T2Offset_Z);
+        rtscheck.RTS_SndData(getAxisSteps_per_mm(E1)   * 10, T2StepMM_E);
       #endif
 
       #if HAS_BED_PROBE
@@ -349,13 +349,13 @@ namespace ExtUI {
       #if HAS_PID_HEATING
         rtscheck.RTS_SndData(pid_hotendAutoTemp, HotendPID_AutoTmp);
         rtscheck.RTS_SndData(pid_bedAutoTemp, BedPID_AutoTmp);
-        rtscheck.RTS_SndData(uint16_t(getPID_Kp(E0)) * 10, HotendPID_P);
-        rtscheck.RTS_SndData(uint16_t(getPID_Ki(E0)) * 10, HotendPID_I);
-        rtscheck.RTS_SndData(uint16_t(getPID_Kd(E0)) * 10, HotendPID_D);
+        rtscheck.RTS_SndData(getPID_Kp(E0) * 10, HotendPID_P);
+        rtscheck.RTS_SndData(getPID_Ki(E0) * 10, HotendPID_I);
+        rtscheck.RTS_SndData(getPID_Kd(E0) * 10, HotendPID_D);
         #if ENABLED(PIDTEMPBED)
-          rtscheck.RTS_SndData(uint16_t(getBedPID_Kp()) * 10, BedPID_P);
-          rtscheck.RTS_SndData(uint16_t(getBedPID_Ki()) * 10, BedPID_I);
-          rtscheck.RTS_SndData(uint16_t(getBedPID_Kd()) * 10, BedPID_D);
+          rtscheck.RTS_SndData(getBedPID_Kp() * 10, BedPID_P);
+          rtscheck.RTS_SndData(getBedPID_Ki() * 10, BedPID_I);
+          rtscheck.RTS_SndData(getBedPID_Kd() * 10, BedPID_D);
         #endif
       #endif
     }
@@ -564,6 +564,25 @@ namespace ExtUI {
     snddat.addr    = addr;
     snddat.data[0] = uint32_t(uint16_t(c) << 8);
     snddat.len     = 5;
+    RTS_SndData();
+  }
+
+  void RTSSHOW::RTS_SndData(const_float_t f, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {
+    int16_t n = f;
+    if (cmd == VarAddr_W) {
+      snddat.data[0] = n;
+      snddat.len = 5;
+    }
+    else if (cmd == RegAddr_W) {
+      snddat.data[0] = n;
+      snddat.len = 3;
+    }
+    else if (cmd == VarAddr_R) {
+      snddat.bytelen = n;
+      snddat.len = 4;
+    }
+    snddat.command = cmd;
+    snddat.addr = addr;
     RTS_SndData();
   }
 
@@ -789,7 +808,6 @@ namespace ExtUI {
         }
         else {
           onStatusChanged(F("Requested Offset Beyond Limits"));
-          RTS_SndData(getZOffset_mm() * 100, ProbeOffset_Z);
         }
 
         rtscheck.RTS_SndData(getZOffset_mm() * 100, ProbeOffset_Z);

--- a/Marlin/src/lcd/extui/ia_creality/creality_extui.h
+++ b/Marlin/src/lcd/extui/ia_creality/creality_extui.h
@@ -232,10 +232,10 @@ namespace ExtUI {
       void RTS_SndData(char,          const uint32_t, const uint8_t=VarAddr_W);
       void RTS_SndData(int,           const uint32_t, const uint8_t=VarAddr_W);
       void RTS_SndData(unsigned long, const uint32_t, const uint8_t=VarAddr_W);
+      void RTS_SndData(const_float_t, const uint32_t, const uint8_t=VarAddr_W);
 
       void RTS_SndData(uint8_t * const str, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData((char *)str, addr, cmd); }
       void RTS_SndData(const unsigned int n, uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData(int(n), addr, cmd); }
-      void RTS_SndData(const_float_t n, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData(int(n), addr, cmd); }
       void RTS_SndData(const long n, const uint32_t addr, const uint8_t cmd=VarAddr_W) { RTS_SndData((unsigned long)n, addr, cmd); }
 
       void RTS_SDcard_Stop();


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
1) expose macro to handle slow lcd startup

2) 96bc084f3d791bc93265f217181986863e8e5fc7 and 445181fc421891726973fa086c1de0601912d45e corrected this statment in
`void RTSSHOW::RTS_SndData(const int n, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {`
```
if ((uint8_t)n > 0xFFFF) {
        snddat.data[0] = n >> 16;
        snddat.data[1] = n & 0xFFFF;
        snddat.len     = 7;
      }
      else {
        snddat.data[0] = n;
        snddat.len     = 5;
      }
```
with this 
```
      if ((unsigned int)n > 0xFFFF) {
        snddat.data[0] = n >> 16;
        snddat.data[1] = n & 0xFFFF;
        snddat.len = 7;
      }
      else {
        snddat.data[0] = n;
        snddat.len = 5;
      }
```
but float values were working just because of the wrong if statement.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
#define DGUS_LCD_UI IA_CREALITY

### Benefits
make float values working again.

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
