### PR TITLE
fix unused variable warning in M569

### DIFF
--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -53,6 +53,8 @@ static void set_stealth_status(const bool enable, const int8_t eindex) {
     constexpr int8_t index = -1;
   #endif
 
+  UNUSED(index);
+
   LOOP_LOGICAL_AXES(i) if (parser.seen(AXIS_CHAR(i))) {
     switch (i) {
       case X_AXIS:


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
fix this warning during compile
```
Marlin\src\gcode\feature\trinamic\M569.cpp: In function 'void set_stealth_status(bool, int8_t)':
Marlin\src\gcode\feature\trinamic\M569.cpp:53:22: warning: unused variable 'index' [-Wunused-variable]
   53 |     constexpr int8_t index = -1;
```
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
#define E0_DRIVER_TYPE TMC2208

### Benefits
silence warning
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
