### PR TITLE
fix compilation for Polargraph with XY Axes (no Z)

### DIFF
--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -815,8 +815,7 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         resume_hotend_temp = thermalManager.degTargetHotend(active_extruder);
         resume_position = current_position;
 
-        if (move_axes && all_axes_homed())
-          nozzle.park(0, park_point /*= NOZZLE_PARK_POINT*/);
+        if (move_axes && all_axes_homed()) nozzle.park(0, park_point);
 
         if (turn_off_nozzle) thermalManager.setTargetHotend(0, active_extruder);
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1148,11 +1148,11 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE, "Movement bounds (X_MIN_POS, X_MAX_POS
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
   constexpr float npp[] = NOZZLE_PARK_POINT;
-  static_assert(COUNT(npp) == XYZ, "NOZZLE_PARK_POINT requires X, Y, and Z values.");
+  static_assert(COUNT(npp) == NUM_AXES, "NOZZLE_PARK_POINT requires X, Y, and Z values.");
   constexpr xyz_pos_t npp_xyz = NOZZLE_PARK_POINT;
   static_assert(WITHIN(npp_xyz.x, X_MIN_POS, X_MAX_POS), "NOZZLE_PARK_POINT.X is out of bounds (X_MIN_POS, X_MAX_POS).");
   static_assert(WITHIN(npp_xyz.y, Y_MIN_POS, Y_MAX_POS), "NOZZLE_PARK_POINT.Y is out of bounds (Y_MIN_POS, Y_MAX_POS).");
-  static_assert(WITHIN(npp_xyz.z, Z_MIN_POS, Z_MAX_POS), "NOZZLE_PARK_POINT.Z is out of bounds (Z_MIN_POS, Z_MAX_POS).");
+  static_assert(TERN1(HAS_Z_AXIS,WITHIN(npp_xyz.z, Z_MIN_POS, Z_MAX_POS)), "NOZZLE_PARK_POINT.Z is out of bounds (Z_MIN_POS, Z_MAX_POS).");
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1148,11 +1148,11 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE, "Movement bounds (X_MIN_POS, X_MAX_POS
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
   constexpr float npp[] = NOZZLE_PARK_POINT;
-  static_assert(COUNT(npp) == NUM_AXES, "NOZZLE_PARK_POINT requires X, Y, and Z values.");
+  static_assert(COUNT(npp) == _MIN(NUM_AXES, XYZ), "NOZZLE_PARK_POINT requires coordinates for enabled axes, but only up to X,Y,Z.");
   constexpr xyz_pos_t npp_xyz = NOZZLE_PARK_POINT;
   static_assert(WITHIN(npp_xyz.x, X_MIN_POS, X_MAX_POS), "NOZZLE_PARK_POINT.X is out of bounds (X_MIN_POS, X_MAX_POS).");
