### PR TITLE
Fix print hang with LA

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2094,10 +2094,8 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
 
   #ifdef CPU_32_BIT
 
-    if (step_rate != 0)
-      return uint32_t(STEPPER_TIMER_RATE) / step_rate; // A fast processor can just do integer division
-
-    return HAL_TIMER_TYPE_MAX;
+    // A fast processor can just do integer division
+    return step_rate ? uint32_t(STEPPER_TIMER_RATE) / step_rate : HAL_TIMER_TYPE_MAX;
 
   #else
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2254,7 +2254,7 @@ hal_timer_t Stepper::block_phase_isr() {
         #if ENABLED(LIN_ADVANCE)
           if (la_active) {
             const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
-            la_interval = calc_timer_interval((acc_step_rate + la_step_rate) >> current_block->la_scaling);
+            la_interval = calc_timer_interval(acc_step_rate + la_step_rate) << current_block->la_scaling;
           }
         #endif
 
@@ -2326,7 +2326,7 @@ hal_timer_t Stepper::block_phase_isr() {
             const uint32_t la_step_rate = la_advance_steps > current_block->final_adv_steps ? current_block->la_advance_rate : 0;
             if (la_step_rate != step_rate) {
               bool reverse_e = la_step_rate > step_rate;
-              la_interval = calc_timer_interval((reverse_e ? la_step_rate - step_rate : step_rate - la_step_rate) >> current_block->la_scaling);
+              la_interval = calc_timer_interval(reverse_e ? la_step_rate - step_rate : step_rate - la_step_rate) << current_block->la_scaling;
 
               if (reverse_e != motor_direction(E_AXIS)) {
                 TBI(last_direction_bits, E_AXIS);
@@ -2384,7 +2384,7 @@ hal_timer_t Stepper::block_phase_isr() {
 
           #if ENABLED(LIN_ADVANCE)
             if (la_active)
-              la_interval = calc_timer_interval(current_block->nominal_rate >> current_block->la_scaling);
+              la_interval = calc_timer_interval(current_block->nominal_rate) << current_block->la_scaling;
           #endif
         }
 
@@ -2706,7 +2706,7 @@ hal_timer_t Stepper::block_phase_isr() {
       #if ENABLED(LIN_ADVANCE)
         if (la_active) {
           const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
-          la_interval = calc_timer_interval((current_block->initial_rate + la_step_rate) >> current_block->la_scaling);
+          la_interval = calc_timer_interval(current_block->initial_rate + la_step_rate) << current_block->la_scaling;
         }
       #endif
     }


### PR DESCRIPTION
### Description

#25541 causes the MCU to hang and then reboot when using LA. This is reported on 32 bit MCUs and so cannot be caused by the changes to the AVR `calc_timer_interval()` code. The only other change was to bit shift the parameter to `calc_timer_interval()` rather than bit shift the result. This must now be causing a division by zero in some cases.

Since the change to the bit shift was only there for high speed edge cases with an AVR and only to increase the accuracy of the LA step timer interval, it can be reverted.

[Edit: But a better change would be to handle the division by zero which is only ever going to happen when the LA ISR interval is supposed to be greater than 1 second, which is an undesirable edge case that block E stepper movement. If `calc_timer_interval()` returns `HAL_TIMER_TYPE_MAX` (i.e. `LA_ADV_NEVER`) then as soon as a more reasonable ISR rate is generated, it will be applied.]

### Related Issues

#25553

