### PR TITLE
🐛 Apply INVERT_*_DIR to FT_MOTION

### DIFF
--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -109,7 +109,7 @@ void BDS_Leveling::process() {
           #endif
         }
         else {
-          babystep.set_mm(Z_AXIS, 0);          //if (old_cur_z <= cur_z) Z_DIR_WRITE(!INVERT_Z_DIR);
+          babystep.set_mm(Z_AXIS, 0);          //if (old_cur_z <= cur_z) Z_DIR_WRITE(INVERT_DIR(Z, HIGH));
           stepper.set_directions();
         }
       #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1952,72 +1952,72 @@ void prepare_line_to_destination() {
           case X_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(X);
             phaseCurrent = stepperX.get_microstep_counter();
-            effectorBackoutDir = -X_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_X_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(X_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_X_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef Y_MICROSTEPS
           case Y_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(Y);
             phaseCurrent = stepperY.get_microstep_counter();
-            effectorBackoutDir = -Y_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_Y_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(Y_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_Y_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef Z_MICROSTEPS
           case Z_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(Z);
             phaseCurrent = stepperZ.get_microstep_counter();
-            effectorBackoutDir = -Z_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_Z_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(Z_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_Z_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef I_MICROSTEPS
           case I_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(I);
             phaseCurrent = stepperI.get_microstep_counter();
-            effectorBackoutDir = -I_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_I_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(I_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_I_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef J_MICROSTEPS
           case J_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(J);
             phaseCurrent = stepperJ.get_microstep_counter();
-            effectorBackoutDir = -J_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_J_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(J_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_J_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef K_MICROSTEPS
           case K_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(K);
             phaseCurrent = stepperK.get_microstep_counter();
-            effectorBackoutDir = -K_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_K_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(K_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_K_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef U_MICROSTEPS
           case U_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(U);
             phaseCurrent = stepperU.get_microstep_counter();
-            effectorBackoutDir = -U_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_U_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(U_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_U_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef V_MICROSTEPS
           case V_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(V);
             phaseCurrent = stepperV.get_microstep_counter();
-            effectorBackoutDir = -V_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_V_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(V_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_V_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         #ifdef W_MICROSTEPS
           case W_AXIS:
             phasePerUStep = PHASE_PER_MICROSTEP(W);
             phaseCurrent = stepperW.get_microstep_counter();
-            effectorBackoutDir = -W_HOME_DIR;
-            stepperBackoutDir = IF_DISABLED(INVERT_W_DIR, -)effectorBackoutDir;
+            effectorBackoutDir = -(W_HOME_DIR);
+            stepperBackoutDir = TERN_(INVERT_W_DIR, -)(-effectorBackoutDir);
             break;
         #endif
         default: return;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -382,7 +382,7 @@ xyze_int8_t Stepper::count_direction{0};
   }
 
 #if HAS_DUAL_X_STEPPERS
-  #define X_APPLY_DIR(v,Q) do{ X_DIR_WRITE(v); X2_DIR_WRITE((v) ^ ENABLED(INVERT_X2_VS_X_DIR)); }while(0)
+  #define X_APPLY_DIR(v,Q) do{ X_DIR_WRITE(v); X2_DIR_WRITE(INVERT_DIR(X2_VS_X, v)); }while(0)
   #if ENABLED(X_DUAL_ENDSTOPS)
     #define X_APPLY_STEP(v,Q) DUAL_ENDSTOP_APPLY_STEP(X,v)
   #else
@@ -403,7 +403,7 @@ xyze_int8_t Stepper::count_direction{0};
 #endif
 
 #if HAS_DUAL_Y_STEPPERS
-  #define Y_APPLY_DIR(v,Q) do{ Y_DIR_WRITE(v); Y2_DIR_WRITE((v) ^ ENABLED(INVERT_Y2_VS_Y_DIR)); }while(0)
+  #define Y_APPLY_DIR(v,Q) do{ Y_DIR_WRITE(v); Y2_DIR_WRITE(INVERT_DIR(Y2_VS_Y, v)); }while(0)
   #if ENABLED(Y_DUAL_ENDSTOPS)
     #define Y_APPLY_STEP(v,Q) DUAL_ENDSTOP_APPLY_STEP(Y,v)
   #else
@@ -416,8 +416,8 @@ xyze_int8_t Stepper::count_direction{0};
 
 #if NUM_Z_STEPPERS == 4
   #define Z_APPLY_DIR(v,Q) do{ \
-    Z_DIR_WRITE(v); Z2_DIR_WRITE((v) ^ ENABLED(INVERT_Z2_VS_Z_DIR)); \
-    Z3_DIR_WRITE((v) ^ ENABLED(INVERT_Z3_VS_Z_DIR)); Z4_DIR_WRITE((v) ^ ENABLED(INVERT_Z4_VS_Z_DIR)); \
+    Z_DIR_WRITE(v); Z2_DIR_WRITE(INVERT_DIR(Z2_VS_Z, v)); \
+    Z3_DIR_WRITE(INVERT_DIR(Z3_VS_Z, v)); Z4_DIR_WRITE(INVERT_DIR(Z4_VS_Z, v)); \
   }while(0)
   #if ENABLED(Z_MULTI_ENDSTOPS)
     #define Z_APPLY_STEP(v,Q) QUAD_ENDSTOP_APPLY_STEP(Z,v)
@@ -428,7 +428,7 @@ xyze_int8_t Stepper::count_direction{0};
   #endif
 #elif NUM_Z_STEPPERS == 3
   #define Z_APPLY_DIR(v,Q) do{ \
-    Z_DIR_WRITE(v); Z2_DIR_WRITE((v) ^ ENABLED(INVERT_Z2_VS_Z_DIR)); Z3_DIR_WRITE((v) ^ ENABLED(INVERT_Z3_VS_Z_DIR)); \
+    Z_DIR_WRITE(v); Z2_DIR_WRITE(INVERT_DIR(Z2_VS_Z, v)); Z3_DIR_WRITE(INVERT_DIR(Z3_VS_Z, v)); \
   }while(0)
   #if ENABLED(Z_MULTI_ENDSTOPS)
     #define Z_APPLY_STEP(v,Q) TRIPLE_ENDSTOP_APPLY_STEP(Z,v)
@@ -438,7 +438,7 @@ xyze_int8_t Stepper::count_direction{0};
     #define Z_APPLY_STEP(v,Q) do{ Z_STEP_WRITE(v); Z2_STEP_WRITE(v); Z3_STEP_WRITE(v); }while(0)
   #endif
 #elif NUM_Z_STEPPERS == 2
-  #define Z_APPLY_DIR(v,Q) do{ Z_DIR_WRITE(v); Z2_DIR_WRITE((v) ^ ENABLED(INVERT_Z2_VS_Z_DIR)); }while(0)
+  #define Z_APPLY_DIR(v,Q) do{ Z_DIR_WRITE(v); Z2_DIR_WRITE(INVERT_DIR(Z2_VS_Z, v)); }while(0)
   #if ENABLED(Z_MULTI_ENDSTOPS)
     #define Z_APPLY_STEP(v,Q) DUAL_ENDSTOP_APPLY_STEP(Z,v)
   #elif ENABLED(Z_STEPPER_AUTO_ALIGN)
@@ -3470,14 +3470,14 @@ void Stepper::report_positions() {
     #endif
 
     if (applyDir) {
-      X_DIR_WRITE(TEST(command, FT_BIT_DIR_X));
-      TERN_(HAS_Y_AXIS, Y_DIR_WRITE(TEST(command, FT_BIT_DIR_Y)));
-      TERN_(HAS_Z_AXIS, Z_DIR_WRITE(z_dir));
-      TERN_(HAS_EXTRUDERS, E0_DIR_WRITE(TEST(command, FT_BIT_DIR_E)));
+      TERN_(HAS_X_AXIS, X_DIR_WRITE(X, TEST(command, FT_BIT_DIR_X)));
+      TERN_(HAS_Y_AXIS, Y_DIR_WRITE(Y, TEST(command, FT_BIT_DIR_Y)));
+      TERN_(HAS_Z_AXIS, Z_DIR_WRITE(Z, z_dir));
+      TERN_(HAS_EXTRUDERS, E0_DIR_WRITE(E0, TEST(command, FT_BIT_DIR_E)));
       DIR_WAIT_AFTER();
     }
 
-    X_STEP_WRITE(TEST(command, FT_BIT_STEP_X));
+    TERN_(HAS_X_AXIS, X_STEP_WRITE(TEST(command, FT_BIT_STEP_X)));
     TERN_(HAS_Y_AXIS, Y_STEP_WRITE(TEST(command, FT_BIT_STEP_Y)));
     TERN_(HAS_Z_AXIS, Z_STEP_WRITE(z_step));
     TERN_(HAS_EXTRUDERS, E0_STEP_WRITE(TEST(command, FT_BIT_STEP_E)));
@@ -3580,7 +3580,6 @@ void Stepper::report_positions() {
 
   #define _ENABLE_AXIS(A) enable_axis(_AXIS(A))
   #define _READ_DIR(AXIS) AXIS ##_DIR_READ()
-  #define _INVERT_DIR(AXIS) ENABLED(INVERT_## AXIS ##_DIR)
   #define _APPLY_DIR(AXIS, INVERT) AXIS ##_APPLY_DIR(INVERT, true)
 
   #if MINIMUM_STEPPER_PULSE
@@ -3627,19 +3626,19 @@ void Stepper::report_positions() {
 
   #if DISABLED(DELTA)
 
-    #define BABYSTEP_AXIS(AXIS, INV, DIR) do{      \
-      const uint8_t old_dir = _READ_DIR(AXIS);     \
-      _ENABLE_AXIS(AXIS);                          \
-      DIR_WAIT_BEFORE();                           \
-      _APPLY_DIR(AXIS, _INVERT_DIR(AXIS)^DIR^INV); \
-      DIR_WAIT_AFTER();                            \
-      _SAVE_START();                               \
-      _APPLY_STEP(AXIS, _STEP_STATE(AXIS), true);  \
-      _PULSE_WAIT();                               \
-      _APPLY_STEP(AXIS, !_STEP_STATE(AXIS), true); \
-      EXTRA_DIR_WAIT_BEFORE();                     \
-      _APPLY_DIR(AXIS, old_dir);                   \
-      EXTRA_DIR_WAIT_AFTER();                      \
+    #define BABYSTEP_AXIS(AXIS, INV, DIR) do{           \
+      const uint8_t old_dir = _READ_DIR(AXIS);          \
+      _ENABLE_AXIS(AXIS);                               \
+      DIR_WAIT_BEFORE();                                \
+      _APPLY_DIR(AXIS, INVERT_DIR(AXIS, (DIR)^(INV)));  \
+      DIR_WAIT_AFTER();                                 \
+      _SAVE_START();                                    \
+      _APPLY_STEP(AXIS, _STEP_STATE(AXIS), true);       \
+      _PULSE_WAIT();                                    \
+      _APPLY_STEP(AXIS, !_STEP_STATE(AXIS), true);      \
+      EXTRA_DIR_WAIT_BEFORE();                          \
+      _APPLY_DIR(AXIS, old_dir);                        \
+      EXTRA_DIR_WAIT_AFTER();                           \
     }while(0)
 
   #endif
@@ -3650,8 +3649,8 @@ void Stepper::report_positions() {
       const xy_byte_t old_dir = { _READ_DIR(A), _READ_DIR(B) }; \
       _ENABLE_AXIS(A); _ENABLE_AXIS(B);                         \
       DIR_WAIT_BEFORE();                                        \
-      _APPLY_DIR(A, _INVERT_DIR(A)^DIR^INV);                    \
-      _APPLY_DIR(B, _INVERT_DIR(B)^DIR^INV^ALT);                \
+      _APPLY_DIR(A, INVERT_DIR(A, (DIR)^(INV));                 \
+      _APPLY_DIR(B, INVERT_DIR(B, (DIR)^(INV)^(ALT));           \
       DIR_WAIT_AFTER();                                         \
       _SAVE_START();                                            \
       _APPLY_STEP(A, _STEP_STATE(A), true);                     \
@@ -3725,19 +3724,23 @@ void Stepper::report_positions() {
             U_DIR_READ(), V_DIR_READ(), W_DIR_READ()
           );
 
-          X_DIR_WRITE(ENABLED(INVERT_X_DIR) ^ z_direction);
+          #ifdef X_DIR_WRITE
+            X_DIR_WRITE(INVERT_DIR(X, z_direction));
+          #endif
           #ifdef Y_DIR_WRITE
-            Y_DIR_WRITE(ENABLED(INVERT_Y_DIR) ^ z_direction);
+            Y_DIR_WRITE(INVERT_DIR(Y, z_direction));
           #endif
           #ifdef Z_DIR_WRITE
-            Z_DIR_WRITE(ENABLED(INVERT_Z_DIR) ^ z_direction);
+            Z_DIR_WRITE(INVERT_DIR(Z, z_direction));
           #endif
 
           DIR_WAIT_AFTER();
 
           _SAVE_START();
 
-          X_STEP_WRITE(STEP_STATE_X);
+          #ifdef X_STEP_WRITE
+            X_STEP_WRITE(STEP_STATE_X);
+          #endif
           #ifdef Y_STEP_WRITE
             Y_STEP_WRITE(STEP_STATE_Y);
           #endif
@@ -3747,7 +3750,9 @@ void Stepper::report_positions() {
 
           _PULSE_WAIT();
 
-          X_STEP_WRITE(!STEP_STATE_X);
+          #ifdef X_STEP_WRITE
+            X_STEP_WRITE(!STEP_STATE_X);
+          #endif
           #ifdef Y_STEP_WRITE
             Y_STEP_WRITE(!STEP_STATE_Y);
           #endif
@@ -3758,7 +3763,9 @@ void Stepper::report_positions() {
           // Restore direction bits
           EXTRA_DIR_WAIT_BEFORE();
 
-          X_DIR_WRITE(old_dir.x);
+          #ifdef X_DIR_WRITE
+            X_DIR_WRITE(old_dir.x);
+          #endif
           #ifdef Y_DIR_WRITE
             Y_DIR_WRITE(old_dir.y);
           #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3470,10 +3470,10 @@ void Stepper::report_positions() {
     #endif
 
     if (applyDir) {
-      TERN_(HAS_X_AXIS, X_DIR_WRITE(X, TEST(command, FT_BIT_DIR_X)));
-      TERN_(HAS_Y_AXIS, Y_DIR_WRITE(Y, TEST(command, FT_BIT_DIR_Y)));
-      TERN_(HAS_Z_AXIS, Z_DIR_WRITE(Z, z_dir));
-      TERN_(HAS_EXTRUDERS, E0_DIR_WRITE(E0, TEST(command, FT_BIT_DIR_E)));
+      TERN_(HAS_X_AXIS, X_DIR_WRITE(INVERT_DIR(X, TEST(command, FT_BIT_DIR_X))));
+      TERN_(HAS_Y_AXIS, Y_DIR_WRITE(INVERT_DIR(Y, TEST(command, FT_BIT_DIR_Y))));
+      TERN_(HAS_Z_AXIS, Z_DIR_WRITE(INVERT_DIR(Z, z_dir)));
+      TERN_(HAS_EXTRUDERS, E0_DIR_WRITE(INVERT_DIR(E0, TEST(command, FT_BIT_DIR_E))));
       DIR_WAIT_AFTER();
     }
 

--- a/Marlin/src/module/stepper/indirection.h
+++ b/Marlin/src/module/stepper/indirection.h
@@ -650,47 +650,17 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #if HAS_DUPLICATION_MODE
 
     #if ENABLED(MULTI_NOZZLE_DUPLICATION)
-      #define _DUPE(N,T,V) do{ if (TEST(duplication_e_mask, N)) E##N##_##T##_WRITE(V); }while(0)
+      #define DUPE(N,T,V) do{ if (TEST(duplication_e_mask, N)) E##N##_##T##_WRITE(V); }while(0);
     #else
-      #define _DUPE(N,T,V) E##N##_##T##_WRITE(V)
+      #define DUPE(N,T,V) E##N##_##T##_WRITE(V);
     #endif
 
-    #define NDIR(N) _DUPE(N,DIR,INVERT_DIR(E, HIGH))
-    #define RDIR(N) _DUPE(N,DIR,INVERT_DIR(E, LOW ))
+    #define NDIR(N) DUPE(N,DIR,INVERT_DIR(E, HIGH));
+    #define RDIR(N) DUPE(N,DIR,INVERT_DIR(E, LOW ));
 
-    #define E_STEP_WRITE(E,V) do{ if (extruder_duplication_enabled) { DUPE(STEP,V); } else _E_STEP_WRITE(E,V); }while(0)
-
-    #if E_STEPPERS > 2
-      #if E_STEPPERS > 7
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); _DUPE(3,T,V); _DUPE(4,T,V); _DUPE(5,T,V); _DUPE(6,T,V); _DUPE(7,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); NDIR(3); NDIR(4); NDIR(5); NDIR(6); NDIR(7); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); RDIR(3); RDIR(4); RDIR(5); RDIR(6); RDIR(7); } else  _REV_E_DIR(E); }while(0)
-      #elif E_STEPPERS > 6
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); _DUPE(3,T,V); _DUPE(4,T,V); _DUPE(5,T,V); _DUPE(6,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); NDIR(3); NDIR(4); NDIR(5); NDIR(6); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); RDIR(3); RDIR(4); RDIR(5); RDIR(6); } else  _REV_E_DIR(E); }while(0)
-      #elif E_STEPPERS > 5
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); _DUPE(3,T,V); _DUPE(4,T,V); _DUPE(5,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); NDIR(3); NDIR(4); NDIR(5); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); RDIR(3); RDIR(4); RDIR(5); } else  _REV_E_DIR(E); }while(0)
-      #elif E_STEPPERS > 4
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); _DUPE(3,T,V); _DUPE(4,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); NDIR(3); NDIR(4); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); RDIR(3); RDIR(4); } else  _REV_E_DIR(E); }while(0)
-      #elif E_STEPPERS > 3
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); _DUPE(3,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); NDIR(3); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); RDIR(3); } else  _REV_E_DIR(E); }while(0)
-      #else
-        #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); _DUPE(2,T,V); }while(0)
-        #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); NDIR(2); } else _NORM_E_DIR(E); }while(0)
-        #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); RDIR(2); } else  _REV_E_DIR(E); }while(0)
-      #endif
-    #else
-      #define DUPE(T,V)     do{ _DUPE(0,T,V); _DUPE(1,T,V); }while(0)
-      #define NORM_E_DIR(E) do{ if (extruder_duplication_enabled) { NDIR(0); NDIR(1); } else _NORM_E_DIR(E); }while(0)
-      #define REV_E_DIR(E)  do{ if (extruder_duplication_enabled) { RDIR(0); RDIR(1); } else  _REV_E_DIR(E); }while(0)
-    #endif
+    #define E_STEP_WRITE(E,V) do{ if (extruder_duplication_enabled) { REPEAT2(E_STEPPERS, DUPE, STEP, V); } else _E_STEP_WRITE(E,V); }while(0)
+    #define NORM_E_DIR(E)     do{ if (extruder_duplication_enabled) { REPEAT(E_STEPPERS, NDIR); } else _NORM_E_DIR(E); }while(0)
+    #define REV_E_DIR(E)      do{ if (extruder_duplication_enabled) { REPEAT(E_STEPPERS, RDIR); } else  _REV_E_DIR(E); }while(0)
 
   #else
 

