### PR TITLE
Fix incorrectly displayed status during G29 J

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -1499,7 +1499,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 
       LOOP_L_N(i, 3) {
         SERIAL_ECHOLNPGM("Tilting mesh (", i + 1, "/3)");
-        TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), i + 1, GET_TEXT(MSG_LCD_TILTING_MESH)));
+        TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), GET_TEXT(MSG_LCD_TILTING_MESH), i + 1));
 
         measured_z = probe.probe_at_point(points[i], i < 2 ? PROBE_PT_RAISE : PROBE_PT_LAST_STOW, param.V_verbosity);
         if ((abort_flag = isnan(measured_z))) break;


### PR DESCRIPTION
### Description
During G29 J, the status screen currently displays no message and a huge number (something like "130154941/3") instead of the correct "Tilting point 1/3". Looks like there was a small typo introduced in #25522, which switches the positions of text and number in the function call. This PR should fix that.

### Requirements

Printer with status message display, UBL active, G29 configured for three-point leveling.

### Benefits

Correctly displays status and current tilting point in status message.

### Configurations

-

### Related Issues

None that I know of.
