### PR TITLE
Fix M122 signed/unsigned warning

### DIFF
--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -47,7 +47,7 @@ void GcodeSuite::M122() {
       if (sflag && !sval)
         tmc_set_report_interval(0);
       else if (parser.seenval('P'))
-        tmc_set_report_interval(_MAX(250, parser.value_ushort()));
+        tmc_set_report_interval(_MAX(uint16_t(250), parser.value_ushort()));
       else if (sval)
         tmc_set_report_interval(MONITOR_DRIVER_STATUS_INTERVAL_MS);
     #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

As described in #25459, there is a signed/unsigned warning in some configurations in M122.

I could have alternately changed the literal to `250u`, but since it is compared at run-time to a fixed-width uint16_t I wanted to guarantee the data width matched across all build targets.

### Requirements

Easily reproducible using the configs from #25459 on bugfix-2.0.x. The same issue still existed in bugfix-2.1.x.

### Benefits

Provides a cleaner build experience.

### Configurations

Refer to #25459.

### Related Issues

#25459