--- a/Marlin/src/module/stepper/indirection.h
+++ b/Marlin/src/module/stepper/indirection.h
@@ -451,6 +451,8 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
 #endif
 #define E7_STEP_READ() bool(READ(E7_STEP_PIN))
 
+#define INVERT_DIR(AXIS, D) (TERN_(INVERT_## AXIS ##_DIR, !)(D))
+
 /**
  * Extruder indirection for the single E axis
  */
@@ -458,91 +460,91 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #if EXTRUDERS > 7
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else if (E < 4) { E1_STEP_WRITE(V); } else if (E < 6) { E2_STEP_WRITE(V); } else { E3_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; \
-        case 6: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; case 7: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; \
+        case 6: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; case 7: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; \
-        case 6: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; case 7: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; \
+        case 6: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; case 7: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
       } }while(0)
   #elif EXTRUDERS > 6
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else if (E < 4) { E1_STEP_WRITE(V); } else if (E < 6) { E2_STEP_WRITE(V); } else { E3_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; \
-        case 6: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; \
+        case 6: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; \
-        case 6: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); } }while(0)
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; \
+        case 6: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); } }while(0)
   #elif EXTRUDERS > 5
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else if (E < 4) { E1_STEP_WRITE(V); } else { E2_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 5: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 5: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; \
       } }while(0)
   #elif EXTRUDERS > 4
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else if (E < 4) { E1_STEP_WRITE(V); } else { E2_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 4: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 4: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; \
       } }while(0)
   #elif EXTRUDERS > 3
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else { E1_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 3: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 3: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
       } }while(0)
   #elif EXTRUDERS > 2
     #define E_STEP_WRITE(E,V) do{ if (E < 2) { E0_STEP_WRITE(V); } else { E1_STEP_WRITE(V); } }while(0)
     #define   NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
       } }while(0)
     #define    REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; \
