### PR TITLE
Sim: Fix sd cards on Windows

### DIFF
--- a/Marlin/src/sd/SdFatStructs.h
+++ b/Marlin/src/sd/SdFatStructs.h
@@ -66,9 +66,9 @@ struct partitionTable {
    * Sector part of Cylinder-head-sector address of the first block in
    * the partition. Legal values are 1-63. Only used in old PC BIOS.
    */
-  unsigned beginSector : 6;
+  uint8_t beginSector : 6;
   /** High bits cylinder for first block in partition. */
-  unsigned beginCylinderHigh : 2;
+  uint8_t beginCylinderHigh : 2;
   /**
    * Combine beginCylinderLow with beginCylinderHigh. Legal values
    * are 0-1023.  Only used in old PC BIOS.
@@ -88,9 +88,9 @@ struct partitionTable {
    * Sector part of cylinder-head-sector address of the last sector in
    * the partition.  Legal values are 1-63. Only used in old PC BIOS.
    */
-  unsigned endSector : 6;
+  uint8_t endSector : 6;
   /** High bits of end cylinder */
-  unsigned endCylinderHigh : 2;
+  uint8_t endCylinderHigh : 2;
   /**
    * Combine endCylinderLow with endCylinderHigh. Legal values
    * are 0-1023.  Only used in old PC BIOS.


### PR DESCRIPTION
### Description

Change the type of the partitionTables bit packed properties to `uint8_t` on Windows this allows for the compiler to pack the struct correctly reducing the size from 22 bytes to 16 as the spec requires.

This should not have any effect on other builds that are already correctly packing.

### Related Issues

fixes https://github.com/p3p/MarlinSimUI/issues/22,
fixes https://github.com/MarlinFirmware/Marlin/issues/25602
