### PR TITLE
Fix z_probe_offset changing with z_min_pos

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2207,11 +2207,11 @@
 // The center of the bed is at (X=0, Y=0)
 //#define BED_CENTER_AT_0_0
 
-// Manually set the home position. Leave these undefined for automatic settings.
+// Manually set the home/zero position. Leave these undefined for automatic settings.
 // For DELTA this is the top-center of the Cartesian print volume.
 //#define MANUAL_X_HOME_POS 0
 //#define MANUAL_Y_HOME_POS 0
-//#define MANUAL_Z_HOME_POS 0
+//#define MANUAL_Z_HOME_POS 0 //This is the position where Marlin expects the nozzle and bed to touch
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0
 //#define MANUAL_K_HOME_POS 0

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -313,7 +313,7 @@
 #ifdef MANUAL_Z_HOME_POS
   #define Z_HOME_POS MANUAL_Z_HOME_POS
 #else
-  #define Z_HOME_POS TERN(Z_HOME_TO_MIN, Z_MIN_POS, Z_MAX_POS)
+  #define Z_HOME_POS TERN(Z_HOME_TO_MIN, 0, Z_MAX_POS)
 #endif
 
 #if HAS_I_AXIS


### PR DESCRIPTION
### Description
Z_HOME_POS (coordinate reference frame, i.e. ideally where the nozzle meets the bed) uses Z_MIN_POS. However, Z_MIN_POS is actually supposed to be a travel limit, not the reference point for moves. When Z_MIN_POS is used instead of zero as the reference point, users inevitably have to set a z offset in their slicer or change the Z aspect of the NOZZLE_TO_PROBE_OFFSET since their zero point (where the machine thinks the probe and the bed are meeting) has shifted by Z_MIN_POS unexpectedly. Neither option reflects the intent of Z_MIN_POS, which is "Travel limits (linear=mm, rotational=°) **after homing**, corresponding to endstop positions" (emphasis added). I.e. Z_MIN_POS is supposed to be relative to Z_HOME_POS, not moving it!

### Requirements

The bug affects everyone who assigns Z_MIN_POS with a nonzero value and enabled USE_PROBE_FOR_Z_HOMING.

### Benefits

Fixes the bug

### Configurations


### Related Issues

#25365,#23434,#23796