-        case 2: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; \
+        case 2: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
       } }while(0)
   #else
     #define E_STEP_WRITE(E,V) E0_STEP_WRITE(V)
-    #define   NORM_E_DIR(E)   do{ E0_DIR_WRITE(E ?  ENABLED(INVERT_E0_DIR) : DISABLED(INVERT_E0_DIR)); }while(0)
-    #define    REV_E_DIR(E)   do{ E0_DIR_WRITE(E ? DISABLED(INVERT_E0_DIR) :  ENABLED(INVERT_E0_DIR)); }while(0)
+    #define   NORM_E_DIR(E)   do{ E0_DIR_WRITE(INVERT_DIR(E0, (E) ? LOW  : HIGH)); }while(0)
+    #define    REV_E_DIR(E)   do{ E0_DIR_WRITE(INVERT_DIR(E0, (E) ? HIGH : LOW )); }while(0)
   #endif
 
 #elif HAS_PRUSA_MMU2  // One multiplexed stepper driver
 
   #define E_STEP_WRITE(E,V) E0_STEP_WRITE(V)
-  #define   NORM_E_DIR(E)   E0_DIR_WRITE(DISABLED(INVERT_E0_DIR))
-  #define    REV_E_DIR(E)   E0_DIR_WRITE( ENABLED(INVERT_E0_DIR))
+  #define   NORM_E_DIR(E)   E0_DIR_WRITE(INVERT_DIR(E0, HIGH))
+  #define    REV_E_DIR(E)   E0_DIR_WRITE(INVERT_DIR(E0, LOW ))
 
 #elif HAS_PRUSA_MMU1  // One multiplexed stepper driver, reversed on odd index
 
   #define E_STEP_WRITE(E,V) E0_STEP_WRITE(V)
