### PR TITLE
Fix hang caused by la_interval == 0

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2119,7 +2119,6 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
              - ((uint16_t(pgm_read_word(table_address + 2)) * uint8_t(step_rate & 0x0007)) >> 3);
     }
     else {
-      step_rate = 0;
       return uint16_t(pgm_read_word(uintptr_t(speed_lookuptable_slow)));
     }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2250,7 +2250,7 @@ hal_timer_t Stepper::block_phase_isr() {
         #if ENABLED(LIN_ADVANCE)
           if (la_active) {
             const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
-            la_interval = calc_timer_interval(acc_step_rate + la_step_rate) << current_block->la_scaling;
+            la_interval = calc_timer_interval((acc_step_rate + la_step_rate) >> current_block->la_scaling);
           }
         #endif
 
@@ -2322,7 +2322,7 @@ hal_timer_t Stepper::block_phase_isr() {
             const uint32_t la_step_rate = la_advance_steps > current_block->final_adv_steps ? current_block->la_advance_rate : 0;
             if (la_step_rate != step_rate) {
               bool reverse_e = la_step_rate > step_rate;
-              la_interval = calc_timer_interval(reverse_e ? la_step_rate - step_rate : step_rate - la_step_rate) << current_block->la_scaling;
+              la_interval = calc_timer_interval((reverse_e ? la_step_rate - step_rate : step_rate - la_step_rate) >> current_block->la_scaling);
 
               if (reverse_e != motor_direction(E_AXIS)) {
                 TBI(last_direction_bits, E_AXIS);
@@ -2379,8 +2379,9 @@ hal_timer_t Stepper::block_phase_isr() {
           ticks_nominal = calc_multistep_timer_interval(current_block->nominal_rate << oversampling_factor);
 
           #if ENABLED(LIN_ADVANCE)
-            if (la_active)
-              la_interval = calc_timer_interval(current_block->nominal_rate) << current_block->la_scaling;
+            if (la_active) {
+              la_interval = calc_timer_interval(current_block->nominal_rate >> current_block->la_scaling);
+            }
           #endif
         }
 
@@ -2702,7 +2703,7 @@ hal_timer_t Stepper::block_phase_isr() {
       #if ENABLED(LIN_ADVANCE)
         if (la_active) {
           const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
-          la_interval = calc_timer_interval(current_block->initial_rate + la_step_rate) << current_block->la_scaling;
+          la_interval = calc_timer_interval((current_block->initial_rate + la_step_rate) >> current_block->la_scaling);
         }
       #endif
     }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2102,7 +2102,7 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
     if (step_rate >= 0x0800) {  // higher step rate
       // AVR is able to keep up at around 65kHz Stepping ISR rate at most.
       // So values for step_rate > 65535 might as well be truncated.
-      // Handle it as quickly as possible, e.g. assume highest byte is zero
+      // Handle it as quickly as possible. i.e., assume highest byte is zero
       // because non-zero would represent a step rate far beyond AVR capabilities.
       if (uint8_t(step_rate >> 16))
         return uint32_t(STEPPER_TIMER_RATE) / 0x10000;
@@ -2118,9 +2118,8 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
       return uint16_t(pgm_read_word(table_address))
              - ((uint16_t(pgm_read_word(table_address + 2)) * uint8_t(step_rate & 0x0007)) >> 3);
     }
-    else {
-      return uint16_t(pgm_read_word(uintptr_t(speed_lookuptable_slow)));
-    }
+
+    return uint16_t(pgm_read_word(uintptr_t(speed_lookuptable_slow)));
 
   #endif // !CPU_32_BIT
 }


### PR DESCRIPTION
### Description

#25474 Introduced a change to `calc_timer_interval()` that exposed a pre-existing linear advance bug by causing a hang.

Under linear advance, the stepper ISR can be called at a much higher rate (but have far less work to do) than the rate normal steps generate. This is to do with how LA uses the bresenham algorithm as a way to drive both advance and ordinary E steps.

In extreme edge cases, `calc_timer_interval()` may even be called with a parameter greater than 65535, i.e. above 16 bits. The case I encountered was for very short segments with backlash compensation enabled where the added backlash confuses the LA acceleration limiting code in planner.cpp. The segment was so short that it really didn't matter, except that it now causes a hang.

With the old `calc_timer_interval()`, a spurious (and much too large) value for la_interval is calculated. With the new one, it is just possible that an overflow in the lookup into `speed_lookuptable_fast` could hit the dummy line which is all zeros. This results in `la_interval == 0` and, consequently, an infinite loop in the stepper ISR.

This PR responds with two fixes. First, the effect of `current_block->la_scaling` is now applied before calling `calc_timer_interval()` which reduces the bitcount of the parameter. Second, `calc_timer_interval()` now handles bitcounts above 16 bits by returning a fixed result (which is in line with the AVR's maximum call rate of the ISR). This new code costs an extra two CPU cycles per call to `calc_timer_interval()`.

### Requirements

`LIN_ADVANCE` and `BACKLASH_COMPENSATION` and a higher steps/mm for the extruder (on mine it was 551 steps/mm).

### Benefits

Print doesn't hang.

### Configurations

[stepperzerointervalfix.zip](https://github.com/MarlinFirmware/Marlin/files/11011909/stepperzerointervalfix.zip)

### Related Issues

#25474
