### PR TITLE
Fix capitalisation in marlin_STM32H723Vx.json to match folder name

### DIFF
--- a/buildroot/share/PlatformIO/boards/marlin_STM32H723Vx.json
+++ b/buildroot/share/PlatformIO/boards/marlin_STM32H723Vx.json
@@ -6,7 +6,7 @@
     "f_cpu": "550000000L",
     "mcu": "stm32h723vet6",
     "product_line": "STM32H723xx",
-    "variant": "MARLIN_H723vx"
+    "variant": "MARLIN_H723Vx"
   },
   "connectivity": [
     "can",


### PR DESCRIPTION
This allows building on case-sensitive filesystems. I have not checked to see if this issues affects any other boards.
