### PR TITLE
Remove Thermal Protection Variance Monitor Recommendation/Warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -63,11 +63,6 @@
   #warning "Warning! Don't use dummy thermistors (998/999) for final build!"
 #endif
 
-#if ANY(THERMAL_PROTECTION_HOTENDS, THERMAL_PROTECTION_BED, THERMAL_PROTECTION_CHAMBER, THERMAL_PROTECTION_COOLER) \
-  && NONE(THERMAL_PROTECTION_VARIANCE_MONITOR, NO_VARIANCE_MONITOR_WARNING)
-  #warning "THERMAL_PROTECTION_VARIANCE_MONITOR is recommended. See Configuration_adv.h for details. (Define NO_VARIANCE_MONITOR_WARNING to suppress this.)"
-#endif
-
 #if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT)
   #warning "Your Configuration provides no method to acquire user feedback!"
 #endif


### PR DESCRIPTION
### Description

This feature is still marked as experimental and easily fails on machines with half-decent PID/MPC tunes.

### Benefits

Users won't be bugged to enable an experimental feature.