### PR TITLE
BLTouch::command Avoid write for duplicate probe commands

### DIFF
--- a/Marlin/src/feature/bltouch.cpp
+++ b/Marlin/src/feature/bltouch.cpp
@@ -42,13 +42,11 @@ bool BLTouch::od_5v_mode;         // Initialized by settings.load, 0 = Open Drai
 #include "../core/debug_out.h"
 
 bool BLTouch::command(const BLTCommand cmd, const millis_t &ms) {
-  unsigned char current = servo[Z_PROBE_SERVO_NR].read();
-  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Command from :", current,
-    " to :", cmd);
-  // If it is already sending this command skip it and the delay, the
-  // previous write would have already delayed to detect the alarm.
-  if(current != cmd)
-  {
+  const BLTCommand current = servo[Z_PROBE_SERVO_NR].read();
+  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch from ", current, " to ", cmd);
+  // If the new command is the same, skip it (and the delay).
+  // The previous write should've already delayed to detect the alarm.
+  if (cmd != current) {
     servo[Z_PROBE_SERVO_NR].move(cmd);
     safe_delay(_MAX(ms, (uint32_t)BLTOUCH_DELAY)); // BLTOUCH_DELAY is also the *minimum* delay
   }

--- a/Marlin/src/feature/bltouch.cpp
+++ b/Marlin/src/feature/bltouch.cpp
@@ -42,9 +42,16 @@ bool BLTouch::od_5v_mode;         // Initialized by settings.load, 0 = Open Drai
 #include "../core/debug_out.h"
 
 bool BLTouch::command(const BLTCommand cmd, const millis_t &ms) {
-  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Command :", cmd);
-  servo[Z_PROBE_SERVO_NR].move(cmd);
-  safe_delay(_MAX(ms, (uint32_t)BLTOUCH_DELAY)); // BLTOUCH_DELAY is also the *minimum* delay
+  unsigned char current = servo[Z_PROBE_SERVO_NR].read();
+  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Command from :", current,
+    " to :", cmd);
+  // If it is already sending this command skip it and the delay, the
+  // previous write would have already delayed to detect the alarm.
+  if(current != cmd)
+  {
+    servo[Z_PROBE_SERVO_NR].move(cmd);
+    safe_delay(_MAX(ms, (uint32_t)BLTOUCH_DELAY)); // BLTOUCH_DELAY is also the *minimum* delay
+  }
   return triggered();
 }
 


### PR DESCRIPTION
### Description

BLTouch::command Avoid write for duplicate probe commands

deploy(); deploy(); or the reverse stow(); stow(); would delay 750 ms
each command giving time to check for an alarm.  If the command is the
same as the last command, it would have already delayed checking for
an alarm, skip the write, and skip the delay.

Here are the calls that result in the duplicate command at the start
and end of a set or probes.  Handling it on the BLTouch side seems
better than coming up with a solution to try to avoid the duplicate calls
in the nested functions.

Probe::probe_at_point() calls deploy(), run_z_probe(), stow()
run_z_probe() calls probe_down_to_z()
probe_down_to_z() calls bltouch.deploy(), bltouch.stow()

### Requirements

BLTouch

### Benefits

My auto bed level probe time increased 1 minute 15 seconds from 2.0.9.3 to bugfix-2.1.x for G29 5x5 with two touches at each point on Ender 6.

2.0.9.3 took 3:19.75
bugfix-2.1.x took 4:34.13,
bugfix-2.1.x + this change 4:02.02

More changes will be needed to get back to the 2.0.9.3 probing speed.