-  #define   NORM_E_DIR(E)   do{ E0_DIR_WRITE(TEST(E, 0) ? DISABLED(INVERT_E0_DIR):  ENABLED(INVERT_E0_DIR)); }while(0)
-  #define    REV_E_DIR(E)   do{ E0_DIR_WRITE(TEST(E, 0) ?  ENABLED(INVERT_E0_DIR): DISABLED(INVERT_E0_DIR)); }while(0)
+  #define   NORM_E_DIR(E)   do{ E0_DIR_WRITE(INVERT_DIR(E0, TEST(E, 0) ? HIGH : LOW )); }while(0)
+  #define    REV_E_DIR(E)   do{ E0_DIR_WRITE(INVERT_DIR(E0, TEST(E, 0) ? LOW  : HIGH)); }while(0)
 
 #elif E_STEPPERS > 1
 
@@ -553,16 +555,16 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
         case 4: E4_STEP_WRITE(V); break; case 5: E5_STEP_WRITE(V); break; case 6: E6_STEP_WRITE(V); break; case 7: E7_STEP_WRITE(V); break; \
       } }while(0)
     #define   _NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE(DISABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE(DISABLED(INVERT_E5_DIR)); break; \
-        case 6: E6_DIR_WRITE(DISABLED(INVERT_E6_DIR)); break; case 7: E7_DIR_WRITE(DISABLED(INVERT_E7_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, HIGH)); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, HIGH)); break; \
+        case 6: E6_DIR_WRITE(INVERT_DIR(E6, HIGH)); break; case 7: E7_DIR_WRITE(INVERT_DIR(E7, HIGH)); break; \
       } }while(0)
     #define    _REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE( ENABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE( ENABLED(INVERT_E5_DIR)); break; \
