### PR TITLE
Update thermocouple 2 pin sanity checks 

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2644,9 +2644,8 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE, "Movement bounds (X_MIN_POS, X_MAX_POS
       #error "TEMP_SENSOR_2 is required with 3 or more HOTENDS."
     #elif !HAS_HEATER_2
       #error "HEATER_2_PIN not defined for this board."
-    #elif !PIN_EXISTS(TEMP_2) && !TEMP_SENSOR_2_IS_DUMMY
-      #error "TEMP_2_PIN not defined for this board."
-    #endif
+    #elif !ANY_PIN(TEMP_2, TEMP_2_CS) && !TEMP_SENSOR_2_IS_DUMMY
+      #error "TEMP_2_PIN or TEMP_2_CS_PIN not defined for this board."    #endif
     #if HOTENDS > 3
       #if TEMP_SENSOR_3 == 0
         #error "TEMP_SENSOR_3 is required with 4 or more HOTENDS."

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2645,7 +2645,8 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE, "Movement bounds (X_MIN_POS, X_MAX_POS
     #elif !HAS_HEATER_2
       #error "HEATER_2_PIN not defined for this board."
     #elif !ANY_PIN(TEMP_2, TEMP_2_CS) && !TEMP_SENSOR_2_IS_DUMMY
-      #error "TEMP_2_PIN or TEMP_2_CS_PIN not defined for this board."    #endif
+      #error "TEMP_2_PIN or TEMP_2_CS_PIN not defined for this board."
+    #endif
     #if HOTENDS > 3
       #if TEMP_SENSOR_3 == 0
         #error "TEMP_SENSOR_3 is required with 4 or more HOTENDS."

--- a/Marlin/src/pins/sam/pins_ULTRATRONICS_PRO.h
+++ b/Marlin/src/pins/sam/pins_ULTRATRONICS_PRO.h
@@ -153,7 +153,7 @@
 #define TEMP_0_CS_PIN                         65
 #define TEMP_1_CS_PIN                         52
 #define TEMP_2_CS_PIN                         50
-#define TEMP_3_CS_PIN                         51
+#define TEMP_3_CS_PIN                         51  // Not yet supported
 
 #define ENC424_SS                             61
 


### PR DESCRIPTION
### Description

PR #24898 increased the number of thermocouples from 2 to 3
But a pin sanity check was missed

Resulting in the sanity check complaining  "TEMP_2_PIN not defined for this board."
But this thermocouple doesn't use a a TEMP_2_PIN, they get their data via spi.

Updated sanity check to the same as thermocouple 0 and 1, requiring either a TEMP_2_PIN or a TEMP_2_CS_PIN to pass the  test.

### Requirements

#define TEMP_SENSOR_0 -2
#define TEMP_SENSOR_1 -2
#define TEMP_SENSOR_2 -2
with 
#define TEMP_0_CS_PIN {boards pin number}
#define TEMP_1_CS_PIN {boards pin number}
#define TEMP_2_CS_PIN {boards pin number}

### Benefits

sanity check doesn't give a false error.

### Related Issues
#24898