### PR TITLE
Update mosfet pins in pins_MKS_GEN_L_V21.h

### DIFF
--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
@@ -35,7 +35,8 @@
 // Heaters / Fans
 //
 // Power outputs EFBF or EFBE
-#define MOSFET_D_PIN                           7
+#define MOSFET_B_PIN                           7
+#define FAN_PIN                                9
 
 //
 // CS Pins wired to avoid conflict with the LCD


### PR DESCRIPTION
### Description

Current configuration does not set up mosfet pins correctly with multiple extruders, single extrudesr worked as expected

### Expected behavior
```cpp
#define HEATER_1_PIN 7
#define HEATER_BED_PIN 8
#define FAN_PIN 9
#define HEATER_0_PIN 10
```

### Actual behavior
```cpp
#define HEATER_1_PIN 9
#define HEATER_BED_PIN 8
#define FAN_PIN 4
#define HEATER_0_PIN 10
```

### with this fix 
```
 PIN:   7   Port: H4        HEATER_1_PIN                     
 PIN:   8   Port: H5        HEATER_BED_PIN               
 PIN:   9   Port: H6        FAN_PIN
 PIN:  10   Port: B4        HEATER_0_PIN
```
### Requirements

`MKS_GEN_L_V21` with 2 extruders.

### Benefits

Mosfet pins are as expected with 2 extruders.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/25488