### PR TITLE
Add warning if PRINTCOUNTER_SAVE_INTERVAL is enabled (>0) on an ESP32 board with an I2S expander.

### DIFF
--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -57,6 +57,6 @@
   #error "I2S stream is currently incompatible with LIN_ADVANCE."
 #endif
 
-#if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0
-  #error "PRINTCOUNTER_SAVE_INTERVAL must be zero (disabled) on ESP32 boards with an I2S expander."
+#if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0 && DISABLED(PRINTCOUNTER_SYNC)
+  #error "PRINTCOUNTER_SAVE_INTERVAL may cause issues on ESP32 with an I2S expander. Define PRINTCOUNTER_SYNC in Configuration.h for an imperfect solution."
 #endif

--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -56,3 +56,7 @@
 #if BOTH(I2S_STEPPER_STREAM, LIN_ADVANCE) && DISABLED(EXPERIMENTAL_I2S_LA)
   #error "I2S stream is currently incompatible with LIN_ADVANCE."
 #endif
+
+#if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0
+  #error "PRINTCOUNTER_SAVE_INTERVAL must be zero (disabled) on ESP32 oards with an I2S expander."
+#endif

--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -58,5 +58,5 @@
 #endif
 
 #if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0
-  #error "PRINTCOUNTER_SAVE_INTERVAL must be zero (disabled) on ESP32 oards with an I2S expander."
+  #error "PRINTCOUNTER_SAVE_INTERVAL must be zero (disabled) on ESP32 boards with an I2S expander."
 #endif

--- a/Marlin/src/HAL/LPC1768/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/LPC1768/inc/Conditionals_post.h
@@ -30,5 +30,5 @@
 // LPC1768 boards seem to lose steps when saving to EEPROM during print (issue #20785)
 // TODO: Which other boards are incompatible?
 #if defined(MCU_LPC1768) && ENABLED(FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
-  #define PRINTCOUNTER_SYNC 1
+  #define PRINTCOUNTER_SYNC
 #endif

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -30,5 +30,5 @@
 
 // Some STM32F4 boards may lose steps when saving to EEPROM during print (PR #17946)
 #if defined(STM32F4xx) && ENABLED(FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
-  #define PRINTCOUNTER_SYNC 1
+  #define PRINTCOUNTER_SYNC
 #endif

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -715,7 +715,7 @@
   #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225, H8=HR4988). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
-#if PRINTCOUNTER_SYNC
+#if ENABLED(PRINTCOUNTER_SYNC)
   #warning "To prevent step loss, motion will pause for PRINTCOUNTER auto-save."
 #endif
 

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -41,7 +41,7 @@ Stopwatch print_job_timer;      // Global Print Job Timer instance
   #include "../libs/buzzer.h"
 #endif
 
-#if PRINTCOUNTER_SYNC
+#if ENABLED(PRINTCOUNTER_SYNC)
   #include "../module/planner.h"
 #endif
 


### PR DESCRIPTION
### Description
Add warning if PRINTCOUNTER_SAVE_INTERVAL is enabled (>0) on an ESP32 board with an I2S expander.

Erasing flash (emulating EEPROM) on an ESP32 takes quite a long time and, if carried out during printing, can result in missed steps and layer shifts.   Not absolutely certain but I think the I2S expander DMA buffers  are underflowing as any non-RAM code execution stops during a flash erase (buffers are swapped/filled by an interrupt and a separate task both of which will stall during the flash erase). 

If flash updates are carried out when not printing the same stalling occurs BUT, even if the continuously running I2S was to underflow, the hardware just re-sends the last word in the buffer when empty (and, 32mSec max. after a print has stopped,  that would (re)set the inactive state for any stepper drives).

Note that the actual flash erase timer will depend on the flash chip type  used on the board. 


### Requirements

Any ESP32 board with an I2S expander.

### Benefits

Prevents missed steps/ layer shifts


### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/24753
https://github.com/MarlinFirmware/Marlin/pull/24731