-        case 6: E6_DIR_WRITE( ENABLED(INVERT_E6_DIR)); break; case 7: E7_DIR_WRITE( ENABLED(INVERT_E7_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, LOW )); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, LOW )); break; \
+        case 6: E6_DIR_WRITE(INVERT_DIR(E6, LOW )); break; case 7: E7_DIR_WRITE(INVERT_DIR(E7, LOW )); break; \
       } }while(0)
 
   #elif E_STEPPERS > 6
@@ -572,16 +574,16 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
         case 4: E4_STEP_WRITE(V); break; case 5: E5_STEP_WRITE(V); break; case 6: E6_STEP_WRITE(V); break; \
       } }while(0)
     #define   _NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE(DISABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE(DISABLED(INVERT_E5_DIR)); break; \
-        case 6: E6_DIR_WRITE(DISABLED(INVERT_E6_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, HIGH)); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, HIGH)); break; \
+        case 6: E6_DIR_WRITE(INVERT_DIR(E6, HIGH)); break; \
       } }while(0)
     #define    _REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE( ENABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE( ENABLED(INVERT_E5_DIR)); break; \
-        case 6: E6_DIR_WRITE( ENABLED(INVERT_E6_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, LOW )); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, LOW )); break; \
+        case 6: E6_DIR_WRITE(INVERT_DIR(E6, LOW )); break; \
       } }while(0)
 
   #elif E_STEPPERS > 5
