### PR TITLE
Refine MKS boards with a dedicated FAN port

### DIFF
--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -146,39 +146,34 @@
 //#define TEMP_1_MOSI_PIN        TEMP_0_MOSI_PIN
 
 //
-// FET Pin Mapping - FET 1 is closest to the input power connector
+// FET Pin Mapping - FET A is closest to the input power connector
 //
 
-#define MOSFET_1_PIN                           6  // Plug EX1 Pin 1-2 -> PH3 #15 -> Logical 06
-#define MOSFET_2_PIN                           7  // Plug EX1 Pin 3-4 -> PH4 #16 -> Logical 07
-#define MOSFET_3_PIN                          11  // Plug EX2 1-2 -> PB5 #24 -> Logical 11
-#define MOSFET_4_PIN                          12  // Plug EX2 3-4 -> PB6 #25 -> Logical 12
-#define MOSFET_5_PIN                          45  // Plug HBD 1-2 -> PL4 #39 -> Logical 45
-#define MOSFET_6_PIN                          44  // Plug Extra 1-2 -> PL5 #40 -> Logical 44 (FET not soldered in all boards)
+#define MOSFET_A_PIN                           6  // Plug EX1 Pin 1-2 -> PH3 #15 -> Logical 06
+#define MOSFET_B_PIN                          11  // Plug EX2 1-2 -> PB5 #24 -> Logical 11
+#define MOSFET_C_PIN                          45  // Plug HBD 1-2 -> PL4 #39 -> Logical 45
+#define MOSFET_D_PIN                           7  // Plug EX1 Pin 3-4 -> PH4 #16 -> Logical 07
+#define MOSFET_E_PIN                          12  // Plug EX2 3-4 -> PB6 #25 -> Logical 12
+#define MOSFET_F_PIN                          44  // Plug Extra 1-2 -> PL5 #40 -> Logical 44 (FET not soldered in all boards)
 
 //
 // Heaters / Fans (24V)
 //
 
-#define HEATER_0_PIN                MOSFET_1_PIN  // EX1
-#define HEATER_1_PIN                MOSFET_3_PIN  // EX2
-#define HEATER_BED_PIN              MOSFET_5_PIN  // HBP
+#define HEATER_0_PIN                MOSFET_A_PIN  // EX1
+#define HEATER_1_PIN                MOSFET_B_PIN  // EX2
+#define HEATER_BED_PIN              MOSFET_C_PIN  // HBP
 
-// EX1 FAN (Automatic Fans are disabled by default in Configuration_adv.h - comment that out for auto fans)
 #ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN           MOSFET_2_PIN
-#else
-  #ifndef FAN_PIN
-    #define FAN_PIN                 MOSFET_2_PIN
-  #endif
+  #define E0_AUTO_FAN_PIN           MOSFET_D_PIN
+#elif !defined(FAN_PIN)
+  #define FAN_PIN                   MOSFET_D_PIN
 #endif
-// EX2 FAN (Automatic Fans are disabled by default in Configuration_adv.h - comment that out for auto fans)
+
 #ifndef E1_AUTO_FAN_PIN
-  #define E1_AUTO_FAN_PIN           MOSFET_4_PIN
-#else
-  #ifndef FAN1_PIN
-    #define FAN1_PIN                MOSFET_4_PIN
-  #endif
+  #define E1_AUTO_FAN_PIN           MOSFET_E_PIN
+#elif !defined(FAN1_PIN)
+  #define FAN1_PIN                  MOSFET_E_PIN
 #endif
 
 //

--- a/Marlin/src/pins/ramps/pins_BIQU_KFB_2.h
+++ b/Marlin/src/pins/ramps/pins_BIQU_KFB_2.h
@@ -35,7 +35,6 @@
 //
 // Heaters / Fans
 //
-// Power outputs BEEF or BEFF
-#define MOSFET_D_PIN        7
+#define MOSFET_D_PIN                           7
 
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_FELIX2.h
+++ b/Marlin/src/pins/ramps/pins_FELIX2.h
@@ -35,7 +35,6 @@
 //
 // Heaters / Fans
 //
-// Power outputs EFBF or EFBE
 #define MOSFET_D_PIN                          7
 
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
@@ -33,11 +33,6 @@
 #define BOARD_INFO_NAME "MKS BASE 1.4"
 #define MKS_BASE_VERSION                      14
 
