### PR TITLE
⚡️ Apply fast types for profiling

### DIFF
--- a/Marlin/src/HAL/DUE/fastio/G2_PWM.h
+++ b/Marlin/src/HAL/DUE/fastio/G2_PWM.h
@@ -59,7 +59,7 @@ extern PWM_map ISR_table[NUM_PWMS];
 extern uint32_t motor_current_setting[3];
 
 #define IR_BIT(p) (WITHIN(p, 0, 3) ? (p) : (p) + 4)
-#define COPY_ACTIVE_TABLE() do{ for (uint8_t i = 0; i < 6; ++i) work_table[i] = active_table[i]; }while(0)
+#define COPY_ACTIVE_TABLE() do{ for (uint_fast8_t i = 0; i < 6; ++i) work_table[i] = active_table[i]; }while(0)
 
 #define PWM_MR0 19999         // base repetition rate minus one count - 20mS
 #define PWM_PR 24             // prescaler value - prescaler divide by 24 + 1  -  1 MHz output

--- a/Marlin/src/HAL/DUE/u8g/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/DUE/u8g/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -81,7 +81,7 @@ Pio *SCK_pPio, *MOSI_pPio;
 uint32_t SCK_dwMask, MOSI_dwMask;
 
 void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     if (val & 0x80)
       MOSI_pPio->PIO_SODR = MOSI_dwMask;
     else
