### PR TITLE
redundant code in runout.h + UBLValidMesh() is not used

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -413,9 +413,6 @@ class FilamentSensorBase {
           const int32_t steps = b->steps.e;
           const float mm = (TEST(b->direction_bits, E_AXIS) ? -steps : steps) * planner.mm_per_step[E_AXIS_N(e)];
           if (e < NUM_RUNOUT_SENSORS) mm_countdown.runout[e] -= mm;
-          #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-            if (e < NUM_MOTION_SENSORS) mm_countdown.motion[e] -= mm;
-          #endif
         }
       }
   };

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -413,6 +413,9 @@ class FilamentSensorBase {
           const int32_t steps = b->steps.e;
           const float mm = (TEST(b->direction_bits, E_AXIS) ? -steps : steps) * planner.mm_per_step[E_AXIS_N(e)];
           if (e < NUM_RUNOUT_SENSORS) mm_countdown.runout[e] -= mm;
+          #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+            if (e < NUM_MOTION_SENSORS) mm_countdown.motion[e] -= mm;
+          #endif
         }
       }
   };

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -229,7 +229,6 @@ void ParkHead();
 #endif
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   void UBLMeshTilt();
-  bool UBLValidMesh();
   void UBLMeshSave();
   void UBLMeshLoad();
 #endif


### PR DESCRIPTION
### Description

in _**runout.h**_
Is this part of the code not redundant?

in _**dwin.h**_
`UBLValidMesh();` is not used.
