### PR TITLE
test for ramps default Z_MIN_PROBE_PIN on stm32

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1345,19 +1345,17 @@
 /**
  * Z_MIN_PROBE_PIN
  *
- * Define this pin if the probe is not connected to Z_MIN_PIN.
- * If not defined the default pin for the selected MOTHERBOARD
- * will be used. Most of the time the default is what you want.
+ * Override this pin only if the probe cannot be connected to
+ * the default Z_MIN_PROBE_PIN for the selected MOTHERBOARD.
  *
  *  - The simplest option is to use a free endstop connector.
  *  - Use 5V for powered (usually inductive) sensors.
  *
- *  - RAMPS 1.3/1.4 boards may use the 5V, GND, and Aux4->D32 pin:
- *    - For simple switches connect...
- *      - normally-closed switches to GND and D32.
- *      - normally-open switches to 5V and D32.
+ *  - For simple switches...
+ *    - Normally-closed (NC) also connect to GND.
+ *    - Normally-open (NO) also connect to 5V.
  */
-//#define Z_MIN_PROBE_PIN 32 // Pin 32 is the RAMPS default
+//#define Z_MIN_PROBE_PIN -1
 
 /**
  * Probe Type

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -109,7 +109,3 @@
 #endif
 #undef CHECK_SERIAL_PIN
 #undef _CHECK_SERIAL_PIN
-
-#if Z_MIN_PROBE_PIN == 32
-  #error "Disable Z_MIN_PROBE_PIN to use the default pin for your controller or set it to the correct custom pin."
-#endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -111,5 +111,5 @@
 #undef _CHECK_SERIAL_PIN
 
 #if Z_MIN_PROBE_PIN == 32
-  #error "Z_MIN_PROBE_PIN is not 32 on any known STM32 controller. This is the default for a RAMPS controller."
+  #error "Disable Z_MIN_PROBE_PIN to use the default pin for your controller or set it to the correct custom pin."
 #endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -109,3 +109,7 @@
 #endif
 #undef CHECK_SERIAL_PIN
 #undef _CHECK_SERIAL_PIN
+
+#if Z_MIN_PROBE_PIN == 32
+  #error "Z_MIN_PROBE_PIN is not 32 on any known STM32 controller. This is the default for a RAMPS controller."
+#endif


### PR DESCRIPTION
### Description

Users are just enabling,#define Z_MIN_PROBE_PIN 32 without updating the pin
Most commonly stm32 based controllers (creality v4xx boards)   
Add a check for setting Z_MIN_PROBE_PIN to 32 on a stm32 

### Benefits

Less confused users