-  static_assert(WITHIN(npp_xyz.y, Y_MIN_POS, Y_MAX_POS), "NOZZLE_PARK_POINT.Y is out of bounds (Y_MIN_POS, Y_MAX_POS).");
-  static_assert(TERN1(HAS_Z_AXIS,WITHIN(npp_xyz.z, Z_MIN_POS, Z_MAX_POS)), "NOZZLE_PARK_POINT.Z is out of bounds (Z_MIN_POS, Z_MAX_POS).");
+  static_assert(TERN1(HAS_Y_AXIS, WITHIN(npp_xyz.y, Y_MIN_POS, Y_MAX_POS)), "NOZZLE_PARK_POINT.Y is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+  static_assert(TERN1(HAS_Z_AXIS, WITHIN(npp_xyz.z, Z_MIN_POS, Z_MAX_POS)), "NOZZLE_PARK_POINT.Z is out of bounds (Z_MIN_POS, Z_MAX_POS).");
 #endif
 
 /**

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -999,12 +999,11 @@ void MarlinUI::draw_status_screen() {
       #endif // LCD_WIDTH >= 20
 
       #if HAS_Z_AXIS
-      lcd_moveto(LCD_WIDTH - 8, 1);
-      _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position.z)), blink);
-      #endif
-
-      #if HAS_LEVELING && !HAS_HEATED_BED
-        lcd_put_lchar(planner.leveling_active || blink ? '_' : ' ');
+        lcd_moveto(LCD_WIDTH - 8, 1);
+        _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position.z)), blink);
+        #if HAS_LEVELING && !HAS_HEATED_BED
+          lcd_put_lchar(planner.leveling_active || blink ? '_' : ' ');
+        #endif
       #endif
 
     #endif // LCD_HEIGHT > 2

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -521,7 +521,7 @@ FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const
   else if (axis_should_home(axis))
     while (const char c = *value++) lcd_put_lchar(c <= '.' ? c : '?');
   else if (NONE(HOME_AFTER_DEACTIVATE, DISABLE_REDUCED_ACCURACY_WARNING) && !axis_is_trusted(axis))
-    lcd_put_u8str(axis == Z_AXIS ? F("       ") : F("    "));
+    lcd_put_u8str(TERN0(HAS_Z_AXIS, axis == Z_AXIS) ? F("       ") : F("    "));
   else
     lcd_put_u8str(value);
 }
@@ -998,8 +998,10 @@ void MarlinUI::draw_status_screen() {
 
       #endif // LCD_WIDTH >= 20
 
+      #if HAS_Z_AXIS
       lcd_moveto(LCD_WIDTH - 8, 1);
       _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position.z)), blink);
+      #endif
 
       #if HAS_LEVELING && !HAS_HEATED_BED
         lcd_put_lchar(planner.leveling_active || blink ? '_' : ' ');

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -597,7 +597,7 @@ void menu_backlash();
       ;
 
       LOOP_LOGICAL_AXES(a) {
-        if (a == C_AXIS || TERN0(HAS_EXTRUDERS, a == E_AXIS))
+        if (TERN0(HAS_C_AXIS, a == C_AXIS) || TERN0(HAS_EXTRUDERS, a == E_AXIS))
           EDIT_ITEM_FAST_N(float52sign, a, MSG_VN_JERK, &planner.max_jerk[a], 0.1f, max_jerk_edit[a]);
         else
           EDIT_ITEM_FAST_N(float3, a, MSG_VN_JERK, &planner.max_jerk[a], 1.0f, max_jerk_edit[a]);

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -225,6 +225,7 @@ Nozzle nozzle;
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
+  #if HAS_Z_AXIS
   float Nozzle::park_mode_0_height(const_float_t park_z) {
     // Apply a minimum raise, if specified. Use park.z as a minimum height instead.
     return _MAX(park_z,                       // Minimum height over 0 based on input
@@ -236,9 +237,12 @@ Nozzle nozzle;
       )
     );
   }
+  #endif
 
   void Nozzle::park(const uint8_t z_action, const xyz_pos_t &park/*=NOZZLE_PARK_POINT*/) {
-    constexpr feedRate_t fr_xy = NOZZLE_PARK_XY_FEEDRATE, fr_z = NOZZLE_PARK_Z_FEEDRATE;
+    constexpr feedRate_t fr_xy = NOZZLE_PARK_XY_FEEDRATE;
+    #if HAS_Z_AXIS
+    constexpr feedRate_t fr_z = NOZZLE_PARK_Z_FEEDRATE;
 
     switch (z_action) {
       case 1: // Go to Z-park height
@@ -253,6 +257,7 @@ Nozzle nozzle;
         do_blocking_move_to_z(park_mode_0_height(park.z), fr_z);
         break;
     }
+    #endif
 
     #ifndef NOZZLE_PARK_MOVE
       #define NOZZLE_PARK_MOVE 0

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -226,42 +226,42 @@ Nozzle nozzle;
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
   #if HAS_Z_AXIS
-  float Nozzle::park_mode_0_height(const_float_t park_z) {
-    // Apply a minimum raise, if specified. Use park.z as a minimum height instead.
-    return _MAX(park_z,                       // Minimum height over 0 based on input
-      _MIN(Z_MAX_POS,                         // Maximum height is fixed
-        #ifdef NOZZLE_PARK_Z_RAISE_MIN
-          NOZZLE_PARK_Z_RAISE_MIN +           // Minimum raise...
-        #endif
-        current_position.z                    // ...over current position
-      )
-    );
-  }
-  #endif
+    float Nozzle::park_mode_0_height(const_float_t park_z) {
+      // Apply a minimum raise, if specified. Use park.z as a minimum height instead.
+      return _MAX(park_z,                       // Minimum height over 0 based on input
+        _MIN(Z_MAX_POS,                         // Maximum height is fixed
+          #ifdef NOZZLE_PARK_Z_RAISE_MIN
+            NOZZLE_PARK_Z_RAISE_MIN +           // Minimum raise...
+          #endif
+          current_position.z                    // ...over current position
+        )
+      );
+    }
+  #endif // HAS_Z_AXIS
 
   void Nozzle::park(const uint8_t z_action, const xyz_pos_t &park/*=NOZZLE_PARK_POINT*/) {
-    constexpr feedRate_t fr_xy = NOZZLE_PARK_XY_FEEDRATE;
     #if HAS_Z_AXIS
-    constexpr feedRate_t fr_z = NOZZLE_PARK_Z_FEEDRATE;
+      constexpr feedRate_t fr_z = NOZZLE_PARK_Z_FEEDRATE;
 
-    switch (z_action) {
-      case 1: // Go to Z-park height
-        do_blocking_move_to_z(park.z, fr_z);
-        break;
+      switch (z_action) {
+        case 1: // Go to Z-park height
+          do_blocking_move_to_z(park.z, fr_z);
+          break;
 
-      case 2: // Raise by Z-park height
-        do_blocking_move_to_z(_MIN(current_position.z + park.z, Z_MAX_POS), fr_z);
-        break;
+        case 2: // Raise by Z-park height
+          do_blocking_move_to_z(_MIN(current_position.z + park.z, Z_MAX_POS), fr_z);
+          break;
 
-      default: // Raise by NOZZLE_PARK_Z_RAISE_MIN, use park.z as a minimum height
-        do_blocking_move_to_z(park_mode_0_height(park.z), fr_z);
-        break;
-    }
-    #endif
+        default: // Raise by NOZZLE_PARK_Z_RAISE_MIN, use park.z as a minimum height
+          do_blocking_move_to_z(park_mode_0_height(park.z), fr_z);
+          break;
+      }
+    #endif // HAS_Z_AXIS
 
     #ifndef NOZZLE_PARK_MOVE
       #define NOZZLE_PARK_MOVE 0
     #endif
+    constexpr feedRate_t fr_xy = NOZZLE_PARK_XY_FEEDRATE;
     switch (NOZZLE_PARK_MOVE) {
       case 0: do_blocking_move_to_xy(park, fr_xy); break;
       case 1: do_blocking_move_to_x(park.x, fr_xy); break;

--- a/Marlin/src/module/polargraph.cpp
+++ b/Marlin/src/module/polargraph.cpp
@@ -43,7 +43,11 @@ xy_pos_t draw_area_min, draw_area_max;
 
 void inverse_kinematics(const xyz_pos_t &raw) {
   const float x1 = raw.x - draw_area_min.x, x2 = draw_area_max.x - raw.x, y = raw.y - draw_area_max.y;
-  delta.set(HYPOT(x1, y), HYPOT(x2, y), raw.z);
+  #if HAS_Z_AXIS
+    delta.set(HYPOT(x1, y), HYPOT(x2, y), raw.z);
+  #else
+    delta.set(HYPOT(x1, y), HYPOT(x2, y));
+  #endif
 }
 
 #endif // POLARGRAPH

--- a/Marlin/src/module/polargraph.cpp
+++ b/Marlin/src/module/polargraph.cpp
@@ -43,11 +43,7 @@ xy_pos_t draw_area_min, draw_area_max;
 
 void inverse_kinematics(const xyz_pos_t &raw) {
   const float x1 = raw.x - draw_area_min.x, x2 = draw_area_max.x - raw.x, y = raw.y - draw_area_max.y;
-  #if HAS_Z_AXIS
-    delta.set(HYPOT(x1, y), HYPOT(x2, y), raw.z);
-  #else
-    delta.set(HYPOT(x1, y), HYPOT(x2, y));
-  #endif
+  delta.set(HYPOT(x1, y), HYPOT(x2, y) OPTARG(HAS_Z_AXIS, raw.z));
 }
 
 #endif // POLARGRAPH


### PR DESCRIPTION

### Description

This PR fixes compilation errors in (some) places that assume Z axis is always defined.
For Polargraphs (Makelangelo) it is not true - these use X & Y axes only.

### Requirements

Machines without Z axis

### Benefits

Z axis can be completely disabled from the build. Good for machines with only X & Y axis.

### Configurations

Attached my example config in ZIP
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/10962225/Configuration.zip)

### Related Issues

#25513 