-//
-// Heaters / Fans
-//
-#define FAN_PIN                                9  // PH6 ** Pin18 ** PWM9
-
 // Other Mods
 
 #define SERVO3_PIN                            12  // PB6 ** Pin25 ** D12

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_common.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_common.h
@@ -34,8 +34,8 @@
   //
   // Heaters / Fans
   //
-  // Power outputs EFBF or EFBE
-  #define MOSFET_D_PIN                         7
+  #define MOSFET_B_PIN                         7
+  #define FAN_PIN                              9
 
   //
   // M3/M4/M5 - Spindle/Laser Control
@@ -50,12 +50,9 @@
     #define CASE_LIGHT_PIN                     2
   #endif
 
-#endif
-
-//
-// Microstepping pins
-//
-#if MKS_BASE_VERSION >= 14                        //     |===== 1.4 =====|===== 1.5+ =====|
+  //
+  // Microstepping pins
+  //                                                     |===== 1.4 =====|===== 1.5+ =====|
   #define X_MS1_PIN                            5  // PE3 | Pin  5 | PWM5 |        | D3    | SERVO2_PIN
   #define X_MS2_PIN                            6  // PH3 | Pin 15 | PWM6 | Pin 14 | D6    | SERVO1_PIN
   #define Y_MS1_PIN                           59  // PF5 | Pin 92 | A5   |        |       |

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_13.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_13.h
@@ -42,8 +42,6 @@
 //
 // Heaters / Fans
 //
-// Power outputs EFBF or EFBE
-//
 #define MOSFET_B_PIN                           7
 #define FAN_PIN                                9
 

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
@@ -37,14 +37,11 @@
 //
 // Heaters / Fans
 //
-// Power outputs EFBF or EFBE
-#define MOSFET_D_PIN                           7
 
-// Hotend, Hotend, Bed + Fan on D9
-#if FET_ORDER_EEB
-  #define MOSFET_B_PIN                         7
-  #define FAN_PIN                              9
-#endif
+#define MOSFET_A_PIN                           9  // HE0
+#define MOSFET_B_PIN                           8  // HE1
+#define MOSFET_C_PIN                          10  // HBED
+#define FAN_PIN                                7
 
 //
 // CS Pins wired to avoid conflict with the LCD

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L_V2.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L_V2.h
@@ -37,8 +37,8 @@
 //
 // Heaters / Fans
 //
-// Power outputs EFBF or EFBE
-#define MOSFET_D_PIN                           7
+#define MOSFET_B_PIN                           7
+#define FAN_PIN                                9
 
 //
 // CS Pins wired to avoid conflict with the LCD

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
@@ -37,7 +37,6 @@
 //
 // Heaters / Fans
 //
-// Power outputs EFBF or EFBE
 #define MOSFET_B_PIN                           7
 #define FAN_PIN                                9
 

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -32,7 +32,7 @@
 //
 // Heaters / Fans
 //
-#define MOSFET_B_PIN                           7  // For HEATER_1_PIN ("EEF" or "EEB")
+#define MOSFET_B_PIN                           7
 #define FAN_PIN                                9
 
 #define FIL_RUNOUT_PIN                         2

--- a/Marlin/src/pins/ramps/pins_ZRIB_V52.h
+++ b/Marlin/src/pins/ramps/pins_ZRIB_V52.h
@@ -39,8 +39,6 @@
 //
 // Heaters / Fans
 //
-#define HEATER_1_PIN                           7
-#define FAN_PIN                                9  // PH6 ** Pin18 ** PWM9
 #define FAN1_PIN                               6
 
 //


### PR DESCRIPTION
Followup to #23965 and #25542…

- According to images and the schematic, the MKS Gen. L v1.0 has a dedicated FAN port on pin 7.

- According to images and the schematic, the MKS Gen. L v2.0 and 2.1 have a dedicated FAN port on pin 9.

- MKS BASE board revisions 1.4 and later have a dedicated FAN port on pin 9, so that assignment is relocated to `pins_MKS_BASE_common.h`. The same goes for `pins_ZRIB_V52.h`.

- Mightyboard Rev. E has 6 MOSFET ports. This PR renames them consistent with the RAMPS (EEB) scheme. This makes it easier to apply the same conditions as `pins_RAMPS.h` in a later revision to accomodate schemes other than EEB.

- Remove labels referring to "BEEF" or "BEFF" schemes, since the expected scheme is actually EEBF, EFBF, but FET "D" might also be used in configurations with additional heaters; e.g., EEBE or EEFE. Of course, for more "unusual" custom FET usage, we expect heater pins to be defined as something other than a RAMPS derivative, with clear commentary.