### PR TITLE
Input Shaping / FT Motion with I2S_STEPPER_STREAM ?

### DIFF
--- a/Marlin/src/HAL/ESP32/i2s.cpp
+++ b/Marlin/src/HAL/ESP32/i2s.cpp
@@ -319,17 +319,6 @@ int i2s_init() {
   // Create the task that will feed the buffer
   xTaskCreatePinnedToCore(stepperTask, "StepperTask", 10000, nullptr, 1, nullptr, CONFIG_ARDUINO_RUNNING_CORE); // run I2S stepper task on same core as rest of Marlin
 
-  // If defined by platform headers...
-  //#if !defined(I2S_DATA_PIN) && defined(I2S_DATA)
-  //  #define I2S_DATA_PIN I2S_DATA
-  //#endif
-  //#if !defined(I2S_BCK_PIN) && defined(I2S_BCK)
-  //  #define I2S_BCK_PIN I2S_BCK
-  //#endif
-  //#if !defined(I2S_WS_PIN) && defined(I2S_WS)
-  //  #define I2S_WS_PIN I2S_WS
-  //#endif
-
   // Route the i2s pins to the appropriate GPIO
   // If a pin is not defined, no need to configure
   #if PIN_EXISTS(I2S_DATA)

--- a/Marlin/src/HAL/ESP32/i2s.cpp
+++ b/Marlin/src/HAL/ESP32/i2s.cpp
@@ -319,16 +319,27 @@ int i2s_init() {
   // Create the task that will feed the buffer
   xTaskCreatePinnedToCore(stepperTask, "StepperTask", 10000, nullptr, 1, nullptr, CONFIG_ARDUINO_RUNNING_CORE); // run I2S stepper task on same core as rest of Marlin
 
+  // If defined by platform headers...
+  //#if !defined(I2S_DATA_PIN) && defined(I2S_DATA)
+  //  #define I2S_DATA_PIN I2S_DATA
+  //#endif
+  //#if !defined(I2S_BCK_PIN) && defined(I2S_BCK)
+  //  #define I2S_BCK_PIN I2S_BCK
+  //#endif
+  //#if !defined(I2S_WS_PIN) && defined(I2S_WS)
+  //  #define I2S_WS_PIN I2S_WS
+  //#endif
+
   // Route the i2s pins to the appropriate GPIO
   // If a pin is not defined, no need to configure
-  #if defined(I2S_DATA) && I2S_DATA >= 0
-    gpio_matrix_out_check(I2S_DATA, I2S0O_DATA_OUT23_IDX, 0, 0);
+  #if PIN_EXISTS(I2S_DATA)
+    gpio_matrix_out_check(I2S_DATA_PIN, I2S0O_DATA_OUT23_IDX, 0, 0);
   #endif
-  #if defined(I2S_BCK) && I2S_BCK >= 0
-    gpio_matrix_out_check(I2S_BCK, I2S0O_BCK_OUT_IDX, 0, 0);
+  #if PIN_EXISTS(I2S_BCK)
+    gpio_matrix_out_check(I2S_BCK_PIN, I2S0O_BCK_OUT_IDX, 0, 0);
   #endif
-  #if defined(I2S_WS) && I2S_WS >= 0
-    gpio_matrix_out_check(I2S_WS, I2S0O_WS_OUT_IDX, 0, 0);
+  #if PIN_EXISTS(I2S_WS)
+    gpio_matrix_out_check(I2S_WS_PIN, I2S0O_WS_OUT_IDX, 0, 0);
   #endif
 
   // Start the I2S peripheral
@@ -355,7 +366,7 @@ uint8_t i2s_state(uint8_t pin) {
 void i2s_push_sample() {
   // Every 4µs (when space in DMA buffer) toggle each expander PWM output using
   // the current duty cycle/frequency so they sync with any steps (once
-  // through the DMA/FIFO buffers).  PWM signal inversion handled by other functions
+  // through the DMA/FIFO buffers). PWM signal inversion is handled by other functions.
   LOOP_L_N(p, MAX_EXPANDER_BITS) {
     if (hal.pwm_pin_data[p].pwm_duty_ticks > 0) { // pin has active pwm?
       if (hal.pwm_pin_data[p].pwm_tick_count == 0) {

--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -67,13 +67,3 @@
 #if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0 && DISABLED(PRINTCOUNTER_SYNC)
   #error "PRINTCOUNTER_SAVE_INTERVAL may cause issues on ESP32 with an I2S expander. Define PRINTCOUNTER_SYNC in Configuration.h for an imperfect solution."
 #endif
-
-#if EITHER(HAS_ZV_SHAPING, FT_MOTION)
-  #if ENABLED(INPUT_SHAPING_X)
-    #error "INPUT_SHAPING_X is not supported on ESP32."
-  #elif ENABLED(INPUT_SHAPING_Y)
-    #error "INPUT_SHAPING_Y is not supported on ESP32."
-  #elif ENABLED(FT_MOTION)
-    #error "FT_MOTION is not supported on ESP32."
-  #endif
-#endif

--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -67,3 +67,13 @@
 #if BOTH(I2S_STEPPER_STREAM, PRINTCOUNTER) && PRINTCOUNTER_SAVE_INTERVAL > 0 && DISABLED(PRINTCOUNTER_SYNC)
   #error "PRINTCOUNTER_SAVE_INTERVAL may cause issues on ESP32 with an I2S expander. Define PRINTCOUNTER_SYNC in Configuration.h for an imperfect solution."
 #endif
+
+#if EITHER(HAS_ZV_SHAPING, FT_MOTION)
+  #if ENABLED(INPUT_SHAPING_X)
+    #error "INPUT_SHAPING_X is not supported on ESP32."
+  #elif ENABLED(INPUT_SHAPING_Y)
+    #error "INPUT_SHAPING_Y is not supported on ESP32."
+  #elif ENABLED(FT_MOTION)
+    #error "FT_MOTION is not supported on ESP32."
+  #endif
+#endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4008,6 +4008,14 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
       static_assert(SHAPING_FREQ_X == SHAPING_FREQ_Y, "SHAPING_FREQ_X and SHAPING_FREQ_Y must be the same for COREXY / COREYX / MARKFORGED_*.");
       static_assert(SHAPING_ZETA_X == SHAPING_ZETA_Y, "SHAPING_ZETA_X and SHAPING_ZETA_Y must be the same for COREXY / COREYX / MARKFORGED_*.");
     #endif
+  #elif ENABLED(I2S_STEPPER_STREAM)
+    #if ENABLED(INPUT_SHAPING_X)
+      #error "INPUT_SHAPING_X is not supported with I2S_STEPPER_STREAM."
+    #elif ENABLED(INPUT_SHAPING_Y)
+      #error "INPUT_SHAPING_Y is not supported with I2S_STEPPER_STREAM."
+    #elif ENABLED(FT_MOTION)
+      #error "FT_MOTION is not supported with I2S_STEPPER_STREAM."
+    #endif
   #endif
 
   #ifdef SHAPING_MIN_FREQ

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4013,8 +4013,6 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
       #error "INPUT_SHAPING_X is not supported with I2S_STEPPER_STREAM."
     #elif ENABLED(INPUT_SHAPING_Y)
       #error "INPUT_SHAPING_Y is not supported with I2S_STEPPER_STREAM."
-    #elif ENABLED(FT_MOTION)
-      #error "FT_MOTION is not supported with I2S_STEPPER_STREAM."
     #endif
   #endif
 
@@ -4050,6 +4048,8 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
     #error "FT_MOTION is currently limited to machines with 3 linear axes."
   #elif ENABLED(MIXING_EXTRUDER)
     #error "FT_MOTION is incompatible with MIXING_EXTRUDER."
+  #elif ENABLED(I2S_STEPPER_STREAM)
+    #error "FT_MOTION is not supported with I2S_STEPPER_STREAM."
   #endif
 #endif
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1505,7 +1505,7 @@ void Stepper::isr() {
             fxdTiCtrl.sts_stepperBusy = false; // Set busy false to allow a reset.
             nextMainISR = 0.01f * (STEPPER_TIMER_RATE); // Come back in 10 msec.
           }
-          else { // !(abort_current_block)
+          else { // !abort_current_block
             if (fxdTiCtrl_stepCmdRdy) {
               fxdTiCtrl_stepper(fxdTiCtrl_applyDir, fxdTiCtrl_stepCmd);
               fxdTiCtrl_stepCmdRdy = false;
@@ -1531,8 +1531,8 @@ void Stepper::isr() {
               fxdTiCtrl.sts_stepperBusy = false;
               nextMainISR = 0.01f * (STEPPER_TIMER_RATE); // Come back in 10 msec.
             }
-          } // !(abort_current_block)
-        } // if (!nextMainISR)
+          } // !abort_current_block
+        } // !nextMainISR
 
         // Define 2.5 msec task for auxilliary functions.
         if (!fxdTiCtrl_nextAuxISR) {

--- a/Marlin/src/pins/esp32/pins_E4D.h
+++ b/Marlin/src/pins/esp32/pins_E4D.h
@@ -41,12 +41,9 @@
 //
 // Redefine I2S for ESP32
 //
-#undef I2S_WS
-#undef I2S_BCK
-#undef I2S_DATA
-#define I2S_WS                                23
-#define I2S_BCK                               22
-#define I2S_DATA                              21
+#define I2S_WS_PIN                            23
+#define I2S_BCK_PIN                           22
+#define I2S_DATA_PIN                          21
 
 //
 // Limit Switches

--- a/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
+++ b/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
@@ -36,9 +36,9 @@
 //
 #define I2S_STEPPER_STREAM
 #if ENABLED(I2S_STEPPER_STREAM)
-  #define I2S_WS                              17
-  #define I2S_BCK                             22
-  #define I2S_DATA                            21
+  #define I2S_WS_PIN                          17
+  #define I2S_BCK_PIN                         22
+  #define I2S_DATA_PIN                        21
 #endif
 
 //

--- a/Marlin/src/pins/esp32/pins_ESP32.h
+++ b/Marlin/src/pins/esp32/pins_ESP32.h
@@ -34,9 +34,9 @@
 //
 #define I2S_STEPPER_STREAM
 #if ENABLED(I2S_STEPPER_STREAM)
-  #define I2S_WS                              25
-  #define I2S_BCK                             26
-  #define I2S_DATA                            27
+  #define I2S_WS_PIN                          25
+  #define I2S_BCK_PIN                         26
+  #define I2S_DATA_PIN                        27
 #endif
 
 //

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -58,9 +58,9 @@
 //
 #define I2S_STEPPER_STREAM
 #if ENABLED(I2S_STEPPER_STREAM)
-  #define I2S_WS                              26
-  #define I2S_BCK                             25
-  #define I2S_DATA                            27
+  #define I2S_WS_PIN                          26
+  #define I2S_BCK_PIN                         25
+  #define I2S_DATA_PIN                        27
 #endif
 
 //

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -53,9 +53,9 @@
 //
 #define I2S_STEPPER_STREAM
 #if ENABLED(I2S_STEPPER_STREAM)
-  #define I2S_WS                              26
-  #define I2S_BCK                             25
-  #define I2S_DATA                            27
+  #define I2S_WS_PIN                          26
+  #define I2S_BCK_PIN                         25
+  #define I2S_DATA_PIN                        27
 #endif
 
 //


### PR DESCRIPTION
### Description

Input Shaping and Fixed-Time-Based Motion Control are incompatible with `I2S_STEPPER_STREAM`, so add a sanity check to prevent them from being enabled on those boards.

> IS is not supported with ESP32. My naive guess is the FT is not either. We should add a sanity check.

> ESP32 works around some of the core stepper logic. We really need a refactor of stepper.cpp that puts all the step generation in one place and prevents more than one step being generated per pass through the loop. Then ESP32 could be integrated with IS properly. (Not to mention baby stepping and really getting it working with LA.)

_Originally posted by @tombrazier in https://github.com/MarlinFirmware/Marlin/issues/25605#issuecomment-1495753241_

### Requirements

Boards with `I2S_STEPPER_STREAM`.

### Benefits

Users will be alerted to incompatible settings for `I2S_STEPPER_STREAM`.

### Configurations

[Marlin.zip](https://github.com/MarlinFirmware/Marlin/files/11113294/Marlin.zip) from #25605

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/25605#issuecomment-1495753241