@@ -591,14 +593,14 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
         case 4: E4_STEP_WRITE(V); break; case 5: E5_STEP_WRITE(V); break; \
       } }while(0)
     #define   _NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE(DISABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE(DISABLED(INVERT_E5_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, HIGH)); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, HIGH)); break; \
       } }while(0)
     #define    _REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE( ENABLED(INVERT_E4_DIR)); break; case 5: E5_DIR_WRITE( ENABLED(INVERT_E5_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, LOW )); break; case 5: E5_DIR_WRITE(INVERT_DIR(E5, LOW )); break; \
       } }while(0)
 
   #elif E_STEPPERS > 4
@@ -608,14 +610,14 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
         case 4: E4_STEP_WRITE(V); break; \
       } }while(0)
     #define   _NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE(DISABLED(INVERT_E4_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, HIGH)); break; \
       } }while(0)
     #define    _REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
-        case 4: E4_DIR_WRITE( ENABLED(INVERT_E4_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
+        case 4: E4_DIR_WRITE(INVERT_DIR(E4, LOW )); break; \
       } }while(0)
 
   #elif E_STEPPERS > 3
@@ -624,37 +626,37 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
         case 0: E0_STEP_WRITE(V); break; case 1: E1_STEP_WRITE(V); break; case 2: E2_STEP_WRITE(V); break; case 3: E3_STEP_WRITE(V); break; \
       } }while(0)
     #define   _NORM_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE(DISABLED(INVERT_E3_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, HIGH)); break; \
       } }while(0)
     #define    _REV_E_DIR(E)   do{ switch (E) { \
