### PR TITLE
Serial echo on Zprobe out-of-bounds

### DIFF
--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -28,6 +28,7 @@
 #include "../../module/motion.h"
 #include "../../module/probe.h"
 #include "../../feature/bedlevel/bedlevel.h"
+#include "../../lcd/marlinui.h"
 
 #if HAS_PTC
   #include "../../feature/probe_temp_comp.h"
@@ -35,10 +36,6 @@
 
 #if HAS_MULTI_HOTEND
   #include "../../module/tool_change.h"
-#endif
-
-#if EITHER(DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
-  #include "../../lcd/marlinui.h"
 #endif
 
 /**
@@ -106,9 +103,7 @@ void GcodeSuite::G30() {
   }
   else {
     SERIAL_ECHOLNF(GET_EN_TEXT_F(MSG_ZPROBE_OUT));
-    #if ENABLED(DWIN_LCD_PROUI)
-      LCD_MESSAGE(MSG_ZPROBE_OUT);
-    #endif
+    LCD_MESSAGE(MSG_ZPROBE_OUT);
   }
 
   probe.use_probing_tool(false);

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -105,8 +105,8 @@ void GcodeSuite::G30() {
     report_current_position();
   }
   else {
+    SERIAL_ECHOLNF(GET_EN_TEXT_F(MSG_ZPROBE_OUT));
     #if ENABLED(DWIN_LCD_PROUI)
-      SERIAL_ECHOLNF(GET_EN_TEXT_F(MSG_ZPROBE_OUT));
       LCD_MESSAGE(MSG_ZPROBE_OUT);
     #endif
   }


### PR DESCRIPTION
### Description

G30 probe command does nothing and echoes nothing on out-of-bounds when DWIN_LCD_PROUI is not enabled.
DWIN_LCD_PROUI should only be used for the LCD_MESSAGE, not the SERIAL_ECHOLNF.

### Requirements

Marlin firmware built without DWIN_LCD_PROUI, run G30 on out-of-bounds point.

### Benefits

Feedback now echoed to serial when probing an out-of-bounds point

### Configurations

Marlin firmware built without DWIN_LCD_PROUI.

### Related Issues