@@ -95,7 +95,7 @@ void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
 }
 
 void u8g_spiSend_sw_DUE_mode_3(uint8_t val) { // 3.5MHz
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     SCK_pPio->PIO_CODR = SCK_dwMask;
     DELAY_NS(50);
     if (val & 0x80)

--- a/Marlin/src/HAL/DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/DUE/usb/usb_task.c
@@ -245,7 +245,7 @@ bool usb_task_extra_string(void) {
     return false;
   }
 
-  for (uint8_t i = 0; i < str_lgt; i++)
+  for (uint_fast8_t i = 0; i < str_lgt; i++)
     extra_strings_desc.string[i] = cpu_to_le16((le16_t)str[i]);
 
   extra_strings_desc.header.bLength = 2 + str_lgt * 2;

--- a/Marlin/src/HAL/ESP32/i2s.cpp
+++ b/Marlin/src/HAL/ESP32/i2s.cpp
@@ -374,7 +374,7 @@ void i2s_push_sample() {
   // Every 4µs (when space in DMA buffer) toggle each expander PWM output using
   // the current duty cycle/frequency so they sync with any steps (once
   // through the DMA/FIFO buffers).  PWM signal inversion handled by other functions
-  for (uint8_t p = 0; p < MAX_EXPANDER_BITS; ++p) {
+  for (uint_fast8_t p = 0; p < MAX_EXPANDER_BITS; ++p) {
     if (hal.pwm_pin_data[p].pwm_duty_ticks > 0) { // pin has active pwm?
       if (hal.pwm_pin_data[p].pwm_tick_count == 0) {
         if (TEST32(i2s_port_data, p)) {  // hi->lo

--- a/Marlin/src/HAL/LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL.cpp
@@ -89,7 +89,7 @@ void MarlinHAL::init() {
     #endif
 
     // Flash status LED 3 times to indicate Marlin has started booting
-    for (uint8_t i = 0; i < 6; ++i) {
+    for (uint_fast8_t i = 0; i < 6; ++i) {
       TOGGLE(LED_PIN);
       delay(100);
     }

--- a/Marlin/src/HAL/LPC1768/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/LPC1768/tft/tft_spi.cpp
@@ -82,7 +82,7 @@ uint32_t TFT_SPI::readID(const uint16_t inReg) {
     WRITE(TFT_CS_PIN, LOW);
     writeReg(inReg);
 
-    for (uint8_t i = 0; i < 4; ++i) {
+    for (uint_fast8_t i = 0; i < 4; ++i) {
       SPIx.read((uint8_t*)&d, 1);
       data = (data << 8) | d;
     }

--- a/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
@@ -120,7 +120,7 @@ extern uint8_t spiTransfer(uint8_t b);
 uint16_t XPT2046::softwareIO(uint16_t data) {
   uint16_t result = 0;
 
-  for (uint8_t j = 0x80; j; j >>= 1) {
+  for (uint_fast8_t j = 0x80; j; j >>= 1) {
     WRITE(TOUCH_SCK_PIN, LOW);
     WRITE(TOUCH_MOSI_PIN, data & j ? HIGH : LOW);
     if (READ(TOUCH_MISO_PIN)) result |= j;

--- a/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -75,7 +75,7 @@
 
 uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       LPC176x::gpio_set(mosi_pin, !!(b & 0x80));
       LPC176x::gpio_set(sck_pin, HIGH);
@@ -85,16 +85,16 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(mosi_pin, state);
 
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         LPC176x::gpio_set(sck_pin, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && LPC176x::gpio_get(miso_pin)) b |= 1;
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(sck_pin, LOW);
     }
   }
@@ -104,7 +104,7 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
 
 uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       LPC176x::gpio_set(sck_pin, LOW);
@@ -113,13 +113,13 @@ uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck
       LPC176x::gpio_set(sck_pin, HIGH);
     }
     else {
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         LPC176x::gpio_set(sck_pin, LOW);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(mosi_pin, state);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(sck_pin, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_st7920_sw_spi.cpp
@@ -70,7 +70,7 @@ static pin_t SCK_pin_ST7920_HAL, MOSI_pin_ST7920_HAL_HAL;
 static uint8_t SPI_speed = 0;
 
 static uint8_t swSpiTransfer(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin) {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint_fast8_t i = 0; i < 8; i++) {
     WRITE_PIN(mosi_pin, !!(b & 0x80));
     DELAY_CYCLES(SPI_SPEED);
     WRITE_PIN(sck_pin, HIGH);

--- a/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
@@ -70,7 +70,7 @@
 #endif
 
 uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       WRITE_PIN(mosi_pin, !!(b & 0x80));
       WRITE_PIN(sck_pin, HIGH);
@@ -80,16 +80,16 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(mosi_pin, state);
 
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE_PIN(sck_pin, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(sck_pin, LOW);
     }
   }
@@ -99,7 +99,7 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
 
 uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       WRITE_PIN(sck_pin, LOW);
@@ -108,13 +108,13 @@ uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck
       WRITE_PIN(sck_pin, HIGH);
     }
     else {
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE_PIN(sck_pin, LOW);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(mosi_pin, state);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(sck_pin, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -713,10 +713,10 @@ void MarlinHAL::adc_init() {
   #if ADC_IS_REQUIRED
     memset(adc_results, 0xFF, sizeof(adc_results));                         // Fill result with invalid values
 
-    for (uint8_t pi = 0; pi < COUNT(adc_pins); ++pi)
+    for (uint_fast8_t pi = 0; pi < COUNT(adc_pins); ++pi)
       pinPeripheral(adc_pins[pi], PIO_ANALOG);
 
-    for (uint8_t ai = FIRST_ADC; ai <= LAST_ADC; ++ai) {
+    for (uint_fast8_t ai = FIRST_ADC; ai <= LAST_ADC; ++ai) {
       Adc* adc = ((Adc*[])ADC_INSTS)[ai];
 
       // ADC clock setup
@@ -748,7 +748,7 @@ void MarlinHAL::adc_init() {
 
 void MarlinHAL::adc_start(const pin_t pin) {
   #if ADC_IS_REQUIRED
-    for (uint8_t pi = 0; pi < COUNT(adc_pins); ++pi)
+    for (uint_fast8_t pi = 0; pi < COUNT(adc_pins); ++pi)
       if (pin == adc_pins[pi]) { adc_result = adc_results[pi]; return; }
   #endif
 

--- a/Marlin/src/HAL/STM32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/STM32/HAL_SPI.cpp
@@ -83,7 +83,7 @@ static SPISettings spiConfig;
   void spiBeginTransaction(uint32_t spiClock, uint8_t bitOrder, uint8_t dataMode) { /* do nothing */ }
 
   uint8_t HAL_SPI_STM32_SpiTransfer_Mode_3(uint8_t b) { // using Mode 3
-    for (uint8_t bits = 8; bits--;) {
+    for (uint_fast8_t bits = 8; bits--;) {
       WRITE(SD_SCK_PIN, LOW);
       WRITE(SD_MOSI_PIN, b & 0x80);
 

--- a/Marlin/src/HAL/STM32/fastio.cpp
+++ b/Marlin/src/HAL/STM32/fastio.cpp
@@ -28,7 +28,7 @@
 GPIO_TypeDef* FastIOPortMap[LastPort + 1] = { 0 };
 
 void FastIO_init() {
-  for (uint8_t i = 0; i < NUM_DIGITAL_PINS; ++i)
+  for (uint_fast8_t i = 0; i < NUM_DIGITAL_PINS; ++i)
     FastIOPortMap[STM_PORT(digitalPin[i])] = get_GPIO_Port(STM_PORT(digitalPin[i]));
 }
 

--- a/Marlin/src/HAL/STM32/tft/gt911.cpp
+++ b/Marlin/src/HAL/STM32/tft/gt911.cpp
@@ -90,7 +90,7 @@ bool SW_IIC::read_ack() {
 }
 
 void SW_IIC::send_byte(uint8_t txd) {
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     write_sda(txd & 0x80); // write data bit
     txd <<= 1;
     iic_delay(1);
@@ -107,7 +107,7 @@ uint8_t SW_IIC::read_byte(bool ack) {
   uint8_t data = 0;
 
   set_sda_in();
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     write_scl(HIGH); // SCL = 1
     iic_delay(1);
     data <<= 1;
@@ -128,12 +128,12 @@ SW_IIC GT911::sw_iic = SW_IIC(GT911_SW_I2C_SDA_PIN, GT911_SW_I2C_SCL_PIN);
 void GT911::write_reg(uint16_t reg, uint8_t reg_len, uint8_t* w_data, uint8_t w_len) {
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address);  // Set IIC Slave address
-  for (uint8_t i = 0; i < reg_len; ++i) {  // Set reg address
+  for (uint_fast8_t i = 0; i < reg_len; ++i) {  // Set reg address
     uint8_t r = (reg >> (8 * (reg_len - 1 - i))) & 0xFF;
     sw_iic.send_byte(r);
   }
 
-  for (uint8_t i = 0; i < w_len; ++i) {  // Write data to reg
+  for (uint_fast8_t i = 0; i < w_len; ++i) {  // Write data to reg
     sw_iic.send_byte(w_data[i]);
   }
   sw_iic.stop();
@@ -142,7 +142,7 @@ void GT911::write_reg(uint16_t reg, uint8_t reg_len, uint8_t* w_data, uint8_t w_
 void GT911::read_reg(uint16_t reg, uint8_t reg_len, uint8_t* r_data, uint8_t r_len) {
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address);  // Set IIC Slave address
-  for (uint8_t i = 0; i < reg_len; ++i) {  // Set reg address
+  for (uint_fast8_t i = 0; i < reg_len; ++i) {  // Set reg address
     uint8_t r = (reg >> (8 * (reg_len - 1 - i))) & 0xFF;
     sw_iic.send_byte(r);
   }
@@ -150,7 +150,7 @@ void GT911::read_reg(uint16_t reg, uint8_t reg_len, uint8_t* r_data, uint8_t r_l
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address + 1);  // Set read mode
 
-  for (uint8_t i = 0; i < r_len; ++i)
+  for (uint_fast8_t i = 0; i < r_len; ++i)
     r_data[i] = sw_iic.read_byte(1);  // Read data from reg
 
   sw_iic.stop();

--- a/Marlin/src/HAL/STM32/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32/tft/xpt2046.cpp
@@ -182,7 +182,7 @@ uint16_t XPT2046::hardwareIO(uint16_t data) {
 uint16_t XPT2046::softwareIO(uint16_t data) {
   uint16_t result = 0;
 
-  for (uint8_t j = 0x80; j > 0; j >>= 1) {
+  for (uint_fast8_t j = 0x80; j > 0; j >>= 1) {
     WRITE(TOUCH_SCK_PIN, LOW);
     __DSB();
     WRITE(TOUCH_MOSI_PIN, data & j ? HIGH : LOW);

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -316,8 +316,8 @@ static constexpr struct { TimerPurpose p; int t; } timers_in_use[] = {
 };
 
 static constexpr bool verify_no_timer_conflicts() {
-  for (uint8_t i = 0; i < COUNT(timers_in_use); ++i)
-    for (uint8_t j = i + 1; j < COUNT(timers_in_use); ++j)
+  for (uint_fast8_t i = 0; i < COUNT(timers_in_use); ++i)
+    for (uint_fast8_t j = i + 1; j < COUNT(timers_in_use); ++j)
       if (timers_in_use[i].t == timers_in_use[j].t) return false;
   return true;
 }

--- a/Marlin/src/HAL/STM32F1/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32F1/fast_pwm.cpp
@@ -31,7 +31,7 @@ static uint16_t timer_freq[NR_TIMERS];
 
 inline uint8_t timer_and_index_for_pin(const pin_t pin, timer_dev **timer_ptr) {
   *timer_ptr = PIN_MAP[pin].timer_device;
-  for (uint8_t i = 0; i < NR_TIMERS; i++) if (*timer_ptr == HAL_get_timer_dev(i))
+  for (uint_fast8_t i = 0; i < NR_TIMERS; i++) if (*timer_ptr == HAL_get_timer_dev(i))
     return i;
   return 0;
 }

--- a/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
@@ -101,7 +101,7 @@ uint32_t TFT_SPI::readID(const uint16_t inReg) {
     dataTransferBegin(DATASIZE_8BIT);
     writeReg(inReg);
 
-    for (uint8_t i = 0; i < 4; ++i) {
+    for (uint_fast8_t i = 0; i < 4; ++i) {
       uint8_t d;
       SPIx.read(&d, 1);
       data = (data << 8) | d;

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
@@ -131,7 +131,7 @@ uint16_t XPT2046::IO(uint16_t data) {
 uint16_t XPT2046::softwareIO(uint16_t data) {
   uint16_t result = 0;
 
-  for (uint8_t j = 0x80; j; j >>= 1) {
+  for (uint_fast8_t j = 0x80; j; j >>= 1) {
     WRITE(TOUCH_SCK_PIN, LOW);
     WRITE(TOUCH_MOSI_PIN, data & j ? HIGH : LOW);
     if (READ(TOUCH_MISO_PIN)) result |= j;

--- a/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
@@ -37,7 +37,7 @@
 static uint8_t SPI_speed = LCD_SPI_SPEED;
 
 static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin=-1) {
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       WRITE(DOGLCD_MOSI, !!(b & 0x80));
       WRITE(DOGLCD_SCK, HIGH);
@@ -47,16 +47,16 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_MOSI, state);
 
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE(DOGLCD_SCK, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && READ(miso_pin)) b |= 1;
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_SCK, LOW);
     }
   }
@@ -64,7 +64,7 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
 }
 
 static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin=-1) {
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       WRITE(DOGLCD_SCK, LOW);
@@ -73,13 +73,13 @@ static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, c
       WRITE(DOGLCD_SCK, HIGH);
     }
     else {
-      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
+      for (uint_fast8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE(DOGLCD_SCK, LOW);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_MOSI, state);
 
-      for (uint8_t j = 0; j < spi_speed; ++j)
+      for (uint_fast8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_SCK, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/shared/MinSerial.h
+++ b/Marlin/src/HAL/shared/MinSerial.h
@@ -53,7 +53,7 @@ struct MinSerial {
   // Send Hex number through UART
   static void TXHex(uint32_t v) {
     TX("0x");
-    for (uint8_t i = 0; i < 8; i++, v <<= 4)
+    for (uint_fast8_t i = 0; i < 8; i++, v <<= 4)
       TXDigit((v >> 28) & 0xF);
   }
 

--- a/Marlin/src/HAL/shared/servo.cpp
+++ b/Marlin/src/HAL/shared/servo.cpp
@@ -67,7 +67,7 @@ uint8_t ServoCount = 0;                         // the total number of attached 
 
 static bool anyTimerChannelActive(const timer16_Sequence_t timer) {
   // returns true if any servo is active on this timer
-  for (uint8_t channel = 0; channel < SERVOS_PER_TIMER; ++channel) {
+  for (uint_fast8_t channel = 0; channel < SERVOS_PER_TIMER; ++channel) {
     if (SERVO(timer, channel).Pin.isActive)
       return true;
   }

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -323,9 +323,9 @@ bool wait_for_heatup = false;
 
 bool pin_is_protected(const pin_t pin) {
   #define pgm_read_pin(P) (sizeof(pin_t) == 2 ? (pin_t)pgm_read_word(P) : (pin_t)pgm_read_byte(P))
-  for (uint8_t i = 0; i < COUNT(sensitive_dio); ++i)
+  for (uint_fast8_t i = 0; i < COUNT(sensitive_dio); ++i)
     if (pin == pgm_read_pin(&sensitive_dio[i])) return true;
-  for (uint8_t i = 0; i < COUNT(sensitive_aio); ++i)
+  for (uint_fast8_t i = 0; i < COUNT(sensitive_aio); ++i)
     if (pin == analogInputToDigitalPin(pgm_read_pin(&sensitive_aio[i]))) return true;
   return false;
 }
@@ -810,7 +810,7 @@ void idle(const bool no_stepper_sleep/*=false*/) {
   // Run StallGuard endstop checks
   #if ENABLED(SPI_ENDSTOPS)
     if (endstops.tmc_spi_homing.any && TERN1(IMPROVE_HOMING_RELIABILITY, ELAPSED(millis(), sg_guard_period)))
-      for (uint8_t i = 0; i < 4; ++i) if (endstops.tmc_spi_homing_check()) break; // Read SGT 4 times per idle loop
+      for (uint_fast8_t i = 0; i < 4; ++i) if (endstops.tmc_spi_homing_check()) break; // Read SGT 4 times per idle loop
   #endif
 
   // Handle SD Card insert / remove
@@ -1694,7 +1694,7 @@ void setup() {
   #ifdef STARTUP_TUNE
     // Play a short startup tune before continuing.
     constexpr uint16_t tune[] = STARTUP_TUNE;
-    for (uint8_t i = 0; i < COUNT(tune) - 1; i += 2) BUZZ(tune[i + 1], tune[i]);
+    for (uint_fast8_t i = 0; i < COUNT(tune) - 1; i += 2) BUZZ(tune[i + 1], tune[i]);
   #endif
 
   SETUP_LOG("setup() completed.");

--- a/Marlin/src/core/endianness.h
+++ b/Marlin/src/core/endianness.h
@@ -58,7 +58,7 @@ namespace Endianness {
     } src{}, dst{};
 
     src.val = V;
-    for (uint8_t i = 0; i < sizeof(T); ++i) dst.byte[i] = src.byte[sizeof(T) - i - 1];
+    for (uint_fast8_t i = 0; i < sizeof(T); ++i) dst.byte[i] = src.byte[sizeof(T) - i - 1];
     return dst.val;
   }
 

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -119,7 +119,7 @@ void serialprintln_onoff(const bool onoff) { serialprint_onoff(onoff); SERIAL_EO
 void serialprint_truefalse(const bool tf) { SERIAL_ECHO(tf ? F("true") : F("false")); }
 
 void print_bin(uint16_t val) {
-  for (uint8_t i = 16; i--;) {
+  for (uint_fast8_t i = 16; i--;) {
     SERIAL_CHAR('0' + TEST(val, i));
     if (!(i & 0x3) && i) SERIAL_CHAR(' ');
   }

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -233,7 +233,7 @@ struct SerialBase {
 
     // Round correctly so that print(1.999, 2) prints as "2.00"
     double rounding = 0.5;
-    for (uint8_t i = 0; i < digits; ++i) rounding *= 0.1;
+    for (uint_fast8_t i = 0; i < digits; ++i) rounding *= 0.1;
     number += rounding;
 
     // Extract the integer part of the number and print it

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -301,7 +301,7 @@ typedef struct {
 //  - A_AXIS, B_AXIS, and C_AXIS should be used for Steppers, corresponding to XYZ on Cartesians
 //  - X_HEAD, Y_HEAD, and Z_HEAD should be used for axes on Core kinematics
 //
-enum AxisEnum : uint8_t {
+enum AxisEnum : uint_fast8_t {
 
   // Linear axes may be controlled directly or indirectly
   NUM_AXIS_LIST_(X_AXIS, Y_AXIS, Z_AXIS, I_AXIS, J_AXIS, K_AXIS, U_AXIS, V_AXIS, W_AXIS)
@@ -341,11 +341,11 @@ enum AxisEnum : uint8_t {
 //
 // Loop over axes
 //
-#define LOOP_ABC(VAR) for (uint8_t VAR = A_AXIS; VAR <= C_AXIS; ++VAR)
-#define LOOP_NUM_AXES(VAR) for (uint8_t VAR = 0; VAR < NUM_AXES; ++VAR)
-#define LOOP_LOGICAL_AXES(VAR) for (uint8_t VAR = 0; VAR < LOGICAL_AXES; ++VAR)
-#define LOOP_DISTINCT_AXES(VAR) for (uint8_t VAR = 0; VAR < DISTINCT_AXES; ++VAR)
-#define LOOP_DISTINCT_E(VAR) for (uint8_t VAR = 0; VAR < DISTINCT_E; ++VAR)
+#define LOOP_ABC(VAR) for (uint_fast8_t VAR = A_AXIS; VAR <= C_AXIS; ++VAR)
+#define LOOP_NUM_AXES(VAR) for (uint_fast8_t VAR = 0; VAR < NUM_AXES; ++VAR)
+#define LOOP_LOGICAL_AXES(VAR) for (uint_fast8_t VAR = 0; VAR < LOGICAL_AXES; ++VAR)
+#define LOOP_DISTINCT_AXES(VAR) for (uint_fast8_t VAR = 0; VAR < DISTINCT_AXES; ++VAR)
+#define LOOP_DISTINCT_E(VAR) for (uint_fast8_t VAR = 0; VAR < DISTINCT_E; ++VAR)
 
 //
 // feedRate_t is just a humble float that can represent mm/s or mm/min

--- a/Marlin/src/feature/adc/adc_mcp3426.cpp
+++ b/Marlin/src/feature/adc/adc_mcp3426.cpp
@@ -81,7 +81,7 @@ int16_t MCP3426::ReadValue(uint8_t channel, uint8_t gain, uint8_t address) {
       return 0;
     }
 
-    for (uint8_t i = 0; i < len; ++i)
+    for (uint_fast8_t i = 0; i < len; ++i)
       buffer[i] = Wire.read();
 
     // Is conversion ready, if not loop around again

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -91,7 +91,7 @@ public:
   // apply accumulated babysteps to the axes.
   //
   static void task() {
-    for (uint8_t i = 0; i <= BS_AXIS_IND(Z_AXIS); ++i) step_axis(BS_AXIS(i));
+    for (uint_fast8_t i = 0; i <= BS_AXIS_IND(Z_AXIS); ++i) step_axis(BS_AXIS(i));
   }
 
 private:

--- a/Marlin/src/feature/bedlevel/abl/bbl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/bbl.cpp
@@ -133,8 +133,8 @@ void LevelingBilinear::extrapolate_unprobed_bed_level() {
                       yend = ctry1;
   #endif
 
-  for (uint8_t xo = 0; xo <= xend; ++xo)
-    for (uint8_t yo = 0; yo <= yend; ++yo) {
+  for (uint_fast8_t xo = 0; xo <= xend; ++xo)
+    for (uint_fast8_t yo = 0; yo <= yend; ++yo) {
       uint8_t x2 = ctrx2 + xo, y2 = ctry2 + yo;
       #ifndef HALF_IN_X
         const uint8_t x1 = ctrx1 - xo;
@@ -231,8 +231,8 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
 
   float LevelingBilinear::virt_2cmr(const uint8_t x, const uint8_t y, const_float_t tx, const_float_t ty) {
     float row[4], column[4];
-    for (uint8_t i = 0; i < 4; ++i) {
-      for (uint8_t j = 0; j < 4; ++j) {
+    for (uint_fast8_t i = 0; i < 4; ++i) {
+      for (uint_fast8_t j = 0; j < 4; ++j) {
         column[j] = virt_coord(i + x - 1, j + y - 1);
       }
       row[i] = virt_cmr(column, 1, ty);
@@ -243,10 +243,10 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
   void LevelingBilinear::subdivide_mesh() {
     grid_spacing_virt = grid_spacing / (BILINEAR_SUBDIVISIONS);
     grid_factor_virt = grid_spacing_virt.reciprocal();
-    for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; ++y)
-      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; ++x)
-        for (uint8_t ty = 0; ty < BILINEAR_SUBDIVISIONS; ++ty)
-          for (uint8_t tx = 0; tx < BILINEAR_SUBDIVISIONS; ++tx) {
+    for (uint_fast8_t y = 0; y < GRID_MAX_POINTS_Y; ++y)
+      for (uint_fast8_t x = 0; x < GRID_MAX_POINTS_X; ++x)
+        for (uint_fast8_t ty = 0; ty < BILINEAR_SUBDIVISIONS; ++ty)
+          for (uint_fast8_t tx = 0; tx < BILINEAR_SUBDIVISIONS; ++tx) {
             if ((ty && y == (GRID_MAX_POINTS_Y) - 1) || (tx && x == (GRID_MAX_POINTS_X) - 1))
               continue;
             z_values_virt[x * (BILINEAR_SUBDIVISIONS) + tx][y * (BILINEAR_SUBDIVISIONS) + ty] =

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -135,9 +135,9 @@ void reset_bed_level() {
   /**
    * Print calibration results for plotting or manual frame adjustment.
    */
-  void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, const float *values) {
+  void print_2d_array(const uint_fast8_t sx, const uint_fast8_t sy, const uint_fast8_t precision, const float *values) {
     #ifndef SCAD_MESH_OUTPUT
-      for (uint8_t x = 0; x < sx; ++x) {
+      for (uint_fast8_t x = 0; x < sx; ++x) {
         SERIAL_ECHO_SP(precision + (x < 10 ? 3 : 2));
         SERIAL_ECHO(x);
       }
@@ -146,14 +146,14 @@ void reset_bed_level() {
     #ifdef SCAD_MESH_OUTPUT
       SERIAL_ECHOLNPGM("measured_z = ["); // open 2D array
     #endif
-    for (uint8_t y = 0; y < sy; ++y) {
+    for (uint_fast8_t y = 0; y < sy; ++y) {
       #ifdef SCAD_MESH_OUTPUT
         SERIAL_ECHOPGM(" [");             // open sub-array
       #else
         if (y < 10) SERIAL_CHAR(' ');
         SERIAL_ECHO(y);
       #endif
-      for (uint8_t x = 0; x < sx; ++x) {
+      for (uint_fast8_t x = 0; x < sx; ++x) {
         SERIAL_CHAR(' ');
         const float offset = values[x * sy + y];
         if (!isnan(offset)) {
@@ -162,11 +162,11 @@ void reset_bed_level() {
         }
         else {
           #ifdef SCAD_MESH_OUTPUT
-            for (uint8_t i = 3; i < precision + 3; i++)
+            for (uint_fast8_t i = 3; i < precision + 3; i++)
               SERIAL_CHAR(' ');
             SERIAL_ECHOPGM("NAN");
           #else
-            for (uint8_t i = 0; i < precision + 3; ++i)
+            for (uint_fast8_t i = 0; i < precision + 3; ++i)
               SERIAL_CHAR(i ? '=' : ' ');
           #endif
         }

--- a/Marlin/src/feature/bedlevel/bedlevel.h
+++ b/Marlin/src/feature/bedlevel/bedlevel.h
@@ -73,12 +73,12 @@ class TemporaryBedLevelingState {
 
     #include <stdint.h>
 
-    typedef float (*element_2d_fn)(const uint8_t, const uint8_t);
+    typedef float (*element_2d_fn)(const uint_fast8_t, const uint_fast8_t);
 
     /**
      * Print calibration results for plotting or manual frame adjustment.
      */
-    void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, const float *values);
+    void print_2d_array(const uint_fast8_t sx, const uint_fast8_t sy, const uint_fast8_t precision, const float *values);
 
   #endif
 

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -40,9 +40,9 @@
         mesh_bed_leveling::index_to_ypos[GRID_MAX_POINTS_Y];
 
   mesh_bed_leveling::mesh_bed_leveling() {
-    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i)
+    for (uint_fast8_t i = 0; i < GRID_MAX_POINTS_X; ++i)
       index_to_xpos[i] = MESH_MIN_X + i * (MESH_X_DIST);
-    for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; ++i)
+    for (uint_fast8_t i = 0; i < GRID_MAX_POINTS_Y; ++i)
       index_to_ypos[i] = MESH_MIN_Y + i * (MESH_Y_DIST);
     reset();
   }

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -148,7 +148,7 @@ static void serial_echo_xy(const uint8_t sp, const int16_t x, const int16_t y) {
 
 static void serial_echo_column_labels(const uint8_t sp) {
   SERIAL_ECHO_SP(7);
-  for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
+  for (uint_fast8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
     if (i < 10) SERIAL_CHAR(' ');
     SERIAL_ECHO(i);
     SERIAL_ECHO_SP(sp);
@@ -198,7 +198,7 @@ void unified_bed_leveling::display_map(const uint8_t map_type) {
     }
 
     // Row Values (I indexes)
-    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
+    for (int_fast8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
 
       // Opening Brace or Space
       const bool is_current = i == curr.x && j == curr.y;

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -417,7 +417,7 @@ void unified_bed_leveling::G29() {
         break;
 
       case 1:
-        for (uint8_t x = 0; x < GRID_MAX_POINTS_X; ++x) {                     // Create a diagonal line several Mesh cells thick that is raised
+        for (uint_fast8_t x = 0; x < GRID_MAX_POINTS_X; ++x) {                     // Create a diagonal line several Mesh cells thick that is raised
           const uint8_t x2 = x + (x < (GRID_MAX_POINTS_Y) - 1 ? 1 : -1);
           z_values[x][x] += 9.999f;
           z_values[x][x2] += 9.999f; // We want the altered line several mesh points thick
@@ -430,8 +430,8 @@ void unified_bed_leveling::G29() {
 
       case 2:
         // Allow the user to specify the height because 10mm is a little extreme in some cases.
-        for (uint8_t x = (GRID_MAX_POINTS_X) / 3; x < 2 * (GRID_MAX_POINTS_X) / 3; x++)     // Create a rectangular raised area in
-          for (uint8_t y = (GRID_MAX_POINTS_Y) / 3; y < 2 * (GRID_MAX_POINTS_Y) / 3; y++) { // the center of the bed
+        for (uint_fast8_t x = (GRID_MAX_POINTS_X) / 3; x < 2 * (GRID_MAX_POINTS_X) / 3; x++)     // Create a rectangular raised area in
+          for (uint_fast8_t y = (GRID_MAX_POINTS_Y) / 3; y < 2 * (GRID_MAX_POINTS_Y) / 3; y++) { // the center of the bed
             z_values[x][y] += parser.seen_test('C') ? param.C_constant : 9.99f;
             TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, z_values[x][y]));
           }
@@ -1460,20 +1460,20 @@ void unified_bed_leveling::smart_fill_mesh() {
     info3 PROGMEM = { (GRID_MAX_POINTS_X) - 1, 0, 0, GRID_MAX_POINTS_Y,       true  };  // Right side of the mesh looking left
   static const smart_fill_info * const info[] PROGMEM = { &info0, &info1, &info2, &info3 };
 
-  for (uint8_t i = 0; i < COUNT(info); ++i) {
+  for (uint_fast8_t i = 0; i < COUNT(info); ++i) {
     const smart_fill_info *f = (smart_fill_info*)pgm_read_ptr(&info[i]);
     const int8_t sx = pgm_read_byte(&f->sx), sy = pgm_read_byte(&f->sy),
                  ex = pgm_read_byte(&f->ex), ey = pgm_read_byte(&f->ey);
     if (pgm_read_byte(&f->yfirst)) {
       const int8_t dir = ex > sx ? 1 : -1;
-      for (uint8_t y = sy; y != ey; ++y)
-        for (uint8_t x = sx; x != ex; x += dir)
+      for (int_fast8_t y = sy; y != ey; ++y)
+        for (int_fast8_t x = sx; x != ex; x += dir)
           if (smart_fill_one(x, y, dir, 0)) break;
     }
     else {
       const int8_t dir = ey > sy ? 1 : -1;
-       for (uint8_t x = sx; x != ex; ++x)
-        for (uint8_t y = sy; y != ey; y += dir)
+       for (int_fast8_t x = sx; x != ex; ++x)
+        for (int_fast8_t y = sy; y != ey; y += dir)
           if (smart_fill_one(x, y, 0, dir)) break;
     }
   }
@@ -1499,7 +1499,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 
       #if ENABLED(UBL_TILT_ON_MESH_POINTS_3POINT)
         mesh_index_pair cpos[3];
-        for (uint8_t ix = 0; ix < 3; ++ix) { // Convert points to coordinates of mesh points
+        for (uint_fast8_t ix = 0; ix < 3; ++ix) { // Convert points to coordinates of mesh points
           cpos[ix] = find_closest_mesh_point_of_type(REAL, points[ix], true);
           points[ix] = cpos[ix].meshpos();
         }
@@ -1509,7 +1509,7 @@ void unified_bed_leveling::smart_fill_mesh() {
         float gotz[3];  // Used for algorithm validation below
       #endif
 
-      for (uint8_t i = 0; i < 3; ++i) {
+      for (uint_fast8_t i = 0; i < 3; ++i) {
         SERIAL_ECHOLNPGM("Tilting mesh (", i + 1, "/3)");
         TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), GET_TEXT_F(MSG_LCD_TILTING_MESH), i + 1));
 
@@ -1549,10 +1549,10 @@ void unified_bed_leveling::smart_fill_mesh() {
       const uint16_t total_points = sq(param.J_grid_size);
       uint16_t point_num = 1;
 
-      for (uint8_t ix = 0; ix < param.J_grid_size; ++ix) {
+      for (uint_fast8_t ix = 0; ix < param.J_grid_size; ++ix) {
         xy_pos_t rpos;
         rpos.x = x_min + ix * dx;
-        for (uint8_t iy = 0; iy < param.J_grid_size; ++iy) {
+        for (uint_fast8_t iy = 0; iy < param.J_grid_size; ++iy) {
           rpos.y = y_min + dy * (zig_zag ? param.J_grid_size - 1 - iy : iy);
 
           #if ENABLED(UBL_TILT_ON_MESH_POINTS)
@@ -1703,17 +1703,17 @@ void unified_bed_leveling::smart_fill_mesh() {
     GRID_LOOP(jx, jy) if (!isnan(z_values[jx][jy])) SBI(bitmap[jx], jy);
 
     xy_pos_t ppos;
-    for (uint8_t ix = 0; ix < GRID_MAX_POINTS_X; ++ix) {
+    for (uint_fast8_t ix = 0; ix < GRID_MAX_POINTS_X; ++ix) {
       ppos.x = get_mesh_x(ix);
-      for (uint8_t iy = 0; iy < GRID_MAX_POINTS_Y; ++iy) {
+      for (uint_fast8_t iy = 0; iy < GRID_MAX_POINTS_Y; ++iy) {
         ppos.y = get_mesh_y(iy);
         if (isnan(z_values[ix][iy])) {
           // undefined mesh point at (ppos.x,ppos.y), compute weighted LSF from original valid mesh points.
           incremental_LSF_reset(&lsf_results);
           xy_pos_t rpos;
-          for (uint8_t jx = 0; jx < GRID_MAX_POINTS_X; ++jx) {
+          for (uint_fast8_t jx = 0; jx < GRID_MAX_POINTS_X; ++jx) {
             rpos.x = get_mesh_x(jx);
-            for (uint8_t jy = 0; jy < GRID_MAX_POINTS_Y; ++jy) {
+            for (uint_fast8_t jy = 0; jy < GRID_MAX_POINTS_Y; ++jy) {
               if (TEST(bitmap[jx], jy)) {
                 rpos.y = get_mesh_y(jy);
                 const float rz = z_values[jx][jy],
@@ -1772,14 +1772,14 @@ void unified_bed_leveling::smart_fill_mesh() {
     SERIAL_ECHOLNPGM("MESH_Y_DIST  ", MESH_Y_DIST);                         serial_delay(50);
 
     SERIAL_ECHOPGM("X-Axis Mesh Points at: ");
-    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
+    for (uint_fast8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
       SERIAL_ECHO(p_float_t(LOGICAL_X_POSITION(get_mesh_x(i)), 3), F("  "));
       serial_delay(25);
     }
     SERIAL_EOL();
 
     SERIAL_ECHOPGM("Y-Axis Mesh Points at: ");
-    for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; ++i) {
+    for (uint_fast8_t i = 0; i < GRID_MAX_POINTS_Y; ++i) {
       SERIAL_ECHO(p_float_t(LOGICAL_Y_POSITION(get_mesh_y(i)), 3), F("  "));
       serial_delay(25);
     }

--- a/Marlin/src/feature/digipot/digipot_mcp4018.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4018.cpp
@@ -89,7 +89,7 @@ void DigipotI2C::set_current(const uint8_t channel, const float current) {
 }
 
 void DigipotI2C::init() {
-  for (uint8_t i = 0; i < DIGIPOT_I2C_NUM_CHANNELS; ++i) pots[i].i2c_init();
+  for (uint_fast8_t i = 0; i < DIGIPOT_I2C_NUM_CHANNELS; ++i) pots[i].i2c_init();
 
   // Init currents according to Configuration_adv.h
   static const float digipot_motor_current[] PROGMEM =
@@ -99,7 +99,7 @@ void DigipotI2C::init() {
       DIGIPOT_I2C_MOTOR_CURRENTS
     #endif
   ;
-  for (uint8_t i = 0; i < COUNT(digipot_motor_current); ++i)
+  for (uint_fast8_t i = 0; i < COUNT(digipot_motor_current); ++i)
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 

--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -88,7 +88,7 @@ void DigipotI2C::init() {
   #endif
   // Set up initial currents as defined in Configuration_adv.h
   static const float digipot_motor_current[] PROGMEM = TERN(DIGIPOT_USE_RAW_VALUES, DIGIPOT_MOTOR_CURRENT, DIGIPOT_I2C_MOTOR_CURRENTS);
-  for (uint8_t i = 0; i < COUNT(digipot_motor_current); ++i)
+  for (uint_fast8_t i = 0; i < COUNT(digipot_motor_current); ++i)
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 

--- a/Marlin/src/feature/direct_stepping.cpp
+++ b/Marlin/src/feature/direct_stepping.cpp
@@ -192,7 +192,7 @@ namespace DirectStepping {
     }
 
     uint8_t crc = 0;
-    for (uint8_t i = 0 ; i < n_bytes ; i++) {
+    for (uint_fast8_t i = 0 ; i < n_bytes ; i++) {
       crc ^= bits_b[i];
       SERIAL_CHAR(bits_b[i]);
     }

--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -134,7 +134,7 @@ void I2CPositionEncoder::update() {
       errIdx = (errIdx >= I2CPE_ERR_ARRAY_SIZE - 1) ? 0 : errIdx + 1;
       err[errIdx] = get_axis_error_steps(false);
 
-      for (uint8_t i = 0; i < I2CPE_ERR_ARRAY_SIZE; ++i) {
+      for (uint_fast8_t i = 0; i < I2CPE_ERR_ARRAY_SIZE; ++i) {
         sum += err[i];
         if (i) diffSum += ABS(err[i-1] - err[i]);
       }
@@ -166,7 +166,7 @@ void I2CPositionEncoder::update() {
           errPrst[errPrstIdx++] = error; // Error must persist for I2CPE_ERR_PRST_ARRAY_SIZE error cycles. This also serves to improve the average accuracy
           if (errPrstIdx >= I2CPE_ERR_PRST_ARRAY_SIZE) {
             float sumP = 0;
-            for (uint8_t i = 0; i < I2CPE_ERR_PRST_ARRAY_SIZE; ++i) sumP += errPrst[i];
+            for (uint_fast8_t i = 0; i < I2CPE_ERR_PRST_ARRAY_SIZE; ++i) sumP += errPrst[i];
             const int32_t errorP = int32_t(sumP * RECIPROCAL(I2CPE_ERR_PRST_ARRAY_SIZE));
             SERIAL_ECHOLN(C(AXIS_CHAR(encoderAxis)), F(" : CORRECT ERR "), errorP * planner.mm_per_step[encoderAxis], F("mm"));
             babystep.add_steps(encoderAxis, -LROUND(errorP));
@@ -392,7 +392,7 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
   planner.synchronize();
 
-  for (uint8_t i = 0; i < iter; ++i) {
+  for (uint_fast8_t i = 0; i < iter; ++i) {
     TERN_(HAS_EXTRUDERS, startCoord.e = planner.get_axis_position_mm(E_AXIS));
     planner.buffer_line(startCoord, fr_mm_s, 0);
     planner.synchronize();
@@ -648,7 +648,7 @@ void I2CPositionEncodersMgr::report_position(const int8_t idx, const bool units,
     const int32_t raw_count = encoders[idx].get_raw_count();
     SERIAL_CHAR(AXIS_CHAR(encoders[idx].get_axis()), ' ');
 
-    for (uint8_t j = 31; j >= 0; j--)
+    for (uint_fast8_t j = 31; j >= 0; j--)
       SERIAL_ECHO(TEST32(raw_count, j));
 
     SERIAL_ECHOLN(C(' '), raw_count);

--- a/Marlin/src/feature/encoder_i2c.h
+++ b/Marlin/src/feature/encoder_i2c.h
@@ -90,7 +90,7 @@
 #define I2CPE_PARSE_ERR               1
 #define I2CPE_PARSE_OK                0
 
-#define LOOP_PE(VAR) for (uint8_t VAR = 0; VAR < I2CPE_ENCODER_CNT; ++VAR)
+#define LOOP_PE(VAR) for (uint_fast8_t VAR = 0; VAR < I2CPE_ENCODER_CNT; ++VAR)
 #define CHECK_IDX() do{ if (!WITHIN(idx, 0, I2CPE_ENCODER_CNT - 1)) return; }while(0)
 
 typedef union {

--- a/Marlin/src/feature/ethernet.cpp
+++ b/Marlin/src/feature/ethernet.cpp
@@ -191,7 +191,7 @@ void MarlinEthernet::MAC_report(const bool forReplay/*=true*/) {
   if (ethernet.hardware_enabled) {
     uint8_t mac[6];
     Ethernet.MACAddress(mac);
-    for (uint8_t i = 0; i < 6; ++i) {
+    for (uint_fast8_t i = 0; i < 6; ++i) {
       if (mac[i] < 0x10) SERIAL_CHAR('0');
       SERIAL_PRINT(mac[i], PrintBase::Hex);
       if (i < 5) SERIAL_CHAR(':');
@@ -207,7 +207,7 @@ void MarlinEthernet::MAC_report(const bool forReplay/*=true*/) {
 void MarlinEthernet::ip_report(const uint16_t cmd, FSTR_P const post, const IPAddress &ipo, const bool forReplay/*=true*/) {
   if (!forReplay) SERIAL_ECHO_START();
   SERIAL_ECHO(F("  M"), cmd, C(' '));
-  for (uint8_t i = 0; i < 4; ++i) {
+  for (uint_fast8_t i = 0; i < 4; ++i) {
     SERIAL_ECHO(ipo[i]);
     if (i < 3) SERIAL_CHAR('.');
   }

--- a/Marlin/src/feature/fancheck.cpp
+++ b/Marlin/src/feature/fancheck.cpp
@@ -72,7 +72,7 @@ void FanCheck::update_tachometers() {
   bool status;
 
   #define _TACHO_CASE(N) case N: status = READ(E##N##_FAN_TACHO_PIN); break;
-  for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
+  for (uint_fast8_t f = 0; f < TACHO_COUNT; ++f) {
     switch (f) {
       #if HAS_E0_FAN_TACHO
         _TACHO_CASE(0)
@@ -113,7 +113,7 @@ void FanCheck::compute_speed(uint16_t elapsedTime) {
   static uint8_t fan_reported_errors_msk = 0;
 
   uint8_t fan_error_msk = 0;
-  for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
+  for (uint_fast8_t f = 0; f < TACHO_COUNT; ++f) {
     switch (f) {
       TERN_(HAS_E0_FAN_TACHO, case 0:)
       TERN_(HAS_E1_FAN_TACHO, case 1:)
@@ -150,7 +150,7 @@ void FanCheck::compute_speed(uint16_t elapsedTime) {
 
   if (fan_error_msk & ~fan_reported_errors_msk) {
     // Handle new faults only
-    for (uint8_t f = 0; f < TACHO_COUNT; ++f) if (TEST(fan_error_msk, f)) report_speed_error(f);
+    for (uint_fast8_t f = 0; f < TACHO_COUNT; ++f) if (TEST(fan_error_msk, f)) report_speed_error(f);
   }
   fan_reported_errors_msk = fan_error_msk;
 }
@@ -176,8 +176,8 @@ void FanCheck::report_speed_error(uint8_t fan) {
 }
 
 void FanCheck::print_fan_states() {
-  for (uint8_t s = 0; s < 2; ++s) {
-    for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
+  for (uint_fast8_t s = 0; s < 2; ++s) {
+    for (uint_fast8_t f = 0; f < TACHO_COUNT; ++f) {
       switch (f) {
         TERN_(HAS_E0_FAN_TACHO, case 0:)
         TERN_(HAS_E1_FAN_TACHO, case 1:)

--- a/Marlin/src/feature/filwidth.cpp
+++ b/Marlin/src/feature/filwidth.cpp
@@ -42,7 +42,7 @@ int8_t FilamentWidthSensor::ratios[MAX_MEASUREMENT_DELAY + 1],          // Ring 
 
 void FilamentWidthSensor::init() {
   const int8_t ratio = sample_to_size_ratio();
-  for (uint8_t i = 0; i < COUNT(ratios); ++i) ratios[i] = ratio;
+  for (uint_fast8_t i = 0; i < COUNT(ratios); ++i) ratios[i] = ratio;
   index_r = index_w = 0;
 }
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -76,8 +76,8 @@ void LEDLights::setup() {
         #endif
         delay(200);
 
-        for (uint8_t i = 0; i < led_pin_count; ++i) {
-          for (uint8_t b = 0; b <= 200; ++b) {
+        for (uint_fast8_t i = 0; i < led_pin_count; ++i) {
+          for (uint_fast8_t b = 0; b <= 200; ++b) {
             const uint16_t led_pwm = b <= 100 ? b : 200 - b;
             if (i == 0 && PWM_PIN(RGB_LED_R_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_R_PIN), led_pwm); else WRITE(RGB_LED_R_PIN, b < 100 ? HIGH : LOW);
             if (i == 1 && PWM_PIN(RGB_LED_G_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_G_PIN), led_pwm); else WRITE(RGB_LED_G_PIN, b < 100 ? HIGH : LOW);
@@ -118,7 +118,7 @@ void LEDLights::setup() {
     while (led_pin_counters[0] != 99 || !canEnd) {
       if (led_pin_counters[0] == 99)        // End loop next time pin0 counter is 99
         canEnd = true;
-      for (uint8_t i = 0; i < led_pin_count; ++i) {
+      for (uint_fast8_t i = 0; i < led_pin_count; ++i) {
         if (led_pin_counters[i] > 0) {
           if (++led_pin_counters[i] == 400) // turn off current pin counter in led_pin_counters
             led_pin_counters[i] = 0;
@@ -140,7 +140,7 @@ void LEDLights::setup() {
     }
 
     // Fade to white
-    for (uint8_t led_pwm = 0; led_pwm <= 100; ++led_pwm) {
+    for (uint_fast8_t led_pwm = 0; led_pwm <= 100; ++led_pwm) {
       NOLESS(curColor.r, led_pwm);
       NOLESS(curColor.g, led_pwm);
       NOLESS(curColor.b, led_pwm);

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -174,7 +174,7 @@ void Max7219::error(FSTR_P const func, const int32_t v1, const int32_t v2/*=-1*/
  */
 inline uint32_t flipped(const uint32_t bits, const uint8_t n_bytes) {
   uint32_t mask = 1, outbits = 0;
-  for (uint8_t b = 0; b < n_bytes * 8; ++b) {
+  for (uint_fast8_t b = 0; b < n_bytes * 8; ++b) {
     outbits <<= 1;
     if (bits & mask) outbits |= 1;
     mask <<= 1;
@@ -186,7 +186,7 @@ void Max7219::noop() {
   CRITICAL_SECTION_START();
   SIG_DELAY();
   WRITE(MAX7219_DIN_PIN, LOW);
-  for (uint8_t i = 16; i--;) {
+  for (uint_fast8_t i = 16; i--;) {
     SIG_DELAY();
     WRITE(MAX7219_CLK_PIN, LOW);
     SIG_DELAY();
@@ -199,7 +199,7 @@ void Max7219::noop() {
 
 void Max7219::putbyte(uint8_t data) {
   CRITICAL_SECTION_START();
-  for (uint8_t i = 8; i--;) {
+  for (uint_fast8_t i = 8; i--;) {
     SIG_DELAY();
     WRITE(MAX7219_CLK_PIN, LOW);       // tick
     SIG_DELAY();
@@ -236,7 +236,7 @@ void Max7219::refresh_unit_line(const uint8_t line) {
   #if MAX7219_NUMBER_UNITS == 1
     send(LINE_REG(line), led_line[line]);
   #else
-    for (uint8_t u = MAX7219_NUMBER_UNITS; u--;)
+    for (uint_fast8_t u = MAX7219_NUMBER_UNITS; u--;)
       if (u == (line >> 3)) send(LINE_REG(line), led_line[line]); else noop();
   #endif
   pulse_load();
@@ -248,7 +248,7 @@ void Max7219::refresh_line(const uint8_t line) {
   #if MAX7219_NUMBER_UNITS == 1
     refresh_unit_line(line);
   #else
-    for (uint8_t u = MAX7219_NUMBER_UNITS; u--;)
+    for (uint_fast8_t u = MAX7219_NUMBER_UNITS; u--;)
       send(LINE_REG(line), led_line[(u << 3) | (line & 0x7)]);
   #endif
   pulse_load();
@@ -357,13 +357,13 @@ void Max7219::fill() {
 
 void Max7219::clear_row(const uint8_t row) {
   if (row >= MAX7219_Y_LEDS) return error(F("clear_row"), row);
-  for (uint8_t x = 0; x < MAX7219_X_LEDS; ++x) CLR_7219(x, row);
+  for (uint_fast8_t x = 0; x < MAX7219_X_LEDS; ++x) CLR_7219(x, row);
   send_row(row);
 }
 
 void Max7219::clear_column(const uint8_t col) {
   if (col >= MAX7219_X_LEDS) return error(F("set_column"), col);
-  for (uint8_t y = 0; y < MAX7219_Y_LEDS; ++y) CLR_7219(col, y);
+  for (uint_fast8_t y = 0; y < MAX7219_Y_LEDS; ++y) CLR_7219(col, y);
   send_column(col);
 }
 
@@ -375,7 +375,7 @@ void Max7219::clear_column(const uint8_t col) {
 void Max7219::set_row(const uint8_t row, const uint32_t val) {
   if (row >= MAX7219_Y_LEDS) return error(F("set_row"), row);
   uint32_t mask = _BV32(MAX7219_X_LEDS - 1);
-  for (uint8_t x = 0; x < MAX7219_X_LEDS; ++x) {
+  for (uint_fast8_t x = 0; x < MAX7219_X_LEDS; ++x) {
     if (val & mask) SET_7219(x, row); else CLR_7219(x, row);
     mask >>= 1;
   }
@@ -390,7 +390,7 @@ void Max7219::set_row(const uint8_t row, const uint32_t val) {
 void Max7219::set_column(const uint8_t col, const uint32_t val) {
   if (col >= MAX7219_X_LEDS) return error(F("set_column"), col);
   uint32_t mask = _BV32(MAX7219_Y_LEDS - 1);
-  for (uint8_t y = 0; y < MAX7219_Y_LEDS; ++y) {
+  for (uint_fast8_t y = 0; y < MAX7219_Y_LEDS; ++y) {
     if (val & mask) SET_7219(col, y); else CLR_7219(col, y);
     mask >>= 1;
   }
@@ -455,23 +455,23 @@ void Max7219::set_columns_32bits(const uint8_t x, uint32_t val) {
 
 // Initialize the Max7219
 void Max7219::register_setup() {
-  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
+  for (uint_fast8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_scanLimit, 0x07);
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
+  for (uint_fast8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_decodeMode, 0x00);       // Using an led matrix (not digits)
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
+  for (uint_fast8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_shutdown, 0x01);         // Not in shutdown mode
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
+  for (uint_fast8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_displayTest, 0x00);      // No display test
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
+  for (uint_fast8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_intensity, 0x01 & 0x0F); // The first 0x0F is the value you can set
                                               // Range: 0x00 to 0x0F
   pulse_load();                               // Tell the chips to load the clocked out data
@@ -615,26 +615,26 @@ void Max7219::mark16(const uint8_t pos, const uint8_t v1, const uint8_t v2, uint
 void Max7219::range16(const uint8_t y, const uint8_t ot, const uint8_t nt, const uint8_t oh,
   const uint8_t nh, uint8_t * const rcm/*=nullptr*/) {
   #if MAX7219_X_LEDS > 8    // At least 16 LEDs on the X-Axis. Use single line.
-    if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
+    if (ot != nt) for (uint_fast8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
       led_off(n & 0xF, y, rcm);
-    if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
+    if (oh != nh) for (uint_fast8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
        led_on(n & 0xF, y, rcm);
   #elif MAX7219_Y_LEDS > 8  // At least 16 LEDs on the Y-Axis. Use a single column.
-    if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
+    if (ot != nt) for (uint_fast8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
       led_off(y, n & 0xF, rcm);
-    if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
+    if (oh != nh) for (uint_fast8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
        led_on(y, n & 0xF, rcm);
   #else                     // Single 8x8 LED matrix. Use two lines to get 16 LEDs.
-    if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
+    if (ot != nt) for (uint_fast8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
       led_off(n & 0x7, y + (n >= 8), rcm);
-    if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
+    if (oh != nh) for (uint_fast8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
        led_on(n & 0x7, y + (n >= 8), rcm);
   #endif
 }
 
 // Apply changes to update a quantity
 void Max7219::quantity(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {
-  for (uint8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
+  for (uint_fast8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
     led_set(
       #if MAX7219_X_LEDS >= MAX7219_Y_LEDS
         i, pos  // Single matrix or multiple matrices in Landscape
@@ -647,7 +647,7 @@ void Max7219::quantity(const uint8_t pos, const uint8_t ov, const uint8_t nv, ui
 }
 
 void Max7219::quantity16(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {
-  for (uint8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
+  for (uint_fast8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
     led_set(
       #if MAX7219_X_LEDS > 8    // At least 16 LEDs on the X-Axis. Use single line.
         i, pos
@@ -761,7 +761,7 @@ void Max7219::idle_tasks() {
     if (multistepping != last_multistepping) {
       static uint8_t log2_old = 0;
       uint8_t log2_new = 0;
-      for (uint8_t val = multistepping; val > 1; val >>= 1) log2_new++;
+      for (uint_fast8_t val = multistepping; val > 1; val >>= 1) log2_new++;
       mark16(MAX7219_DEBUG_MULTISTEPPING, log2_old, log2_new, &row_change_mask);
       last_multistepping = multistepping;
       log2_old = log2_new;
@@ -780,7 +780,7 @@ void Max7219::idle_tasks() {
   // batch line updates
   suspended--;
   if (!suspended)
-    for (uint8_t i = 0; i < 8; ++i) if (row_change_mask & _BV(i))
+    for (uint_fast8_t i = 0; i < 8; ++i) if (row_change_mask & _BV(i))
       refresh_line(i);
 
   // After resume() automatically do a refresh()

--- a/Marlin/src/feature/max7219.h
+++ b/Marlin/src/feature/max7219.h
@@ -148,7 +148,7 @@ public:
   static void send(const uint8_t reg, const uint8_t data);
 
   // Refresh all units
-  static void refresh() { for (uint8_t i = 0; i < 8; i++) refresh_line(i); }
+  static void refresh() { for (uint_fast8_t i = 0; i < 8; i++) refresh_line(i); }
 
   // Suspend / resume updates to the LED unit
   // Use these methods to speed up multiple changes

--- a/Marlin/src/feature/meatpack.cpp
+++ b/Marlin/src/feature/meatpack.cpp
@@ -209,7 +209,7 @@ uint8_t MeatPack::get_result_char(char * const __restrict out) {
   if (char_out_count) {
     res = char_out_count;
     char_out_count = 0;
-    for (uint8_t i = 0; i < res; ++i)
+    for (uint_fast8_t i = 0; i < res; ++i)
       out[i] = (char)char_out_buf[i];
   }
   return res;

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -83,13 +83,13 @@ void Mixer::normalize(const uint8_t tool_index) {
 void Mixer::reset_vtools() {
   // Virtual Tools 0, 1, 2, 3 = Filament 1, 2, 3, 4, etc.
   // Every virtual tool gets a pure filament
-  for (uint8_t t = 0; t < _MIN(MIXING_VIRTUAL_TOOLS, MIXING_STEPPERS); ++t)
+  for (uint_fast8_t t = 0; t < _MIN(MIXING_VIRTUAL_TOOLS, MIXING_STEPPERS); ++t)
     MIXER_STEPPER_LOOP(i)
       color[t][i] = (t == i) ? COLOR_A_MASK : 0;
 
   // Remaining virtual tools are 100% filament 1
   #if MIXING_VIRTUAL_TOOLS > MIXING_STEPPERS
-    for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; ++t)
+    for (uint_fast8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; ++t)
       MIXER_STEPPER_LOOP(i)
         color[t][i] = (i == 0) ? COLOR_A_MASK : 0;
   #endif

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -407,7 +407,7 @@ void MMU2::tx_str(FSTR_P fstr) {
 void MMU2::tx_printf(FSTR_P format, int argument = -1) {
   clear_rx_buffer();
   const uint8_t len = sprintf_P(tx_buffer, FTOP(format), argument);
-  for (uint8_t i = 0; i < len; ++i) MMU_SERIAL.write(tx_buffer[i]);
+  for (uint_fast8_t i = 0; i < len; ++i) MMU_SERIAL.write(tx_buffer[i]);
   prev_request = millis();
 }
 
@@ -417,7 +417,7 @@ void MMU2::tx_printf(FSTR_P format, int argument = -1) {
 void MMU2::tx_printf(FSTR_P format, int argument1, int argument2) {
   clear_rx_buffer();
   const uint8_t len = sprintf_P(tx_buffer, FTOP(format), argument1, argument2);
-  for (uint8_t i = 0; i < len; ++i) MMU_SERIAL.write(tx_buffer[i]);
+  for (uint_fast8_t i = 0; i < len; ++i) MMU_SERIAL.write(tx_buffer[i]);
   prev_request = millis();
 }
 
@@ -471,7 +471,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   bool MMU2::load_to_gears() {
     command(MMU_CMD_C0);
     manage_response(true, true);
-    for (uint8_t i = 0; i < MMU2_C0_RETRY; ++i) {  // Keep loading until filament reaches gears
+    for (uint_fast8_t i = 0; i < MMU2_C0_RETRY; ++i) {  // Keep loading until filament reaches gears
       if (mmu2s_triggered) break;
       command(MMU_CMD_C0);
       manage_response(true, true);
@@ -485,7 +485,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   /**
    * Handle tool change
    */
-  void MMU2::tool_change(const uint8_t index) {
+  void MMU2::tool_change(const uint_fast8_t index) {
 
     if (!_enabled) return;
 
@@ -572,7 +572,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   /**
    * Handle tool change
    */
-  void MMU2::tool_change(const uint8_t index) {
+  void MMU2::tool_change(const uint_fast8_t index) {
     if (!_enabled) return;
 
     set_runout_valid(false);
@@ -660,7 +660,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   void MMU2::mmu_continue_loading() {
     // Try to load the filament a limited number of times
     bool fil_present = 0;
-    for (uint8_t i = 0; i < MMU2_LOADING_ATTEMPTS_NR; i++) {
+    for (uint_fast8_t i = 0; i < MMU2_LOADING_ATTEMPTS_NR; i++) {
       DEBUG_ECHOLNPGM("Load attempt #", i + 1);
 
       // Done as soon as filament is present
@@ -697,7 +697,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   /**
    * Handle tool change
    */
-  void MMU2::tool_change(const uint8_t index) {
+  void MMU2::tool_change(const uint_fast8_t index) {
     if (!_enabled) return;
 
     set_runout_valid(false);
@@ -903,7 +903,7 @@ void MMU2::filament_runout() {
     int filament_detected_count = 0;
     const int steps = (MMU2_CAN_LOAD_RETRACT) / (MMU2_CAN_LOAD_INCREMENT);
     DEBUG_ECHOLNPGM("MMU can_load:");
-    for (uint8_t i = 0; i < steps; ++i) {
+    for (uint_fast8_t i = 0; i < steps; ++i) {
       execute_extruder_sequence(can_load_increment_sequence, COUNT(can_load_increment_sequence));
       check_filament(); // Don't trust the idle function
       DEBUG_CHAR(mmu2s_triggered ? 'O' : 'o');
@@ -1051,7 +1051,7 @@ void MMU2::execute_extruder_sequence(const E_Step * const sequence, const uint8_
 
   const E_Step *step = sequence;
 
-  for (uint8_t i = 0; i < steps; ++i) {
+  for (uint_fast8_t i = 0; i < steps; ++i) {
     const float es = pgm_read_float(&(step->extrude));
     const feedRate_t fr_mm_m = pgm_read_float(&(step->feedRate));
     DEBUG_ECHO_MSG("E step ", es, "/", fr_mm_m);

--- a/Marlin/src/feature/mmu/mmu2.h
+++ b/Marlin/src/feature/mmu/mmu2.h
@@ -49,7 +49,7 @@ public:
   static void reset();
   static bool enabled() { return _enabled; }
   static void mmu_loop();
-  static void tool_change(const uint8_t index);
+  static void tool_change(const uint_fast8_t index);
   static void tool_change(const char *special);
   static int8_t get_current_tool();
   static void set_filament_type(const uint8_t index, const uint8_t type);

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -236,7 +236,7 @@ bool load_filament(const_float_t slow_load_length/*=0*/, const_float_t fast_load
   if (show_lcd) ui.pause_show_message(PAUSE_MESSAGE_LOAD, mode);
 
   #if ENABLED(DUAL_X_CARRIAGE)
-    const int8_t saved_ext        = active_extruder;
+    const int_fast8_t saved_ext   = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
     set_duplication_enabled(false, DXC_ext);
   #endif
@@ -486,7 +486,7 @@ bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool 
   if (!do_park) LCD_MESSAGE(MSG_PARK_FAILED);
 
   #if ENABLED(DUAL_X_CARRIAGE)
-    const int8_t saved_ext        = active_extruder;
+    const int_fast8_t saved_ext   = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
     set_duplication_enabled(false, DXC_ext);
   #endif
@@ -546,7 +546,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
   HOTEND_LOOP() thermalManager.heater_idle[e].start(nozzle_timeout);
 
   #if ENABLED(DUAL_X_CARRIAGE)
-    const int8_t saved_ext        = active_extruder;
+    const int_fast8_t saved_ext   = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
     set_duplication_enabled(false, DXC_ext);
   #endif

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -628,9 +628,9 @@ void PrintJobRecovery::resume() {
         #endif
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
-          const uint8_t ind = info.stored_repeat.count();
+          const uint_fast8_t ind = info.stored_repeat.count();
           DEBUG_ECHOLNPGM("repeat markers: ", ind);
-          for (uint8_t i = ind; i--;)
+          for (uint_fast8_t i = ind; i--;)
             DEBUG_ECHOLNPGM("...", i, " sdpos: ", info.stored_repeat.get_marker_sdpos(i), " count: ", info.stored_repeat.get_marker_counter(i));
         #endif
 

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -85,7 +85,7 @@ typedef struct {
     xyz_pos_t workspace_offset;
   #endif
   #if HAS_MULTI_EXTRUDER
-    uint8_t active_extruder;
+    uint_fast8_t active_extruder;
   #endif
 
   #if DISABLED(NO_VOLUMETRICS)
@@ -102,7 +102,7 @@ typedef struct {
     celsius_t target_temperature_chamber;
   #endif
   #if HAS_FAN
-    uint8_t fan_speed[FAN_COUNT];
+    uint_fast8_t fan_speed[FAN_COUNT];
   #endif
 
   #if HAS_LEVELING

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -66,13 +66,13 @@ float ProbeTempComp::init_measurement; // = 0.0
 bool ProbeTempComp::enabled = true;
 
 void ProbeTempComp::reset() {
-  TERN_(PTC_PROBE, for (uint8_t i = 0; i < PTC_PROBE_COUNT; ++i) z_offsets_probe[i] = z_offsets_probe_default[i]);
-  TERN_(PTC_BED, for (uint8_t i = 0; i < PTC_BED_COUNT; ++i) z_offsets_bed[i] = z_offsets_bed_default[i]);
-  TERN_(PTC_HOTEND, for (uint8_t i = 0; i < PTC_HOTEND_COUNT; ++i) z_offsets_hotend[i] = z_offsets_hotend_default[i]);
+  TERN_(PTC_PROBE, for (uint_fast8_t i = 0; i < PTC_PROBE_COUNT; ++i) z_offsets_probe[i] = z_offsets_probe_default[i]);
+  TERN_(PTC_BED, for (uint_fast8_t i = 0; i < PTC_BED_COUNT; ++i) z_offsets_bed[i] = z_offsets_bed_default[i]);
+  TERN_(PTC_HOTEND, for (uint_fast8_t i = 0; i < PTC_HOTEND_COUNT; ++i) z_offsets_hotend[i] = z_offsets_hotend_default[i]);
 }
 
 void ProbeTempComp::clear_offsets(const TempSensorID tsi) {
-  for (uint8_t i = 0; i < cali_info[tsi].measurements; ++i)
+  for (uint_fast8_t i = 0; i < cali_info[tsi].measurements; ++i)
     sensor_z_offsets[tsi][i] = 0;
   calib_idx = 0;
 }
@@ -84,7 +84,7 @@ bool ProbeTempComp::set_offset(const TempSensorID tsi, const uint8_t idx, const 
 }
 
 void ProbeTempComp::print_offsets() {
-  for (uint8_t s = 0; s < TSI_COUNT; ++s) {
+  for (uint_fast8_t s = 0; s < TSI_COUNT; ++s) {
     celsius_t temp = cali_info[s].start_temp;
     for (int16_t i = -1; i < cali_info[s].measurements; ++i) {
       SERIAL_ECHOLN(
@@ -227,7 +227,7 @@ bool ProbeTempComp::linear_regression(const TempSensorID tsi, float &k, float &d
         sum_xy = 0, sum_y = 0;
 
   float xi = static_cast<float>(start_temp);
-  for (uint8_t i = 0; i < calib_idx; ++i) {
+  for (uint_fast8_t i = 0; i < calib_idx; ++i) {
     const float yi = static_cast<float>(data[i]);
     xi += res_temp;
     sum_x += xi;

--- a/Marlin/src/feature/repeat.cpp
+++ b/Marlin/src/feature/repeat.cpp
@@ -66,7 +66,7 @@ void Repeat::loop() {
   }
 }
 
-void Repeat::cancel() { for (uint8_t i = 0; i < index; ++i) marker[i].counter = 0; }
+void Repeat::cancel() { for (uint_fast8_t i = 0; i < index; ++i) marker[i].counter = 0; }
 
 void Repeat::early_parse_M808(char * const cmd) {
   if (is_command_M808(cmd)) {

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -40,7 +40,7 @@ private:
 public:
   static void reset() { index = 0; }
   static bool is_active() {
-    for (uint8_t i = 0; i < index; ++i) if (marker[i].counter) return true;
+    for (uint_fast8_t i = 0; i < index; ++i) if (marker[i].counter) return true;
     return false;
   }
   static bool is_command_M808(char * const cmd) { return cmd[0] == 'M' && cmd[1] == '8' && cmd[2] == '0' && cmd[3] == '8' && !NUMERIC(cmd[4]); }

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -155,13 +155,13 @@ class TFilamentMonitor : public FilamentMonitorBase {
           #endif
         #else
           const bool ran_out = bool(runout_flags);
-          uint8_t extruder = active_extruder;
+          uint_fast8_t extruder = active_extruder;
         #endif
 
         if (ran_out) {
           #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
             SERIAL_ECHOPGM("Runout Sensors: ");
-            for (uint8_t i = 0; i < 8; ++i) SERIAL_CHAR('0' + char(runout_flags[i]));
+            for (uint_fast8_t i = 0; i < 8; ++i) SERIAL_CHAR('0' + char(runout_flags[i]));
             SERIAL_ECHOLNPGM(" -> ", extruder, " RUN OUT");
           #endif
 
@@ -257,7 +257,7 @@ class FilamentSensorBase {
         #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
           if (change) {
             SERIAL_ECHOPGM("Motion detected:");
-            for (uint8_t e = 0; e < TERN(FILAMENT_SWITCH_AND_MOTION, NUM_MOTION_SENSORS, NUM_RUNOUT_SENSORS); ++e)
+            for (uint_fast8_t e = 0; e < TERN(FILAMENT_SWITCH_AND_MOTION, NUM_MOTION_SENSORS, NUM_RUNOUT_SENSORS); ++e)
               if (TEST(change, e)) SERIAL_CHAR(' ', '0' + e);
             SERIAL_EOL();
           }
@@ -306,7 +306,7 @@ class FilamentSensorBase {
       static void block_completed(const block_t * const) {}
 
       static void run() {
-        for (uint8_t s = 0; s < NUM_RUNOUT_SENSORS; ++s) {
+        for (uint_fast8_t s = 0; s < NUM_RUNOUT_SENSORS; ++s) {
           const bool out = poll_runout_state(s);
           if (!out) filament_present(s);
           #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
@@ -367,9 +367,9 @@ class FilamentSensorBase {
       static float runout_distance_mm;
 
       static void reset() {
-        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
+        for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
         #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-          for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i) filament_motion_present(i);
+          for (uint_fast8_t i = 0; i < NUM_MOTION_SENSORS; ++i) filament_motion_present(i);
         #endif
       }
 
@@ -379,10 +379,10 @@ class FilamentSensorBase {
           const millis_t ms = millis();
           if (ELAPSED(ms, t)) {
             t = millis() + 1000UL;
-            for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i)
+            for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i)
               SERIAL_ECHO(i ? F(", ") : F("Runout remaining mm: "), mm_countdown.runout[i]);
             #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-              for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i)
+              for (uint_fast8_t i = 0; i < NUM_MOTION_SENSORS; ++i)
                 SERIAL_ECHO(i ? F(", ") : F("Motion remaining mm: "), mm_countdown.motion[i]);
             #endif
             SERIAL_EOL();
@@ -392,9 +392,9 @@ class FilamentSensorBase {
 
       static runout_flags_t has_run_out() {
         runout_flags_t runout_flags{0};
-        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (mm_countdown.runout[i] < 0) runout_flags.set(i);
+        for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (mm_countdown.runout[i] < 0) runout_flags.set(i);
         #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-          for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i) if (mm_countdown.motion[i] < 0) runout_flags.set(i);
+          for (uint_fast8_t i = 0; i < NUM_MOTION_SENSORS; ++i) if (mm_countdown.motion[i] < 0) runout_flags.set(i);
         #endif
         return runout_flags;
       }
@@ -465,16 +465,16 @@ class FilamentSensorBase {
 
     public:
       static void reset() {
-        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
+        for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
       }
 
       static void run() {
-        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] >= 0) runout_count[i]--;
+        for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] >= 0) runout_count[i]--;
       }
 
       static runout_flags_t has_run_out() {
         runout_flags_t runout_flags{0};
-        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] < 0) runout_flags.set(i);
+        for (uint_fast8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] < 0) runout_flags.set(i);
         return runout_flags;
       }
 

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -144,7 +144,7 @@ void TWIBus::echodata(uint8_t bytes, FSTR_P const pref, uint8_t adr, const uint8
 
 void TWIBus::echobuffer(FSTR_P const prefix, uint8_t adr) {
   echoprefix(buffer_s, prefix, adr);
-  for (uint8_t i = 0; i < buffer_s; ++i) SERIAL_CHAR(buffer[i]);
+  for (uint_fast8_t i = 0; i < buffer_s; ++i) SERIAL_CHAR(buffer[i]);
   SERIAL_EOL();
 }
 

--- a/Marlin/src/feature/x_twist.cpp
+++ b/Marlin/src/feature/x_twist.cpp
@@ -43,12 +43,12 @@ void XATC::reset() {
 
 void XATC::print_points() {
   SERIAL_ECHOLNPGM(" X-Twist Correction:");
-  for (uint8_t x = 0; x < XATC_MAX_POINTS; ++x) {
+  for (uint_fast8_t x = 0; x < XATC_MAX_POINTS; ++x) {
     SERIAL_CHAR(' ');
     if (!isnan(z_offset[x]))
       serial_offset(z_offset[x]);
     else
-      for (uint8_t i = 0; i < 6; ++i) SERIAL_CHAR(i ? '=' : ' ');
+      for (uint_fast8_t i = 0; i < 6; ++i) SERIAL_CHAR(i ? '=' : ' ');
   }
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -709,7 +709,7 @@ void GcodeSuite::G26() {
       #error "A_CNT must be a positive value. Please change A_INT."
     #endif
     float trig_table[A_CNT];
-    for (uint8_t i = 0; i < A_CNT; ++i)
+    for (uint_fast8_t i = 0; i < A_CNT; ++i)
       trig_table[i] = INTERSECTION_CIRCLE_RADIUS * cos(RADIANS(i * A_INT));
 
   #endif // !ARC_SUPPORT

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -92,7 +92,7 @@ void GcodeSuite::G35() {
   bool err_break = false;
 
   // Probe all positions
-  for (uint8_t i = 0; i < G35_PROBE_COUNT; ++i) {
+  for (uint_fast8_t i = 0; i < G35_PROBE_COUNT; ++i) {
     const float z_probed_height = probe.probe_at_point(tramming_points[i], PROBE_PT_RAISE);
     if (isnan(z_probed_height)) {
       SERIAL_ECHOLN(
@@ -120,7 +120,7 @@ void GcodeSuite::G35() {
     const float threads_factor[] = { 0.5, 0.7, 0.8 };
 
     // Calculate adjusts
-    for (uint8_t i = 1; i < G35_PROBE_COUNT; ++i) {
+    for (uint_fast8_t i = 1; i < G35_PROBE_COUNT; ++i) {
       const float diff = z_measured[0] - z_measured[i],
                   adjust = ABS(diff) < 0.001f ? 0 : diff / threads_factor[(screw_thread - 30) / 10];
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -820,7 +820,7 @@ G29_TYPE GcodeSuite::G29() {
 
       // Probe at 3 arbitrary points
 
-      for (uint8_t i = 0; i < 3; ++i) {
+      for (uint_fast8_t i = 0; i < 3; ++i) {
         if (abl.verbose_level) SERIAL_ECHOLNPGM("Probing point ", i + 1, "/3.");
         TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), GET_TEXT_F(MSG_PROBING_POINT), int(i + 1)));
 
@@ -931,7 +931,7 @@ G29_TYPE GcodeSuite::G29() {
         auto print_topo_map = [&](FSTR_P const title, const bool get_min) {
           SERIAL_ECHO(title);
           for (int8_t yy = abl.grid_points.y - 1; yy >= 0; yy--) {
-            for (uint8_t xx = 0; xx < abl.grid_points.x; ++xx) {
+            for (uint_fast8_t xx = 0; xx < abl.grid_points.x; ++xx) {
               const int ind = abl.indexIntoAB[xx][yy];
               xyz_float_t tmp = { abl.eqnAMatrix[ind + 0 * abl.abl_points],
                                   abl.eqnAMatrix[ind + 1 * abl.abl_points], 0 };

--- a/Marlin/src/gcode/bedlevel/abl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/M421.cpp
@@ -56,8 +56,8 @@ void GcodeSuite::M421() {
       const float zval = parser.value_linear_units();
       uint8_t sx = ix >= 0 ? ix : 0, ex = ix >= 0 ? ix : GRID_MAX_POINTS_X - 1,
               sy = iy >= 0 ? iy : 0, ey = iy >= 0 ? iy : GRID_MAX_POINTS_Y - 1;
-      for (uint8_t x = sx; x <= ex; ++x) {
-        for (uint8_t y = sy; y <= ey; ++y) {
+      for (uint_fast8_t x = sx; x <= ex; ++x) {
+        for (uint_fast8_t y = sy; y <= ey; ++y) {
           bedlevel.z_values[x][y] = zval + (hasQ ? bedlevel.z_values[x][y] : 0);
           TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, bedlevel.z_values[x][y]));
         }

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -296,7 +296,7 @@ void GcodeSuite::G28() {
     // Always home with tool 0 active
     #if HAS_MULTI_HOTEND
       #if DISABLED(DELTA) || ENABLED(DELTA_HOME_TO_SAFE_ZONE)
-        const uint8_t old_tool_index = active_extruder;
+        const uint_fast8_t old_tool_index = active_extruder;
       #endif
       // PARKING_EXTRUDER homing requires different handling of movement / solenoid activation, depending on the side of homing
       #if ENABLED(PARKING_EXTRUDER)

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -52,7 +52,7 @@ enum CalEnum : char {                        // the 7 main calibration points - 
   _CA      = __C + _7P_STEP,
 };
 
-#define LOOP_CAL_PT(VAR, S, N) for (uint8_t VAR=S; VAR<=NPP; VAR+=N)
+#define LOOP_CAL_PT(VAR, S, N) for (uint_fast8_t VAR=S; VAR<=NPP; VAR+=N)
 #define F_LOOP_CAL_PT(VAR, S, N) for (float VAR=S; VAR<NPP+0.9999; VAR+=N)
 #define I_LOOP_CAL_PT(VAR, S, N) for (float VAR=S; VAR>CEN+0.9999; VAR-=N)
 #define LOOP_CAL_ALL(VAR) LOOP_CAL_PT(VAR, CEN, 1)

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -201,7 +201,7 @@ void GcodeSuite::G34() {
         float z_measured_max = -100000.0f;
 
         // Probe all positions (one per Z-Stepper)
-        for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
+        for (uint_fast8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
           // iteration odd/even --> downward / upward stepper sequence
           const uint8_t iprobe = (iteration & 1) ? NUM_Z_STEPPERS - 1 - i : i;
 
@@ -278,14 +278,14 @@ void GcodeSuite::G34() {
           // This allows the actual adjustment logic to be shared by both algorithms.
           linear_fit_data lfd;
           incremental_LSF_reset(&lfd);
-          for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
+          for (uint_fast8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
             SERIAL_ECHOLNPGM("PROBEPT_", i, ": ", z_measured[i]);
             incremental_LSF(&lfd, z_stepper_align.xy[i], z_measured[i]);
           }
           finish_incremental_LSF(&lfd);
 
           z_measured_min = 100000.0f;
-          for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
+          for (uint_fast8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
             z_measured[i] = -(lfd.A * z_stepper_align.stepper_xy[i].x + lfd.B * z_stepper_align.stepper_xy[i].y + lfd.D);
             z_measured_min = _MIN(z_measured_min, z_measured[i]);
           }
@@ -332,12 +332,12 @@ void GcodeSuite::G34() {
 
           // Calculate mean value as a reference
           float z_measured_mean = 0.0f;
-          for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) z_measured_mean += z_measured[zstepper];
+          for (uint_fast8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) z_measured_mean += z_measured[zstepper];
           z_measured_mean /= NUM_Z_STEPPERS;
 
           // Calculate the sum of the absolute deviations from the mean value
           float z_align_level_indicator = 0.0f;
-          for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper)
+          for (uint_fast8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper)
             z_align_level_indicator += ABS(z_measured[zstepper] - z_measured_mean);
 
           // If it's getting worse, stop and throw an error
@@ -352,7 +352,7 @@ void GcodeSuite::G34() {
 
         bool success_break = true;
         // Correct the individual stepper offsets
-        for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) {
+        for (uint_fast8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) {
           // Calculate current stepper move
           float z_align_move = z_measured[zstepper] - z_measured_min;
           const float z_align_abs = ABS(z_align_move);
@@ -540,7 +540,7 @@ void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading(forReplay, F(STR_Z_AUTO_ALIGN));
-  for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
+  for (uint_fast8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(
       PSTR("  M422 S"), i + 1,
@@ -549,7 +549,7 @@ void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
     );
   }
   #if HAS_Z_STEPPER_ALIGN_STEPPER_XY
-    for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
+    for (uint_fast8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(
         PSTR("  M422 W"), i + 1,

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -174,7 +174,7 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
 #if HAS_HOTEND_OFFSET
 
   inline void normalize_hotend_offsets() {
-    for (uint8_t e = 1; e < HOTENDS; ++e)
+    for (uint_fast8_t e = 1; e < HOTENDS; ++e)
       hotend_offset[e] -= hotend_offset[0];
     hotend_offset[0].reset();
   }
@@ -617,7 +617,7 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     // This function requires normalize_hotend_offsets() to be called
     //
     inline void report_hotend_offsets() {
-      for (uint8_t e = 1; e < HOTENDS; ++e)
+      for (uint_fast8_t e = 1; e < HOTENDS; ++e)
         SERIAL_ECHOLNPGM_P(PSTR("T"), e, PSTR(" Hotend Offset X"), hotend_offset[e].x, SP_Y_STR, hotend_offset[e].y, SP_Z_STR, hotend_offset[e].z);
     }
   #endif

--- a/Marlin/src/gcode/calibrate/G76_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M871.cpp
@@ -186,7 +186,7 @@
       // Disable leveling so it won't mess with us
       TERN_(HAS_LEVELING, set_bed_leveling_enabled(false));
 
-      for (uint8_t idx = 0; idx <= PTC_BED_COUNT; idx++) {
+      for (uint_fast8_t idx = 0; idx <= PTC_BED_COUNT; idx++) {
         thermalManager.setTargetBed(target_bed);
 
         report_targets(target_bed, target_probe);
@@ -250,7 +250,7 @@
       TERN_(HAS_LEVELING, set_bed_leveling_enabled(false));
 
       bool timeout = false;
-      for (uint8_t idx = 0; idx <= PTC_PROBE_COUNT; idx++) {
+      for (uint_fast8_t idx = 0; idx <= PTC_PROBE_COUNT; idx++) {
         // Move probe to probing point and wait for it to reach target temperature
         do_blocking_move_to(noz_pos_xyz);
 

--- a/Marlin/src/gcode/calibrate/M100.cpp
+++ b/Marlin/src/gcode/calibrate/M100.cpp
@@ -163,14 +163,14 @@ inline int32_t count_test_bytes(const char * const start_free_memory) {
     while (start_free_memory < end_free_memory) {
       print_hex_address(start_free_memory);             // Print the address
       SERIAL_CHAR(':');
-      for (uint8_t i = 0; i < 16; ++i) {  // and 16 data bytes
+      for (uint_fast8_t i = 0; i < 16; ++i) {  // and 16 data bytes
         if (i == 8) SERIAL_CHAR('-');
         print_hex_byte(start_free_memory[i]);
         SERIAL_CHAR(' ');
       }
       serial_delay(25);
       SERIAL_CHAR('|');                   // Point out non test bytes
-      for (uint8_t i = 0; i < 16; ++i) {
+      for (uint_fast8_t i = 0; i < 16; ++i) {
         char ccc = (char)start_free_memory[i]; // cast to char before automatically casting to char on assignment, in case the compiler is broken
         ccc = (ccc == TEST_BYTE) ? ' ' : '?';
         SERIAL_CHAR(ccc);

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -146,7 +146,7 @@ void GcodeSuite::M48() {
 
     float sample_sum = 0.0;
 
-    for (uint8_t n = 0; n < n_samples; ++n) {
+    for (int_fast8_t n = 0; n < n_samples; ++n) {
       #if HAS_STATUS_MESSAGE
         // Display M48 progress in the status bar
         ui.status_printf(0, F(S_FMT ": %d/%d"), GET_TEXT_F(MSG_M48_POINT), int(n + 1), int(n_samples));
@@ -173,7 +173,7 @@ void GcodeSuite::M48() {
         }
 
         // Move from leg to leg in rapid succession
-        for (uint8_t l = 0; l < n_legs - 1; ++l) {
+        for (int_fast8_t l = 0; l < n_legs - 1; ++l) {
 
           // Move some distance around the perimeter
           float delta_angle;
@@ -241,7 +241,7 @@ void GcodeSuite::M48() {
       // Calculate the standard deviation so far.
       // The value after the last sample will be the final output.
       float dev_sum = 0.0;
-      for (uint8_t j = 0; j <= n; ++j) dev_sum += sq(sample_set[j] - mean);
+      for (int_fast8_t j = 0; j <= n; ++j) dev_sum += sq(sample_set[j] - mean);
       sigma = SQRT(dev_sum / (n + 1));
 
       if (verbose_level > 1) {

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -41,7 +41,7 @@
     if (!parser.seen("DST" TERN_(VOLUMETRIC_EXTRUDER_LIMIT, "L")))
       return M200_report();
 
-    const int8_t target_extruder = get_target_extruder_from_command();
+    const int_fast8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
 
     bool vol_enable = parser.volumetric_enabled,
@@ -127,7 +127,7 @@ void GcodeSuite::M201() {
   if (!parser.seen("T" STR_AXES_LOGICAL TERN_(XY_FREQUENCY_LIMIT, "FS")))
     return M201_report();
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   #ifdef XY_FREQUENCY_LIMIT
@@ -172,7 +172,7 @@ void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
   #endif
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
+    for (uint_fast8_t i = 0; i < E_STEPPERS; ++i) {
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(
           PSTR("  M201 T"), i
@@ -191,7 +191,7 @@ void GcodeSuite::M203() {
   if (!parser.seen("T" STR_AXES_LOGICAL))
     return M203_report();
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   LOOP_LOGICAL_AXES(i)
@@ -230,7 +230,7 @@ void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
   #endif
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
+    for (uint_fast8_t i = 0; i < E_STEPPERS; ++i) {
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(
           PSTR("  M203 T"), i

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -143,7 +143,7 @@ void GcodeSuite::M217() {
     if (parser.seen('T')) {     // Migrate now
       if (parser.has_value()) {
         const int16_t tval = parser.value_int();
-        if (WITHIN(tval, 0, EXTRUDERS - 1) && tval != active_extruder) {
+        if (WITHIN(tval, 0, EXTRUDERS - 1) && tval != signed(active_extruder)) {
           migration.target = tval + 1;
           extruder_migration();
           migration.target = 0; // disable

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -43,7 +43,7 @@ void GcodeSuite::M218() {
 
   if (!parser.seen_any()) return M218_report();
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   #if HAS_X_AXIS
@@ -66,7 +66,7 @@ void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading(forReplay, F(STR_HOTEND_OFFSETS));
-  for (uint8_t e = 1; e < HOTENDS; ++e) {
+  for (uint_fast8_t e = 1; e < HOTENDS; ++e) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(
       PSTR("  M218 T"), e,

--- a/Marlin/src/gcode/config/M221.cpp
+++ b/Marlin/src/gcode/config/M221.cpp
@@ -30,7 +30,7 @@
  */
 void GcodeSuite::M221() {
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   if (parser.seenval('S'))

--- a/Marlin/src/gcode/config/M281.cpp
+++ b/Marlin/src/gcode/config/M281.cpp
@@ -58,7 +58,7 @@ void GcodeSuite::M281_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading_etc(forReplay, F(STR_SERVO_ANGLES));
-  for (uint8_t i = 0; i < NUM_SERVOS; ++i) {
+  for (uint_fast8_t i = 0; i < NUM_SERVOS; ++i) {
     switch (i) {
       default: break;
       #if ENABLED(SWITCHING_EXTRUDER)

--- a/Marlin/src/gcode/config/M305.cpp
+++ b/Marlin/src/gcode/config/M305.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::M305() {
         SERIAL_ECHO_MSG("!Invalid Steinhart-Hart C coeff. (-0.01 < C < +0.01)");
   }                       // If not setting then report parameters
   else if (t_index < 0) { // ...all user thermistors
-    for (uint8_t i = 0; i < USER_THERMISTORS; ++i)
+    for (uint_fast8_t i = 0; i < USER_THERMISTORS; ++i)
       thermalManager.M305_report(i);
   }
   else                    // ...one user thermistor

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -61,7 +61,7 @@ inline void toggle_pins() {
             end = PARSED_PIN_INDEX('L', NUM_DIGITAL_PINS - 1),
             wait = parser.intval('W', 500);
 
-  for (uint8_t i = start; i <= end; ++i) {
+  for (uint_fast8_t i = start; i <= end; ++i) {
     pin_t pin = GET_PIN_MAP_PIN_M43(i);
     if (!isValidPin(pin)) continue;
     if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) {
@@ -189,7 +189,7 @@ inline void servo_probe_test() {
       // DEPLOY and STOW 4 times and see if the signal follows
       // Then it is a mechanical switch
       SERIAL_ECHOLNPGM(". Deploy & stow 4 times");
-      for (uint8_t i = 0; i < 4; ++i) {
+      for (uint_fast8_t i = 0; i < 4; ++i) {
         servo[probe_index].move(servo_angles[Z_PROBE_SERVO_NR][0]); // Deploy
         safe_delay(500);
         deploy_state = READ(PROBE_TEST_PIN);
@@ -326,7 +326,7 @@ void GcodeSuite::M43() {
     const uint8_t pin_count = last_pin - first_pin + 1;
     uint8_t pin_state[pin_count];
     bool can_watch = false;
-    for (uint8_t i = first_pin; i <= last_pin; ++i) {
+    for (uint_fast8_t i = first_pin; i <= last_pin; ++i) {
       pin_t pin = GET_PIN_MAP_PIN_M43(i);
       if (!isValidPin(pin)) continue;
       if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
@@ -369,7 +369,7 @@ void GcodeSuite::M43() {
     #endif
 
     for (;;) {
-      for (uint8_t i = first_pin; i <= last_pin; ++i) {
+      for (uint_fast8_t i = first_pin; i <= last_pin; ++i) {
         const pin_t pin = GET_PIN_MAP_PIN_M43(i);
         if (!isValidPin(pin)) continue;
         if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
@@ -398,7 +398,7 @@ void GcodeSuite::M43() {
   }
   else {
     // Report current state of selected pin(s)
-    for (uint8_t i = first_pin; i <= last_pin; ++i) {
+    for (uint_fast8_t i = first_pin; i <= last_pin; ++i) {
       const pin_t pin = GET_PIN_MAP_PIN_M43(i);
       if (isValidPin(pin)) printPinStateExt(pin, ignore_protection, true);
     }

--- a/Marlin/src/gcode/config/M672.cpp
+++ b/Marlin/src/gcode/config/M672.cpp
@@ -54,7 +54,7 @@
 //  b3 b2 b1 b0 ~b0  ... lo bits, NOT last bit
 //
 void M672_send(uint8_t b) {    // bit rate requirement: 1kHz +/- 30%
-  for (uint8_t bits = 0; bits < 14; ++bits) {
+  for (uint_fast8_t bits = 0; bits < 14; ++bits) {
     switch (bits) {
       default: { OUT_WRITE(SMART_EFFECTOR_MOD_PIN, !!(b & 0x80)); b <<= 1; break; } // send bit, shift next into place
       case  7:

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -44,7 +44,7 @@
 
 void GcodeSuite::M92() {
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   // No arguments? Show M92 report.
@@ -122,7 +122,7 @@ void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/
   if (ENABLED(PRINT_EOL)) SERIAL_EOL();
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
+    for (uint_fast8_t i = 0; i < E_STEPPERS; ++i) {
       if (e >= 0 && i != e) continue;
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -54,7 +54,7 @@ void GcodeSuite::M111() {
   SERIAL_ECHOPGM(STR_DEBUG_PREFIX);
   if (marlin_debug_flags) {
     uint8_t comma = 0;
-    for (uint8_t i = 0; i < COUNT(debug_strings); ++i) {
+    for (uint_fast8_t i = 0; i < COUNT(debug_strings); ++i) {
       PGM_P const pstr = (PGM_P)pgm_read_ptr(&debug_strings[i]);
       if (pstr && TEST(marlin_debug_flags, i)) {
         if (comma++) SERIAL_CHAR(',');

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -94,7 +94,7 @@
 
           // Do a small 'jog' motion in the X axis
           xyze_pos_t dest = current_position; dest.x -= 0.1f;
-          for (uint8_t i = 2; --i;) {
+          for (uint_fast8_t i = 2; --i;) {
             planner.buffer_line(dest, feedrate_mm_s, 0);
             dest.x += 0.1f;
           }

--- a/Marlin/src/gcode/control/T.cpp
+++ b/Marlin/src/gcode/control/T.cpp
@@ -52,7 +52,7 @@
  *   Tx   Same as T?, but nozzle doesn't have to be preheated. Tc requires a preheated nozzle to finish filament load.
  *   Tc   Load to nozzle after filament was prepared by Tc and nozzle is already heated.
  */
-void GcodeSuite::T(const int8_t tool_index) {
+void GcodeSuite::T(const int_fast8_t tool_index) {
 
   #if HAS_MULTI_EXTRUDER
     // For 'T' with no parameter report the current tool.

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -84,14 +84,14 @@
 
     inline void spin_photo_pin() {
       static constexpr uint32_t sequence[] = PHOTO_PULSES_US;
-      for (uint8_t i = 0; i < COUNT(sequence); ++i)
+      for (uint_fast8_t i = 0; i < COUNT(sequence); ++i)
         pulse_photo_pin(sequence[i], !(i & 1));
     }
 
   #else
 
     constexpr uint8_t NUM_PULSES = 16;
-    inline void spin_photo_pin() { for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin(); }
+    inline void spin_photo_pin() { for (uint_fast8_t i = NUM_PULSES; i--;) tweak_photo_pin(); }
 
   #endif
 #endif

--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -54,7 +54,7 @@ void GcodeSuite::M907() {
 
     // S<current> - Set current in mA for all axes
     if (parser.seenval('S'))
-      for (uint8_t i = 0; i < MOTOR_CURRENT_COUNT; ++i)
+      for (uint_fast8_t i = 0; i < MOTOR_CURRENT_COUNT; ++i)
         stepper.set_digipot_current(i, parser.value_int());
 
     // X Y Z I J K U V W E
@@ -98,7 +98,7 @@ void GcodeSuite::M907() {
       // S<current> - Set all stepper current to the same value
       if (parser.seenval('S')) {
         const int16_t v = parser.value_int();
-        for (uint8_t a = 0; a < MOTOR_CURRENT_COUNT; ++a)
+        for (uint_fast8_t a = 0; a < MOTOR_CURRENT_COUNT; ++a)
           stepper.set_digipot_current(a, v);
       }
 
@@ -130,7 +130,7 @@ void GcodeSuite::M907() {
     // S<current> - Set the same current in Amps on all channels
     if (parser.seenval('S')) {
       const float v = parser.value_float();
-      for (uint8_t q = 0; q < DIGIPOT_I2C_NUM_CHANNELS; ++q)
+      for (uint_fast8_t q = 0; q < DIGIPOT_I2C_NUM_CHANNELS; ++q)
         digipot_i2c.set_current(q, v);
     }
 
@@ -144,7 +144,7 @@ void GcodeSuite::M907() {
     // Additional extruders use B,C,D.
     // TODO: Make parameters work like other axis-specific / stepper-specific. See above.
     #if E_STEPPERS >= 2
-      for (uint8_t i = E_AXIS + 1; i < _MAX(DIGIPOT_I2C_NUM_CHANNELS, (NUM_AXES + 3)); i++)
+      for (uint_fast8_t i = E_AXIS + 1; i < _MAX(DIGIPOT_I2C_NUM_CHANNELS, (NUM_AXES + 3)); i++)
         if (parser.seenval('B' + i - (E_AXIS + 1)))
           digipot_i2c.set_current(i, parser.value_float());
     #endif

--- a/Marlin/src/gcode/feature/leds/M7219.cpp
+++ b/Marlin/src/gcode/feature/leds/M7219.cpp
@@ -79,12 +79,12 @@ void GcodeSuite::M7219() {
   }
 
   if (parser.seen('P')) {
-    for (uint8_t r = 0; r < MAX7219_LINES; ++r) {
+    for (uint_fast8_t r = 0; r < MAX7219_LINES; ++r) {
       SERIAL_ECHOPGM("led_line[");
       if (r < 10) SERIAL_CHAR(' ');
       SERIAL_ECHO(r);
       SERIAL_ECHOPGM("]=");
-      for (uint8_t b = 8; b--;) SERIAL_CHAR('0' + TEST(max7219.led_line[r], b));
+      for (uint_fast8_t b = 8; b--;) SERIAL_CHAR('0' + TEST(max7219.led_line[r], b));
       SERIAL_EOL();
     }
   }

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -85,7 +85,7 @@
 void GcodeSuite::M600() {
 
   #if ENABLED(MIXING_EXTRUDER)
-    const int8_t eindex = get_target_e_stepper_from_command();
+    const int_fast8_t eindex = get_target_e_stepper_from_command();
     if (eindex < 0) return;
 
     const uint8_t old_mixing_tool = mixer.get_current_vtool();
@@ -94,9 +94,9 @@ void GcodeSuite::M600() {
     MIXER_STEPPER_LOOP(i) mixer.set_collector(i, i == uint8_t(eindex) ? 1.0 : 0.0);
     mixer.normalize();
 
-    const int8_t target_extruder = active_extruder;
+    const int_fast8_t target_extruder = active_extruder;
   #else
-    const int8_t target_extruder = get_target_extruder_from_command();
+    const int_fast8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
   #endif
 
@@ -126,7 +126,7 @@ void GcodeSuite::M600() {
 
   #if HAS_MULTI_EXTRUDER
     // Change toolhead if specified
-    const uint8_t active_extruder_before_filament_change = active_extruder;
+    const uint_fast8_t active_extruder_before_filament_change = active_extruder;
     if (active_extruder != target_extruder && TERN1(DUAL_X_CARRIAGE, !idex_is_duplicating()))
       tool_change(target_extruder);
   #endif

--- a/Marlin/src/gcode/feature/pause/M603.cpp
+++ b/Marlin/src/gcode/feature/pause/M603.cpp
@@ -40,7 +40,7 @@ void GcodeSuite::M603() {
 
   if (!parser.seen("TUL")) return M603_report();
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   // Unload length

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -62,7 +62,7 @@ void GcodeSuite::M701() {
   if (TERN0(NO_MOTION_BEFORE_HOMING, axes_should_home())) park_point.z = 0;
 
   #if ENABLED(MIXING_EXTRUDER)
-    const int8_t eindex = get_target_e_stepper_from_command();
+    const int_fast8_t eindex = get_target_e_stepper_from_command();
     if (eindex < 0) return;
 
     const uint8_t old_mixing_tool = mixer.get_current_vtool();
@@ -71,9 +71,9 @@ void GcodeSuite::M701() {
     MIXER_STEPPER_LOOP(i) mixer.set_collector(i, i == uint8_t(eindex) ? 1.0 : 0.0);
     mixer.normalize();
 
-    const int8_t target_extruder = active_extruder;
+    const int_fast8_t target_extruder = active_extruder;
   #else
-    const int8_t target_extruder = get_target_extruder_from_command();
+    const int_fast8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
   #endif
 
@@ -85,7 +85,7 @@ void GcodeSuite::M701() {
 
   #if HAS_MULTI_EXTRUDER && (HAS_PRUSA_MMU1 || !HAS_MMU)
     // Change toolhead if specified
-    uint8_t active_extruder_before_filament_change = active_extruder;
+    uint_fast8_t active_extruder_before_filament_change = active_extruder;
     if (active_extruder != target_extruder)
       tool_change(target_extruder);
   #endif
@@ -169,16 +169,16 @@ void GcodeSuite::M702() {
     #endif
 
     if (seenT) {
-      const int8_t eindex = get_target_e_stepper_from_command();
+      const int_fast8_t eindex = get_target_e_stepper_from_command();
       if (eindex < 0) return;
       mixer.T(MIXER_DIRECT_SET_TOOL);
       MIXER_STEPPER_LOOP(i) mixer.set_collector(i, i == uint8_t(eindex) ? 1.0 : 0.0);
       mixer.normalize();
     }
 
-    const int8_t target_extruder = active_extruder;
+    const int_fast8_t target_extruder = active_extruder;
   #else
-    const int8_t target_extruder = get_target_extruder_from_command();
+    const int_fast8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
   #endif
 
@@ -190,7 +190,7 @@ void GcodeSuite::M702() {
 
   #if HAS_MULTI_EXTRUDER && (HAS_PRUSA_MMU1 || !HAS_MMU)
     // Change toolhead if specified
-    uint8_t active_extruder_before_filament_change = active_extruder;
+    uint_fast8_t active_extruder_before_filament_change = active_extruder;
     if (active_extruder != target_extruder)
       tool_change(target_extruder);
   #endif

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -120,7 +120,7 @@ void GcodeSuite::M906() {
 
       #if ANY(E0_IS_TRINAMIC, E1_IS_TRINAMIC, E2_IS_TRINAMIC, E3_IS_TRINAMIC, E4_IS_TRINAMIC, E5_IS_TRINAMIC, E6_IS_TRINAMIC, E7_IS_TRINAMIC)
         case E_AXIS: {
-          const int8_t eindex = get_target_e_stepper_from_command(-2);
+          const uint_fast8_t eindex = get_target_e_stepper_from_command(-2);
           TERN_(E0_IS_TRINAMIC, if (eindex < 0 || eindex == 0) TMC_SET_CURRENT(E0));
           TERN_(E1_IS_TRINAMIC, if (eindex < 0 || eindex == 1) TMC_SET_CURRENT(E1));
           TERN_(E2_IS_TRINAMIC, if (eindex < 0 || eindex == 2) TMC_SET_CURRENT(E2));

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -351,7 +351,7 @@
 
         #if E0_HAS_STEALTHCHOP || E1_HAS_STEALTHCHOP || E2_HAS_STEALTHCHOP || E3_HAS_STEALTHCHOP || E4_HAS_STEALTHCHOP || E5_HAS_STEALTHCHOP || E6_HAS_STEALTHCHOP || E7_HAS_STEALTHCHOP
           case E_AXIS: {
-            const int8_t eindex = get_target_e_stepper_from_command(-2);
+            const int_fast8_t eindex = get_target_e_stepper_from_command(-2);
             TERN_(E0_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 0) TMC_SET_PWMTHRS_E(0));
             TERN_(E1_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 1) TMC_SET_PWMTHRS_E(1));
             TERN_(E2_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 2) TMC_SET_PWMTHRS_E(2));
@@ -361,7 +361,7 @@
             TERN_(E6_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 6) TMC_SET_PWMTHRS_E(6));
             TERN_(E7_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 7) TMC_SET_PWMTHRS_E(7));
           } break;
-        #endif // E_STEPPERS
+        #endif // E*_HAS_STEALTHCHOP
       }
     }
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -121,7 +121,7 @@ void GcodeSuite::say_units() {
  * Get the target extruder from the T parameter or the active_extruder
  * Return -1 if the T parameter is out of range
  */
-int8_t GcodeSuite::get_target_extruder_from_command() {
+int_fast8_t GcodeSuite::get_target_extruder_from_command() {
   #if HAS_TOOLCHANGE
     if (parser.seenval('T')) {
       const int8_t e = parser.value_byte();
@@ -141,7 +141,7 @@ int8_t GcodeSuite::get_target_extruder_from_command() {
  * Returns -1 if the resulting E stepper index is out of range.
  * Use a default of -2 for silent failure.
  */
-int8_t GcodeSuite::get_target_e_stepper_from_command(const int8_t dval/*=-1*/) {
+int_fast8_t GcodeSuite::get_target_e_stepper_from_command(const int_fast8_t dval/*=-1*/) {
   const int8_t e = parser.intval('T', dval);
   if (WITHIN(e, 0, E_STEPPERS - 1)) return e;
   if (dval == -2) return dval;

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -454,8 +454,8 @@ public:
   }
   static void say_units();
 
-  static int8_t get_target_extruder_from_command();
-  static int8_t get_target_e_stepper_from_command(const int8_t dval=-1);
+  static int_fast8_t get_target_extruder_from_command();
+  static int_fast8_t get_target_e_stepper_from_command(const int_fast8_t dval=-1);
   static void get_destination_from_command();
 
   static void process_parsed_command(const bool no_ok=false);
@@ -1347,7 +1347,7 @@ private:
     static void M710_report(const bool forReplay=true);
   #endif
 
-  static void T(const int8_t tool_index) IF_DISABLED(HAS_TOOLCHANGE, { UNUSED(tool_index); });
+  static void T(const int_fast8_t tool_index) IF_DISABLED(HAS_TOOLCHANGE, { UNUSED(tool_index); });
 
 };
 

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -29,7 +29,7 @@
 #if ENABLED(M114_DETAIL)
 
   void report_all_axis_pos(const xyze_pos_t &pos, const uint8_t n=LOGICAL_AXES, const uint8_t precision=3) {
-    for (uint8_t a = 0; a < n; ++a) {
+    for (uint_fast8_t a = 0; a < n; ++a) {
       SERIAL_ECHOPGM_P((PGM_P)pgm_read_ptr(&SP_AXIS_LBL[a]));
       if (pos[a] >= 0) SERIAL_CHAR(' ');
       SERIAL_ECHO(p_float_t(pos[a], precision));

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M118() {
     int8_t port = -1; // Assume no redirect
   #endif
   char *p = parser.string_arg;
-  for (uint8_t i = 3; i--;) {
+  for (uint_fast8_t i = 3; i--;) {
     // A1, E1, and Pn are always parsed out
     if (!( ((p[0] == 'A' || p[0] == 'E') && p[1] == '1') || (p[0] == 'P' && NUMERIC(p[1])) )) break;
     switch (p[0]) {

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::M145_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading(forReplay, F(STR_MATERIAL_HEATUP));
-  for (uint8_t i = 0; i < PREHEAT_COUNT; ++i) {
+  for (uint_fast8_t i = 0; i < PREHEAT_COUNT; ++i) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(
       PSTR("  M145 S"), i

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -216,7 +216,7 @@ public:
 
     // At least one of a list of code letters was seen
     static bool seen(const char * const str) {
-      for (uint8_t i = 0; const char c = str[i]; i++)
+      for (uint_fast8_t i = 0; const char c = str[i]; i++)
         if (seen_test(c)) return true;
       return false;
     }
@@ -272,17 +272,17 @@ public:
   }
 
   // Code value as a long or ulong
-  static int32_t value_long() { return value_ptr ? strtol(value_ptr, nullptr, 10) : 0L; }
-  static uint32_t value_ulong() { return value_ptr ? strtoul(value_ptr, nullptr, 10) : 0UL; }
+  static int_fast32_t value_long()   { return value_ptr ? strtol(value_ptr, nullptr, 10) : 0L; }
+  static uint_fast32_t value_ulong() { return value_ptr ? strtoul(value_ptr, nullptr, 10) : 0UL; }
 
   // Code value for use as time
   static millis_t value_millis() { return value_ulong(); }
   static millis_t value_millis_from_seconds() { return (millis_t)SEC_TO_MS(value_float()); }
 
   // Reduce to fewer bits
-  static int16_t value_int() { return (int16_t)value_long(); }
-  static uint16_t value_ushort() { return (uint16_t)value_long(); }
-  static uint8_t value_byte() { return (uint8_t)constrain(value_long(), 0, 255); }
+  static int_fast16_t value_int()     { return int_fast16_t(value_long()); }
+  static uint_fast16_t value_ushort() { return uint_fast16_t(value_long()); }
+  static uint_fast8_t value_byte()    { return uint_fast8_t(constrain(value_long(), 0, 255)); }
 
   // Bool is true with no value or non-zero
   static bool value_bool() { return !has_value() || !!value_byte(); }
@@ -420,19 +420,19 @@ public:
   void unknown_command_warning();
 
   // Provide simple value accessors with default option
-  static char*     stringval(const char c, char * const dval=nullptr) { return seenval(c) ? value_string()   : dval; }
-  static float     floatval(const char c, const float dval=0.0)   { return seenval(c) ? value_float()        : dval; }
-  static bool      boolval(const char c, const bool dval=false)   { return seenval(c) ? value_bool()         : (seen(c) ? true : dval); }
-  static uint8_t   byteval(const char c, const uint8_t dval=0)    { return seenval(c) ? value_byte()         : dval; }
-  static int16_t   intval(const char c, const int16_t dval=0)     { return seenval(c) ? value_int()          : dval; }
-  static uint16_t  ushortval(const char c, const uint16_t dval=0) { return seenval(c) ? value_ushort()       : dval; }
-  static int32_t   longval(const char c, const int32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
-  static uint32_t  ulongval(const char c, const uint32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
-  static float     linearval(const char c, const float dval=0)    { return seenval(c) ? value_linear_units() : dval; }
-  static float     axisunitsval(const char c, const AxisEnum a, const float dval=0)
-                                                                         { return seenval(c) ? value_axis_units(a)  : dval; }
-  static celsius_t celsiusval(const char c, const celsius_t dval=0)    { return seenval(c) ? value_celsius() : dval; }
-  static feedRate_t feedrateval(const char c, const feedRate_t dval=0) { return seenval(c) ? value_feedrate() : dval; }
+  static char*         stringval(const char c, char * const dval=nullptr)  { return seenval(c) ? value_string()       : dval; }
+  static float         floatval(const char c, const float dval=0.0)        { return seenval(c) ? value_float()        : dval; }
+  static bool          boolval(const char c, const bool dval=false)        { return seenval(c) ? value_bool()         : (seen(c) ? true : dval); }
+  static uint_fast8_t  byteval(const char c, const uint_fast8_t dval=0)    { return seenval(c) ? value_byte()         : dval; }
+  static int_fast16_t  intval(const char c, const int_fast16_t dval=0)     { return seenval(c) ? value_int()          : dval; }
+  static uint_fast16_t ushortval(const char c, const uint_fast16_t dval=0) { return seenval(c) ? value_ushort()       : dval; }
+  static int_fast32_t  longval(const char c, const int_fast32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
+  static uint_fast32_t ulongval(const char c, const uint_fast32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
+  static float         linearval(const char c, const float dval=0)         { return seenval(c) ? value_linear_units() : dval; }
+  static float         axisunitsval(const char c, const AxisEnum a, const float dval=0)
+                                                                           { return seenval(c) ? value_axis_units(a)  : dval; }
+  static celsius_t celsiusval(const char c, const celsius_t dval=0)        { return seenval(c) ? value_celsius()      : dval; }
+  static feedRate_t feedrateval(const char c, const feedRate_t dval=0)     { return seenval(c) ? value_feedrate()     : dval; }
 
   #if ENABLED(MARLIN_DEV_MODE)
 

--- a/Marlin/src/gcode/probe/M423.cpp
+++ b/Marlin/src/gcode/probe/M423.cpp
@@ -90,7 +90,7 @@ void GcodeSuite::M423_report(const bool forReplay/*=true*/) {
 
   report_heading_etc(forReplay, F("X-Twist Correction"));
   SERIAL_ECHOLNPGM("  M423 A", xatc.start, " I", xatc.spacing);
-  for (uint8_t x = 0; x < XATC_MAX_POINTS; ++x) {
+  for (uint_fast8_t x = 0; x < XATC_MAX_POINTS; ++x) {
     const float z = xatc.z_offset[x];
     report_echo_start(forReplay);
     SERIAL_ECHOPGM("  M423 X", x, " Z");

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -290,7 +290,7 @@ static bool serial_data_available(serial_index_t index) {
 #if NO_TIMEOUTS > 0
   // Multiserial already handles dispatch to/from multiple ports
   static bool any_serial_data_available() {
-    for (uint8_t p = 0; p < NUM_SERIAL; ++p)
+    for (uint_fast8_t p = 0; p < NUM_SERIAL; ++p)
       if (serial_data_available(p))
         return true;
     return false;
@@ -309,7 +309,7 @@ inline int read_serial(const serial_index_t index) { return SERIAL_IMPL.read(ind
    */
   void GCodeQueue::flush_rx() {
     // Flush receive buffer
-    for (uint8_t p = 0; p < NUM_SERIAL; ++p) {
+    for (uint_fast8_t p = 0; p < NUM_SERIAL; ++p) {
       if (!serial_data_available(p)) continue; // No data for this port? Skip.
       while (SERIAL_IMPL.available(p)) (void)read_serial(p);
     }
@@ -437,7 +437,7 @@ void GCodeQueue::get_serial_commands() {
     // Unless a serial port has data, this will exit on next iteration
     hadData = false;
 
-    for (uint8_t p = 0; p < NUM_SERIAL; ++p) {
+    for (uint_fast8_t p = 0; p < NUM_SERIAL; ++p) {
       // Check if the queue is full and exit if it is.
       if (ring_buffer.full()) return;
 

--- a/Marlin/src/gcode/temp/M104_M109.cpp
+++ b/Marlin/src/gcode/temp/M104_M109.cpp
@@ -74,9 +74,9 @@ void GcodeSuite::M104_M109(const bool isM109) {
   if (DEBUGGING(DRYRUN)) return;
 
   #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
-    constexpr int8_t target_extruder = 0;
+    constexpr int_fast8_t target_extruder = 0;
   #else
-    const int8_t target_extruder = get_target_extruder_from_command();
+    const int_fast8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
   #endif
 

--- a/Marlin/src/gcode/temp/M105.cpp
+++ b/Marlin/src/gcode/temp/M105.cpp
@@ -28,7 +28,7 @@
  */
 void GcodeSuite::M105() {
 
-  const int8_t target_extruder = get_target_extruder_from_command();
+  const int_fast8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
   SERIAL_ECHOPGM(STR_OK);

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -40,7 +40,7 @@
   #define _ALT_P active_extruder
   #define _CNT_P EXTRUDERS
 #else
-  #define _ALT_P _MIN(active_extruder, FAN_COUNT - 1)
+  #define _ALT_P _MIN(active_extruder, unsigned(FAN_COUNT - 1))
   #define _CNT_P FAN_COUNT
 #endif
 
@@ -59,23 +59,23 @@
  *           3-255 = Set the speed for use with T2
  */
 void GcodeSuite::M106() {
-  const uint8_t pfan = parser.byteval('P', _ALT_P);
+  const uint_fast8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;
 
   #if ENABLED(EXTRA_FAN_SPEED)
-    const uint16_t t = parser.intval('T');
+    const uint_fast16_t t = parser.intval('T');
     if (t > 0) return thermalManager.set_temp_fan_speed(pfan, t);
   #endif
 
-  const uint16_t dspeed = parser.seen_test('A') ? thermalManager.fan_speed[active_extruder] : 255;
+  const uint_fast16_t dspeed = parser.seen_test('A') ? thermalManager.fan_speed[active_extruder] : 255;
 
-  uint16_t speed = dspeed;
+  uint_fast16_t speed = dspeed;
 
   // Accept 'I' if temperature presets are defined
   #if HAS_PREHEAT
     const bool got_preset = parser.seenval('I');
-    if (got_preset) speed = ui.material_preset[_MIN(parser.value_byte(), PREHEAT_COUNT - 1)].fan_speed;
+    if (got_preset) speed = ui.material_preset[_MIN(parser.value_byte(), unsigned(PREHEAT_COUNT - 1))].fan_speed;
   #else
     constexpr bool got_preset = false;
   #endif
@@ -98,7 +98,7 @@ void GcodeSuite::M106() {
  * M107: Fan Off
  */
 void GcodeSuite::M107() {
-  const uint8_t pfan = parser.byteval('P', _ALT_P);
+  const uint_fast8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;
 

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -608,7 +608,7 @@
 
 #ifdef GRID_MAX_POINTS_X
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
-  #define GRID_LOOP(A,B) for (uint8_t A = 0; A < GRID_MAX_POINTS_X; ++A) for (uint8_t B = 0; B < GRID_MAX_POINTS_Y; ++B)
+  #define GRID_LOOP(A,B) for (uint_fast8_t A = 0; A < GRID_MAX_POINTS_X; ++A) for (uint_fast8_t B = 0; B < GRID_MAX_POINTS_Y; ++B)
 #endif
 
 /**

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -130,7 +130,7 @@
 
 static void createChar_P(const char c, const byte * const ptr) {
   byte temp[8];
-  for (uint8_t i = 0; i < 8; ++i)
+  for (uint_fast8_t i = 0; i < 8; ++i)
     temp[i] = pgm_read_byte(&ptr[i]);
   lcd.createChar(c, temp);
 }
@@ -336,13 +336,13 @@ void MarlinUI::set_custom_characters(const HD44780CharSet screen_charset/*=CHARS
     #if ENABLED(SHOW_BOOTSCREEN)
       case CHARSET_BOOT: {
         // Set boot screen corner characters
-        for (uint8_t i = 4; i--;) createChar_P(i, corner[i]);
+        for (uint_fast8_t i = 4; i--;) createChar_P(i, corner[i]);
       } break;
     #endif
 
     #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
       case CHARSET_BOOT_CUSTOM: {
-        for (uint8_t i = COUNT(customBootChars); i--;)
+        for (uint_fast8_t i = COUNT(customBootChars); i--;)
           createChar_P(i, customBootChars[i]);
       } break;
     #endif
@@ -473,7 +473,7 @@ void MarlinUI::clear_for_drawing() { clear_lcd(); }
 
   void lcd_erase_line(const lcd_uint_t line) {
     lcd_moveto(0, line);
-    for (uint8_t i = LCD_WIDTH + 1; --i;)
+    for (uint_fast8_t i = LCD_WIDTH + 1; --i;)
       lcd_put_u8str(F(" "));
   }
 
@@ -488,13 +488,13 @@ void MarlinUI::clear_for_drawing() { clear_lcd(); }
     else {
       PGM_P p = FTOP(ftxt);
       int dly = time / _MAX(slen, 1);
-      for (uint8_t i = 0; i <= slen; ++i) {
+      for (uint_fast8_t i = 0; i <= slen; ++i) {
 
         // Print the text at the correct place
         lcd_put_u8str_max_P(col, line, p, len);
 
         // Fill with spaces
-        for (uint8_t ix = slen - i; ix < len; ++ix) lcd_put_u8str(F(" "));
+        for (uint_fast8_t ix = slen - i; ix < len; ++ix) lcd_put_u8str(F(" "));
 
         // Delay
         safe_delay(dly);

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -193,7 +193,7 @@ bool MarlinUI::detected() { return true; }
         #if DISABLED(CUSTOM_BOOTSCREEN_ANIMATED_FRAME_TIME)
           constexpr millis_t frame_time = CUSTOM_BOOTSCREEN_FRAME_TIME;
         #endif
-        for (uint8_t f = 0; f < COUNT(custom_bootscreen_animation); ++f)
+        for (uint_fast8_t f = 0; f < COUNT(custom_bootscreen_animation); ++f)
       #endif
         {
           #if ENABLED(CUSTOM_BOOTSCREEN_ANIMATED_FRAME_TIME)
@@ -266,7 +266,7 @@ bool MarlinUI::detected() { return true; }
       draw_bootscreen_bmp(start_bmp);
     #else
       constexpr millis_t frame_time = MARLIN_BOOTSCREEN_FRAME_TIME;
-      for (uint8_t f = 0; f < COUNT(marlin_bootscreen_animation); ++f) {
+      for (uint_fast8_t f = 0; f < COUNT(marlin_bootscreen_animation); ++f) {
         draw_bootscreen_bmp((uint8_t*)pgm_read_ptr(&marlin_bootscreen_animation[f]));
         if (frame_time) safe_delay(frame_time);
       }
@@ -275,7 +275,7 @@ bool MarlinUI::detected() { return true; }
 
   // Show the Marlin bootscreen, with the u8g loop and delays
   void MarlinUI::show_marlin_bootscreen() {
-    for (uint8_t q = bootscreen_pages; q--;) {
+    for (uint_fast8_t q = bootscreen_pages; q--;) {
       draw_marlin_bootscreen(q == 0);
       if (q) safe_delay((BOOTSCREEN_TIMEOUT) / bootscreen_pages);
     }
@@ -663,9 +663,9 @@ void MarlinUI::clear_for_drawing() {
       u8g.setColorIndex(1);
       const u8g_uint_t sx = x_offset + pixels_per_x_mesh_pnt / 2;
             u8g_uint_t  y = y_offset + pixels_per_y_mesh_pnt / 2;
-      for (uint8_t j = 0; j < (GRID_MAX_POINTS_Y); j++, y += pixels_per_y_mesh_pnt)
+      for (uint_fast8_t j = 0; j < (GRID_MAX_POINTS_Y); j++, y += pixels_per_y_mesh_pnt)
         if (PAGE_CONTAINS(y, y))
-          for (uint8_t i = 0, x = sx; i < (GRID_MAX_POINTS_X); i++, x += pixels_per_x_mesh_pnt)
+          for (uint_fast8_t i = 0, x = sx; i < (GRID_MAX_POINTS_X); i++, x += pixels_per_x_mesh_pnt)
             u8g.drawBox(x, y, 1, 1);
 
       // Fill in the Specified Mesh Point

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -172,7 +172,7 @@
     #endif
 
     // ensure we have the right one selected for display
-    for (uint8_t i = 0; i < 3; i++) {
+    for (uint_fast8_t i = 0; i < 3; i++) {
       #if ENABLED(POWER_MONITOR_CURRENT)
         if (power_monitor.display_item == 0 && !iflag) ++power_monitor.display_item;
       #endif
@@ -696,7 +696,7 @@ void MarlinUI::draw_status_screen() {
   if (PAGE_UNDER(6 + 1 + 12 + 1 + 6 + 1)) {
     // Extruders
     #if DO_DRAW_HOTENDS
-      for (uint8_t e = 0; e < MAX_HOTEND_DRAW; ++e) _draw_hotend_status((heater_id_t)e, blink);
+      for (uint_fast8_t e = 0; e < MAX_HOTEND_DRAW; ++e) _draw_hotend_status((heater_id_t)e, blink);
     #endif
 
     // Laser / Spindle

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -232,15 +232,15 @@ void ST7920_Lite_Status_Screen::home() {
 void ST7920_Lite_Status_Screen::clear_ddram() {
   set_ddram_address(DDRAM_LINE_1);
   begin_data();
-  for (uint8_t i = 64; i--;) write_byte(' ');
+  for (uint_fast8_t i = 64; i--;) write_byte(' ');
 }
 
 /* This fills the entire graphics buffer with zeros */
 void ST7920_Lite_Status_Screen::clear_gdram() {
-  for (uint8_t y = 0; y < BUFFER_HEIGHT; ++y) {
+  for (uint_fast8_t y = 0; y < BUFFER_HEIGHT; ++y) {
     set_gdram_address(0, y);
     begin_data();
-    for (uint8_t i = (BUFFER_WIDTH) / 16; i--;) write_word(0);
+    for (uint_fast8_t i = (BUFFER_WIDTH) / 16; i--;) write_word(0);
   }
 }
 
@@ -248,7 +248,7 @@ void ST7920_Lite_Status_Screen::load_cgram_icon(const uint16_t addr, const void 
   const uint16_t *p_word = (const uint16_t *)data;
   set_cgram_address(addr);
   begin_data();
-  for (uint8_t i = 16; i--;)
+  for (uint_fast8_t i = 16; i--;)
     write_word(pgm_read_word(p_word++));
 }
 
@@ -435,7 +435,7 @@ void ST7920_Lite_Status_Screen::draw_degree_symbol(uint8_t x, uint8_t y, const b
     const uint8_t x_word  = x >> 1,
                   y_top   = degree_symbol_y_top,
                   y_bot   = y_top + COUNT(degree_symbol);
-    for (uint8_t i = y_top; i < y_bot; ++i) {
+    for (uint_fast8_t i = y_top; i < y_bot; ++i) {
       uint8_t byte = pgm_read_byte(p_bytes++);
       set_gdram_address(x_word, i + y * 16);
       begin_data();
@@ -751,10 +751,10 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
     // This drawing is a mess and only produce readable result around 25% steps
     // i.e. 74-76% look fine [||||||||||||||||||||||||        ], but 73% look like this: [||||||||||||||||       |        ]
     // meaning partially filled bytes produce only single vertical line, and i bet they're not supposed to!
-    for (uint8_t y = top; y <= bottom; ++y) {
+    for (uint_fast8_t y = top; y <= bottom; ++y) {
       set_gdram_address(left, y);
       begin_data();
-      for (uint8_t x = 0; x < width; ++x) {
+      for (uint_fast8_t x = 0; x < width; ++x) {
         uint16_t gfx_word = 0x0000;
         if ((x + 1) * char_pcnt <= value)
           gfx_word = 0xFFFF;                                              // Draw completely filled bytes

--- a/Marlin/src/lcd/dogm/u8g/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g/u8g_dev_st7920_128x64_HAL.cpp
@@ -87,11 +87,11 @@ void clear_graphics_DRAM(u8g_t *u8g, u8g_dev_t *dev) {
   u8g_SetAddress(u8g, dev, 0);                    // Cmd mode
   u8g_WriteByte(u8g, dev, 0x08);                  // Display off, cursor+blink off
   u8g_WriteByte(u8g, dev, 0x3E);                  // Extended mode + GDRAM active
-  for (uint8_t y = 0; y < (LCD_PIXEL_HEIGHT) / 2; ++y) {  // Clear GDRAM
+  for (uint_fast8_t y = 0; y < (LCD_PIXEL_HEIGHT) / 2; ++y) {  // Clear GDRAM
     u8g_WriteByte(u8g, dev, 0x80 | y);            // Set y
     u8g_WriteByte(u8g, dev, 0x80);                // Set x = 0
     u8g_SetAddress(u8g, dev, 1);                  // Data mode
-    for (uint8_t i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; ++i) // 2x width clears both segments
+    for (uint_fast8_t i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; ++i) // 2x width clears both segments
       u8g_WriteByte(u8g, dev, 0);
     u8g_SetAddress(u8g, dev, 0);                  // Cmd mode
   }

--- a/Marlin/src/lcd/dogm/u8g/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g/u8g_dev_tft_upscale_from_128x64.cpp
@@ -292,16 +292,16 @@ static void setWindow(u8g_t *u8g, u8g_dev_t *dev, uint16_t xMin, uint16_t yMin, 
           v = color;
         else
           v = TFT_MARLINBG_COLOR;
-        for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = v;
+        for (uint_fast8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = v;
       }
       #if HAS_LCD_IO
-        for (uint8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
+        for (uint_fast8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
           for (uint16_t l = 0; l < UPSCALE0(length); l++)
             buffer[l + n * UPSCALE0(length)] = buffer[l];
 
         tftio.writeSequence(buffer, length * sq(GRAPHICAL_TFT_UPSCALE));
       #else
-        for (uint8_t i = GRAPHICAL_TFT_UPSCALE; i--;)
+        for (uint_fast8_t i = GRAPHICAL_TFT_UPSCALE; i--;)
           u8g_WriteSequence(u8g, dev, k << 1, (uint8_t*)buffer);
       #endif
     }
@@ -410,24 +410,24 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
       #endif
       if (++page > (HEIGHT / PAGE_HEIGHT)) return 1;
 
-      for (uint8_t y = 0; y < PAGE_HEIGHT; ++y) {
+      for (uint_fast8_t y = 0; y < PAGE_HEIGHT; ++y) {
         uint32_t k = 0;
         TERN_(HAS_LCD_IO, buffer = (y & 1) ? bufferB : bufferA);
         for (uint16_t i = 0; i < (uint32_t)pb->width; i++) {
           const uint8_t b = *(((uint8_t *)pb->buf) + i);
           const uint16_t c = TEST(b, y) ? TFT_MARLINUI_COLOR : TFT_MARLINBG_COLOR;
-          for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = c;
+          for (uint_fast8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = c;
         }
         #if HAS_LCD_IO
-          for (uint8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
+          for (uint_fast8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
             for (uint16_t l = 0; l < UPSCALE0(WIDTH); l++)
               buffer[l + n * UPSCALE0(WIDTH)] = buffer[l];
 
           tftio.writeSequence(buffer, COUNT(bufferA));
         #else
           uint8_t *bufptr = (uint8_t*) buffer;
-          for (uint8_t i = GRAPHICAL_TFT_UPSCALE; i--;) {
-            for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE * 2; ++n) {
+          for (uint_fast8_t i = GRAPHICAL_TFT_UPSCALE; i--;) {
+            for (uint_fast8_t n = 0; n < GRAPHICAL_TFT_UPSCALE * 2; ++n) {
               u8g_WriteSequence(u8g, dev, WIDTH, &bufptr[WIDTH * n]);
             }
           }
@@ -477,7 +477,7 @@ uint8_t u8g_com_hal_tft_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_p
 
     case U8G_COM_MSG_WRITE_SEQ:
       tftio.dataTransferBegin(DATASIZE_16BIT);
-      for (uint8_t i = 0; i < arg_val; i += 2)
+      for (uint_fast8_t i = 0; i < arg_val; i += 2)
         tftio.writeData(*(uint16_t *)(((uintptr_t)arg_ptr) + i));
       tftio.dataTransferEnd();
       break;

--- a/Marlin/src/lcd/dogm/u8g/ultralcd_st7920_u8glib_rrd_AVR.h
+++ b/Marlin/src/lcd/dogm/u8g/ultralcd_st7920_u8glib_rrd_AVR.h
@@ -50,4 +50,4 @@ void ST7920_SWSPI_SND_8BIT(uint8_t val);
 #define ST7920_SET_CMD()         { ST7920_SWSPI_SND_8BIT(0xF8); U8G_DELAY(); }
 #define ST7920_SET_DAT()         { ST7920_SWSPI_SND_8BIT(0xFA); U8G_DELAY(); }
 #define ST7920_WRITE_BYTE(a)     { ST7920_SWSPI_SND_8BIT((uint8_t)((a)&0xF0u)); ST7920_SWSPI_SND_8BIT((uint8_t)((a)<<4U)); U8G_DELAY(); }
-#define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }
+#define ST7920_WRITE_BYTES(p,l)  { for (uint_fast8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }

--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -38,8 +38,8 @@ uint8_t databuf[26] = { 0 };
 // Send the data in the buffer plus the packet tail
 void dwinSend(size_t &i) {
   ++i;
-  for (uint8_t n = 0; n < i; ++n) { LCD_SERIAL.write(dwinSendBuf[n]); delayMicroseconds(1); }
-  for (uint8_t n = 0; n < 4; ++n) { LCD_SERIAL.write(dwinBufTail[n]); delayMicroseconds(1); }
+  for (uint_fast8_t n = 0; n < i; ++n) { LCD_SERIAL.write(dwinSendBuf[n]); delayMicroseconds(1); }
+  for (uint_fast8_t n = 0; n < 4; ++n) { LCD_SERIAL.write(dwinBufTail[n]); delayMicroseconds(1); }
 }
 
 /*-------------------------------------- System variable function --------------------------------------*/

--- a/Marlin/src/lcd/e3v2/common/encoder.cpp
+++ b/Marlin/src/lcd/e3v2/common/encoder.cpp
@@ -159,7 +159,7 @@ EncoderState encoderReceiveAnalyze() {
   //  RGB_Scale: RGB color ratio
   //  luminance: brightness (0~0xFF)
   void LED_Control(const uint8_t RGB_Scale, const uint8_t luminance) {
-    for (uint8_t i = 0; i < LED_NUM; i++) {
+    for (uint_fast8_t i = 0; i < LED_NUM; i++) {
       LED_DataArray[i] = 0;
       switch (RGB_Scale) {
         case RGB_SCALE_R10_G7_B5: LED_DataArray[i] = (luminance * 10/10) << 8 | (luminance * 7/10) << 16 | luminance * 5/10; break;
@@ -176,7 +176,7 @@ EncoderState encoderReceiveAnalyze() {
   //  change_Time: gradient time (ms)
   void LED_GraduallyControl(const uint8_t RGB_Scale, const uint8_t luminance, const uint16_t change_Interval) {
     struct { uint8_t g, r, b; } led_data[LED_NUM];
-    for (uint8_t i = 0; i < LED_NUM; i++) {
+    for (uint_fast8_t i = 0; i < LED_NUM; i++) {
       switch (RGB_Scale) {
         case RGB_SCALE_R10_G7_B5:
           led_data[i] = { luminance * 7/10, luminance * 10/10, luminance * 5/10 };
@@ -191,7 +191,7 @@ EncoderState encoderReceiveAnalyze() {
     }
 
     struct { bool g, r, b; } led_flag = { false, false, false };
-    for (uint8_t i = 0; i < LED_NUM; i++) {
+    for (uint_fast8_t i = 0; i < LED_NUM; i++) {
       while (1) {
         const uint8_t g = uint8_t(LED_DataArray[i] >> 16),
                       r = uint8_t(LED_DataArray[i] >> 8),

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1943,7 +1943,7 @@ void redrawSDList() {
 
   if (card.isMounted()) {
     // As many files as will fit
-    for (uint8_t i = 0; i < _MIN(nr_sd_menu_items(), MROWS); ++i)
+    for (uint_fast8_t i = 0; i < _MIN(nr_sd_menu_items(), MROWS); ++i)
       drawSDItem(i, i + 1);
 
     TERN_(SCROLL_LONG_FILENAMES, initSDItemShift());
@@ -2090,7 +2090,7 @@ void drawInfoMenu() {
   dwinDrawString(false, font8x16, COLOR_WHITE, COLOR_BG_BLACK, (DWIN_WIDTH - strlen(CORP_WEBSITE) * MENU_CHR_W) / 2, 268, F(CORP_WEBSITE));
 
   drawBackFirst();
-  for (uint8_t i = 0; i < 3; ++i) {
+  for (uint_fast8_t i = 0; i < 3; ++i) {
     dwinIconShow(ICON, ICON_PrintSize + i, 26, 99 + i * 73);
     dwinDrawLine(COLOR_LINE, 16, MBASE(2) + i * 73, 256, 156 + i * 73);
   }
@@ -2280,7 +2280,7 @@ void hmiSelectFile() {
       #if HAS_FAN
         // All fans on for Ender-3 v2 ?
         // The slicer should manage this for us.
-        //for (uint8_t i = 0; i < FAN_COUNT; i++)
+        //for (uint_fast8_t i = 0; i < FAN_COUNT; i++)
         //  thermalManager.fan_speed[i] = 255;
       #endif
 
@@ -2442,7 +2442,7 @@ void drawMoveMenu() {
   if (select_axis.now != CASE_BACK) drawMenuCursor(select_axis.now);
 
   // Draw separators and icons
-  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MoveX + i);
+  for (uint_fast8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MoveX + i);
 }
 
 void itemAdvHomeOffsets(const uint8_t row) {
@@ -3323,7 +3323,7 @@ void drawMaxSpeedMenu() {
   }
 
   drawBackFirst();
-  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxSpeedX + i);
+  for (uint_fast8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxSpeedX + i);
   drawEditInteger4(1, planner.settings.max_feedrate_mm_s[X_AXIS]);
   drawEditInteger4(2, planner.settings.max_feedrate_mm_s[Y_AXIS]);
   drawEditInteger4(3, planner.settings.max_feedrate_mm_s[Z_AXIS]);
@@ -3377,7 +3377,7 @@ void drawMaxAccelMenu() {
   }
 
   drawBackFirst();
-  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxAccX + i);
+  for (uint_fast8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxAccX + i);
   drawEditInteger4(1, planner.settings.max_acceleration_mm_per_s2[X_AXIS]);
   drawEditInteger4(2, planner.settings.max_acceleration_mm_per_s2[Y_AXIS]);
   drawEditInteger4(3, planner.settings.max_acceleration_mm_per_s2[Z_AXIS]);
@@ -3436,7 +3436,7 @@ void drawMaxAccelMenu() {
     }
 
     drawBackFirst();
-    for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxSpeedJerkX + i);
+    for (uint_fast8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_MaxSpeedJerkX + i);
     drawEditFloat3(1, planner.max_jerk.x * MINUNITMULT);
     drawEditFloat3(2, planner.max_jerk.y * MINUNITMULT);
     drawEditFloat3(3, planner.max_jerk.z * MINUNITMULT);
@@ -3487,7 +3487,7 @@ void drawStepsMenu() {
   }
 
   drawBackFirst();
-  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_StepX + i);
+  for (uint_fast8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) drawMenuLine(i + 1, ICON_StepX + i);
   drawEditFloat3(1, planner.settings.axis_steps_per_mm[X_AXIS] * MINUNITMULT);
   drawEditFloat3(2, planner.settings.axis_steps_per_mm[Y_AXIS] * MINUNITMULT);
   drawEditFloat3(3, planner.settings.axis_steps_per_mm[Z_AXIS] * MINUNITMULT);

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.h
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.h
@@ -222,10 +222,13 @@ public:
   static void setupValue(const_float_t value, const_float_t min, const_float_t max, const_float_t unit, const uint8_t type);
   static void modifyValue(float &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
   static void modifyValue(uint8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
+  static void modifyValue(int8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
   static void modifyValue(uint16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
   static void modifyValue(int16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
   static void modifyValue(uint32_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(int8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
+  static void modifyValue(int32_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
+  static void modifyValue(uint_fast8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
+  static void modifyValue(int_fast8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
   static void modifyOption(const uint8_t value, const char * const * options, const uint8_t max);
 
   static void updateStatus(const char * const text);

--- a/Marlin/src/lcd/e3v2/marlinui/ui_common.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_common.cpp
@@ -540,8 +540,8 @@ void MarlinUI::draw_status_message(const bool blink) {
       // Display Mesh Point Locations
       const dwin_coord_t sx = x_offset + pixels_per_x_mesh_pnt / 2;
             dwin_coord_t  y = y_offset + pixels_per_y_mesh_pnt / 2;
-      for (uint8_t j = 0; j < (GRID_MAX_POINTS_Y); j++, y += pixels_per_y_mesh_pnt)
-        for (uint8_t i = 0, x = sx; i < (GRID_MAX_POINTS_X); i++, x += pixels_per_x_mesh_pnt)
+      for (uint_fast8_t j = 0; j < (GRID_MAX_POINTS_Y); j++, y += pixels_per_y_mesh_pnt)
+        for (uint_fast8_t i = 0, x = sx; i < (GRID_MAX_POINTS_X); i++, x += pixels_per_x_mesh_pnt)
           dwinDrawPoint(COLOR_WHITE, 1, 1, x, y);
 
       // Put Relevant Text on Display

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -598,7 +598,7 @@ void dwinPrintHeader(const char * const cstr/*=nullptr*/) {
   static char headertxt[31] = "";  // Print header text
   if (cstr) {
     const int8_t size = _MIN(30U, strlen(cstr));
-    for (uint8_t i = 0; i < size; ++i) headertxt[i] = cstr[i];
+    for (int_fast8_t i = 0; i < size; ++i) headertxt[i] = cstr[i];
     headertxt[size] = '\0';
   }
   if (checkkey == ID_PrintProcess || checkkey == ID_PrintDone) {
@@ -1016,7 +1016,7 @@ void drawPrintFileMenu() {
   if (card.isMounted()) {
     if (SET_MENU(fileMenu, MSG_MEDIA_MENU, nr_sd_menu_items() + 1)) {
       BACK_ITEM(gotoMainMenu);
-      for (uint8_t i = 0; i < nr_sd_menu_items(); ++i)
+      for (uint_fast8_t i = 0; i < nr_sd_menu_items(); ++i)
         menuItemAdd(onDrawFileName, onClickSDItem);
     }
     updateMenu(fileMenu);
@@ -1116,7 +1116,7 @@ void drawInfoMenu() {
   DWINUI::drawCenteredString(122, F(MACHINE_SIZE));
   DWINUI::drawCenteredString(195, F(SHORT_BUILD_VERSION));
 
-  for (uint8_t i = 0; i < 3; ++i) {
+  for (uint_fast8_t i = 0; i < 3; ++i) {
     DWINUI::drawIcon(ICON_PrintSize + i, ICOX, 99 + i * 73);
     dwinDrawHLine(hmiData.colorSplitLine, 16, MBASE(2) + i * 73, 240);
   }
@@ -2515,9 +2515,9 @@ void setFlow() { setPIntOnClick(FLOW_EDIT_MIN, FLOW_EDIT_MAX, []{ planner.refres
       DWINUI::drawCenteredString(160, F("and relative heights"));
       safe_delay(1000);
       float avg = 0.0f;
-      for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) avg += zval[x][y];
+      for (uint_fast8_t x = 0; x < 2; ++x) for (uint_fast8_t y = 0; y < 2; ++y) avg += zval[x][y];
       avg /= 4.0f;
-      for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) zval[x][y] -= avg;
+      for (uint_fast8_t x = 0; x < 2; ++x) for (uint_fast8_t y = 0; y < 2; ++y) zval[x][y] -= avg;
       meshViewer.drawMesh(zval, 2, 2);
       ui.reset_status();
 
@@ -2534,7 +2534,7 @@ void setFlow() { setPIntOnClick(FLOW_EDIT_MIN, FLOW_EDIT_MAX, []{ planner.refres
         float max = 0.0f;
         FSTR_P plabel;
         bool s = true;
-        for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) {
+        for (uint_fast8_t x = 0; x < 2; ++x) for (uint_fast8_t y = 0; y < 2; ++y) {
           const float d = ABS(zval[x][y]);
           if (max < d) {
             s = (zval[x][y] >= 0);
@@ -4295,7 +4295,7 @@ void drawMaxAccelMenu() {
   }
 
   void ublSmartFillMesh() {
-    for (uint8_t x = 0; x < GRID_MAX_POINTS_Y; ++x) bedlevel.smart_fill_mesh();
+    for (uint_fast8_t x = 0; x < GRID_MAX_POINTS_Y; ++x) bedlevel.smart_fill_mesh();
     LCD_MESSAGE(MSG_UBL_MESH_FILLED);
   }
 

--- a/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
@@ -119,9 +119,9 @@ void dwinWriteToMem(uint8_t mem, uint16_t addr, uint16_t length, uint8_t *data) 
     dwinByte(i, mem);
     dwinWord(i, addr + indx); // start address of the data block
     ++i;
-    for (uint8_t j = 0; j < i; ++j) { LCD_SERIAL.write(dwinSendBuf[j]); delayMicroseconds(1); }  // Buf header
+    for (uint_fast8_t j = 0; j < i; ++j) { LCD_SERIAL.write(dwinSendBuf[j]); delayMicroseconds(1); }  // Buf header
     for (uint16_t j = indx; j <= indx + to_send - 1; j++) { LCD_SERIAL.write(*(data + j)); delayMicroseconds(1); } // write block of data
-    for (uint8_t j = 0; j < 4; ++j) { LCD_SERIAL.write(dwinBufTail[j]); delayMicroseconds(1); }
+    for (uint_fast8_t j = 0; j < 4; ++j) { LCD_SERIAL.write(dwinBufTail[j]); delayMicroseconds(1); }
     block++;
     pending -= to_send;
   }

--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -149,9 +149,9 @@ bool Preview::hasPreview() {
 
   // Get the size of the thumbnail
   card.setIndex(fileprop.thumbstart + strlen_P(tbstart));
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint_fast8_t i = 0; i < 16; i++) {
     const char c = card.get();
-    if (ISEOL(c)) { buf[i] = '\0'; break; }
+    if (ISEOL(c)) { buf[i] = 0; break; }
     buf[i] = c;
   }
   fileprop.thumbsize = atoi(buf);

--- a/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
@@ -69,8 +69,8 @@ void MeshViewer::drawMeshGrid(const uint8_t csizex, const uint8_t csizey) {
   max = -100;
   DWINUI::clearMainArea();
   dwinDrawRectangle(0, hmiData.colorSplitLine, px(0), py(0), px(sizex - 1), py(sizey - 1));
-  for (uint8_t x = 1; x < sizex - 1; ++x) dwinDrawVLine(hmiData.colorSplitLine, px(x), py(sizey - 1), width);
-  for (uint8_t y = 1; y < sizey - 1; ++y) dwinDrawHLine(hmiData.colorSplitLine, px(0), py(y), width);
+  for (int_fast8_t x = 1; x < sizex - 1; ++x) dwinDrawVLine(hmiData.colorSplitLine, px(x), py(sizey - 1), width);
+  for (int_fast8_t y = 1; y < sizey - 1; ++y) dwinDrawHLine(hmiData.colorSplitLine, px(0), py(y), width);
 }
 
 void MeshViewer::drawMeshPoint(const uint8_t x, const uint8_t y, const float z) {
@@ -104,9 +104,9 @@ void MeshViewer::drawMeshPoint(const uint8_t x, const uint8_t y, const float z) 
 
 void MeshViewer::drawMesh(const bed_mesh_t zval, const uint8_t csizex, const uint8_t csizey) {
   drawMeshGrid(csizex, csizey);
-  for (uint8_t y = 0; y < csizey; ++y) {
+  for (uint_fast8_t y = 0; y < csizey; ++y) {
     hal.watchdog_refresh();
-    for (uint8_t x = 0; x < csizex; ++x) drawMeshPoint(x, y, zval[x][y]);
+    for (uint_fast8_t x = 0; x < csizex; ++x) drawMeshPoint(x, y, zval[x][y]);
   }
 }
 

--- a/Marlin/src/lcd/e3v2/proui/plot.cpp
+++ b/Marlin/src/lcd/e3v2/proui/plot.cpp
@@ -45,15 +45,15 @@ Plot plot;
 
 Plot::PlotData Plot::data;
 
-void Plot::draw(const frame_rect_t &frame, const_celsius_float_t max, const_celsius_float_t ref/*=0*/) {
+void Plot::draw(const frame_rect_t &frame, const_celsius_float_t max, const_float_t ref/*=0*/) {
   data.graphframe = frame;
   data.graphpoints = 0;
   data.scale = frame.h / max;
   data.x2 = frame.x + frame.w - 1;
   data.y2 = frame.y + frame.h - 1;
-  data.r = LROUND((data.y2) - ref * data.scale);
+  data.r = round((data.y2) - ref * data.scale);
   DWINUI::drawBox(1, plotBgColor, frame);
-  for (uint8_t i = 1; i < 4; i++) if (i * 60 < frame.w) dwinDrawVLine(COLOR_LINE, i * 60 + frame.x, frame.y, frame.h);
+  for (uint_fast8_t i = 1; i < 4; i++) if (i * 60 < frame.w) dwinDrawVLine(COLOR_LINE, i * 60 + frame.x, frame.y, frame.h);
   DWINUI::drawBox(0, COLOR_WHITE, DWINUI::extendFrame(frame, 1));
   dwinDrawHLine(COLOR_RED, frame.x, data.r, frame.w);
 }

--- a/Marlin/src/lcd/extui/anycubic/Tunes.cpp
+++ b/Marlin/src/lcd/extui/anycubic/Tunes.cpp
@@ -41,7 +41,7 @@ namespace Anycubic {
 
   void playTune(const uint16_t *tune, const uint8_t speed/*=1*/) {
     const uint16_t wholenotelen = tune[0] / speed;
-    for (uint8_t pos = 1; pos < MAX_TUNE_LENGTH; pos += 2) {
+    for (uint_fast8_t pos = 1; pos < MAX_TUNE_LENGTH; pos += 2) {
       const uint16_t freq = tune[pos];
       if (freq == n_END) break;
       BUZZ(wholenotelen / tune[pos + 1], freq);

--- a/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
@@ -143,7 +143,7 @@ namespace Anycubic {
     }
     else {
       char *pos = nullptr;
-      for (uint8_t f = 0; f < folderdepth; f++)
+      for (uint_fast8_t f = 0; f < folderdepth; f++)
         pos = strchr(currentDirPath, '/');
 
       *(pos + 1) = '\0';

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -713,26 +713,26 @@ namespace Anycubic {
 
   void DgusTFT::sendValueToTFT(const uint16_t value, const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF), uint8_t(value >> 8), uint8_t(value & 0xFF) };
-    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::requestValueFromTFT(const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x04, 0x83, uint8_t(address >> 8), uint8_t(address & 0xFF), 0x01 };
-    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::sendTxtToTFT(const char *pdata, const uint16_t address) {
     uint8_t data_len = strlen(pdata);
     uint8_t data[] = { 0x5A, 0xA5, uint8_t(data_len + 5), 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF) };
-    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
-    for (uint8_t i = 0; i < data_len; ++i) TFTSer.write(pdata[i]);
+    for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < data_len; ++i) TFTSer.write(pdata[i]);
     TFTSer.write(0xFF); TFTSer.write(0xFF);
   }
 
   void DgusTFT::sendColorToTFT(const uint16_t color, const uint16_t address) {
     uint16_t color_address = address + 3;
     uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(color_address >> 8), uint8_t(color_address & 0xFF), uint8_t(color >> 8), uint8_t(color & 0xFF) };
-    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::sendTimeToTFT(const uint32_t minutes, const uint16_t address) {
@@ -741,7 +741,7 @@ namespace Anycubic {
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x04, 0x83, uint8_t(address >> 8), uint8_t(address & 0xFF), number };
-    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::changePageOfTFT(const uint16_t page_index, const bool no_send/*=false*/) {
@@ -771,7 +771,7 @@ namespace Anycubic {
 
     if (!no_send) {
       uint8_t data[] = { 0x5A, 0xA5, 0x07, 0x82, 0x00, 0x84, 0x5A, 0x01, uint8_t(data_temp >> 8), uint8_t(data_temp & 0xFF) };
-      for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+      for (uint_fast8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
     }
 
     page_index_last_2 = page_index_last;
@@ -814,7 +814,7 @@ namespace Anycubic {
     // On:  5A A5 07 82 00 80 5A 00 00 1A
     // Off: 5A A5 07 82 00 80 5A 00 00 12
     uint8_t data[] = { 0x5A, 0xA5, 0x07, 0x82, 0x00, 0x80, 0x5A, 0x00, 0x00, uint8_t(audio_on ? 0x1A : 0x12) };
-    for (uint8_t i = 0; i < 10; ++i) TFTSer.write(data[i]);
+    for (uint_fast8_t i = 0; i < 10; ++i) TFTSer.write(data[i]);
   }
 
   bool DgusTFT::readTFTCommand() {

--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
@@ -413,7 +413,7 @@ void DGUSScreenHandler::handleTemperatureChanged(DGUS_VP_Variable &var, void *va
 void DGUSScreenHandler::handleFlowRateChanged(DGUS_VP_Variable &var, void *val_ptr) {
   #if HAS_EXTRUDERS
     const uint16_t newvalue = BE16_P(val_ptr);
-    uint8_t target_extruder;
+    uint_fast8_t target_extruder;
     switch (var.VP) {
       default: return;
       case VP_Flowrate_E0: target_extruder = 0; break;

--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandlerBase.h
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandlerBase.h
@@ -187,7 +187,7 @@ public:
     if (!var.memadr) return;
     union { unsigned char tmp[sizeof(T)]; T t; } x;
     unsigned char *ptr = (unsigned char*)val_ptr;
-    for (uint8_t i = 0; i < sizeof(T); ++i) x.tmp[i] = ptr[sizeof(T) - i - 1];
+    for (uint_fast8_t i = 0; i < sizeof(T); ++i) x.tmp[i] = ptr[sizeof(T) - i - 1];
     *(T*)var.memadr = x.t;
   }
 

--- a/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSDisplay.cpp
@@ -297,7 +297,7 @@ void DGUSDisplay::processRx() {
             unsigned char buffer[vp.size];
             memset(buffer, 0, vp.size);
 
-            for (uint8_t i = 0; i < dlen; i++) {
+            for (uint_fast8_t i = 0; i < dlen; i++) {
               if (i >= vp.size) break;
 
               if (i + 1 < dlen && tmp[i + 3] == 0xFF && tmp[i + 4] == 0xFF)
@@ -360,7 +360,7 @@ void DGUSDisplay::writeHeader(uint16_t addr, uint8_t command, uint8_t len) {
     uint8_t u8[2];
   } data = { Endianness::toBE(addr) };
 
-  for (uint8_t i = 0; i < sizeof(data.u8); ++i) LCD_SERIAL.write(data.u8[i]);
+  for (uint_fast8_t i = 0; i < sizeof(data.u8); ++i) LCD_SERIAL.write(data.u8[i]);
 }
 
 bool DGUS_PopulateVP(const DGUS_Addr addr, DGUS_VP * const buffer) {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
@@ -298,7 +298,7 @@ void DGUSDisplay::processRx() {
             unsigned char buffer[vp.size];
             memset(buffer, 0, vp.size);
 
-            for (uint8_t i = 0; i < dlen; i++) {
+            for (uint_fast8_t i = 0; i < dlen; i++) {
               if (i >= vp.size) break;
 
               if (i + 1 < dlen && tmp[i + 3] == 0xFF && tmp[i + 4] == 0xFF)

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
@@ -124,7 +124,7 @@ public:
     } src, dst;
 
     src.val = value;
-    for (uint8_t i = 0; i < sizeof(T); ++i) dst.byte[i] = src.byte[sizeof(T) - i - 1];
+    for (uint_fast8_t i = 0; i < sizeof(T); ++i) dst.byte[i] = src.byte[sizeof(T) - i - 1];
     return dst.val;
   }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
@@ -187,7 +187,7 @@ bool UIFlashStorage::is_present = false;
   }
 
   void UIFlashStorage::initialize() {
-    for (uint8_t i = 0; i < 10; i++) {
+    for (uint_fast8_t i = 0; i < 10; i++) {
       if (check_known_device()) {
         is_present = true;
         break;
@@ -393,7 +393,7 @@ bool UIFlashStorage::is_present = false;
   uint32_t UIFlashStorage::get_media_file_start(uint8_t slot) {
     uint32_t addr = media_storage_addr + sizeof(uint32_t) * media_storage_slots;
     spi_read_begin(media_storage_addr);
-    for (uint8_t i = 0; i < slot; i++)
+    for (uint_fast8_t i = 0; i < slot; i++)
       addr += spi_read_32();
     spi_read_end();
     return addr;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/files_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/files_screen.cpp
@@ -132,7 +132,7 @@ void FilesScreen::drawFileList() {
   mydata.flags.is_empty = true;
 
   uint16_t fileIndex = mydata.cur_page * FILES_PER_PAGE;
-  for (uint8_t i = 0; i < FILES_PER_PAGE; i++, fileIndex++) {
+  for (uint_fast8_t i = 0; i < FILES_PER_PAGE; i++, fileIndex++) {
     if (!files.seek(fileIndex)) break;
     drawFileButton(files.filename(), getTagForLine(i), files.isDir(), false);
     mydata.flags.is_empty = false;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.cpp
@@ -69,7 +69,7 @@ using namespace FTDI;
 
 void DLCache::init() {
   CLCD::mem_write_32(DL_FREE_ADDR, DL_FREE_ADDR + 4);
-  for (uint8_t slot = 0; slot < DL_CACHE_SLOTS; slot++)
+  for (uint_fast8_t slot = 0; slot < DL_CACHE_SLOTS; slot++)
     save_slot(slot, 0, 0, 0);
 }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.cpp
@@ -26,7 +26,7 @@
 /********************** VIRTUAL DISPATCH DATA TYPE  ******************************/
 
 uint8_t ScreenRef::lookupScreen(onRedraw_func_t onRedraw_ptr) {
-  for (uint8_t type = 0; type < tableSize(); type++) {
+  for (uint_fast8_t type = 0; type < tableSize(); type++) {
     if (GET_METHOD(type, onRedraw) == onRedraw_ptr) {
       return type;
     }
@@ -49,7 +49,7 @@ void ScreenRef::setScreen(onRedraw_func_t onRedraw_ptr) {
 }
 
 void ScreenRef::initializeAll() {
-  for (uint8_t type = 0; type < tableSize(); type++)
+  for (uint_fast8_t type = 0; type < tableSize(); type++)
     GET_METHOD(type, onStartup)();
 }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/cyrillic_char_set.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/cyrillic_char_set.cpp
@@ -58,11 +58,11 @@
     cyrillic_fm.stride = 20;
     cyrillic_fm.width  = 40;
     cyrillic_fm.height = 49;
-    for (uint8_t i = 0; i < 127; ++i)
+    for (uint_fast8_t i = 0; i < 127; ++i)
       cyrillic_fm.char_widths[i] = 0;
 
     // For cyrillic characters, copy the character widths from the widths tables
-    for (uint8_t i = 0; i < NUM_ELEMENTS(cyrillic_font_widths); ++i) {
+    for (uint_fast8_t i = 0; i < NUM_ELEMENTS(cyrillic_font_widths); ++i) {
       cyrillic_fm.char_widths[i] = cyrillic_font_widths[i];
     }
     CLCD::mem_write_bulk(addr, &cyrillic_fm,  148);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/western_char_set.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/western_char_set.cpp
@@ -342,11 +342,11 @@
     alt_fm.stride = 19;
     alt_fm.width  = 38;
     alt_fm.height = 49;
-    for (uint8_t i = 0; i < 127; ++i)
+    for (uint_fast8_t i = 0; i < 127; ++i)
       alt_fm.char_widths[i] = 0;
 
     // For special characters, copy the character widths from the char tables
-    for (uint8_t i = 0; i < NUM_ELEMENTS(char_recipe); ++i) {
+    for (uint_fast8_t i = 0; i < NUM_ELEMENTS(char_recipe); ++i) {
       uint8_t std_char, alt_char, alt_data;
       get_char_data(i, std_char, alt_char, alt_data);
       if (std_char == 0)

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_base.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_base.cpp
@@ -42,8 +42,8 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
   uint8_t val_cnt  = 0;
 
   if (opts & USE_AUTOSCALE) {
-    for (uint8_t y = 0; y < rows; y++) {
-      for (uint8_t x = 0; x < cols; x++) {
+    for (uint_fast8_t y = 0; y < rows; y++) {
+      for (uint_fast8_t x = 0; x < cols; x++) {
         if (ISVAL(x,y)) {
           const float val = VALUE(x,y);
           val_mean += val;
@@ -118,8 +118,8 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
      .cmd(TAG_MASK(false))
      .cmd(SAVE_CONTEXT());
 
-  for (uint8_t y = 0; y < rows; y++) {
-    for (uint8_t x = 0; x < cols; x++) {
+  for (uint_fast8_t y = 0; y < rows; y++) {
+    for (uint_fast8_t x = 0; x < cols; x++) {
       if (ISVAL(x,y)) {
        const bool hasLeftSegment  = x < cols - 1 && ISVAL(x+1,y);
        const bool hasRightSegment = y < rows - 1 && ISVAL(x,y+1);
@@ -137,7 +137,7 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
       const float sq_max = sq(val_max - val_mean);
       cmd.cmd(POINT_SIZE(basePointSize * 2));
       cmd.cmd(BEGIN(POINTS));
-      for (uint8_t x = 0; x < cols; x++) {
+      for (uint_fast8_t x = 0; x < cols; x++) {
         if (ISVAL(x,y)) {
           if (opts & USE_COLORS) {
             const float val_dev = sq(VALUE(x, y) - val_mean);
@@ -170,8 +170,8 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
     cmd.cmd(COLOR_MASK(false, false, false, false))
        .cmd(POINT_SIZE(basePointSize * 10))
        .cmd(BEGIN(POINTS));
-    for (uint8_t y = 0; y < rows; y++) {
-      for (uint8_t x = 0; x < cols; x++) {
+    for (uint_fast8_t y = 0; y < rows; y++) {
+      for (uint_fast8_t x = 0; x < cols; x++) {
         const uint8_t tag = pointToTag(x, y);
         cmd.tag(tag).cmd(VERTEX2F(TRANSFORM(x, y, HEIGHT(x, y))));
       }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/files_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/files_screen.cpp
@@ -132,7 +132,7 @@ void FilesScreen::drawFileList() {
   mydata.flags.is_empty = true;
 
   uint16_t fileIndex = mydata.cur_page * FILES_PER_PAGE;
-  for (uint8_t i = 0; i < FILES_PER_PAGE; i++, fileIndex++) {
+  for (uint_fast8_t i = 0; i < FILES_PER_PAGE; i++, fileIndex++) {
     if (!files.seek(fileIndex)) break;
     drawFileButton(files.filename(), getTagForLine(i), files.isDir(), false);
     mydata.flags.is_empty = false;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/interface_settings_screen.cpp
@@ -218,7 +218,7 @@ void InterfaceSettingsScreen::saveSettings(char *buff) {
   eeprom.touch_transform_f    = CLCD::mem_read_32(CLCD::REG::TOUCH_TRANSFORM_F);
   eeprom.display_h_offset_adj = CLCD::mem_read_16(CLCD::REG::HOFFSET) - FTDI::Hoffset;
   eeprom.display_v_offset_adj = CLCD::mem_read_16(CLCD::REG::VOFFSET) - FTDI::Voffset;
-  for (uint8_t i = 0; i < InterfaceSoundsScreen::NUM_EVENTS; i++)
+  for (uint_fast8_t i = 0; i < InterfaceSoundsScreen::NUM_EVENTS; i++)
     eeprom.event_sounds[i] = InterfaceSoundsScreen::event_sounds[i];
 
   memcpy(buff, &eeprom, sizeof(eeprom));
@@ -249,7 +249,7 @@ void InterfaceSettingsScreen::loadSettings(const char *buff) {
   CLCD::mem_write_32(CLCD::REG::TOUCH_TRANSFORM_F, eeprom.touch_transform_f);
   CLCD::mem_write_16(CLCD::REG::HOFFSET,           eeprom.display_h_offset_adj + FTDI::Hoffset);
   CLCD::mem_write_16(CLCD::REG::VOFFSET,           eeprom.display_v_offset_adj + FTDI::Voffset);
-  for (uint8_t i = 0; i < InterfaceSoundsScreen::NUM_EVENTS; i++)
+  for (uint_fast8_t i = 0; i < InterfaceSoundsScreen::NUM_EVENTS; i++)
     InterfaceSoundsScreen::event_sounds[i] = eeprom.event_sounds[i];
 
   TERN_(TOUCH_UI_DEVELOPER_MENU, StressTestScreen::startupCheck());

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/interface_sounds_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/interface_sounds_screen.cpp
@@ -42,7 +42,7 @@ void InterfaceSoundsScreen::toggleSoundSelection(event_t event) {
 }
 
 void InterfaceSoundsScreen::setSoundSelection(event_t event, const SoundPlayer::sound_t* sound) {
-  for (uint8_t i = 0; i < SoundList::n; i++)
+  for (uint_fast8_t i = 0; i < SoundList::n; i++)
     if (SoundList::data(i) == sound)
       event_sounds[event] = i;
 }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
@@ -38,7 +38,7 @@ void BaseMoveAxisScreen::onEntry() {
   // ourselves. The relative distances are reset to zero whenever this
   // screen is entered.
 
-  for (uint8_t i = 0; i < ExtUI::extruderCount; ++i) {
+  for (uint_fast8_t i = 0; i < ExtUI::extruderCount; ++i) {
     mydata.e_rel[i] = 0;
   }
   BaseNumericAdjustmentScreen::onEntry();

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/stress_test_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/stress_test_screen.cpp
@@ -39,7 +39,7 @@ constexpr static StressTestScreenData &mydata = screen_data.StressTestScreen;
 
 void StressTestScreen::drawDots(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   CommandProcessor cmd;
-  for (uint8_t i = 0; i < 100; i++) {
+  for (uint_fast8_t i = 0; i < 100; i++) {
     cmd.cmd(BEGIN(POINTS))
        .cmd(POINT_SIZE(20*16))
        .cmd(COLOR_RGB(random(0xFFFFFF)))

--- a/Marlin/src/lcd/extui/ia_creality/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/FileNavigator.cpp
@@ -163,7 +163,7 @@ void FileNavigator::upDIR() {
   }
   else {
     char *pos = nullptr;
-    for (uint8_t f = 0; f < folderdepth; f++)
+    for (uint_fast8_t f = 0; f < folderdepth; f++)
       pos = strchr(currentDirPath, '/');
     pos[1] = '\0';
   }

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
@@ -123,7 +123,7 @@ void onPrintTimerStopped() {
   if (waitway == 3) return;
 
   #if FAN_COUNT > 0
-    for (uint8_t i = 0; i < FAN_COUNT; i++) setTargetFan_percent(FanOff, (fan_t)i);
+    for (uint_fast8_t i = 0; i < FAN_COUNT; i++) setTargetFan_percent(FanOff, (fan_t)i);
   #endif
 
   printerStatusKey[0] = 0;
@@ -316,8 +316,8 @@ void onSettingsLoaded(const bool success) {
   #if HAS_MESH
     if (ExtUI::getLevelingIsValid()) {
       uint8_t abl_probe_index = 0;
-      for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-        for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+      for (uint_fast8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
+        for (uint_fast8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
           const bool zig = outer & 1;
           const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
           rts.sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + (abl_probe_index * 2));
@@ -346,8 +346,8 @@ void onPostprocessSettings() {}
     #if HAS_MESH
       if (ExtUI::getLevelingIsValid()) {
         uint8_t abl_probe_index = 0;
-        for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-          for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+        for (uint_fast8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
+          for (uint_fast8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
             const bool zig = outer & 1;
             const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
             rts.sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + abl_probe_index * 2);
@@ -374,8 +374,8 @@ void onPostprocessSettings() {}
         rts.sendData(ExchangePageBase + 64, ExchangepageAddr);
     #if HAS_MESH
       uint8_t abl_probe_index = 0;
-      for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-        for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+      for (uint_fast8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
+        for (uint_fast8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
           const bool zig = outer & 1; // != ((PR_OUTER_END) & 1);
           const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
           if (point.x == xpos && outer == ypos)

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
@@ -854,7 +854,7 @@ void RTS::handleData() {
       else if (recdat.data[0] == 0xF1) {
         //show_status = true;
         #if FAN_COUNT > 0
-          for (uint8_t i = 0; i < FAN_COUNT; i++) setTargetFan_percent(0, (fan_t)i);
+          for (uint_fast8_t i = 0; i < FAN_COUNT; i++) setTargetFan_percent(0, (fan_t)i);
         #endif
         setTargetTemp_celsius(0.0, H0);
         TERN_(HAS_MULTI_HOTEND, setTargetTemp_celsius(0.0, H1));
@@ -1060,8 +1060,8 @@ void RTS::handleData() {
 
           if (ExtUI::getLevelingIsValid()) {
             uint8_t abl_probe_index = 0;
-            for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-              for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+            for (uint_fast8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
+              for (uint_fast8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
                 const bool zig = outer & 1;
                 const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
                 sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + abl_probe_index * 2);

--- a/Marlin/src/lcd/extui/malyan/malyan.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan.cpp
@@ -79,7 +79,7 @@ void write_to_lcd(FSTR_P const fmsg) {
   char encoded_message[MAX_CURLY_COMMAND];
   uint8_t message_length = _MIN(strlen_P(pmsg), sizeof(encoded_message));
 
-  for (uint8_t i = 0; i < message_length; ++i)
+  for (uint_fast8_t i = 0; i < message_length; ++i)
     encoded_message[i] = pgm_read_byte(&pmsg[i]) | 0x80;
 
   LCD_SERIAL.Print::write(encoded_message, message_length);
@@ -89,7 +89,7 @@ void write_to_lcd(const char * const cmsg) {
   char encoded_message[MAX_CURLY_COMMAND];
   const uint8_t message_length = _MIN(strlen(cmsg), sizeof(encoded_message));
 
-  for (uint8_t i = 0; i < message_length; ++i)
+  for (uint_fast8_t i = 0; i < message_length; ++i)
     encoded_message[i] = cmsg[i] | 0x80;
 
   LCD_SERIAL.Print::write(encoded_message, message_length);

--- a/Marlin/src/lcd/extui/mks_ui/draw_wifi_list.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_wifi_list.cpp
@@ -70,7 +70,7 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     }
   }
   else {
-    for (uint8_t i = 0; i < NUMBER_OF_PAGE; i++) {
+    for (uint_fast8_t i = 0; i < NUMBER_OF_PAGE; i++) {
       if (obj->mks_obj_id == i + 1) {
         if (wifi_list.getNameNum != 0) {
           const bool do_wifi = wifi_link_state == WIFI_CONNECTED && strcmp((const char *)wifi_list.wifiConnectedName, (const char *)wifi_list.wifiName[wifi_list.nameIndex + i]) == 0;
@@ -95,7 +95,7 @@ void lv_draw_wifi_list() {
   lv_obj_t *buttonDown = lv_imgbtn_create(scr, "F:/bmp_pageDown.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H, event_handler, ID_WL_DOWN);
   lv_obj_t *buttonBack = lv_imgbtn_create(scr, "F:/bmp_back.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + (OTHER_BTN_YPIEL + INTERVAL_H) * 2, event_handler, ID_WL_RETURN);
 
-  for (uint8_t i = 0; i < NUMBER_OF_PAGE; i++) {
+  for (uint_fast8_t i = 0; i < NUMBER_OF_PAGE; i++) {
     buttonWifiN[i] = lv_label_btn_create(scr, 0, NAME_BTN_Y * i + 10 + titleHeight, NAME_BTN_X, NAME_BTN_Y, event_handler, i + 1);
     labelWifiText[i] = lv_label_create_empty(buttonWifiN[i]);
     #if HAS_ROTARY_ENCODER

--- a/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
@@ -379,7 +379,7 @@ uint32_t picInfoWrite(uint8_t *P_name, uint32_t P_size) {
 
   static void dosName2LongName(const char dosName[11], char *longName) {
     uint8_t j = 0;
-    for (uint8_t i = 0; i < 11; ++i) {
+    for (uint_fast8_t i = 0; i < 11; ++i) {
       if (i == 8) longName[j++] = '.';
       if (dosName[i] == '\0' || dosName[i] == ' ') continue;
       longName[j++] = dosName[i];
@@ -388,7 +388,7 @@ uint32_t picInfoWrite(uint8_t *P_name, uint32_t P_size) {
   }
 
   static int8_t arrayFindStr(FSTR_P const arr[], uint8_t arraySize, const char *str) {
-    for (uint8_t a = 0; a < arraySize; a++) {
+    for (uint_fast8_t a = 0; a < arraySize; a++) {
       if (strcasecmp(FTOP(arr[a]), str) == 0)
         return a;
     }

--- a/Marlin/src/lcd/extui/mks_ui/wifi_module.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/wifi_module.cpp
@@ -327,7 +327,7 @@ static bool sanitizeName(const char * const unsanitizedName, char * const saniti
     bb_peri_set_bit(&USART1_BASE->CR3, USART_CR3_DMAR_BIT, 1);
     dma_enable(DMA1, DMA_CH5);   // enable transmit
 
-    for (uint8_t i = 0; i < TRANS_RCV_FIFO_BLOCK_NUM; i++) {
+    for (uint_fast8_t i = 0; i < TRANS_RCV_FIFO_BLOCK_NUM; i++) {
       wifiDmaRcvFifo.bufferAddr[i] = &bmp_public_buf[1024 * i];
       wifiDmaRcvFifo.state[i] = udisk_buf_empty;
     }
@@ -595,7 +595,7 @@ static bool sanitizeName(const char * const unsanitizedName, char * const saniti
 
     SET_BIT(USART1->CR3, USART_CR3_DMAR);   // Enable Rx DMA Request
 
-    for (uint8_t i = 0; i < TRANS_RCV_FIFO_BLOCK_NUM; i++) {
+    for (uint_fast8_t i = 0; i < TRANS_RCV_FIFO_BLOCK_NUM; i++) {
       wifiDmaRcvFifo.bufferAddr[i] = &bmp_public_buf[1024 * i];
       wifiDmaRcvFifo.state[i] = udisk_buf_empty;
     }

--- a/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
@@ -160,7 +160,7 @@ void FileNavigator::upDIR() {
   }
   else {
     char *pos = nullptr;
-    for (uint8_t f = 0; f < folderdepth; f++)
+    for (uint_fast8_t f = 0; f < folderdepth; f++)
       pos = strchr(currentDirPath, '/');
     pos[1] = '\0';
   }

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1285,7 +1285,7 @@ void MarlinUI::init() {
         thermalManager.current_ADCKey_raw = HAL_ADC_RANGE;
         thermalManager.ADCKey_count = 0;
         if (currentkpADCValue < adc_other_button)
-          for (uint8_t i = 0; i < ADC_KEY_NUM; ++i) {
+          for (uint_fast8_t i = 0; i < ADC_KEY_NUM; ++i) {
             const raw_adc_t lo = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMin),
                             hi = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMax);
             if (WITHIN(currentkpADCValue, lo, hi)) return pgm_read_byte(&stADCKeyTable[i].ADCKeyNo);

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -826,7 +826,7 @@ public:
        * printer unusable in practice.
        */
       static bool hw_button_pressed() {
-        for (uint8_t s = 0; s < ENCODER_SAMPLES; ++s) {
+        for (uint_fast8_t s = 0; s < ENCODER_SAMPLES; ++s) {
           if (!BUTTON_CLICK()) return false;
           safe_delay(1);
         }

--- a/Marlin/src/lcd/menu/game/brickout.cpp
+++ b/Marlin/src/lcd/menu/game/brickout.cpp
@@ -44,7 +44,7 @@ brickout_data_t &bdat = marlin_game_data.brickout;
 
 inline void reset_bricks(const uint16_t v) {
   bdat.brick_count = (BRICK_COLS) * (BRICK_ROWS);
-  for (uint8_t i = 0; i < BRICK_ROWS; ++i) bdat.bricks[i] = v;
+  for (uint_fast8_t i = 0; i < BRICK_ROWS; ++i) bdat.bricks[i] = v;
 }
 
 void reset_ball() {
@@ -142,10 +142,10 @@ void BrickoutGame::game_screen() {
     int color_index = 0;
   #endif
   if (PAGE_CONTAINS(BRICK_TOP, BRICK_BOT)) {
-    for (uint8_t y = 0; y < BRICK_ROWS; ++y) {
+    for (uint_fast8_t y = 0; y < BRICK_ROWS; ++y) {
       const uint8_t yy = y * BRICK_H + BRICK_TOP;
       if (PAGE_CONTAINS(yy, yy + BRICK_H - 1)) {
-        for (uint8_t x = 0; x < BRICK_COLS; ++x) {
+        for (uint_fast8_t x = 0; x < BRICK_COLS; ++x) {
           #if IS_DWIN_MARLINUI
             // Cycle through colors, even if the brick is gone.
             // Otherwise, bricks would change color if their neighbor is hit
@@ -159,7 +159,7 @@ void BrickoutGame::game_screen() {
               if (PAGE_CONTAINS(yy, yy + BRICK_H - 1))
                 draw_box(xx, yy, BRICK_W - 1, BRICK_H - 1);
             #else
-              for (uint8_t v = 0; v < BRICK_H - 1; ++v)
+              for (uint_fast8_t v = 0; v < BRICK_H - 1; ++v)
                 if (PAGE_CONTAINS(yy + v, yy + v))
                   u8g.drawHLine(xx, yy + v, BRICK_W - 1);
             #endif

--- a/Marlin/src/lcd/menu/game/invaders.cpp
+++ b/Marlin/src/lcd/menu/game/invaders.cpp
@@ -176,29 +176,29 @@ inline void update_invader_data() {
   uint8_t inv_mask = 0;
   // Get a list of all active invaders
   uint8_t sc = 0;
-  for (uint8_t y = 0; y < INVADER_ROWS; ++y) {
+  for (uint_fast8_t y = 0; y < INVADER_ROWS; ++y) {
     uint8_t m = idat.bugs[y];
     if (m) idat.botmost = y + 1;
     inv_mask |= m;
-    for (uint8_t x = 0; x < INVADER_COLS; ++x)
+    for (uint_fast8_t x = 0; x < INVADER_COLS; ++x)
       if (TEST(m, x)) idat.shooters[sc++] = (y << 4) | x;
   }
   idat.leftmost = 0;
-  for (uint8_t i = 0; i < INVADER_COLS; ++i) { if (TEST(inv_mask, i)) break; idat.leftmost -= INVADER_COL_W; }
+  for (uint_fast8_t i = 0; i < INVADER_COLS; ++i) { if (TEST(inv_mask, i)) break; idat.leftmost -= INVADER_COL_W; }
   idat.rightmost = GAME_WIDTH - (INVADERS_WIDE);
-  for (uint8_t i = INVADER_COLS; i--;) { if (TEST(inv_mask, i)) break; idat.rightmost += INVADER_COL_W; }
+  for (uint_fast8_t i = INVADER_COLS; i--;) { if (TEST(inv_mask, i)) break; idat.rightmost += INVADER_COL_W; }
   if (idat.count == 2) idat.dir = idat.dir > 0 ? INVADER_VEL + 1 : -(INVADER_VEL + 1);
 }
 
 inline void reset_bullets() {
-  for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) idat.bullet[i].v = 0;
+  for (uint_fast8_t i = 0; i < COUNT(idat.bullet); ++i) idat.bullet[i].v = 0;
 }
 
 inline void reset_invaders() {
   idat.pos.x = 0; idat.pos.y = INVADER_TOP;
   idat.dir = INVADER_VEL;
   idat.count = (INVADER_COLS) * (INVADER_ROWS);
-  for (uint8_t i = 0; i < INVADER_ROWS; ++i) idat.bugs[i] = _BV(INVADER_COLS) - 1;
+  for (uint_fast8_t i = 0; i < INVADER_ROWS; ++i) idat.bugs[i] = _BV(INVADER_COLS) - 1;
   update_invader_data();
   reset_bullets();
 }
@@ -283,7 +283,7 @@ void InvadersGame::game_screen() {
 
           // Find a free bullet
           laser_t *b = nullptr;
-          for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) if (!idat.bullet[i].v) { b = &idat.bullet[i]; break; }
+          for (uint_fast8_t i = 0; i < COUNT(idat.bullet); ++i) if (!idat.bullet[i].v) { b = &idat.bullet[i]; break; }
           if (b) {
             // Pick a random shooter and update the bullet
             //SERIAL_ECHOLNPGM("free bullet found");
@@ -331,7 +331,7 @@ void InvadersGame::game_screen() {
       } // laser in invader zone
 
       // Handle alien bullets
-      for (uint8_t s = 0; s < COUNT(idat.bullet); ++s) {
+      for (uint_fast8_t s = 0; s < COUNT(idat.bullet); ++s) {
         laser_t *b = &idat.bullet[s];
         if (b->v) {
           // Update alien bullet position
@@ -380,11 +380,11 @@ void InvadersGame::game_screen() {
   // Draw invaders
   if (PAGE_CONTAINS(idat.pos.y, idat.pos.y + idat.botmost * (INVADER_ROW_H) - 2 - 1)) {
     int8_t yy = idat.pos.y;
-    for (uint8_t y = 0; y < INVADER_ROWS; ++y) {
+    for (uint_fast8_t y = 0; y < INVADER_ROWS; ++y) {
       const uint8_t type = inv_type[y];
       if (PAGE_CONTAINS(yy, yy + INVADER_H - 1)) {
         int8_t xx = idat.pos.x;
-        for (uint8_t x = 0; x < INVADER_COLS; ++x) {
+        for (uint_fast8_t x = 0; x < INVADER_COLS; ++x) {
           if (TEST(idat.bugs[y], x)) {
             #if IS_DWIN_MARLINUI
               constexpr color invader_color[] = INVADER_COLOR;
@@ -418,7 +418,7 @@ void InvadersGame::game_screen() {
   }
 
   // Draw invader bullets
-  for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) {
+  for (uint_fast8_t i = 0; i < COUNT(idat.bullet); ++i) {
     if (idat.bullet[i].v && PAGE_CONTAINS(idat.bullet[i].y - (SHOT_H - 1), idat.bullet[i].y)) {
       TERN_(IS_DWIN_MARLINUI, set_color(BULLET_COLOR));
       draw_vline(idat.bullet[i].x, idat.bullet[i].y - (SHOT_H - 1), SHOT_H);
@@ -441,7 +441,7 @@ void InvadersGame::game_screen() {
   if (PAGE_UNDER(GAME_FONT_ASCENT - 1)) {
     // Draw lives
     if (idat.cannons_left)
-      for (uint8_t i = 1; i <= idat.cannons_left; ++i) {
+      for (uint_fast8_t i = 1; i <= idat.cannons_left; ++i) {
         TERN_(IS_DWIN_MARLINUI, set_color(LIFE_COLOR));
         draw_bitmap(GAME_WIDTH - i * (LIFE_W), 6 - (LIFE_H), 1, LIFE_H, life);
       }

--- a/Marlin/src/lcd/menu/game/maze.cpp
+++ b/Marlin/src/lcd/menu/game/maze.cpp
@@ -83,7 +83,7 @@ void MazeGame::game_screen() {
   if (PAGE_UNDER(HEADER_H)) lcd_put_int(0, HEADER_H - 1, score);
 
   // Draw the maze
-  // for (uint8_t n = 0; n < head_ind; ++n) {
+  // for (uint_fast8_t n = 0; n < head_ind; ++n) {
   //   const pos_t &p = maze_walls[n], &q = maze_walls[n + 1];
   //   if (p.x == q.x) {
   //     const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));

--- a/Marlin/src/lcd/menu/game/snake.cpp
+++ b/Marlin/src/lcd/menu/game/snake.cpp
@@ -84,14 +84,14 @@ void shorten_tail() {
   }
   if (shift) {
     sdat.head_ind--;
-    for (uint8_t i = 0; i <= sdat.head_ind; ++i)
+    for (uint_fast8_t i = 0; i <= sdat.head_ind; ++i)
       sdat.snake_tail[i] = sdat.snake_tail[i + 1];
   }
 }
 
 // The food is on a line
 inline bool food_on_line() {
-  for (uint8_t n = 0; n < sdat.head_ind; ++n) {
+  for (uint_fast8_t n = 0; n < sdat.head_ind; ++n) {
     pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
     if (p.x == q.x) {
       if ((sdat.foodx == p.x - 1 || sdat.foodx == p.x) && WITHIN(sdat.foody, _MIN(p.y, q.y), _MAX(p.y, q.y)))
@@ -151,7 +151,7 @@ bool snake_overlap() {
   // VERTICAL head segment?
   if (h1.x == h2.x) {
     // Loop from oldest to segment two away from head
-    for (uint8_t n = 0; n < sdat.head_ind - 2; ++n) {
+    for (uint_fast8_t n = 0; n < sdat.head_ind - 2; ++n) {
       // Segment p to q
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x != q.x) {
@@ -163,7 +163,7 @@ bool snake_overlap() {
   }
   else {
     // Loop from oldest to segment two away from head
-    for (uint8_t n = 0; n < sdat.head_ind - 2; ++n) {
+    for (uint_fast8_t n = 0; n < sdat.head_ind - 2; ++n) {
       // Segment p to q
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.y != q.y) {
@@ -235,7 +235,7 @@ void SnakeGame::game_screen() {
   #if SNAKE_WH < 2
 
     // At this scale just draw a line
-    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
+    for (uint_fast8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));
@@ -251,7 +251,7 @@ void SnakeGame::game_screen() {
   #elif SNAKE_WH == 2
 
     // At this scale draw two lines
-    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
+    for (uint_fast8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));
@@ -270,7 +270,7 @@ void SnakeGame::game_screen() {
   #else
 
     // Draw a series of boxes
-    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
+    for (uint_fast8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = _MIN(p.y, q.y), y2 = _MAX(p.y, q.y);

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -482,7 +482,7 @@ void menu_backlash();
       EDIT_ITEM_FAST_N(float5, E_AXIS, MSG_VMAX_N, &planner.settings.max_feedrate_mm_s[E_AXIS_N(active_extruder)], 1, max_fr_edit_scaled.e);
     #endif
     #if ENABLED(DISTINCT_E_FACTORS)
-      for (uint8_t n = 0; n < E_STEPPERS; ++n)
+      for (uint_fast8_t n = 0; n < E_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(float5, n, MSG_VMAX_EN, &planner.settings.max_feedrate_mm_s[E_AXIS_N(n)], 1, max_fr_edit_scaled.e);
     #endif
 
@@ -557,7 +557,7 @@ void menu_backlash();
 
     #if ENABLED(DISTINCT_E_FACTORS)
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(active_extruder)], 100, max_accel_edit_scaled.e, []{ planner.refresh_acceleration_rates(); });
-      for (uint8_t n = 0; n < E_STEPPERS; ++n)
+      for (uint_fast8_t n = 0; n < E_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{
           if (MenuItemBase::itemIndex == active_extruder)
             planner.refresh_acceleration_rates();
@@ -650,7 +650,7 @@ void menu_backlash();
       EDIT_ITEM_FAST_N(float72, a, MSG_N_STEPS, &planner.settings.axis_steps_per_mm[a], 5, 9999, []{ planner.refresh_positioning(); });
 
     #if ENABLED(DISTINCT_E_FACTORS)
-      for (uint8_t n = 0; n < E_STEPPERS; ++n)
+      for (uint_fast8_t n = 0; n < E_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(float72, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{
           const uint8_t e = MenuItemBase::itemIndex;
           if (e == active_extruder)

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -684,7 +684,7 @@ void menu_configuration() {
 
   // Preheat configurations
   #if HAS_PREHEAT && DISABLED(SLIM_LCD_MENUS)
-    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m)
+    for (uint_fast8_t m = 0; m < PREHEAT_COUNT; ++m)
       SUBMENU_N_f(m, ui.get_preheat_label(m), MSG_PREHEAT_M_SETTINGS, _menu_configuration_preheat_settings);
   #endif
 

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -96,7 +96,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   if (LCD_HEIGHT >= 4) STATIC_ITEM_F(change_filament_header(mode), SS_DEFAULT|SS_INVERT);
   BACK_ITEM(MSG_BACK);
   #if HAS_PREHEAT
-    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m)
+    for (uint_fast8_t m = 0; m < PREHEAT_COUNT; ++m)
       ACTION_ITEM_N_f(m, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
   #endif
   EDIT_ITEM_FAST_N(int3, extruder, MSG_PREHEAT_CUSTOM, &thermalManager.temp_hotend[extruder].target,
@@ -121,7 +121,7 @@ void menu_change_filament() {
 
     #if E_STEPPERS > 1 && ENABLED(FILAMENT_UNLOAD_ALL_EXTRUDERS)
       bool too_cold = false;
-      for (uint8_t s = 0; !too_cold && s < E_STEPPERS; s++)
+      for (uint_fast8_t s = 0; !too_cold && s < E_STEPPERS; s++)
         too_cold = thermalManager.targetTooColdToExtrude(s);
     #endif
 
@@ -141,7 +141,7 @@ void menu_change_filament() {
         GCODES_ITEM_F(fmsg, F("M600 B0"));
     #else
       FSTR_P const fmsg = GET_TEXT_F(MSG_FILAMENTCHANGE_E);
-      for (uint8_t s = 0; s < E_STEPPERS; ++s) {
+      for (uint_fast8_t s = 0; s < E_STEPPERS; ++s) {
         if (thermalManager.targetTooColdToExtrude(s))
           SUBMENU_N_F(s, fmsg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex); });
         else {
@@ -166,7 +166,7 @@ void menu_change_filament() {
             GCODES_ITEM_F(msg_load, F("M701"));
         #else
           FSTR_P const msg_load = GET_TEXT_F(MSG_FILAMENTLOAD_E);
-          for (uint8_t s = 0; s < E_STEPPERS; ++s) {
+          for (uint_fast8_t s = 0; s < E_STEPPERS; ++s) {
             if (thermalManager.targetTooColdToExtrude(s))
               SUBMENU_N_F(s, msg_load, []{ _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, MenuItemBase::itemIndex); });
             else {
@@ -194,7 +194,7 @@ void menu_change_filament() {
               GCODES_ITEM(MSG_FILAMENTUNLOAD_ALL, F("M702"));
           #endif
           FSTR_P const msg_unload = GET_TEXT_F(MSG_FILAMENTUNLOAD_E);
-          for (uint8_t s = 0; s < E_STEPPERS; ++s) {
+          for (uint_fast8_t s = 0; s < E_STEPPERS; ++s) {
             if (thermalManager.targetTooColdToExtrude(s))
               SUBMENU_N_F(s, msg_unload, []{ _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, MenuItemBase::itemIndex); });
             else {

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -170,7 +170,7 @@ void lcd_mixer_mix_edit() {
 
     #if CHANNEL_MIX_EDITING
 
-      for (uint8_t n = 1; n <= MIXING_STEPPERS; ++n)
+      for (uint_fast8_t n = 1; n <= MIXING_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(float42_52, n, MSG_MIX_COMPONENT_N, &mixer.collector[n-1], 0, 10);
 
       ACTION_ITEM(MSG_CYCLE_MIX, _lcd_mixer_cycle_mix);

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -85,7 +85,7 @@ void Password::authentication_done() {
 // A single digit was completed
 void Password::digit_entered() {
   uint32_t multiplier = CAT(1e, PASSWORD_LENGTH); // 1e5 = 100000
-  for (uint8_t i = 0; i <= digit_no; ++i) multiplier /= 10;
+  for (uint_fast8_t i = 0; i <= digit_no; ++i) multiplier /= 10;
   value_entry += editable.uint8 * multiplier;
   string[digit_no++] = '0' + editable.uint8;
 

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -160,7 +160,7 @@ void menu_temperature() {
   #endif
 
   #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
-    for (uint8_t e = 1; e < EXTRUDERS; ++e)
+    for (uint_fast8_t e = 1; e < EXTRUDERS; ++e)
       EDIT_ITEM_FAST_N(int3, e, MSG_NOZZLE_STANDBY, &thermalManager.singlenozzle_temp[e], 0, thermalManager.hotend_max_target(0));
   #endif
 
@@ -247,7 +247,7 @@ void menu_temperature() {
     //
     // Preheat for all Materials
     //
-    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m) {
+    for (uint_fast8_t m = 0; m < PREHEAT_COUNT; ++m) {
       editable.int8 = m;
       #if HAS_MULTI_HOTEND || HAS_HEATED_BED
         SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);
@@ -274,7 +274,7 @@ void menu_temperature() {
     START_MENU();
     BACK_ITEM(MSG_MAIN_MENU);
 
-    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m) {
+    for (uint_fast8_t m = 0; m < PREHEAT_COUNT; ++m) {
       editable.int8 = m;
       #if HAS_MULTI_HOTEND || HAS_HEATED_BED
         SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -132,7 +132,7 @@ void menu_tune() {
   #endif
 
   #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
-    for (uint8_t e = 1; e < EXTRUDERS; ++e)
+    for (uint_fast8_t e = 1; e < EXTRUDERS; ++e)
       EDIT_ITEM_FAST_N(int3, e, MSG_NOZZLE_STANDBY, &thermalManager.singlenozzle_temp[e], 0, thermalManager.hotend_max_target(0));
   #endif
 

--- a/Marlin/src/lcd/menu/menu_x_twist.cpp
+++ b/Marlin/src/lcd/menu/menu_x_twist.cpp
@@ -155,12 +155,12 @@ void xatc_wizard_goto_next_point() {
   else {
     // Compute the z-offset by averaging the values found with this wizard
     z_offset = 0;
-    for (uint8_t i = 0; i < XATC_MAX_POINTS; ++i) z_offset += xatc.z_offset[i];
+    for (uint_fast8_t i = 0; i < XATC_MAX_POINTS; ++i) z_offset += xatc.z_offset[i];
     z_offset /= XATC_MAX_POINTS;
 
     // Subtract the average from the values found with this wizard.
     // This way they are indipendent from the z-offset
-    for (uint8_t i = 0; i < XATC_MAX_POINTS; ++i) xatc.z_offset[i] -= z_offset;
+    for (uint_fast8_t i = 0; i < XATC_MAX_POINTS; ++i) xatc.z_offset[i] -= z_offset;
 
     ui.goto_screen(xatc_wizard_update_z_offset);
   }

--- a/Marlin/src/lcd/tft/canvas.cpp
+++ b/Marlin/src/lcd/tft/canvas.cpp
@@ -77,7 +77,7 @@ void Canvas::addText(uint16_t x, uint16_t y, uint16_t color, uint16_t *string, u
   uint16_t colors[16];
   uint16_t stringWidth = 0;
   if (getFontType() == FONT_MARLIN_GLYPHS_2BPP) {
-    for (uint8_t i = 0; i < 3; i++) {
+    for (uint_fast8_t i = 0; i < 3; i++) {
       colors[i] = gradient(ENDIAN_COLOR(color), ENDIAN_COLOR(background_color), ((i+1) << 8) / 3);
       colors[i] = ENDIAN_COLOR(colors[i]);
     }

--- a/Marlin/src/libs/BL24CXX.cpp
+++ b/Marlin/src/libs/BL24CXX.cpp
@@ -141,7 +141,7 @@ void IIC::nAck() {
 void IIC::send_byte(uint8_t txd) {
   SDA_OUT();
   IIC_SCL_0(); // Pull down the clock to start data transmission
-  for (uint8_t t = 0; t < 8; ++t) {
+  for (uint_fast8_t t = 0; t < 8; ++t) {
     // IIC_SDA = (txd & 0x80) >> 7;
     if (txd & 0x80) IIC_SDA_1(); else IIC_SDA_0();
     txd <<= 1;
@@ -157,7 +157,7 @@ void IIC::send_byte(uint8_t txd) {
 uint8_t IIC::read_byte(unsigned char ack_chr) {
   unsigned char receive = 0;
   SDA_IN(); // SDA is set as input
-  for (uint8_t i = 0; i < 8; ++i) {
+  for (uint_fast8_t i = 0; i < 8; ++i) {
     IIC_SCL_0();
     delay_us(2);
     IIC_SCL_1();
@@ -228,7 +228,7 @@ void BL24CXX::writeOneByte(uint16_t WriteAddr, uint8_t DataToWrite) {
 // DataToWrite: the first address of the data array
 // Len: The length of the data to be written 2, 4
 void BL24CXX::writeLenByte(uint16_t WriteAddr, uint32_t DataToWrite, uint8_t Len) {
-  for (uint8_t t = 0; t < Len; ++t)
+  for (uint_fast8_t t = 0; t < Len; ++t)
     writeOneByte(WriteAddr + t, (DataToWrite >> (8 * t)) & 0xFF);
 }
 
@@ -239,7 +239,7 @@ void BL24CXX::writeLenByte(uint16_t WriteAddr, uint32_t DataToWrite, uint8_t Len
 // Len: The length of the data to be read 2,4
 uint32_t BL24CXX::readLenByte(uint16_t ReadAddr, uint8_t Len) {
   uint32_t temp = 0;
-  for (uint8_t t = 0; t < Len; ++t) {
+  for (uint_fast8_t t = 0; t < Len; ++t) {
     temp <<= 8;
     temp += readOneByte(ReadAddr + Len - t - 1);
   }

--- a/Marlin/src/libs/bresenham.h
+++ b/Marlin/src/libs/bresenham.h
@@ -48,7 +48,7 @@ public:
 
   // Default: Instantiate all items with the identical parameters
   Bresenham(const T &inDivisor=1, const int8_t &inDir=1, const T &inDividend=1, const T &inValue=0) {
-    for (uint8_t i = 0; i < Cfg::SIZE; i++) init(i, inDivisor, inDir, inDividend, inValue);
+    for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) init(i, inDivisor, inDir, inDividend, inValue);
   }
 
   // Instantiate all items with the same divisor
@@ -73,7 +73,7 @@ public:
   // Init all items with the same divisor
   FORCE_INLINE static void init(const T &inDivisor, const int8_t (&inDir)[Cfg::SIZE], const T (&inDividend)[Cfg::SIZE], const T (&inValue)[Cfg::SIZE]={0}) {
     divisor = inDivisor;
-    for (uint8_t i = 0; i < Cfg::SIZE; i++) {
+    for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) {
       dir[i]      = inDir[i];
       dividend[i] = inDividend[i];
       value[i]    = inValue[i];
@@ -84,7 +84,7 @@ public:
   // Init all items with the same divisor and direction
   FORCE_INLINE static void init(const T &inDivisor, const int8_t &inDir, const T (&inDividend)[Cfg::SIZE], const T (&inValue)[Cfg::SIZE]={0}) {
     divisor = inDivisor;
-    for (uint8_t i = 0; i < Cfg::SIZE; i++) {
+    for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) {
       dir[i]      = inDir;
       dividend[i] = inDividend[i];
       value[i]    = inValue[i];
@@ -101,7 +101,7 @@ public:
   }
 
   FORCE_INLINE static void prime(const uint8_t index) { counter[index] = -(divisor / 2); }
-  FORCE_INLINE static void prime() { for (uint8_t i = 0; i < Cfg::SIZE; i++) prime(i); }
+  FORCE_INLINE static void prime() { for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) prime(i); }
 
   FORCE_INLINE static void back(const uint8_t index) { counter[index] -= divisor; }
 
@@ -114,9 +114,9 @@ public:
     if (tick1(index)) { value[index] += dir[index]; back(index); }
   }
 
-  FORCE_INLINE static void tick1() __O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick1(i); }
+  FORCE_INLINE static void tick1() __O3 { for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) (void)tick1(i); }
 
-  FORCE_INLINE static void tick() __O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick(i); }
+  FORCE_INLINE static void tick() __O3 { for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) (void)tick(i); }
 
   static void report(const uint8_t index) {
     if (index < Cfg::SIZE) {
@@ -128,5 +128,5 @@ public:
     }
   }
 
-  static void report() { for (uint8_t i = 0; i < Cfg::SIZE; i++) report(i); }
+  static void report() { for (uint_fast8_t i = 0; i < Cfg::SIZE; i++) report(i); }
 };

--- a/Marlin/src/libs/crc16.cpp
+++ b/Marlin/src/libs/crc16.cpp
@@ -26,7 +26,7 @@ void crc16(uint16_t *crc, const void * const data, uint16_t cnt) {
   uint8_t *ptr = (uint8_t *)data;
   while (cnt--) {
     *crc = (uint16_t)(*crc ^ (uint16_t)(((uint16_t)*ptr++) << 8));
-    for (uint8_t i = 0; i < 8; i++)
+    for (uint_fast8_t i = 0; i < 8; i++)
       *crc = (uint16_t)((*crc & 0x8000) ? ((uint16_t)(*crc << 1) ^ 0x1021) : (*crc << 1));
   }
 }

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -63,7 +63,7 @@ Nozzle nozzle;
       #endif
 
       // Start the stroke pattern
-      for (uint8_t i = 0; i < strokes >> 1; ++i) {
+      for (uint_fast8_t i = 0; i < strokes >> 1; ++i) {
         #if ENABLED(NOZZLE_CLEAN_NO_Y)
           do_blocking_move_to_x(end.x);
           do_blocking_move_to_x(start.x);
@@ -105,7 +105,7 @@ Nozzle nozzle;
       const bool horiz = ABS(diff.x) >= ABS(diff.y);    // Do a horizontal wipe?
       const float P = (horiz ? diff.x : diff.y) / zigs; // Period of each zig / zag
       const xyz_pos_t *side;
-      for (uint8_t j = 0; j < strokes; ++j) {
+      for (uint_fast8_t j = 0; j < strokes; ++j) {
         for (int8_t i = 0; i < zigs; i++) {
           side = (i & 1) ? &end : &start;
           if (horiz)
@@ -143,8 +143,8 @@ Nozzle nozzle;
       #endif
       TERN(NOZZLE_CLEAN_NO_Z, do_blocking_move_to_xy, do_blocking_move_to)(start);
 
-      for (uint8_t s = 0; s < strokes; ++s)
-        for (uint8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; ++i)
+      for (uint_fast8_t s = 0; s < strokes; ++s)
+        for (uint_fast8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; ++i)
           do_blocking_move_to_xy(
             middle.x + sin((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
             middle.y + cos((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius

--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -94,8 +94,8 @@ void matrix_3x3::apply_rotation_xyz(float &_x, float &_y, float &_z) {
 
 // Reset to identity. No rotate or translate.
 void matrix_3x3::set_to_identity() {
-  for (uint8_t i = 0; i < 3; ++i)
-    for (uint8_t j = 0; j < 3; ++j)
+  for (uint_fast8_t i = 0; i < 3; ++i)
+    for (uint_fast8_t j = 0; j < 3; ++j)
       vectors[i][j] = float(i == j);
 }
 
@@ -132,16 +132,16 @@ matrix_3x3 matrix_3x3::create_look_at(const vector_3 &target) {
 // Get a transposed copy of the matrix
 matrix_3x3 matrix_3x3::transpose(const matrix_3x3 &original) {
   matrix_3x3 new_matrix;
-  for (uint8_t i = 0; i < 3; ++i)
-    for (uint8_t j = 0; j < 3; ++j)
+  for (uint_fast8_t i = 0; i < 3; ++i)
+    for (uint_fast8_t j = 0; j < 3; ++j)
       new_matrix.vectors[i][j] = original.vectors[j][i];
   return new_matrix;
 }
 
 void matrix_3x3::debug(FSTR_P const title) {
   if (title) SERIAL_ECHOLN(title);
-  for (uint8_t i = 0; i < 3; ++i) {
-    for (uint8_t j = 0; j < 3; ++j) {
+  for (uint_fast8_t i = 0; i < 3; ++i) {
+    for (uint_fast8_t j = 0; j < 3; ++j) {
       serial_offset(vectors[i][j], 2);
       SERIAL_CHAR(' ');
     }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -126,11 +126,11 @@ Planner planner;
  * A ring buffer of moves described in steps
  */
 block_t Planner::block_buffer[BLOCK_BUFFER_SIZE];
-volatile uint8_t Planner::block_buffer_head,    // Index of the next block to be pushed
-                 Planner::block_buffer_nonbusy, // Index of the first non-busy block
-                 Planner::block_buffer_tail;    // Index of the busy block, if any
-uint16_t Planner::cleaning_buffer_counter;      // A counter to disable queuing of blocks
-uint8_t Planner::delay_before_delivering;       // Delay block delivery so initial blocks in an empty queue may merge
+volatile uint_fast8_t Planner::block_buffer_head,     // Index of the next block to be pushed
+                      Planner::block_buffer_nonbusy,  // Index of the first non-busy block
+                      Planner::block_buffer_tail;     // Index of the busy block, if any
+uint_fast16_t Planner::cleaning_buffer_counter;       // A counter to disable queuing of blocks
+uint_fast8_t Planner::delay_before_delivering;        // Delay block delivery so initial blocks in an empty queue may merge
 
 #if ENABLED(EDITABLE_STEPS_PER_UNIT)
   float Planner::mm_per_step[DISTINCT_AXES];    // (mm) Millimeters per step
@@ -165,7 +165,7 @@ uint32_t Planner::max_acceleration_steps_per_s2[DISTINCT_AXES]; // (steps/s^2) D
 #endif
 
 #if ENABLED(DISTINCT_E_FACTORS)
-  uint8_t Planner::last_extruder = 0;     // Respond to extruder change
+  uint_fast8_t Planner::last_extruder = 0;      // Respond to extruder change
 #endif
 
 #if ENABLED(DIRECT_STEPPING)
@@ -739,7 +739,7 @@ void Planner::init() {
  */
 block_t* Planner::get_current_block() {
   // Get the number of moves in the planner queue so far
-  const uint8_t nr_moves = movesplanned();
+  const uint_fast8_t nr_moves = movesplanned();
 
   // If there are any moves queued ...
   if (nr_moves) {
@@ -1045,10 +1045,10 @@ bool Planner::reverse_pass_kernel(block_t * const current, const block_t * const
 void Planner::reverse_pass(const_float_t safe_exit_speed_sqr) {
   // Initialize block index to the last block in the planner buffer.
   // This last block will have flag.recalculate set.
-  uint8_t block_index = prev_block_index(block_buffer_head);
+  uint_fast8_t block_index = prev_block_index(block_buffer_head);
 
   // The ISR may change block_buffer_nonbusy so get a stable local copy.
-  uint8_t nonbusy_block_index = block_buffer_nonbusy;
+  uint_fast8_t nonbusy_block_index = block_buffer_nonbusy;
 
   const block_t *next = nullptr;
   // Don't try to change the entry speed of the first non-busy block.
@@ -1106,8 +1106,8 @@ void Planner::forward_pass_kernel(const block_t * const previous, block_t * cons
  */
 void Planner::recalculate_trapezoids(const_float_t safe_exit_speed_sqr) {
   // Start with the block that's about to execute or is executing.
-  uint8_t block_index = block_buffer_tail,
-          head_block_index = block_buffer_head;
+  uint_fast8_t block_index = block_buffer_tail,
+               head_block_index = block_buffer_head;
 
   block_t *block = nullptr, *next = nullptr;
   float next_entry_speed = 0.0f;
@@ -1190,7 +1190,7 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
  */
 #if HAS_FAN
 
-  void Planner::sync_fan_speeds(uint8_t (&fan_speed)[FAN_COUNT]) {
+  void Planner::sync_fan_speeds(uint_fast8_t (&fan_speed)[FAN_COUNT]) {
 
     #if ENABLED(FAN_SOFT_PWM)
       #define _FAN_SET(F) thermalManager.soft_pwm_amount_fan[F] = CALC_FAN_SPEED(fan_speed[F]);
@@ -1208,7 +1208,7 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
 
   #if FAN_KICKSTART_TIME
 
-    void Planner::kickstart_fan(uint8_t (&fan_speed)[FAN_COUNT], const millis_t &ms, const uint8_t f) {
+    void Planner::kickstart_fan(uint_fast8_t (&fan_speed)[FAN_COUNT], const millis_t &ms, const uint_fast8_t f) {
       static millis_t fan_kick_end[FAN_COUNT] = { 0 };
       #if ENABLED(FAN_KICKSTART_LINEAR)
         static uint8_t set_fan_speed[FAN_COUNT] = { 0 };
@@ -1241,7 +1241,7 @@ void Planner::check_axes_activity() {
 
   #if HAS_FAN && DISABLED(LASER_SYNCHRONOUS_M106_M107)
     #define HAS_TAIL_FAN_SPEED 1
-    static uint8_t tail_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 13);
+    static uint_fast8_t tail_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 13);
     bool fans_need_update = false;
   #endif
 
@@ -1262,7 +1262,7 @@ void Planner::check_axes_activity() {
 
     #if HAS_TAIL_FAN_SPEED
       FANS_LOOP(i) {
-        const uint8_t spd = thermalManager.scaledFanSpeed(i, block->fan_speed[i]);
+        const uint_fast8_t spd = thermalManager.scaledFanSpeed(i, block->fan_speed[i]);
         if (tail_fan_speed[i] != spd) {
           fans_need_update = true;
           tail_fan_speed[i] = spd;
@@ -1276,7 +1276,7 @@ void Planner::check_axes_activity() {
     #endif
 
     #if HAS_DISABLE_AXES
-      for (uint8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
+      for (uint_fast8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
         block_t * const bnext = &block_buffer[b];
         LOGICAL_AXIS_CODE(
           if (TERN0(DISABLE_E, bnext->steps.e)) axis_active.e = true,
@@ -1299,7 +1299,7 @@ void Planner::check_axes_activity() {
 
     #if HAS_TAIL_FAN_SPEED
       FANS_LOOP(i) {
-        const uint8_t spd = thermalManager.scaledFanSpeed(i);
+        const uint_fast8_t spd = thermalManager.scaledFanSpeed(i);
         if (tail_fan_speed[i] != spd) {
           fans_need_update = true;
           tail_fan_speed[i] = spd;
@@ -1394,7 +1394,7 @@ void Planner::check_axes_activity() {
     if (thermalManager.degTargetHotend(active_extruder) < autotemp.min - 2) return; // Below the min?
 
     float high = 0.0f;
-    for (uint8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
+    for (uint_fast8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
       const block_t * const block = &block_buffer[b];
       if (NUM_AXIS_GANG(block->steps.x, || block->steps.y, || block->steps.z, || block->steps.i, || block->steps.j, || block->steps.k, || block->steps.u, || block->steps.v, || block->steps.w)) {
         const float se = float(block->steps.e) / block->step_event_count * block->nominal_speed; // mm/sec
@@ -1427,7 +1427,7 @@ void Planner::check_axes_activity() {
    * The multiplier converts a given E value into a length.
    */
   void Planner::calculate_volumetric_multipliers() {
-    for (uint8_t i = 0; i < COUNT(filament_size); ++i) {
+    for (uint_fast8_t i = 0; i < COUNT(filament_size); ++i) {
       volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
       refresh_e_factor(i);
     }
@@ -1443,7 +1443,7 @@ void Planner::check_axes_activity() {
   /**
    * Convert volumetric based limits into pre calculated extruder feedrate limits.
    */
-  void Planner::calculate_volumetric_extruder_limit(const uint8_t e) {
+  void Planner::calculate_volumetric_extruder_limit(const uint_fast8_t e) {
     const float &lim = volumetric_extruder_limit[e], &siz = filament_size[e];
     volumetric_extruder_feedrate_limit[e] = (lim && siz) ? lim / CIRCLE_AREA(siz * 0.5f) : 0;
   }
@@ -1732,11 +1732,11 @@ void Planner::synchronize() { while (busy()) idle(); }
 bool Planner::_buffer_steps(const xyze_long_t &target
   OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
   OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-  , feedRate_t fr_mm_s, const uint8_t extruder, const PlannerHints &hints
+  , feedRate_t fr_mm_s, const uint_fast8_t extruder, const PlannerHints &hints
 ) {
 
   // Wait for the next available block
-  uint8_t next_buffer_head;
+  uint_fast8_t next_buffer_head;
   block_t * const block = get_next_free_block(next_buffer_head);
 
   // If we are cleaning, do not accept queuing of movements
@@ -1805,7 +1805,7 @@ bool Planner::_populate_block(
   const abce_long_t &target
   OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
   OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-  , feedRate_t fr_mm_s, const uint8_t extruder, const PlannerHints &hints
+  , feedRate_t fr_mm_s, const uint_fast8_t extruder, const PlannerHints &hints
   , float &minimum_planner_speed_sqr
 ) {
   xyze_long_t dist = target - position;
@@ -2180,7 +2180,7 @@ bool Planner::_populate_block(
       #if ENABLED(DISABLE_OTHER_EXTRUDERS) // Enable only the selected extruder
 
         // Count down all steppers that were recently moved
-        for (uint8_t i = 0; i < E_STEPPERS; ++i)
+        for (uint_fast8_t i = 0; i < E_STEPPERS; ++i)
           if (extruder_last_move[i]) extruder_last_move[i]--;
 
         // Switching Extruder uses one E stepper motor per two nozzles
@@ -2800,7 +2800,7 @@ bool Planner::_populate_block(
 void Planner::buffer_sync_block(const BlockFlagBit sync_flag/*=BLOCK_BIT_SYNC_POSITION*/) {
 
   // Wait for the next available block
-  uint8_t next_buffer_head;
+  uint_fast8_t next_buffer_head;
   block_t * const block = get_next_free_block(next_buffer_head);
 
   // Clear block
@@ -2854,7 +2854,7 @@ void Planner::buffer_sync_block(const BlockFlagBit sync_flag/*=BLOCK_BIT_SYNC_PO
 bool Planner::buffer_segment(const abce_pos_t &abce
   OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
   , const_feedRate_t fr_mm_s
-  , const uint8_t extruder/*=active_extruder*/
+  , const uint_fast8_t extruder/*=active_extruder*/
   , const PlannerHints &hints/*=PlannerHints()*/
 ) {
 
@@ -2979,7 +2979,7 @@ bool Planner::buffer_segment(const abce_pos_t &abce
  * @param hints     Optional parameters to aid planner calculations
  */
 bool Planner::buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s
-  , const uint8_t extruder/*=active_extruder*/
+  , const uint_fast8_t extruder/*=active_extruder*/
   , const PlannerHints &hints/*=PlannerHints()*/
 ) {
   xyze_pos_t machine = cart;
@@ -3088,7 +3088,7 @@ bool Planner::buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s
       return;
     }
 
-    uint8_t next_buffer_head;
+    uint_fast8_t next_buffer_head;
     block_t * const block = get_next_free_block(next_buffer_head);
 
     block->flag.reset(BLOCK_BIT_PAGE);
@@ -3205,7 +3205,7 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
    * Special setter for planner E position (also setting E stepper position).
    */
   void Planner::set_e_position_mm(const_float_t e) {
-    const uint8_t axis_index = E_AXIS_N(active_extruder);
+    const uint_fast8_t axis_index = E_AXIS_N(active_extruder);
     TERN_(DISTINCT_E_FACTORS, last_extruder = active_extruder);
 
     // Unapply the current retraction before (immediately) setting the planner position
@@ -3332,7 +3332,7 @@ void Planner::set_max_feedrate(const AxisEnum axis, float inMaxFeedrateMMS) {
 
 #if HAS_WIRED_LCD
 
-  uint16_t Planner::block_buffer_runtime() {
+  uint_fast16_t Planner::block_buffer_runtime() {
     #ifdef __AVR__
       // Protect the access to the variable. Only required for AVR, as
       // any 32bit CPU offers atomic access to 32bit variables

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -232,9 +232,9 @@ typedef struct PlannerBlock {
   uint32_t step_event_count;                // The number of step events required to complete this block
 
   #if HAS_MULTI_EXTRUDER
-    uint8_t extruder;                       // The extruder to move (if E move)
+    uint_fast8_t extruder;                  // The extruder to move (if E move)
   #else
-    static constexpr uint8_t extruder = 0;
+    static constexpr uint_fast8_t extruder = 0;
   #endif
 
   #if ENABLED(MIXING_EXTRUDER)
@@ -268,10 +268,10 @@ typedef struct PlannerBlock {
     #if ENABLED(SMOOTH_LIN_ADVANCE)
       bool use_advance_lead;
     #else
-      uint32_t la_advance_rate;             // The rate at which steps are added whilst accelerating
-      uint8_t  la_scaling;                  // Scale ISR frequency down and step frequency up by 2 ^ la_scaling
-      uint16_t max_adv_steps,               // Max advance steps to get cruising speed pressure
-               final_adv_steps;             // Advance steps for exit speed pressure
+      uint_fast32_t la_advance_rate;        // The rate at which steps are added whilst accelerating
+      uint_fast8_t  la_scaling;             // Scale ISR frequency down and step frequency up by 2 ^ la_scaling
+      uint_fast16_t max_adv_steps,          // Max advance steps to get cruising speed pressure
+                    final_adv_steps;        // Advance steps for exit speed pressure
     #endif
   #endif
 
@@ -289,7 +289,7 @@ typedef struct PlannerBlock {
   #endif
 
   #if HAS_FAN
-    uint8_t fan_speed[FAN_COUNT];
+    uint_fast8_t fan_speed[FAN_COUNT];
   #endif
 
   #if ENABLED(BARICUDA)
@@ -317,11 +317,11 @@ typedef struct PlannerBlock {
   #define HAS_POSITION_FLOAT 1
 #endif
 
-constexpr uint8_t block_dec_mod(const uint8_t v1, const uint8_t v2) {
+constexpr uint_fast8_t block_dec_mod(const uint_fast8_t v1, const uint_fast8_t v2) {
   return v1 >= v2 ? v1 - v2 : v1 - v2 + BLOCK_BUFFER_SIZE;
 }
 
-constexpr uint8_t block_inc_mod(const uint8_t v1, const uint8_t v2) {
+constexpr uint_fast8_t block_inc_mod(const uint_fast8_t v1, const uint_fast8_t v2) {
   return v1 + v2 < BLOCK_BUFFER_SIZE ? v1 + v2 : v1 + v2 - BLOCK_BUFFER_SIZE;
 }
 
@@ -454,14 +454,14 @@ class Planner {
      *  Reader of tail is Stepper::isr(). Always consider tail busy / read-only
      */
     static block_t block_buffer[BLOCK_BUFFER_SIZE];
-    static volatile uint8_t block_buffer_head,      // Index of the next block to be pushed
-                            block_buffer_nonbusy,   // Index of the first non busy block
-                            block_buffer_tail;      // Index of the busy block, if any
-    static uint16_t cleaning_buffer_counter;        // A counter to disable queuing of blocks
-    static uint8_t delay_before_delivering;         // This counter delays delivery of blocks when queue becomes empty to allow the opportunity of merging blocks
+    static volatile uint_fast8_t block_buffer_head,     // Index of the next block to be pushed
+                                 block_buffer_nonbusy,  // Index of the first non busy block
+                                 block_buffer_tail;     // Index of the busy block, if any
+    static uint_fast16_t cleaning_buffer_counter;       // A counter to disable queuing of blocks
+    static uint_fast8_t delay_before_delivering;        // This counter delays delivery of blocks when queue becomes empty to allow the opportunity of merging blocks
 
     #if ENABLED(DISTINCT_E_FACTORS)
-      static uint8_t last_extruder;                 // Respond to extruder change
+      static uint_fast8_t last_extruder;                // Respond to extruder change
     #endif
 
     #if ENABLED(DIRECT_STEPPING)
@@ -655,11 +655,11 @@ class Planner {
 
     // Apply fan speeds
     #if HAS_FAN
-      static void sync_fan_speeds(uint8_t (&fan_speed)[FAN_COUNT]);
+      static void sync_fan_speeds(uint_fast8_t (&fan_speed)[FAN_COUNT]);
       #if FAN_KICKSTART_TIME
-        static void kickstart_fan(uint8_t (&fan_speed)[FAN_COUNT], const millis_t &ms, const uint8_t f);
+        static void kickstart_fan(uint_fast8_t (&fan_speed)[FAN_COUNT], const millis_t &ms, const uint_fast8_t f);
       #else
-        FORCE_INLINE static void kickstart_fan(uint8_t (&)[FAN_COUNT], const millis_t &, const uint8_t) {}
+        static void kickstart_fan(uint_fast8_t (&)[FAN_COUNT], const millis_t &, const uint_fast8_t) {}
       #endif
     #endif
 
@@ -685,22 +685,22 @@ class Planner {
 
       #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
         // Update pre calculated extruder feedrate limits based on volumetric values
-        static void calculate_volumetric_extruder_limit(const uint8_t e);
+        static void calculate_volumetric_extruder_limit(const uint_fast8_t e);
         static void calculate_volumetric_extruder_limits();
       #endif
 
-      FORCE_INLINE static void set_filament_size(const uint8_t e, const_float_t v) {
+      FORCE_INLINE static void set_filament_size(const uint_fast8_t e, const_float_t v) {
         filament_size[e] = v;
         if (v > 0) volumetric_area_nominal = CIRCLE_AREA(v * 0.5); //TODO: should it be per extruder
         // make sure all extruders have some sane value for the filament size
-        for (uint8_t i = 0; i < COUNT(filament_size); ++i)
+        for (uint_fast8_t i = 0; i < COUNT(filament_size); ++i)
           if (!filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
       }
 
     #endif
 
     #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-      FORCE_INLINE static void set_volumetric_extruder_limit(const uint8_t e, const_float_t v) {
+      FORCE_INLINE static void set_volumetric_extruder_limit(const uint_fast8_t e, const_float_t v) {
         volumetric_extruder_limit[e] = v;
         calculate_volumetric_extruder_limit(e);
       }
@@ -825,10 +825,10 @@ class Planner {
     #endif // HAS_POSITION_MODIFIERS
 
     // Number of moves currently in the planner including the busy block, if any
-    FORCE_INLINE static uint8_t movesplanned() { return block_dec_mod(block_buffer_head, block_buffer_tail); }
+    FORCE_INLINE static uint_fast8_t movesplanned() { return block_dec_mod(block_buffer_head, block_buffer_tail); }
 
     // Number of nonbusy moves currently in the planner
-    FORCE_INLINE static uint8_t nonbusy_movesplanned() { return block_dec_mod(block_buffer_head, block_buffer_nonbusy); }
+    FORCE_INLINE static uint_fast8_t nonbusy_movesplanned() { return block_dec_mod(block_buffer_head, block_buffer_nonbusy); }
 
     // Remove all blocks from the buffer
     FORCE_INLINE static void clear_block_buffer() {
@@ -841,7 +841,7 @@ class Planner {
     FORCE_INLINE static bool is_full() { return block_buffer_tail == next_block_index(block_buffer_head); }
 
     // Get count of movement slots free
-    FORCE_INLINE static uint8_t moves_free() { return (BLOCK_BUFFER_SIZE) - 1 - movesplanned(); }
+    FORCE_INLINE static uint_fast8_t moves_free() { return (BLOCK_BUFFER_SIZE) - 1 - movesplanned(); }
 
     /**
      * @fn Planner::get_next_free_block
@@ -851,7 +851,7 @@ class Planner {
      *
      * @return  The first head block
      */
-    FORCE_INLINE static block_t* get_next_free_block(uint8_t &next_buffer_head, const uint8_t count=1) {
+    FORCE_INLINE static block_t* get_next_free_block(uint_fast8_t &next_buffer_head, const uint_fast8_t count=1) {
 
       // Wait until there are enough slots free
       while (moves_free() < count) { idle(); }
@@ -878,7 +878,7 @@ class Planner {
     static bool _buffer_steps(const xyze_long_t &target
       OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
       OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-      , feedRate_t fr_mm_s, const uint8_t extruder, const PlannerHints &hints
+      , feedRate_t fr_mm_s, const uint_fast8_t extruder, const PlannerHints &hints
     );
 
     /**
@@ -902,7 +902,7 @@ class Planner {
     static bool _populate_block(block_t * const block, const xyze_long_t &target
       OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
       OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-      , feedRate_t fr_mm_s, const uint8_t extruder, const PlannerHints &hints
+      , feedRate_t fr_mm_s, const uint_fast8_t extruder, const PlannerHints &hints
       , float &minimum_planner_speed_sqr
     );
 
@@ -936,7 +936,7 @@ class Planner {
     static bool buffer_segment(const abce_pos_t &abce
       OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
       , const_feedRate_t fr_mm_s
-      , const uint8_t extruder=active_extruder
+      , const uint_fast8_t extruder=active_extruder
       , const PlannerHints &hints=PlannerHints()
     );
 
@@ -955,7 +955,7 @@ class Planner {
      * @return  false if no segment was queued due to cleaning, cold extrusion, full queue, etc...
      */
     static bool buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s
-      , const uint8_t extruder=active_extruder
+      , const uint_fast8_t extruder=active_extruder
       , const PlannerHints &hints=PlannerHints()
     );
 
@@ -1074,7 +1074,7 @@ class Planner {
     }
 
     #if HAS_WIRED_LCD
-      static uint16_t block_buffer_runtime();
+      static uint_fast16_t block_buffer_runtime();
       static void clear_block_buffer_runtime();
     #endif
 
@@ -1106,8 +1106,8 @@ class Planner {
     /**
      * Get the index of the next / previous block in the ring buffer
      */
-    static constexpr uint8_t next_block_index(const uint8_t block_index) { return block_inc_mod(block_index, 1); }
-    static constexpr uint8_t prev_block_index(const uint8_t block_index) { return block_dec_mod(block_index, 1); }
+    static constexpr uint_fast8_t next_block_index(const uint_fast8_t block_index) { return block_inc_mod(block_index, 1); }
+    static constexpr uint_fast8_t prev_block_index(const uint_fast8_t block_index) { return block_dec_mod(block_index, 1); }
 
     /**
      * Calculate the maximum allowable speed squared at this point, in order

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -858,7 +858,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_p
 
       #if EXTRA_PROBING > 0
         // Insert Z measurement into probes[]. Keep it sorted ascending.
-        for (uint8_t i = 0; i <= p; ++i) {                            // Iterate the saved Zs to insert the new Z
+        for (uint_fast8_t i = 0; i <= p; ++i) {                            // Iterate the saved Zs to insert the new Z
           if (i == p || probes[i] > z) {                              // Last index or new Z is smaller than this Z
             for (int8_t m = p; --m >= i;) probes[m + 1] = probes[m];  // Shift items down after the insertion point
             probes[i] = z;                                            // Insert the new Z measurement
@@ -891,12 +891,12 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_p
 
       // Remove values farthest from the median
       uint8_t min_avg_idx = 0, max_avg_idx = TOTAL_PROBING - 1;
-      for (uint8_t i = EXTRA_PROBING; i--;)
+      for (uint_fast8_t i = EXTRA_PROBING; i--;)
         if (ABS(probes[max_avg_idx] - median) > ABS(probes[min_avg_idx] - median))
           max_avg_idx--; else min_avg_idx++;
 
       // Return the average value of all remaining probes.
-      for (uint8_t i = min_avg_idx; i <= max_avg_idx; ++i)
+      for (uint_fast8_t i = min_avg_idx; i <= max_avg_idx; ++i)
         probes_z_sum += probes[i];
 
     #endif

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -201,7 +201,7 @@ typedef struct {     bool NUM_AXIS_LIST_(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1,
 #undef _EN_ITEM
 
 // Limit an index to an array size
-#define ALIM(I,ARR) _MIN(I, (signed)COUNT(ARR) - 1)
+#define ALIM(I,ARR) _MIN(I, COUNT(ARR) - 1)
 
 // Defaults for reset / fill in on load
 static const uint32_t   _DMA[] PROGMEM = DEFAULT_MAX_ACCELERATION;
@@ -739,7 +739,7 @@ void MarlinSettings::postprocess() {
   #if DISABLED(NO_VOLUMETRICS)
     planner.calculate_volumetric_multipliers();
   #elif EXTRUDERS
-    for (uint8_t i = COUNT(planner.e_factor); i--;)
+    for (uint_fast8_t i = COUNT(planner.e_factor); i--;)
       planner.refresh_e_factor(i);
   #endif
 
@@ -908,7 +908,7 @@ void MarlinSettings::postprocess() {
     const uint16_t data_size = datasize();
     EEPROM_WRITE(data_size);
 
-    const uint8_t e_factors = DISTINCT_AXES - (NUM_AXES);
+    const uint_fast8_t e_factors = DISTINCT_AXES - (NUM_AXES);
     _FIELD_TEST(e_factors);
     EEPROM_WRITE(e_factors);
 
@@ -957,7 +957,7 @@ void MarlinSettings::postprocess() {
     {
       #if HAS_HOTEND_OFFSET
         // Skip hotend 0 which must be 0
-        for (uint8_t e = 1; e < HOTENDS; ++e)
+        for (uint_fast8_t e = 1; e < HOTENDS; ++e)
           EEPROM_WRITE(hotend_offset[e]);
       #endif
     }
@@ -1040,7 +1040,7 @@ void MarlinSettings::postprocess() {
       #if ENABLED(MESH_BED_LEVELING)
         EEPROM_WRITE(bedlevel.z_values);
       #else
-        for (uint8_t q = mesh_num_x * mesh_num_y; q--;) EEPROM_WRITE(dummyf);
+        for (uint_fast8_t q = mesh_num_x * mesh_num_y; q--;) EEPROM_WRITE(dummyf);
       #endif
     }
 
@@ -1067,7 +1067,7 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(planner.bed_level_matrix);
       #else
         dummyf = 0;
-        for (uint8_t q = 9; q--;) EEPROM_WRITE(dummyf);
+        for (uint_fast8_t q = 9; q--;) EEPROM_WRITE(dummyf);
       #endif
     }
 
@@ -1405,7 +1405,7 @@ void MarlinSettings::postprocess() {
           EEPROM_WRITE(planner.volumetric_extruder_limit);
         #else
           dummyf = 0.0;
-          for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
+          for (uint_fast8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
         #endif
 
       #else
@@ -1413,9 +1413,9 @@ void MarlinSettings::postprocess() {
         const bool volumetric_enabled = false;
         EEPROM_WRITE(volumetric_enabled);
         dummyf = DEFAULT_NOMINAL_FILAMENT_DIA;
-        for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
+        for (uint_fast8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
         dummyf = 0.0;
-        for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
+        for (uint_fast8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummyf);
 
       #endif
     }
@@ -1938,7 +1938,7 @@ void MarlinSettings::postprocess() {
       // Number of e_factors may change
       //
       _FIELD_TEST(e_factors);
-      uint8_t e_factors;
+      uint_fast8_t e_factors;
       EEPROM_READ_ALWAYS(e_factors);
 
       //
@@ -1981,7 +1981,7 @@ void MarlinSettings::postprocess() {
             EEPROM_READ(dummyf);
           #endif
         #else
-          for (uint8_t q = LOGICAL_AXES; q--;) EEPROM_READ(dummyf);
+          for (uint_fast8_t q = LOGICAL_AXES; q--;) EEPROM_READ(dummyf);
         #endif
 
         EEPROM_READ(TERN(CLASSIC_JERK, dummyf, planner.junction_deviation_mm));
@@ -2011,7 +2011,7 @@ void MarlinSettings::postprocess() {
       {
         #if HAS_HOTEND_OFFSET
           // Skip hotend 0 which must be 0
-          for (uint8_t e = 1; e < HOTENDS; ++e)
+          for (uint_fast8_t e = 1; e < HOTENDS; ++e)
             EEPROM_READ(hotend_offset[e]);
         #endif
       }
@@ -2120,7 +2120,7 @@ void MarlinSettings::postprocess() {
         #if ABL_PLANAR
           EEPROM_READ(planner.bed_level_matrix);
         #else
-          for (uint8_t q = 9; q--;) EEPROM_READ(dummyf);
+          for (uint_fast8_t q = 9; q--;) EEPROM_READ(dummyf);
         #endif
       }
 
@@ -3561,7 +3561,7 @@ void MarlinSettings::reset() {
     #if HAS_FAN
       constexpr uint8_t fpre[] = { REPEAT2_S(1, INCREMENT(PREHEAT_COUNT), _PITEM, FAN_SPEED) };
     #endif
-    for (uint8_t i = 0; i < PREHEAT_COUNT; ++i) {
+    for (uint_fast8_t i = 0; i < PREHEAT_COUNT; ++i) {
       TERN_(HAS_HOTEND,         ui.material_preset[i].hotend_temp  = hpre[i]);
       TERN_(HAS_HEATED_BED,     ui.material_preset[i].bed_temp     = bpre[i]);
       TERN_(HAS_HEATED_CHAMBER, ui.material_preset[i].chamber_temp = cpre[i]);
@@ -3733,10 +3733,10 @@ void MarlinSettings::reset() {
   //
   #if DISABLED(NO_VOLUMETRICS)
     parser.volumetric_enabled = ENABLED(VOLUMETRIC_DEFAULT_ON);
-    for (uint8_t q = 0; q < COUNT(planner.filament_size); ++q)
+    for (uint_fast8_t q = 0; q < COUNT(planner.filament_size); ++q)
       planner.filament_size[q] = DEFAULT_NOMINAL_FILAMENT_DIA;
     #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-      for (uint8_t q = 0; q < COUNT(planner.volumetric_extruder_limit); ++q)
+      for (uint_fast8_t q = 0; q < COUNT(planner.volumetric_extruder_limit); ++q)
         planner.volumetric_extruder_limit[q] = DEFAULT_VOLUMETRIC_EXTRUDER_LIMIT;
     #endif
   #endif
@@ -3776,7 +3776,7 @@ void MarlinSettings::reset() {
 
   #if HAS_MOTOR_CURRENT_PWM
     constexpr uint32_t tmp_motor_current_setting[MOTOR_CURRENT_COUNT] = PWM_MOTOR_CURRENT;
-    for (uint8_t q = 0; q < MOTOR_CURRENT_COUNT; ++q)
+    for (uint_fast8_t q = 0; q < MOTOR_CURRENT_COUNT; ++q)
       stepper.set_digipot_current(q, tmp_motor_current_setting[q]);
   #endif
 
@@ -3785,7 +3785,7 @@ void MarlinSettings::reset() {
   //
   #if HAS_MOTOR_CURRENT_SPI
     static constexpr uint32_t tmp_motor_current_setting[] = DIGIPOT_MOTOR_CURRENT;
-    for (uint8_t q = 0; q < COUNT(tmp_motor_current_setting); ++q)
+    for (uint_fast8_t q = 0; q < COUNT(tmp_motor_current_setting); ++q)
       stepper.set_digipot_current(q, tmp_motor_current_setting[q]);
   #endif
 
@@ -4020,8 +4020,8 @@ void MarlinSettings::reset() {
       #if ENABLED(MESH_BED_LEVELING)
 
         if (leveling_is_valid()) {
-          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
-            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
+          for (uint_fast8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
+            for (uint_fast8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
               CONFIG_ECHO_START();
               SERIAL_ECHOLN(F("  G29 S3 I"), px, F(" J"), py, FPSTR(SP_Z_STR), p_float_t(LINEAR_UNIT(bedlevel.z_values[px][py]), 5));
             }
@@ -4045,8 +4045,8 @@ void MarlinSettings::reset() {
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
         if (leveling_is_valid()) {
-          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
-            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
+          for (uint_fast8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
+            for (uint_fast8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
               CONFIG_ECHO_START();
               SERIAL_ECHOLN(F("  G29 W I"), px, F(" J"), py, FPSTR(SP_Z_STR), p_float_t(LINEAR_UNIT(bedlevel.z_values[px][py]), 5));
             }
@@ -4097,7 +4097,7 @@ void MarlinSettings::reset() {
     TERN_(PIDTEMPCHAMBER, gcode.M309_report(forReplay));
 
     #if HAS_USER_THERMISTORS
-      for (uint8_t i = 0; i < USER_THERMISTORS; ++i)
+      for (uint_fast8_t i = 0; i < USER_THERMISTORS; ++i)
         thermalManager.M305_report(i, forReplay);
     #endif
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -166,7 +166,7 @@ AxisBits Stepper::last_direction_bits, // = 0
 bool Stepper::abort_current_block;
 
 #if DISABLED(MIXING_EXTRUDER) && HAS_MULTI_EXTRUDER
-  uint8_t Stepper::last_moved_extruder = 0xFF;
+  uint_fast8_t Stepper::last_moved_extruder = 0xFF;
 #endif
 
 #if ENABLED(X_DUAL_ENDSTOPS)
@@ -191,7 +191,7 @@ bool Stepper::abort_current_block;
 uint32_t Stepper::acceleration_time, Stepper::deceleration_time;
 
 #if MULTISTEPPING_LIMIT > 1
-  uint8_t Stepper::steps_per_isr = 1; // Count of steps to perform per Stepper ISR call
+  uint_fast8_t Stepper::steps_per_isr = 1; // Count of steps to perform per Stepper ISR call
 #endif
 
 #if DISABLED(OLD_ADAPTIVE_MULTISTEPPING)
@@ -205,9 +205,9 @@ uint32_t Stepper::acceleration_time, Stepper::deceleration_time;
     constexpr bool Stepper::adaptive_step_smoothing_enabled; // = true
   #endif
   // Oversampling factor (log2(multiplier)) to increase temporal resolution of axis
-  uint8_t Stepper::oversampling_factor;
+  uint_fast8_t Stepper::oversampling_factor;
 #else
-  constexpr uint8_t Stepper::oversampling_factor; // = 0
+  constexpr uint_fast8_t Stepper::oversampling_factor; // = 0
 #endif
 
 #if ENABLED(FREEZE_FEATURE)
@@ -224,9 +224,9 @@ uint32_t Stepper::advance_divisor = 0,
          Stepper::step_event_count;          // The total event count for the current block
 
 #if ANY(HAS_MULTI_EXTRUDER, MIXING_EXTRUDER)
-  uint8_t Stepper::stepper_extruder;
+  uint_fast8_t Stepper::stepper_extruder;
 #else
-  constexpr uint8_t Stepper::stepper_extruder;
+  constexpr uint_fast8_t Stepper::stepper_extruder;
 #endif
 
 #if ENABLED(S_CURVE_ACCELERATION)
@@ -590,16 +590,16 @@ bool Stepper::disable_axis(const AxisEnum axis) {
 
 #if HAS_EXTRUDERS
 
-  void Stepper::enable_extruder(E_TERN_(const uint8_t eindex)) {
-    IF_DISABLED(HAS_MULTI_EXTRUDER, constexpr uint8_t eindex = 0);
+  void Stepper::enable_extruder(E_TERN_(const uint_fast8_t eindex)) {
+    IF_DISABLED(HAS_MULTI_EXTRUDER, constexpr uint_fast8_t eindex = 0);
     #define _CASE_ENA_E(N) case N: ENABLE_AXIS_E##N(); mark_axis_enabled(E_AXIS E_OPTARG(eindex)); break;
     switch (eindex) {
       REPEAT(E_STEPPERS, _CASE_ENA_E)
     }
   }
 
-  bool Stepper::disable_extruder(E_TERN_(const uint8_t eindex/*=0*/)) {
-    IF_DISABLED(HAS_MULTI_EXTRUDER, constexpr uint8_t eindex = 0);
+  bool Stepper::disable_extruder(E_TERN_(const uint_fast8_t eindex/*=0*/)) {
+    IF_DISABLED(HAS_MULTI_EXTRUDER, constexpr uint_fast8_t eindex = 0);
     mark_axis_disabled(E_AXIS E_OPTARG(eindex));
     const bool can_disable = can_axis_disable(E_AXIS E_OPTARG(eindex));
     if (can_disable) {
@@ -2285,7 +2285,7 @@ hal_timer_t Stepper::calc_multistep_timer_interval(uint32_t step_rate) {
 
       // Find a doable step rate using multistepping
       uint8_t multistep = 1;
-      for (uint8_t i = 0; i < COUNT(limit) && step_rate > uint32_t(pgm_read_dword(&limit[i])); ++i) {
+      for (uint_fast8_t i = 0; i < COUNT(limit) && step_rate > uint32_t(pgm_read_dword(&limit[i])); ++i) {
         step_rate >>= 1;
         multistep <<= 1;
       }
@@ -2671,9 +2671,8 @@ hal_timer_t Stepper::block_phase_isr() {
 
       // For non-inline cutter, grossly apply power
       #if HAS_CUTTER
-        if (cutter.cutter_mode == CUTTER_MODE_STANDARD) {
+        if (cutter.cutter_mode == CUTTER_MODE_STANDARD)
           cutter.apply_power(current_block->cutter_power);
-        }
       #endif
 
       #if ENABLED(POWER_LOSS_RECOVERY)
@@ -3110,7 +3109,7 @@ void Stepper::init() {
   #if MB(ALLIGATOR)
     const float motor_current[] = MOTOR_CURRENT;
     unsigned int digipot_motor = 0;
-    for (uint8_t i = 0; i < 3 + EXTRUDERS; ++i) {
+    for (uint_fast8_t i = 0; i < 3 + EXTRUDERS; ++i) {
       digipot_motor = 255 * (motor_current[i] / 2.5);
       dac084s085::setValue(i, digipot_motor);
     }

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -333,9 +333,9 @@ class Stepper {
 
     // Last-moved extruder, as set when the last movement was fetched from planner
     #if HAS_MULTI_EXTRUDER
-      static uint8_t last_moved_extruder;
+      static uint_fast8_t last_moved_extruder;
     #else
-      static constexpr uint8_t last_moved_extruder = 0;
+      static constexpr uint_fast8_t last_moved_extruder = 0;
     #endif
 
     #if ENABLED(FREEZE_FEATURE)
@@ -391,9 +391,9 @@ class Stepper {
     static uint32_t acceleration_time, deceleration_time; // time measured in Stepper Timer ticks
 
     #if MULTISTEPPING_LIMIT == 1
-      static constexpr uint8_t steps_per_isr = 1; // Count of steps to perform per Stepper ISR call
+      static constexpr uint_fast8_t steps_per_isr = 1; // Count of steps to perform per Stepper ISR call
     #else
-      static uint8_t steps_per_isr;
+      static uint_fast8_t steps_per_isr;
     #endif
 
     #if DISABLED(OLD_ADAPTIVE_MULTISTEPPING)
@@ -401,9 +401,9 @@ class Stepper {
     #endif
 
     #if ENABLED(ADAPTIVE_STEP_SMOOTHING)
-      static uint8_t oversampling_factor; // Oversampling factor (log2(multiplier)) to increase temporal resolution of axis
+      static uint_fast8_t oversampling_factor; // Oversampling factor (log2(multiplier)) to increase temporal resolution of axis
     #else
-      static constexpr uint8_t oversampling_factor = 0; // Without smoothing apply no shift
+      static constexpr uint_fast8_t oversampling_factor = 0; // Without smoothing apply no shift
     #endif
 
     // Delta error variables for the Bresenham line tracer
@@ -416,9 +416,9 @@ class Stepper {
                     step_event_count;       // The total event count for the current block
 
     #if ANY(HAS_MULTI_EXTRUDER, MIXING_EXTRUDER)
-      static uint8_t stepper_extruder;
+      static uint_fast8_t stepper_extruder;
     #else
-      static constexpr uint8_t stepper_extruder = 0;
+      static constexpr uint_fast8_t stepper_extruder = 0;
     #endif
 
     #if ENABLED(S_CURVE_ACCELERATION)
@@ -682,8 +682,8 @@ class Stepper {
     static bool disable_axis(const AxisEnum axis);
 
     #if HAS_EXTRUDERS
-      static void enable_extruder(E_TERN_(const uint8_t eindex=0));
-      static bool disable_extruder(E_TERN_(const uint8_t eindex=0));
+      static void enable_extruder(E_TERN_(const uint_fast8_t eindex=0));
+      static bool disable_extruder(E_TERN_(const uint_fast8_t eindex=0));
       static void enable_e_steppers();
       static void disable_e_steppers();
     #else

--- a/Marlin/src/module/stepper/control.cpp
+++ b/Marlin/src/module/stepper/control.cpp
@@ -75,7 +75,7 @@
       SPI.begin();
       SET_OUTPUT(DIGIPOTSS_PIN);
 
-      for (uint8_t i = 0; i < COUNT(motor_current_setting); ++i)
+      for (uint_fast8_t i = 0; i < COUNT(motor_current_setting); ++i)
         set_digipot_current(i, motor_current_setting[i]);
     }
 
@@ -91,7 +91,7 @@
 
   void Stepper::refresh_motor_power() {
     if (!initialized) return;
-    for (uint8_t i = 0; i < COUNT(motor_current_setting); ++i) {
+    for (uint_fast8_t i = 0; i < COUNT(motor_current_setting); ++i) {
       switch (i) {
         #if ANY_PIN(MOTOR_CURRENT_PWM_XY, MOTOR_CURRENT_PWM_X, MOTOR_CURRENT_PWM_Y, MOTOR_CURRENT_PWM_I, MOTOR_CURRENT_PWM_J, MOTOR_CURRENT_PWM_K, MOTOR_CURRENT_PWM_U, MOTOR_CURRENT_PWM_V, MOTOR_CURRENT_PWM_W)
           case 0:

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -502,7 +502,7 @@ enum StealthIndex : uint8_t {
       struct {
         const void *ptr[TMCAxis::TOTAL];
         bool began(const TMCAxis a, const void * const p) {
-          for (uint8_t i = 0; i < a; ++i) if (p == ptr[i]) return true;
+          for (uint_fast8_t i = 0; i < a; ++i) if (p == ptr[i]) return true;
           ptr[a] = p; return false;
         };
       } sp_helper;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -395,19 +395,19 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 #endif
 
 #if ANY(AUTO_POWER_E_FANS, HAS_FANCHECK)
-  uint8_t Temperature::autofan_speed[HOTENDS] = ARRAY_N_1(HOTENDS, FAN_OFF_PWM);
+  uint_fast8_t Temperature::autofan_speed[HOTENDS] = ARRAY_N_1(HOTENDS, FAN_OFF_PWM);
 #endif
 
 #if ENABLED(AUTO_POWER_CHAMBER_FAN)
-  uint8_t Temperature::chamberfan_speed = FAN_OFF_PWM;
+  uint_fast8_t Temperature::chamberfan_speed = FAN_OFF_PWM;
 #endif
 
 #if ENABLED(AUTO_POWER_COOLER_FAN)
-  uint8_t Temperature::coolerfan_speed = FAN_OFF_PWM;
+  uint_fast8_t Temperature::coolerfan_speed = FAN_OFF_PWM;
 #endif
 
 #if ALL(FAN_SOFT_PWM, USE_CONTROLLER_FAN)
-  uint8_t Temperature::soft_pwm_controller_speed = FAN_OFF_PWM;
+  uint_fast8_t Temperature::soft_pwm_controller_speed = FAN_OFF_PWM;
 #endif
 
 // Init fans according to whether they're native PWM or Software PWM
@@ -431,7 +431,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 // HAS_FAN does not include CONTROLLER_FAN
 #if HAS_FAN
 
-  uint8_t Temperature::fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
+  uint_fast8_t Temperature::fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
 
   #if ENABLED(EXTRA_FAN_SPEED)
 
@@ -443,7 +443,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
      *  T2       = Save the fan speed, then set to the last T<3-255> value
      *  T<3-255> = Set the "extra fan speed"
      */
-    void Temperature::set_temp_fan_speed(const uint8_t fan, const uint16_t command_or_speed) {
+    void Temperature::set_temp_fan_speed(const uint_fast8_t fan, const uint16_t command_or_speed) {
       switch (command_or_speed) {
         case 1:
           set_fan_speed(fan, extra_fan_speed[fan].saved);
@@ -462,17 +462,17 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 
   #if ANY(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
     bool Temperature::fans_paused; // = false
-    uint8_t Temperature::saved_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
+    uint_fast8_t Temperature::saved_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
   #endif
 
   #if ENABLED(ADAPTIVE_FAN_SLOWING)
-    uint8_t Temperature::fan_speed_scaler[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 128);
+    uint_fast8_t Temperature::fan_speed_scaler[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 128);
   #endif
 
   /**
    * Set the print fan speed for a target extruder
    */
-  void Temperature::set_fan_speed(uint8_t fan, uint16_t speed) {
+  void Temperature::set_fan_speed(uint_fast8_t fan, uint_fast16_t speed) {
 
     NOMORE(speed, 255U);
 
@@ -491,7 +491,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 
     #if NUM_REDUNDANT_FANS
       if (fan == 0) {
-        for (uint8_t f = REDUNDANT_PART_COOLING_FAN; f < REDUNDANT_PART_COOLING_FAN + NUM_REDUNDANT_FANS; ++f)
+        for (uint_fast8_t f = REDUNDANT_PART_COOLING_FAN; f < REDUNDANT_PART_COOLING_FAN + NUM_REDUNDANT_FANS; ++f)
           thermalManager.set_fan_speed(f, speed);
       }
     #endif
@@ -503,7 +503,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
     /**
      * Report print fan speed for a target extruder
      */
-    void Temperature::report_fan_speed(const uint8_t fan) {
+    void Temperature::report_fan_speed(const uint_fast8_t fan) {
       if (fan >= FAN_COUNT) return;
       PORT_REDIRECT(SerialMask::All);
       SERIAL_ECHOLNPGM("M106 P", fan, " S", fan_speed[fan]);
@@ -654,15 +654,15 @@ volatile bool Temperature::raw_temps_ready = false;
 #endif
 
 #if ENABLED(FAN_SOFT_PWM)
-  uint8_t Temperature::soft_pwm_amount_fan[FAN_COUNT],
-          Temperature::soft_pwm_count_fan[FAN_COUNT];
+  uint_fast8_t Temperature::soft_pwm_amount_fan[FAN_COUNT],
+               Temperature::soft_pwm_count_fan[FAN_COUNT];
 #endif
 
 #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
   celsius_t Temperature::singlenozzle_temp[EXTRUDERS];
 #endif
 #if ENABLED(SINGLENOZZLE_STANDBY_FAN)
-  uint8_t Temperature::singlenozzle_fan_speed[EXTRUDERS];
+  uint_fast8_t Temperature::singlenozzle_fan_speed[EXTRUDERS];
 #endif
 
 #if ENABLED(PROBING_HEATERS_OFF)
@@ -881,7 +881,7 @@ volatile bool Temperature::raw_temps_ready = false;
       // Report heater states every 2 seconds
       if (ELAPSED(ms, next_temp_ms)) {
         #if HAS_TEMP_SENSOR
-          print_heater_states(heater_id < 0 ? active_extruder : (int8_t)heater_id);
+          print_heater_states(heater_id < 0 ? active_extruder : int_fast8_t(heater_id));
           SERIAL_EOL();
         #endif
         next_temp_ms = ms + 2000UL;
@@ -936,7 +936,7 @@ volatile bool Temperature::raw_temps_ready = false;
           say_default_(); SERIAL_ECHOLNPGM("Kd ", tune_pid.d);
         #endif
 
-        auto _set_hotend_pid = [](const uint8_t tool, const raw_pid_t &in_pid) {
+        auto _set_hotend_pid = [](const uint_fast8_t tool, const raw_pid_t &in_pid) {
           #if ENABLED(PIDTEMP)
             #if ENABLED(PID_PARAMS_PER_HOTEND)
               thermalManager.temp_hotend[tool].pid.set(in_pid);
@@ -1099,7 +1099,7 @@ volatile bool Temperature::raw_temps_ready = false;
 
           // If there are too many samples, space them more widely
           if (sample_count == COUNT(temp_samples)) {
-            for (uint8_t i = 0; i < COUNT(temp_samples) / 2; i++)
+            for (uint_fast8_t i = 0; i < COUNT(temp_samples) / 2; i++)
               temp_samples[i] = temp_samples[i * 2];
             sample_count /= 2;
             sample_distance *= 2;
@@ -1132,7 +1132,7 @@ volatile bool Temperature::raw_temps_ready = false;
       SERIAL_ECHOLNPGM("t1_time ", t1_time);
       SERIAL_ECHOLNPGM("sample_count ", sample_count);
       SERIAL_ECHOLNPGM("sample_distance ", sample_distance);
-      for (uint8_t i = 0; i < sample_count; i++)
+      for (uint_fast8_t i = 0; i < sample_count; i++)
         SERIAL_ECHOLNPGM("sample ", i, " : ", temp_samples[i]);
       SERIAL_ECHOLNPGM("t1 ", get_sample_1_temp(), " t2 ", get_sample_2_temp(), " t3 ", get_sample_3_temp());
     #endif
@@ -1231,7 +1231,7 @@ volatile bool Temperature::raw_temps_ready = false;
     return MeasurementState::SUCCESS;
   }
 
-  void Temperature::MPC_autotune(const uint8_t e, MPCTuningType tuning_type=AUTO) {
+  void Temperature::MPC_autotune(const uint_fast8_t e, MPCTuningType tuning_type=AUTO) {
     SERIAL_ECHOLNPGM(STR_MPC_AUTOTUNE_START, e);
 
     MPC_autotuner tuner(e);
@@ -1449,7 +1449,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
     }while(0)
 
     uint8_t fanDone = 0;
-    for (uint8_t f = 0; f < COUNT(fanBit); ++f) {
+    for (uint_fast8_t f = 0; f < COUNT(fanBit); ++f) {
       const uint8_t realFan = pgm_read_byte(&fanBit[f]);
       if (TEST(fanDone, realFan)) continue;
       const bool fan_on = TEST(fanState, realFan);
@@ -1510,7 +1510,7 @@ inline void loud_kill(FSTR_P const lcd_msg, const heater_id_t heater_id) {
   marlin_state = MarlinState::MF_KILLED;
   thermalManager.disable_all_heaters();
   #if HAS_BEEPER
-    for (uint8_t i = 20; i--;) {
+    for (uint_fast8_t i = 20; i--;) {
       hal.watchdog_refresh();
       buzzer.click(25);
       delay(80);
@@ -1662,7 +1662,7 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
 
     PIDRunner(TT &t) : tempinfo(t) { }
 
-    float get_pid_output(const uint8_t extr=0) {
+    float get_pid_output(const uint_fast8_t extr=0) {
       #if ENABLED(PID_OPENLOOP)
 
         return constrain(tempinfo.target, 0, MAX_POW);
@@ -1714,8 +1714,8 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
    * @param E_NAME:  The extruder index
    * @return The power output for the hotend
    */
-  float Temperature::get_pid_output_hotend(const uint8_t E_NAME) {
-    const uint8_t ee = HOTEND_INDEX;
+  float Temperature::get_pid_output_hotend(const uint_fast8_t E_NAME) {
+    const uint_fast8_t ee = HOTEND_INDEX;
 
     const bool is_idling = TERN0(HEATER_IDLE_HANDLER, heater_idle[ee].timed_out);
 
@@ -1754,7 +1754,7 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
 
       float ambient_xfer_coeff = mpc.ambient_xfer_coeff_fan0;
       #if ENABLED(MPC_INCLUDE_FAN)
-        const uint8_t fan_index = TERN(SINGLEFAN, 0, ee);
+        const uint_fast8_t fan_index = TERN(SINGLEFAN, 0, ee);
         const float fan_fraction = TERN_(MPC_FAN_0_ACTIVE_HOTEND, !this_hotend ? 0.0f :) fan_speed[fan_index] * RECIPROCAL(255);
         ambient_xfer_coeff += fan_fraction * mpc.fan255_adjustment;
       #endif
@@ -2448,7 +2448,7 @@ void Temperature::task() {
     COPY(user_thermistor, default_user_thermistor);
   }
 
-  void Temperature::M305_report(const uint8_t t_index, const bool forReplay/*=true*/) {
+  void Temperature::M305_report(const uint_fast8_t t_index, const bool forReplay/*=true*/) {
     TERN_(MARLIN_SMALL_BUILD, return);
 
     gcode.report_heading_etc(forReplay, F(STR_USER_THERMISTORS));
@@ -2480,7 +2480,7 @@ void Temperature::task() {
     );
   }
 
-  celsius_float_t Temperature::user_thermistor_to_deg_c(const uint8_t t_index, const raw_adc_t raw) {
+  celsius_float_t Temperature::user_thermistor_to_deg_c(const uint_fast8_t t_index, const raw_adc_t raw) {
 
     if (!WITHIN(t_index, 0, COUNT(user_thermistor) - 1)) return 25;
 
@@ -2516,7 +2516,7 @@ void Temperature::task() {
 #if HAS_HOTEND
   // Derived from RepRap FiveD extruder::getTemperature()
   // For hot end temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_hotend(const raw_adc_t raw, const uint8_t e) {
+  celsius_float_t Temperature::analog_to_celsius_hotend(const raw_adc_t raw, const uint_fast8_t e) {
     if (e >= HOTENDS) {
       SERIAL_ERROR_START();
       SERIAL_ECHO(e);
@@ -2832,7 +2832,7 @@ void Temperature::updateTemperaturesFromRawValues() {
 
   #if HAS_HOTEND
     #define _TEMPDIR(N) TEMP_SENSOR_IS_ANY_MAX_TC(N) ? 0 : TEMPDIR(N),
-    static constexpr int8_t temp_dir[HOTENDS] = { REPEAT(HOTENDS, _TEMPDIR) };
+    static constexpr int_fast8_t temp_dir[HOTENDS] = { REPEAT(HOTENDS, _TEMPDIR) };
 
     HOTEND_LOOP() {
       const raw_adc_t r = temp_hotend[e].getraw();
@@ -3528,7 +3528,7 @@ void Temperature::disable_all_heaters() {
 
 #if ANY(SINGLENOZZLE_STANDBY_TEMP, SINGLENOZZLE_STANDBY_FAN)
 
-  void Temperature::singlenozzle_change(const uint8_t old_tool, const uint8_t new_tool) {
+  void Temperature::singlenozzle_change(const uint_fast8_t old_tool, const uint_fast8_t new_tool) {
     #if ENABLED(SINGLENOZZLE_STANDBY_FAN)
       singlenozzle_fan_speed[old_tool] = fan_speed[0];
       fan_speed[0] = singlenozzle_fan_speed[new_tool];
@@ -3564,7 +3564,7 @@ void Temperature::disable_all_heaters() {
    * @param  hindex  the hotend we're referencing (if MULTI_MAX_TC)
    * @return         integer representing the board's buffer, to be converted later if needed
    */
-  raw_adc_t Temperature::read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex/*=0*/)) {
+  raw_adc_t Temperature::read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint_fast8_t hindex/*=0*/)) {
     #define MAXTC_HEAT_INTERVAL 250UL
 
     #if HAS_MAX31855
@@ -3595,7 +3595,7 @@ void Temperature::disable_all_heaters() {
     #else
       // When we have only 1 max tc, THERMO_SEL will pick the appropriate sensor
       // variable, and MAXTC_*() macros will be hardcoded to the correct CS pin.
-      constexpr uint8_t hindex = 0;
+      constexpr uint_fast8_t hindex = 0;
       #define THERMO_TEMP(I) max_tc_temp
       #if TEMP_SENSOR_IS_ANY_MAX_TC(0)
         #define THERMO_SEL(A,B,C) A
@@ -3639,7 +3639,7 @@ void Temperature::disable_all_heaters() {
       DELAY_NS(100);        // Ensure 100ns delay
 
       // Read a big-endian temperature value without using a library
-      for (uint8_t i = sizeof(max_tc_temp); i--;) {
+      for (uint_fast8_t i = sizeof(max_tc_temp); i--;) {
         max_tc_temp |= TERN(HAS_MAXTC_SW_SPI, max_tc_spi.receive(), spiRec());
         if (i > 0) max_tc_temp <<= 8; // shift left if not the last byte
       }
@@ -3936,13 +3936,13 @@ HAL_TEMP_TIMER_ISR() {
 
 class SoftPWM {
 public:
-  uint8_t count;
-  inline bool add(const uint8_t mask, const uint8_t amount) {
+  uint_fast8_t count;
+  inline bool add(const uint_fast8_t mask, const uint_fast8_t amount) {
     count = (count & mask) + amount; return (count > mask);
   }
   #if ENABLED(SLOW_PWM_HEATERS)
     bool state_heater;
-    uint8_t state_timer_heater;
+    uint_fast8_t state_timer_heater;
     inline void dec() { if (state_timer_heater > 0) state_timer_heater--; }
     inline bool ready(const bool v) {
       const bool rdy = !state_timer_heater;
@@ -3975,16 +3975,16 @@ void Temperature::isr() {
     }
   #endif
 
-  static int8_t temp_count = -1;
+  static int_fast8_t temp_count = -1;
   static ADCSensorState adc_sensor_state = StartupDelay;
 
   #ifndef SOFT_PWM_SCALE
     #define SOFT_PWM_SCALE 0
   #endif
-  static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
+  static uint_fast8_t pwm_count = _BV(SOFT_PWM_SCALE);
 
   // Avoid multiple loads of pwm_count
-  uint8_t pwm_count_tmp = pwm_count;
+  uint_fast8_t pwm_count_tmp = pwm_count;
 
   #if HAS_ADC_BUTTONS
     static raw_adc_t raw_ADCKey_value = 0;
@@ -4056,7 +4056,7 @@ void Temperature::isr() {
         #endif
 
         #define _FAN_PWM(N) do{                                     \
-          uint8_t &spcf = soft_pwm_count_fan[N];                    \
+          uint_fast8_t &spcf = soft_pwm_count_fan[N];               \
           spcf = (spcf & pwm_mask) + (soft_pwm_amount_fan[N] >> 1); \
           WRITE_FAN(N, spcf > pwm_mask ? HIGH : LOW);               \
         }while(0)
@@ -4158,7 +4158,7 @@ void Temperature::isr() {
     #define _SLOW_PWM(NR,PWM,SRC) do{ PWM.count = SRC.soft_pwm_amount; _SLOW_SET(NR,PWM,(PWM.count > 0)); }while(0)
     #define _PWM_OFF(NR,PWM) do{ if (PWM.count < slow_pwm_count) _SLOW_SET(NR,PWM,0); }while(0)
 
-    static uint8_t slow_pwm_count = 0;
+    static uint_fast8_t slow_pwm_count = 0;
 
     if (slow_pwm_count == 0) {
 
@@ -4319,8 +4319,8 @@ void Temperature::isr() {
     case SensorsReady: {
       // All sensors have been read. Stay in this state for a few
       // ISRs to save on calls to temp update/checking code below.
-      constexpr int8_t extra_loops = MIN_ADC_ISR_LOOPS - (int8_t)SensorsReady;
-      static uint8_t delay_count = 0;
+      constexpr int_fast8_t extra_loops = MIN_ADC_ISR_LOOPS - int_fast8_t(SensorsReady);
+      static uint_fast8_t delay_count = 0;
       if (extra_loops > 0) {
         if (delay_count == 0) delay_count = extra_loops;  // Init this delay
         if (--delay_count)                                // While delaying...
@@ -4579,7 +4579,7 @@ void Temperature::isr() {
    *       Cooler: " L@:nnn"
    *      Hotends: " @0:nnn @1:nnn ..."
    */
-  void Temperature::print_heater_states(const int8_t target_extruder
+  void Temperature::print_heater_states(const int_fast8_t target_extruder
     OPTARG(HAS_TEMP_REDUNDANT, const bool include_r/*=false*/)
   ) {
     #if HAS_TEMP_HOTEND
@@ -4630,7 +4630,7 @@ void Temperature::isr() {
   #endif
 
   #if HAS_HOTEND && HAS_STATUS_MESSAGE
-    void Temperature::set_heating_message(const uint8_t e, const bool isM104/*=false*/) {
+    void Temperature::set_heating_message(const uint_fast8_t e, const bool isM104/*=false*/) {
       const bool heating = isHeatingHotend(e);
       ui.status_printf(0,
         #if HAS_MULTI_HOTEND
@@ -4642,7 +4642,7 @@ void Temperature::isr() {
       );
 
       if (isM104) {
-        static uint8_t wait_e; wait_e = e;
+        static uint_fast8_t wait_e; wait_e = e;
         ui.set_status_reset_fn([]{
           const celsius_t c = degTargetHotend(wait_e);
           return c < 30 || degHotendNear(wait_e, c);
@@ -4660,7 +4660,7 @@ void Temperature::isr() {
       #define MIN_COOLING_SLOPE_TIME 60
     #endif
 
-    bool Temperature::wait_for_hotend(const uint8_t target_extruder, const bool no_wait_for_cooling/*=true*/
+    bool Temperature::wait_for_hotend(const uint_fast8_t target_extruder, const bool no_wait_for_cooling/*=true*/
       OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel/*=false*/)
     ) {
       #if ENABLED(AUTOTEMP)
@@ -4785,7 +4785,7 @@ void Temperature::isr() {
     }
 
     #if ENABLED(WAIT_FOR_HOTEND)
-      void Temperature::wait_for_hotend_heating(const uint8_t target_extruder) {
+      void Temperature::wait_for_hotend_heating(const uint_fast8_t target_extruder) {
         if (isHeatingHotend(target_extruder)) {
           SERIAL_ECHOLNPGM("Wait for hotend heating...");
           LCD_MESSAGE(MSG_HEATING);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -267,7 +267,7 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
         base::reset();
         prev_e_pos = 0;
         lpq_ptr = 0;
-        for (uint8_t i = 0; i < LPQ_ARR_SZ; ++i) lpq[i] = 0;
+        for (uint_fast8_t i = 0; i < LPQ_ARR_SZ; ++i) lpq[i] = 0;
       }
 
       float get_extrusion_scale_output(const bool is_active, const int32_t e_position, const float e_mm_per_step, const int16_t lpq_len) {
@@ -317,7 +317,7 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
       void set(const raw_pid_t &raw) { set(raw.p, raw.i, raw.d); }
       void set(const raw_pidcf_t &raw) { set(raw.p, raw.i, raw.d, raw.c, raw.f); }
 
-      float get_fan_scale_output(const uint8_t fan_speed) {
+      float get_fan_scale_output(const uint_fast8_t fan_speed) {
         work_f = 0;
         if (fan_speed > SCALE_MIN_SPEED)
           work_f = Kf + (SCALE_LIN_FACTOR) * fan_speed;
@@ -353,7 +353,7 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
 
       void reset() { cPID::reset(); }
 
-      float get_fan_scale_output(const uint8_t fan_speed) {
+      float get_fan_scale_output(const uint_fast8_t fan_speed) {
         work_f = fan_speed > (SCALE_MIN_SPEED) ? Kf + (SCALE_LIN_FACTOR) * fan_speed : 0;
         return work_f;
       }
@@ -603,7 +603,7 @@ class Temperature {
     #if HAS_HOTEND
       static hotend_info_t temp_hotend[HOTENDS];
       static constexpr celsius_t hotend_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP, HEATER_5_MAXTEMP, HEATER_6_MAXTEMP, HEATER_7_MAXTEMP);
-      static constexpr celsius_t hotend_max_target(const uint8_t e) { return hotend_maxtemp[e] - (HOTEND_OVERSHOOT); }
+      static constexpr celsius_t hotend_max_target(const uint_fast8_t e) { return hotend_maxtemp[e] - (HOTEND_OVERSHOOT); }
     #endif
 
     #if HAS_HEATED_BED
@@ -629,22 +629,22 @@ class Temperature {
     #endif
 
     #if ANY(AUTO_POWER_E_FANS, HAS_FANCHECK)
-      static uint8_t autofan_speed[HOTENDS];
+      static uint_fast8_t autofan_speed[HOTENDS];
     #endif
     #if ENABLED(AUTO_POWER_CHAMBER_FAN)
-      static uint8_t chamberfan_speed;
+      static uint_fast8_t chamberfan_speed;
     #endif
     #if ENABLED(AUTO_POWER_COOLER_FAN)
-      static uint8_t coolerfan_speed;
+      static uint_fast8_t coolerfan_speed;
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)
-      static uint8_t soft_pwm_amount_fan[FAN_COUNT],
-                     soft_pwm_count_fan[FAN_COUNT];
+      static uint_fast8_t soft_pwm_amount_fan[FAN_COUNT],
+                          soft_pwm_count_fan[FAN_COUNT];
     #endif
 
     #if ALL(FAN_SOFT_PWM, USE_CONTROLLER_FAN)
-      static uint8_t soft_pwm_controller_speed;
+      static uint_fast8_t soft_pwm_controller_speed;
     #endif
 
     #if ALL(HAS_MARLINUI_MENU, PREVENT_COLD_EXTRUSION) && E_MANUAL > 0
@@ -659,24 +659,24 @@ class Temperature {
       static bool allow_cold_extrude;
       static celsius_t extrude_min_temp;
       static bool tooCold(const celsius_t temp) { return !allow_cold_extrude && !allow_cold_extrude_override && temp < extrude_min_temp - (TEMP_WINDOW); }
-      static bool tooColdToExtrude(const uint8_t E_NAME)       { return tooCold(wholeDegHotend(HOTEND_INDEX)); }
-      static bool targetTooColdToExtrude(const uint8_t E_NAME) { return tooCold(degTargetHotend(HOTEND_INDEX)); }
+      static bool tooColdToExtrude(const uint_fast8_t E_NAME)       { return tooCold(wholeDegHotend(HOTEND_INDEX)); }
+      static bool targetTooColdToExtrude(const uint_fast8_t E_NAME) { return tooCold(degTargetHotend(HOTEND_INDEX)); }
     #else
       static constexpr bool allow_cold_extrude = true;
       static constexpr celsius_t extrude_min_temp = 0;
-      static bool tooColdToExtrude(const uint8_t) { return false; }
-      static bool targetTooColdToExtrude(const uint8_t) { return false; }
+      static bool tooColdToExtrude(const uint_fast8_t) { return false; }
+      static bool targetTooColdToExtrude(const uint_fast8_t) { return false; }
     #endif
 
-    static bool hotEnoughToExtrude(const uint8_t e) { return !tooColdToExtrude(e); }
-    static bool targetHotEnoughToExtrude(const uint8_t e) { return !targetTooColdToExtrude(e); }
+    static bool hotEnoughToExtrude(const uint_fast8_t e) { return !tooColdToExtrude(e); }
+    static bool targetHotEnoughToExtrude(const uint_fast8_t e) { return !targetTooColdToExtrude(e); }
 
     #if ANY(SINGLENOZZLE_STANDBY_TEMP, SINGLENOZZLE_STANDBY_FAN)
       #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
         static celsius_t singlenozzle_temp[EXTRUDERS];
       #endif
       #if ENABLED(SINGLENOZZLE_STANDBY_FAN)
-        static uint8_t singlenozzle_fan_speed[EXTRUDERS];
+        static uint_fast8_t singlenozzle_fan_speed[EXTRUDERS];
       #endif
       static void singlenozzle_change(const uint8_t old_tool, const uint8_t new_tool);
     #endif
@@ -821,28 +821,28 @@ class Temperature {
 
     #if HAS_USER_THERMISTORS
       static user_thermistor_t user_thermistor[USER_THERMISTORS];
-      static void M305_report(const uint8_t t_index, const bool forReplay=true);
+      static void M305_report(const uint_fast8_t t_index, const bool forReplay=true);
       static void reset_user_thermistors();
-      static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const raw_adc_t raw);
-      static bool set_pull_up_res(int8_t t_index, float value) {
+      static celsius_float_t user_thermistor_to_deg_c(const uint_fast8_t t_index, const raw_adc_t raw);
+      static bool set_pull_up_res(int_fast8_t t_index, float value) {
         //if (!WITHIN(t_index, 0, USER_THERMISTORS - 1)) return false;
         if (!WITHIN(value, 1, 1000000)) return false;
         user_thermistor[t_index].series_res = value;
         return true;
       }
-      static bool set_res25(int8_t t_index, float value) {
+      static bool set_res25(int_fast8_t t_index, float value) {
         if (!WITHIN(value, 1, 10000000)) return false;
         user_thermistor[t_index].res_25 = value;
         user_thermistor[t_index].pre_calc = true;
         return true;
       }
-      static bool set_beta(int8_t t_index, float value) {
+      static bool set_beta(int_fast8_t t_index, float value) {
         if (!WITHIN(value, 1, 1000000)) return false;
         user_thermistor[t_index].beta = value;
         user_thermistor[t_index].pre_calc = true;
         return true;
       }
-      static bool set_sh_coeff(int8_t t_index, float value) {
+      static bool set_sh_coeff(int_fast8_t t_index, float value) {
         if (!WITHIN(value, -0.01f, 0.01f)) return false;
         user_thermistor[t_index].sh_c_coeff = value;
         user_thermistor[t_index].pre_calc = true;
@@ -851,7 +851,7 @@ class Temperature {
     #endif
 
     #if HAS_HOTEND
-      static celsius_float_t analog_to_celsius_hotend(const raw_adc_t raw, const uint8_t e);
+      static celsius_float_t analog_to_celsius_hotend(const raw_adc_t raw, const uint_fast8_t e);
     #endif
     #if HAS_HEATED_BED
       static celsius_float_t analog_to_celsius_bed(const raw_adc_t raw);
@@ -877,41 +877,41 @@ class Temperature {
 
     #if HAS_FAN
 
-      static uint8_t fan_speed[FAN_COUNT];
-      #define FANS_LOOP(I) for (uint8_t I = 0; I < FAN_COUNT; ++I)
+      static uint_fast8_t fan_speed[FAN_COUNT];
+      #define FANS_LOOP(I) for (uint_fast8_t I = 0; I < FAN_COUNT; ++I)
 
-      static void set_fan_speed(const uint8_t fan, const uint16_t speed);
+      static void set_fan_speed(const uint_fast8_t fan, const uint_fast16_t speed);
 
       #if ENABLED(REPORT_FAN_CHANGE)
-        static void report_fan_speed(const uint8_t fan);
+        static void report_fan_speed(const uint_fast8_t fan);
       #endif
 
       #if ANY(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
         static bool fans_paused;
-        static uint8_t saved_fan_speed[FAN_COUNT];
+        static uint_fast8_t saved_fan_speed[FAN_COUNT];
       #endif
 
       #if ENABLED(ADAPTIVE_FAN_SLOWING)
-        static uint8_t fan_speed_scaler[FAN_COUNT];
+        static uint_fast8_t fan_speed_scaler[FAN_COUNT];
       #endif
 
-      static uint8_t scaledFanSpeed(const uint8_t fan, const uint8_t fs) {
+      static uint_fast8_t scaledFanSpeed(const uint_fast8_t fan, const uint_fast8_t fs) {
         UNUSED(fan); // Potentially unused!
         return (fs * uint16_t(TERN(ADAPTIVE_FAN_SLOWING, fan_speed_scaler[fan], 128))) >> 7;
       }
 
-      static uint8_t scaledFanSpeed(const uint8_t fan) {
+      static uint_fast8_t scaledFanSpeed(const uint_fast8_t fan) {
         return scaledFanSpeed(fan, fan_speed[fan]);
       }
 
-      static constexpr inline uint8_t pwmToPercent(const uint8_t speed) { return ui8_to_percent(speed); }
-      static uint8_t fanSpeedPercent(const uint8_t fan)          { return ui8_to_percent(fan_speed[fan]); }
-      static uint8_t scaledFanSpeedPercent(const uint8_t fan)    { return ui8_to_percent(scaledFanSpeed(fan)); }
+      static constexpr uint_fast8_t pwmToPercent(const uint_fast8_t speed) { return ui8_to_percent(speed); }
+      static uint_fast8_t fanSpeedPercent(const uint_fast8_t fan)          { return ui8_to_percent(fan_speed[fan]); }
+      static uint_fast8_t scaledFanSpeedPercent(const uint_fast8_t fan)    { return ui8_to_percent(scaledFanSpeed(fan)); }
 
       #if ENABLED(EXTRA_FAN_SPEED)
-        typedef struct { uint8_t saved, speed; } extra_fan_t;
+        typedef struct { uint_fast8_t saved, speed; } extra_fan_t;
         static extra_fan_t extra_fan_speed[FAN_COUNT];
-        static void set_temp_fan_speed(const uint8_t fan, const uint16_t command_or_speed);
+        static void set_temp_fan_speed(const uint_fast8_t fan, const uint_fast16_t command_or_speed);
       #endif
 
       #if ANY(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
@@ -942,17 +942,17 @@ class Temperature {
      */
     #if PREHEAT_TIME_HOTEND_MS > 0
       static millis_t preheat_end_ms_hotend[HOTENDS];
-      static bool is_hotend_preheating(const uint8_t E_NAME) {
+      static bool is_hotend_preheating(const uint_fast8_t E_NAME) {
         return preheat_end_ms_hotend[HOTEND_INDEX] && PENDING(millis(), preheat_end_ms_hotend[HOTEND_INDEX]);
       }
-      static void start_hotend_preheat_time(const uint8_t E_NAME) {
+      static void start_hotend_preheat_time(const uint_fast8_t E_NAME) {
         preheat_end_ms_hotend[HOTEND_INDEX] = millis() + PREHEAT_TIME_HOTEND_MS;
       }
-      static void reset_hotend_preheat_time(const uint8_t E_NAME) {
+      static void reset_hotend_preheat_time(const uint_fast8_t E_NAME) {
         preheat_end_ms_hotend[HOTEND_INDEX] = 0;
       }
     #else
-      static bool is_hotend_preheating(const uint8_t) { return false; }
+      static bool is_hotend_preheating(const uint_fast8_t) { return false; }
     #endif
 
     #if HAS_HEATED_BED
@@ -976,28 +976,28 @@ class Temperature {
     //inline so that there is no performance decrease.
     //deg=degreeCelsius
 
-    static celsius_float_t degHotend(const uint8_t E_NAME) {
+    static celsius_float_t degHotend(const uint_fast8_t E_NAME) {
       return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].celsius);
     }
 
-    static celsius_t wholeDegHotend(const uint8_t E_NAME) {
+    static celsius_t wholeDegHotend(const uint_fast8_t E_NAME) {
       return TERN0(HAS_HOTEND, static_cast<celsius_t>(temp_hotend[HOTEND_INDEX].celsius + 0.5f));
     }
 
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      static raw_adc_t rawHotendTemp(const uint8_t E_NAME) {
+      static raw_adc_t rawHotendTemp(const uint_fast8_t E_NAME) {
         return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].getraw());
       }
     #endif
 
-    static celsius_t degTargetHotend(const uint8_t E_NAME) {
+    static celsius_t degTargetHotend(const uint_fast8_t E_NAME) {
       return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].target);
     }
 
     #if HAS_HOTEND
 
-      static void setTargetHotend(const celsius_t celsius, const uint8_t E_NAME) {
-        const uint8_t ee = HOTEND_INDEX;
+      static void setTargetHotend(const celsius_t celsius, const uint_fast8_t E_NAME) {
+        const uint_fast8_t ee = HOTEND_INDEX;
         #if PREHEAT_TIME_HOTEND_MS > 0
           if (celsius == 0)
             reset_hotend_preheat_time(ee);
@@ -1009,34 +1009,34 @@ class Temperature {
         start_watching_hotend(ee);
       }
 
-      static bool isHeatingHotend(const uint8_t E_NAME) {
+      static bool isHeatingHotend(const uint_fast8_t E_NAME) {
         return temp_hotend[HOTEND_INDEX].target > temp_hotend[HOTEND_INDEX].celsius;
       }
 
-      static bool isCoolingHotend(const uint8_t E_NAME) {
+      static bool isCoolingHotend(const uint_fast8_t E_NAME) {
         return temp_hotend[HOTEND_INDEX].target < temp_hotend[HOTEND_INDEX].celsius;
       }
 
       #if HAS_TEMP_HOTEND
-        static bool wait_for_hotend(const uint8_t target_extruder, const bool no_wait_for_cooling=true
+        static bool wait_for_hotend(const uint_fast8_t target_extruder, const bool no_wait_for_cooling=true
           OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel=false)
         );
 
         #if ENABLED(WAIT_FOR_HOTEND)
-          static void wait_for_hotend_heating(const uint8_t target_extruder);
+          static void wait_for_hotend_heating(const uint_fast8_t target_extruder);
         #endif
       #endif
 
-      static bool degHotendNear(const uint8_t e, const celsius_t temp) {
+      static bool degHotendNear(const uint_fast8_t e, const celsius_t temp) {
         return ABS(wholeDegHotend(e) - temp) < (TEMP_HYSTERESIS);
       }
 
-      static bool still_heating(const uint8_t e) {
+      static bool still_heating(const uint_fast8_t e) {
         return degTargetHotend(e) > TEMP_HYSTERESIS && !degHotendNear(e, degTargetHotend(e));
       }
 
       // Start watching a Hotend to make sure it's really heating up
-      static void start_watching_hotend(const uint8_t E_NAME) {
+      static void start_watching_hotend(const uint_fast8_t E_NAME) {
         UNUSED(HOTEND_INDEX);
         #if WATCH_HOTENDS
           watch_hotend[HOTEND_INDEX].restart(degHotend(HOTEND_INDEX), degTargetHotend(HOTEND_INDEX));
@@ -1291,7 +1291,7 @@ class Temperature {
       };
 
       enum MPCTuningType { AUTO, FORCE_ASYMPTOTIC, FORCE_DIFFERENTIAL };
-      static void MPC_autotune(const uint8_t e, MPCTuningType tuning_type);
+      static void MPC_autotune(const uint_fast8_t e, MPCTuningType tuning_type);
 
     #endif // MPC_AUTOTUNE
 
@@ -1301,7 +1301,7 @@ class Temperature {
 
     #if HEATER_IDLE_HANDLER
 
-      static void reset_hotend_idle_timer(const uint8_t E_NAME) {
+      static void reset_hotend_idle_timer(const uint_fast8_t E_NAME) {
         heater_idle[HOTEND_INDEX].reset();
         start_watching_hotend(HOTEND_INDEX);
       }
@@ -1316,7 +1316,7 @@ class Temperature {
     #endif // HEATER_IDLE_HANDLER
 
     #if HAS_TEMP_SENSOR
-      static void print_heater_states(const int8_t target_extruder
+      static void print_heater_states(const int_fast8_t target_extruder
         OPTARG(HAS_TEMP_REDUNDANT, const bool include_r=false)
       );
       #if ENABLED(AUTO_REPORT_TEMPERATURES)
@@ -1326,9 +1326,9 @@ class Temperature {
     #endif
 
     #if HAS_HOTEND && HAS_STATUS_MESSAGE
-      static void set_heating_message(const uint8_t e, const bool isM104=false);
+      static void set_heating_message(const uint_fast8_t e, const bool isM104=false);
     #else
-      static void set_heating_message(const uint8_t, const bool=false) {}
+      static void set_heating_message(const uint_fast8_t, const bool=false) {}
     #endif
 
   private:
@@ -1365,7 +1365,7 @@ class Temperature {
     #endif
 
     #if HAS_HOTEND
-      static float get_pid_output_hotend(const uint8_t e);
+      static float get_pid_output_hotend(const uint_fast8_t e);
     #endif
     #if ENABLED(PIDTEMPBED)
       static float get_pid_output_bed();

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -111,7 +111,7 @@
     #define _SERVO_NR(E) SWITCHING_EXTRUDER_SERVO_NR
   #endif
 
-  void move_extruder_servo(const uint8_t e) {
+  void move_extruder_servo(const uint_fast8_t e) {
     planner.synchronize();
     constexpr bool evenExtruders = !(EXTRUDERS & 1);
     if (evenExtruders || e < EXTRUDERS - 1) {
@@ -126,19 +126,19 @@
 
   #if SWITCHING_NOZZLE_TWO_SERVOS
 
-    inline void _move_nozzle_servo(const uint8_t e, const uint8_t angle_index) {
+    inline void _move_nozzle_servo(const uint_fast8_t e, const uint_fast8_t angle_index) {
       constexpr int8_t  sns_index[2] = { SWITCHING_NOZZLE_SERVO_NR, SWITCHING_NOZZLE_E1_SERVO_NR };
       planner.synchronize();
       servo[sns_index[e]].move(servo_angles[sns_index[e]][angle_index]);
       safe_delay(SWITCHING_NOZZLE_SERVO_DWELL);
     }
 
-    void lower_nozzle(const uint8_t e) { _move_nozzle_servo(e, 0); }
-    void raise_nozzle(const uint8_t e) { _move_nozzle_servo(e, 1); }
+    void lower_nozzle(const uint_fast8_t e) { _move_nozzle_servo(e, 0); }
+    void raise_nozzle(const uint_fast8_t e) { _move_nozzle_servo(e, 1); }
 
   #else
 
-    void move_nozzle_servo(const uint8_t angle_index) {
+    void move_nozzle_servo(const uint_fast8_t angle_index) {
       planner.synchronize();
       servo[SWITCHING_NOZZLE_SERVO_NR].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][angle_index]);
       safe_delay(SWITCHING_NOZZLE_SERVO_DWELL);
@@ -167,7 +167,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
         parkingtraveldistance,    // M951 D
         compensationmultiplier;
 
-  inline void magnetic_parking_extruder_tool_change(const uint8_t new_tool) {
+  inline void magnetic_parking_extruder_tool_change(const uint_fast8_t new_tool) {
 
     const float oldx = current_position.x,
                 grabpos = mpe_settings.parking_xpos[new_tool] + (new_tool ? mpe_settings.grab_distance : -mpe_settings.grab_distance),
@@ -256,10 +256,10 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 #elif ENABLED(PARKING_EXTRUDER)
 
   void pe_solenoid_init() {
-    for (uint8_t n = 0; n <= 1; ++n) pe_solenoid_set_pin_state(n, !PARKING_EXTRUDER_SOLENOIDS_PINS_ACTIVE);
+    for (uint_fast8_t n = 0; n <= 1; ++n) pe_solenoid_set_pin_state(n, !PARKING_EXTRUDER_SOLENOIDS_PINS_ACTIVE);
   }
 
-  void pe_solenoid_set_pin_state(const uint8_t extruder_num, const uint8_t state) {
+  void pe_solenoid_set_pin_state(const uint_fast8_t extruder_num, const bool state) {
     switch (extruder_num) {
       case 1: OUT_WRITE(SOL1_PIN, state); break;
       default: OUT_WRITE(SOL0_PIN, state); break;
@@ -272,7 +272,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
   bool extruder_parked = true, do_solenoid_activation = true;
 
   // Modifies tool_change() behavior based on homing side
-  bool parking_extruder_unpark_after_homing(const uint8_t final_tool, bool homed_towards_final_tool) {
+  bool parking_extruder_unpark_after_homing(const uint_fast8_t final_tool, bool homed_towards_final_tool) {
     do_solenoid_activation = false; // Tell parking_extruder_tool_change to skip solenoid activation
 
     if (!extruder_parked) return false; // nothing to do
@@ -289,7 +289,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     return true;
   }
 
-  inline void parking_extruder_tool_change(const uint8_t new_tool, bool no_move) {
+  inline void parking_extruder_tool_change(const uint_fast8_t new_tool, bool no_move) {
     if (!no_move) {
 
       constexpr float parkingposx[] = PARKING_EXTRUDER_PARKING_X;
@@ -421,7 +421,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     );
   }
 
-  uint8_t check_tool_sensor_stats(const uint8_t tool_index, const bool kill_on_error/*=false*/, const bool disable/*=false*/) {
+  uint8_t check_tool_sensor_stats(const uint_fast8_t tool_index, const bool kill_on_error/*=false*/, const bool disable/*=false*/) {
     static uint8_t sensor_tries; // = 0
     for (;;) {
       if (poll_tool_sensor_pins() == _BV(tool_index)) {
@@ -497,7 +497,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     #endif // TOOL_SENSOR
   }
 
-  inline void switching_toolhead_tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
+  inline void switching_toolhead_tool_change(const uint_fast8_t new_tool, bool no_move/*=false*/) {
     if (no_move) return;
 
     constexpr float toolheadposx[] = SWITCHING_TOOLHEAD_X_POS;
@@ -601,7 +601,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
 #elif ENABLED(MAGNETIC_SWITCHING_TOOLHEAD)
 
-  inline void magnetic_switching_toolhead_tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
+  inline void magnetic_switching_toolhead_tool_change(const uint_fast8_t new_tool, bool no_move/*=false*/) {
     if (no_move) return;
 
     constexpr float toolheadposx[] = SWITCHING_TOOLHEAD_X_POS,
@@ -726,7 +726,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
   inline void est_deactivate_solenoid() { OUT_WRITE(SOL0_PIN, LOW); }
   void est_init() { est_activate_solenoid(); }
 
-  inline void em_switching_toolhead_tool_change(const uint8_t new_tool, bool no_move) {
+  inline void em_switching_toolhead_tool_change(const uint_fast8_t new_tool, bool no_move) {
     if (no_move) return;
 
     constexpr float toolheadposx[] = SWITCHING_TOOLHEAD_X_POS;
@@ -823,7 +823,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 #endif // ELECTROMAGNETIC_SWITCHING_TOOLHEAD
 
 #if HAS_EXTRUDERS
-  inline void invalid_extruder_error(const uint8_t e) {
+  inline void invalid_extruder_error(const uint_fast8_t e) {
     SERIAL_ECHO_START();
     SERIAL_CHAR('T'); SERIAL_ECHO(e);
     SERIAL_CHAR(' '); SERIAL_ECHOLNPGM(STR_INVALID_EXTRUDER);
@@ -839,7 +839,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
    * @param new_tool Tool index to activate
    * @param no_move Flag indicating no moves should take place
    */
-  inline void dualx_tool_change(const uint8_t new_tool, bool &no_move) {
+  inline void dualx_tool_change(const uint_fast8_t new_tool, bool &no_move) {
 
     DEBUG_ECHOPGM("Dual X Carriage Mode ");
     switch (dual_x_carriage_mode) {
@@ -924,7 +924,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
    * Returns TRUE if too cold to move (also echos message: STR_ERR_HOTEND_TOO_COLD)
    * Returns FALSE if able to  move.
    */
-  bool too_cold(uint8_t toolID){
+  bool too_cold(uint_fast8_t toolID){
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(toolID)) {
       SERIAL_ECHO_MSG(STR_ERR_HOTEND_TOO_COLD);
       return true;
@@ -1107,7 +1107,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
  * Perform a tool-change, which may result in moving the
  * previous tool out of the way and the new tool into place.
  */
-void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
+void tool_change(const uint_fast8_t new_tool, bool no_move/*=false*/) {
 
   if (TERN0(MAGNETIC_SWITCHING_TOOLHEAD, new_tool == active_extruder))
     return;
@@ -1173,7 +1173,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       constexpr bool idex_full_control = false;
     #endif
 
-    const uint8_t old_tool = active_extruder;
+    const uint_fast8_t old_tool = active_extruder;
     const bool can_move_away = !no_move && !idex_full_control;
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -1539,7 +1539,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
     // Migrate to a target or the next extruder
 
-    uint8_t migration_extruder = active_extruder;
+    uint_fast8_t migration_extruder = active_extruder;
 
     if (migration.target) {
       DEBUG_ECHOLNPGM("Migration using fixed target");

--- a/Marlin/src/module/tool_change.h
+++ b/Marlin/src/module/tool_change.h
@@ -72,31 +72,31 @@
 #endif
 
 #if DO_SWITCH_EXTRUDER
-  void move_extruder_servo(const uint8_t e);
+  void move_extruder_servo(const uint_fast8_t e);
 #endif
 
 #if ENABLED(SWITCHING_NOZZLE)
   #if SWITCHING_NOZZLE_TWO_SERVOS
-    void lower_nozzle(const uint8_t e);
-    void raise_nozzle(const uint8_t e);
+    void lower_nozzle(const uint_fast8_t e);
+    void raise_nozzle(const uint_fast8_t e);
   #else
-    void move_nozzle_servo(const uint8_t angle_index);
+    void move_nozzle_servo(const uint_fast8_t angle_index);
   #endif
 #endif
 
 #if ENABLED(PARKING_EXTRUDER)
 
-  void pe_solenoid_set_pin_state(const uint8_t extruder_num, const uint8_t state);
+  void pe_solenoid_set_pin_state(const uint_fast8_t extruder_num, const bool state);
 
   #define PE_MAGNET_ON_STATE TERN_(PARKING_EXTRUDER_SOLENOIDS_INVERT, !)PARKING_EXTRUDER_SOLENOIDS_PINS_ACTIVE
-  inline void pe_solenoid_magnet_on(const uint8_t extruder_num)  { pe_solenoid_set_pin_state(extruder_num,  PE_MAGNET_ON_STATE); }
-  inline void pe_solenoid_magnet_off(const uint8_t extruder_num) { pe_solenoid_set_pin_state(extruder_num, !PE_MAGNET_ON_STATE); }
+  inline void pe_solenoid_magnet_on(const uint_fast8_t extruder_num)  { pe_solenoid_set_pin_state(extruder_num,  PE_MAGNET_ON_STATE); }
+  inline void pe_solenoid_magnet_off(const uint_fast8_t extruder_num) { pe_solenoid_set_pin_state(extruder_num, !PE_MAGNET_ON_STATE); }
 
   void pe_solenoid_init();
 
   extern bool extruder_parked;
   inline void parking_extruder_set_parked(const bool parked) { extruder_parked = parked; }
-  bool parking_extruder_unpark_after_homing(const uint8_t final_tool, bool homed_towards_final_tool);
+  bool parking_extruder_unpark_after_homing(const uint_fast8_t final_tool, bool homed_towards_final_tool);
 
 #elif ENABLED(MAGNETIC_PARKING_EXTRUDER)
 
@@ -122,13 +122,13 @@
 #endif
 
 #if ENABLED(TOOL_SENSOR)
-  uint8_t check_tool_sensor_stats(const uint8_t active_tool, const bool kill_on_error=false, const bool disable=false);
+  uint8_t check_tool_sensor_stats(const uint_fast8_t active_tool, const bool kill_on_error=false, const bool disable=false);
 #else
-  inline uint8_t check_tool_sensor_stats(const uint8_t, const bool=false, const bool=false) { return 0; }
+  inline uint8_t check_tool_sensor_stats(const uint_fast8_t, const bool=false, const bool=false) { return 0; }
 #endif
 
 /**
  * Perform a tool-change, which may result in moving the
  * previous tool out of the way and the new tool into place.
  */
-void tool_change(const uint8_t tmp_extruder, bool no_move=false);
+void tool_change(const uint_fast8_t tmp_extruder, bool no_move=false);

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -205,7 +205,7 @@ inline void printPinStateExt(const pin_t pin, const bool ignore, const bool exte
     return true;
   };
 
-  for (uint8_t x = 0; x < COUNT(pin_array); ++x)  {    // scan entire array and report all instances of this pin
+  for (uint_fast8_t x = 0; x < COUNT(pin_array); ++x)  {  // scan entire array and report all instances of this pin
     if (getPinByIndex(x) == pin) {
       if (!found) {    // report digital and analog pin number only on the first time through
         if (start_string) SERIAL_ECHO(start_string);
@@ -213,7 +213,7 @@ inline void printPinStateExt(const pin_t pin, const bool ignore, const bool exte
         printPinNumber(pin);
         printPinPort(pin);
         if (int8_t(digitalPinToAnalogIndex(pin)) >= 0) printPinAnalog(pin); // analog pin number
-        else SERIAL_ECHO_SP(8);                                                 // add padding if not an analog pin
+        else SERIAL_ECHO_SP(8);                                             // add padding if not an analog pin
       }
       else {
         SERIAL_CHAR('.');

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -105,7 +105,7 @@
   #else
     static uint8_t CRC7(const uint8_t *data, uint8_t n) {
       uint8_t crc = 0;
-      for (uint8_t i = 0; i < n; ++i) {
+      for (uint_fast8_t i = 0; i < n; ++i) {
         uint8_t d = data[i];
         d ^= crc << 1;
         if (d & 0x80) d ^= 9;
@@ -143,7 +143,7 @@ uint8_t DiskIODriver_SPI_SD::cardCommand(const uint8_t cmd, const uint32_t arg) 
     d[5] = CRC7(d, 5);
 
     // Send message
-    for (uint8_t k = 0; k < 6; ++k) spiSend(d[k]);
+    for (uint_fast8_t k = 0; k < 6; ++k) spiSend(d[k]);
 
   #else
     // Send command
@@ -160,7 +160,7 @@ uint8_t DiskIODriver_SPI_SD::cardCommand(const uint8_t cmd, const uint32_t arg) 
   if (cmd == CMD12) spiRec();
 
   // Wait for response
-  for (uint8_t i = 0; ((status_ = spiRec()) & 0x80) && i != 0xFF; i++) { /* Intentionally left empty */ }
+  for (uint_fast8_t i = 0; ((status_ = spiRec()) & 0x80) && i != 0xFF; i++) { /* Intentionally left empty */ }
   return status_;
 }
 
@@ -316,7 +316,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
   spiInit(spiRate_);
 
   // Must supply min of 74 clock cycles with CS high.
-  for (uint8_t i = 0; i < 10; ++i) spiSend(0xFF);
+  for (uint_fast8_t i = 0; i < 10; ++i) spiSend(0xFF);
 
   hal.watchdog_refresh(); // In case init takes too long
 
@@ -342,7 +342,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
     }
 
     // Get the last byte of r7 response
-    for (uint8_t i = 0; i < 4; ++i) status_ = spiRec();
+    for (uint_fast8_t i = 0; i < 4; ++i) status_ = spiRec();
     if (status_ == 0xAA) {
       type(SD_CARD_TYPE_SD2);
       break;
@@ -374,7 +374,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
     }
     if ((spiRec() & 0xC0) == 0xC0) type(SD_CARD_TYPE_SDHC);
     // Discard rest of ocr - contains allowed voltage range
-    for (uint8_t i = 0; i < 3; ++i) spiRec();
+    for (uint_fast8_t i = 0; i < 3; ++i) spiRec();
   }
 
   chipDeselect();

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -80,7 +80,7 @@ bool SdBaseFile::addDirCluster() {
   memset(vol_->cacheBuffer_.data, 0, 512);
 
   // zero rest of cluster
-  for (uint8_t i = 1; i < vol_->blocksPerCluster_; i++) {
+  for (uint_fast8_t i = 1; i < vol_->blocksPerCluster_; i++) {
     if (!vol_->writeBlock(block + i, vol_->cacheBuffer_.data)) return false;
   }
   // Increase directory file size by cluster size
@@ -209,7 +209,7 @@ bool SdBaseFile::dirEntry(dir_t *dir) {
  */
 void SdBaseFile::dirName(const dir_t &dir, char *name) {
   uint8_t j = 0;
-  for (uint8_t i = 0; i < 11; ++i) {
+  for (uint_fast8_t i = 0; i < 11; ++i) {
     if (dir.name[i] == ' ')continue;
     if (i == 8) name[j++] = '.';
     name[j++] = dir.name[i];
@@ -350,10 +350,10 @@ int8_t SdBaseFile::lsPrintNext(const uint8_t flags, const uint8_t indent) {
         && DIR_IS_FILE_OR_SUBDIR(&dir)) break;
   }
   // indent for dir level
-  for (uint8_t i = 0; i < indent; ++i) SERIAL_CHAR(' ');
+  for (uint_fast8_t i = 0; i < indent; ++i) SERIAL_CHAR(' ');
 
   // print name
-  for (uint8_t i = 0; i < 11; ++i) {
+  for (uint_fast8_t i = 0; i < 11; ++i) {
     if (dir.name[i] == ' ')continue;
     if (i == 8) {
       SERIAL_CHAR('.');
@@ -394,7 +394,7 @@ int8_t SdBaseFile::lsPrintNext(const uint8_t flags, const uint8_t indent) {
  */
 uint8_t lfn_checksum(const uint8_t *name) {
   uint8_t sum = 0;
-  for (uint8_t i = 11; i; i--)
+  for (uint_fast8_t i = 11; i; i--)
     sum = ((sum & 1) << 7) + (sum >> 1) + *name++;
   return sum;
 }
@@ -504,7 +504,7 @@ bool SdBaseFile::mkdir(SdBaseFile * const parent, const uint8_t dname[11]
   dir_t d;
   memcpy(&d, p, sizeof(d));
   d.name[0] = '.';
-  for (uint8_t i = 1; i < 11; ++i) d.name[i] = ' ';
+  for (uint_fast8_t i = 1; i < 11; ++i) d.name[i] = ' ';
 
   // cache block for '.'  and '..'
   uint32_t block = vol_->clusterStartBlock(firstCluster_);
@@ -771,7 +771,7 @@ bool SdBaseFile::open(SdBaseFile * const dirFile, const uint8_t dname[11]
       if (!dirFile->seekSet(32 * index)) return false;
 
       // Dir entries write loop: [LFN] + SFN(1)
-      for (uint8_t dirWriteIdx = 0; dirWriteIdx < reqEntriesNum; ++dirWriteIdx) {
+      for (uint_fast8_t dirWriteIdx = 0; dirWriteIdx < reqEntriesNum; ++dirWriteIdx) {
         index = (dirFile->curPosition_ / 32) & 0xF;
         p = dirFile->readDirCache();
         // LFN or SFN Entry?
@@ -1137,7 +1137,7 @@ bool SdBaseFile::openNext(SdBaseFile *dirFile, const uint8_t oflag) {
    */
   void SdBaseFile::getLFNName(vfat_t *pFatDir, char *lname, const uint8_t sequenceNumber) {
     const uint8_t startOffset = (sequenceNumber - 1) * FILENAME_LENGTH;
-    for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
+    for (uint_fast8_t i = 0; i < FILENAME_LENGTH; ++i) {
       const uint16_t utf16_ch = (i >= 11) ? pFatDir->name3[i - 11] : (i >= 5) ? pFatDir->name2[i - 5] : pFatDir->name1[i];
       #if ENABLED(UTF_FILENAME_SUPPORT)
         // We can't reconvert to UTF-8 here as UTF-8 is variable-size encoding, but joining LFN blocks
@@ -1158,7 +1158,7 @@ bool SdBaseFile::openNext(SdBaseFile *dirFile, const uint8_t oflag) {
   void SdBaseFile::setLFNName(vfat_t *pFatDir, char *lname, const uint8_t sequenceNumber) {
     const uint8_t startOffset = (sequenceNumber - 1) * FILENAME_LENGTH,
                   nameLength = strlen(lname);
-    for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
+    for (uint_fast8_t i = 0; i < FILENAME_LENGTH; ++i) {
       uint16_t ch = 0;
       if ((startOffset + i) < nameLength)
         ch = lname[startOffset + i];
@@ -1479,7 +1479,7 @@ int8_t SdBaseFile::readDir(dir_t * const dir, char * const longFilename) {
 
               n = (seq - 1) * (FILENAME_LENGTH);
 
-              for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
+              for (uint_fast8_t i = 0; i < FILENAME_LENGTH; ++i) {
                 const uint16_t utf16_ch = (i >= 11) ? VFAT->name3[i - 11] : (i >= 5) ? VFAT->name2[i - 5] : VFAT->name1[i];
                 #if ENABLED(UTF_FILENAME_SUPPORT)
                   // We can't reconvert to UTF-8 here as UTF-8 is variable-size encoding, but joining LFN blocks
@@ -1627,7 +1627,7 @@ bool SdBaseFile::remove() {
     // Check if the entry has a LFN
     bool lastEntry = false;
     // loop back to search for any LFN entries related to this file
-    for (uint8_t sequenceNumber = 1; sequenceNumber <= VFAT_ENTRIES_LIMIT; ++sequenceNumber) {
+    for (uint_fast8_t sequenceNumber = 1; sequenceNumber <= VFAT_ENTRIES_LIMIT; ++sequenceNumber) {
       dirIndex_ = (dirIndex_ - 1) & 0xF;
       if (dirBlock_ == 0) break;
       if (dirIndex_ == 0xF) dirBlock_--;

--- a/Marlin/src/sd/SdFile.cpp
+++ b/Marlin/src/sd/SdFile.cpp
@@ -82,7 +82,7 @@ void SdFile::write(const char * const str) { SdBaseFile::write(str, strlen(str))
  * Use writeError to check for errors.
  */
 void SdFile::write_P(PGM_P str) {
-  for (uint8_t c; (c = pgm_read_byte(str)); str++) write(c);
+  for (uint_fast8_t c; (c = pgm_read_byte(str)); str++) write(c);
 }
 
 /**

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -194,7 +194,7 @@ CardReader::CardReader() {
 //
 char *createFilename(char * const buffer, const dir_t &p) {
   char *pos = buffer;
-  for (uint8_t i = 0; i < 11; ++i) {
+  for (uint_fast8_t i = 0; i < 11; ++i) {
     if (p.name[i] == ' ') continue;
     if (i == 8) *pos++ = '.';
     *pos++ = p.name[i];
@@ -267,7 +267,7 @@ void CardReader::selectByIndex(MediaFile dir, const int16_t index) {
 //
 void CardReader::selectByName(MediaFile dir, const char * const match) {
   dir_t p;
-  for (uint8_t cnt = 0; dir.readDir(&p, longFilename) > 0; cnt++) {
+  for (uint_fast8_t cnt = 0; dir.readDir(&p, longFilename) > 0; cnt++) {
     if (is_visible_entity(p)) {
       createFilename(filename, p);
       if (strcasecmp(match, filename) == 0) return;
@@ -655,7 +655,7 @@ void CardReader::getAbsFilenameInCWD(char *dst) {
     if (cnt < MAXPATHNAMELENGTH) { *dst = '/'; dst++; cnt++; }
   };
 
-  for (uint8_t i = 0; i < workDirDepth; ++i)                // Loop down to current work dir
+  for (uint_fast8_t i = 0; i < workDirDepth; ++i)                // Loop down to current work dir
     appendAtom(workDirParents[i]);
 
   if (cnt < MAXPATHNAMELENGTH - (FILENAME_LENGTH) - 1) {    // Leave room for filename and nul
@@ -1412,7 +1412,7 @@ void CardReader::cdroot() {
       #if ENABLED(SDSORT_DYNAMIC_RAM)
         delete [] sort_order;
         #if ENABLED(SDSORT_CACHE_NAMES)
-          for (uint8_t i = 0; i < sort_count; ++i) {
+          for (uint_fast8_t i = 0; i < sort_count; ++i) {
             free(sortshort[i]); // strdup
             free(sortnames[i]); // strdup
           }

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/Usb.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/Usb.cpp
@@ -59,7 +59,7 @@ EpInfo* USB::getEpInfoEntry(uint8_t addr, uint8_t ep) {
 
   EpInfo *pep = p->epinfo;
 
-  for (uint8_t i = 0; i < p->epcount; i++) {
+  for (uint_fast8_t i = 0; i < p->epcount; i++) {
     if ((pep)->epAddr == ep)
       return pep;
 
@@ -455,14 +455,14 @@ void USB::Task() { // USB state machine
       break;
   }
 
-  for (uint8_t i = 0; i < USB_NUMDEVICES; i++)
+  for (uint_fast8_t i = 0; i < USB_NUMDEVICES; i++)
     if (devConfig[i]) rcode = devConfig[i]->Poll();
 
   switch (usb_task_state) {
     case USB_DETACHED_SUBSTATE_INITIALIZE:
       init();
 
-      for (uint8_t i = 0; i < USB_NUMDEVICES; i++)
+      for (uint_fast8_t i = 0; i < USB_NUMDEVICES; i++)
         if (devConfig[i])
           rcode = devConfig[i]->Release();
 
@@ -733,7 +733,7 @@ uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
 
 uint8_t USB::ReleaseDevice(uint8_t addr) {
   if (addr) {
-    for (uint8_t i = 0; i < USB_NUMDEVICES; i++) {
+    for (uint_fast8_t i = 0; i < USB_NUMDEVICES; i++) {
       if (!devConfig[i]) continue;
       if (devConfig[i]->GetAddress() == addr)
         return devConfig[i]->Release();

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/UsbCore.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/UsbCore.h
@@ -229,7 +229,7 @@ public:
   };
 
   uint8_t RegisterDeviceClass(USBDeviceConfig *pdev) {
-    for (uint8_t i = 0; i < USB_NUMDEVICES; i++) {
+    for (uint_fast8_t i = 0; i < USB_NUMDEVICES; i++) {
       if (!devConfig[i]) {
         devConfig[i] = pdev;
         return 0;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/address.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/address.h
@@ -117,7 +117,7 @@ class AddressPoolImpl : public AddressPool {
   // Return thePool index for a given address
 
   uint8_t FindAddressIndex(uint8_t address = 0) {
-    for (uint8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
+    for (uint_fast8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
       if (thePool[i].address.devAddress == address)
         return i;
 
@@ -127,7 +127,7 @@ class AddressPoolImpl : public AddressPool {
   // Return thePool child index for a given parent
 
   uint8_t FindChildIndex(UsbDeviceAddress addr, uint8_t start = 1) {
-    for (uint8_t i = (start < 1 || start >= MAX_DEVICES_ALLOWED) ? 1 : start; i < MAX_DEVICES_ALLOWED; i++) {
+    for (uint_fast8_t i = (start < 1 || start >= MAX_DEVICES_ALLOWED) ? 1 : start; i < MAX_DEVICES_ALLOWED; i++) {
       if (thePool[i].address.bmParent == addr.bmAddress)
         return i;
     }
@@ -143,7 +143,7 @@ class AddressPoolImpl : public AddressPool {
     UsbDeviceAddress uda = thePool[index].address;
     // If a hub was switched off all port addresses should be freed
     if (uda.bmHub == 1) {
-      for (uint8_t i = 1; (i = FindChildIndex(uda, i));)
+      for (uint_fast8_t i = 1; (i = FindChildIndex(uda, i));)
         FreeAddressByIndex(i);
 
       // If the hub had the last allocated address, hubCounter should be decremented
@@ -155,7 +155,7 @@ class AddressPoolImpl : public AddressPool {
   // Initialize the whole address pool at once
 
   void InitAllAddresses() {
-    for (uint8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
+    for (uint_fast8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
       InitEntry(i);
 
     hubCounter = 0;
@@ -190,7 +190,7 @@ public:
 
   void ForEachUsbDevice(UsbDeviceHandleFunc pfunc) {
     if (pfunc) {
-      for (uint8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
+      for (uint_fast8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
         if (thePool[i].address.devAddress)
           pfunc(thePool + i);
     }
@@ -264,7 +264,7 @@ public:
   //uint8_t GetNumHubs() { return hubCounter; }
   //uint8_t GetNumDevices() {
   //  uint8_t counter = 0;
-  //  for (uint8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
+  //  for (uint_fast8_t i = 1; i < MAX_DEVICES_ALLOWED; i++)
   //    if (thePool[i].address != 0); counter++;
   //  return counter;
   //}

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
@@ -188,7 +188,7 @@ void ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::PrintHidDescrip
   Notify(PSTR("\r\nbNumDescriptors:\t"), 0x80);
   PrintHex<uint8_t > (pDesc->bNumDescriptors, 0x80);
 
-  for (uint8_t i = 0; i < pDesc->bNumDescriptors; i++) {
+  for (uint_fast8_t i = 0; i < pDesc->bNumDescriptors; i++) {
     HID_CLASS_DESCRIPTOR_LEN_AND_TYPE *pLT = (HID_CLASS_DESCRIPTOR_LEN_AND_TYPE*)&(pDesc->bDescrType);
 
     Notify(PSTR("\r\nbDescrType:\t\t"), 0x80);

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
@@ -357,7 +357,7 @@ uint8_t BulkOnly::Init(uint8_t parent __attribute__((unused)), uint8_t port __at
 
   USBTRACE2("NC:", num_of_conf);
 
-  for (uint8_t i = 0; i < num_of_conf; i++) {
+  for (uint_fast8_t i = 0; i < num_of_conf; i++) {
     ConfigDescParser< USB_CLASS_MASS_STORAGE,
       MASS_SUBCLASS_SCSI,
       MASS_PROTO_BBB,
@@ -395,7 +395,7 @@ uint8_t BulkOnly::Init(uint8_t parent __attribute__((unused)), uint8_t port __at
 
   delay(1000); // Delay a bit for slow firmware.
 
-  for (uint8_t lun = 0; lun <= bMaxLUN; lun++) {
+  for (uint_fast8_t lun = 0; lun <= bMaxLUN; lun++) {
     InquiryResponse response;
     rcode = Inquiry(lun, sizeof (InquiryResponse), (uint8_t*) & response);
     if (rcode) {
@@ -591,7 +591,7 @@ uint8_t BulkOnly::Release() {
 bool BulkOnly::CheckLUN(uint8_t lun) {
   uint8_t rcode;
   Capacity capacity;
-  for (uint8_t i = 0; i < 8; i++) capacity.data[i] = 0;
+  for (uint_fast8_t i = 0; i < 8; i++) capacity.data[i] = 0;
 
   rcode = ReadCapacity10(lun, (uint8_t*)capacity.data);
   if (rcode) {
@@ -599,7 +599,7 @@ bool BulkOnly::CheckLUN(uint8_t lun) {
     return false;
   }
   ErrorMessage<uint8_t> (PSTR(">>>>>>>>>>>>>>>>CAPACITY OK ON LUN"), lun);
-  for (uint8_t i = 0; i < 8 /*sizeof (Capacity)*/; i++)
+  for (uint_fast8_t i = 0; i < 8 /*sizeof (Capacity)*/; i++)
           D_PrintHex<uint8_t> (capacity.data[i], 0x80);
   Notify(PSTR("\r\n\r\n"), 0x80);
 
@@ -628,7 +628,7 @@ bool BulkOnly::CheckLUN(uint8_t lun) {
  * Scan for media change on all LUNs
  */
 void BulkOnly::CheckMedia() {
-  for (uint8_t lun = 0; lun <= bMaxLUN; lun++) {
+  for (uint_fast8_t lun = 0; lun <= bMaxLUN; lun++) {
     if (TestUnitReady(lun)) {
       LUNOk[lun] = false;
       continue;
@@ -637,7 +637,7 @@ void BulkOnly::CheckMedia() {
   }
   #if 0
     printf("}}}}}}}}}}}}}}}}STATUS ");
-    for (uint8_t lun = 0; lun <= bMaxLUN; lun++)
+    for (uint_fast8_t lun = 0; lun <= bMaxLUN; lun++)
       printf(LUNOk[lun] ? "#" : ".");
     printf("\r\n");
   #endif
@@ -857,7 +857,7 @@ uint8_t BulkOnly::ResetRecovery() {
  * Clear all EP data and clear all LUN status
  */
 void BulkOnly::ClearAllEP() {
-  for (uint8_t i = 0; i < MASS_MAX_ENDPOINTS; i++) {
+  for (uint_fast8_t i = 0; i < MASS_MAX_ENDPOINTS; i++) {
     epInfo[i].epAddr = 0;
     epInfo[i].maxPktSize = (i) ? 0 : 8;
     epInfo[i].bmSndToggle = 0;
@@ -865,7 +865,7 @@ void BulkOnly::ClearAllEP() {
     epInfo[i].bmNakPower = USB_NAK_DEFAULT;
   }
 
-  for (uint8_t i = 0; i < MASS_MAX_SUPPORTED_LUN; i++) {
+  for (uint_fast8_t i = 0; i < MASS_MAX_SUPPORTED_LUN; i++) {
     LUNOk[i] = false;
     WriteOk[i] = false;
     CurrentCapacity[i] = 0UL;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/usbhost.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/usbhost.cpp
@@ -97,7 +97,7 @@ uint8_t MAX3421e::gpioRd() {
 bool MAX3421e::reset() {
   regWr(rUSBCTL, bmCHIPRES);
   regWr(rUSBCTL, 0x00);
-  for (uint8_t i = 100; i--;) {
+  for (uint_fast8_t i = 100; i--;) {
     if (regRd(rUSBIRQ) & bmOSCOKIRQ) return true;
     delay(10);
   }

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD_INLINE.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD_INLINE.h
@@ -882,7 +882,7 @@ void UHS_NI MAX3421E_HOST::ISRbottom() {
     #ifdef USB_HOST_MANUAL_POLL
       if (usb_task_state == UHS_USB_HOST_STATE_RUNNING) {
         noInterrupts();
-        for (uint8_t x = 0; x < UHS_HOST_MAX_INTERFACE_DRIVERS; x++)
+        for (uint_fast8_t x = 0; x < UHS_HOST_MAX_INTERFACE_DRIVERS; x++)
           if (devConfig[x] && devConfig[x]->bPollEnable)
             devConfig[x]->Poll();
         interrupts();


### PR DESCRIPTION
- Use fast types for most commonly-accessed variables to remove the need for extension / sign-extension to the full register size.
- Every case should be examined closely in the compiled assembler code to see whether it actually makes a difference.
- Rather than changing every variable everywhere, focus on areas of the code where the MCU spends the most time.