-        case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; \
-        case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); break; case 3: E3_DIR_WRITE( ENABLED(INVERT_E3_DIR)); break; \
+        case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; \
+        case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); break; case 3: E3_DIR_WRITE(INVERT_DIR(E3, LOW )); break; \
       } }while(0)
 
   #elif E_STEPPERS > 2
 
     #define _E_STEP_WRITE(E,V) do{ switch (E) { case 0: E0_STEP_WRITE(V); break; case 1: E1_STEP_WRITE(V); break; case 2: E2_STEP_WRITE(V); } }while(0)
-    #define   _NORM_E_DIR(E)   do{ switch (E) { case 0: E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); break; case 2: E2_DIR_WRITE(DISABLED(INVERT_E2_DIR)); } }while(0)
-    #define    _REV_E_DIR(E)   do{ switch (E) { case 0: E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); break; case 1: E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); break; case 2: E2_DIR_WRITE( ENABLED(INVERT_E2_DIR)); } }while(0)
+    #define   _NORM_E_DIR(E)   do{ switch (E) { case 0: E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); break; case 2: E2_DIR_WRITE(INVERT_DIR(E2, HIGH)); } }while(0)
+    #define    _REV_E_DIR(E)   do{ switch (E) { case 0: E0_DIR_WRITE(INVERT_DIR(E0, LOW )); break; case 1: E1_DIR_WRITE(INVERT_DIR(E1, LOW )); break; case 2: E2_DIR_WRITE(INVERT_DIR(E2, LOW )); } }while(0)
 
   #else
 
     #define _E_STEP_WRITE(E,V) do{ if (E == 0) { E0_STEP_WRITE(V); } else { E1_STEP_WRITE(V); } }while(0)
-    #define   _NORM_E_DIR(E)   do{ if (E == 0) { E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); } else { E1_DIR_WRITE(DISABLED(INVERT_E1_DIR)); } }while(0)
-    #define    _REV_E_DIR(E)   do{ if (E == 0) { E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); } else { E1_DIR_WRITE( ENABLED(INVERT_E1_DIR)); } }while(0)
+    #define   _NORM_E_DIR(E)   do{ if (E == 0) { E0_DIR_WRITE(INVERT_DIR(E0, HIGH)); } else { E1_DIR_WRITE(INVERT_DIR(E1, HIGH)); } }while(0)
+    #define    _REV_E_DIR(E)   do{ if (E == 0) { E0_DIR_WRITE(INVERT_DIR(E0, LOW )); } else { E1_DIR_WRITE(INVERT_DIR(E1, LOW )); } }while(0)
   #endif
 
   #if HAS_DUPLICATION_MODE
 
     #if ENABLED(MULTI_NOZZLE_DUPLICATION)
-      #define _DUPE(N,T,V)  do{ if (TEST(duplication_e_mask, N)) E##N##_##T##_WRITE(V); }while(0)
+      #define _DUPE(N,T,V) do{ if (TEST(duplication_e_mask, N)) E##N##_##T##_WRITE(V); }while(0)
     #else
-      #define _DUPE(N,T,V)  E##N##_##T##_WRITE(V)
+      #define _DUPE(N,T,V) E##N##_##T##_WRITE(V)
     #endif
 
-    #define NDIR(N) _DUPE(N,DIR,DISABLED(INVERT_E##N##_DIR))
-    #define RDIR(N) _DUPE(N,DIR, ENABLED(INVERT_E##N##_DIR))
+    #define NDIR(N) _DUPE(N,DIR,INVERT_DIR(E, HIGH))
+    #define RDIR(N) _DUPE(N,DIR,INVERT_DIR(E, LOW ))
 
     #define E_STEP_WRITE(E,V) do{ if (extruder_duplication_enabled) { DUPE(STEP,V); } else _E_STEP_WRITE(E,V); }while(0)
 
@@ -700,13 +702,13 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
 
 #elif ENABLED(E_DUAL_STEPPER_DRIVERS)
   #define E_STEP_WRITE(E,V) do{ E0_STEP_WRITE(V); E1_STEP_WRITE(V); }while(0)
-  #define   NORM_E_DIR(E)   do{ E0_DIR_WRITE(DISABLED(INVERT_E0_DIR)); E1_DIR_WRITE(DISABLED(INVERT_E0_DIR) ^ ENABLED(INVERT_E1_VS_E0_DIR)); }while(0)
-  #define    REV_E_DIR(E)   do{ E0_DIR_WRITE( ENABLED(INVERT_E0_DIR)); E1_DIR_WRITE( ENABLED(INVERT_E0_DIR) ^ ENABLED(INVERT_E1_VS_E0_DIR)); }while(0)
+  #define   NORM_E_DIR(E)   do{ constexpr bool d = INVERT_DIR(E0, HIGH); E0_DIR_WRITE(d); E1_DIR_WRITE(INVERT_DIR(E1_VS_E0, d)); }while(0)
+  #define    REV_E_DIR(E)   do{ constexpr bool d = INVERT_DIR(E0, LOW ); E0_DIR_WRITE(d); E1_DIR_WRITE(INVERT_DIR(E1_VS_E0, d)); }while(0)
 
 #elif E_STEPPERS
   #define E_STEP_WRITE(E,V) E0_STEP_WRITE(V)
-  #define   NORM_E_DIR(E)   E0_DIR_WRITE(DISABLED(INVERT_E0_DIR))
-  #define    REV_E_DIR(E)   E0_DIR_WRITE( ENABLED(INVERT_E0_DIR))
+  #define   NORM_E_DIR(E)   E0_DIR_WRITE(INVERT_DIR(E0, HIGH))
+  #define    REV_E_DIR(E)   E0_DIR_WRITE(INVERT_DIR(E0, LOW ))
 
 #else
   #define E_STEP_WRITE(E,V) NOOP


### PR DESCRIPTION
Addressing #25635…

Fixed-Time Motion Planning was originally written to a very specific test target, so it does not account for the wide variety of machines that Marlin targets. This PR adds support to `FT_MOTION` for the `INVERT_*_DIR` settings, and applies the `INVERT_DIR` macro more globally to somewhat simplify axis inverting.
