### PR TITLE
Fix for G38 not compiling without Z endstops

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -341,21 +341,21 @@
   #ifdef MANUAL_U_HOME_POS
     #define U_HOME_POS MANUAL_U_HOME_POS
   #else
-    #define U_HOME_POS (U_HOME_DIR < 0 ? U_MIN_POS : U_MAX_POS)
+    #define U_HOME_POS TERN(U_HOME_TO_MIN, U_MIN_POS, U_MAX_POS)
   #endif
 #endif
 #if HAS_V_AXIS
   #ifdef MANUAL_V_HOME_POS
     #define V_HOME_POS MANUAL_V_HOME_POS
   #else
-    #define V_HOME_POS (V_HOME_DIR < 0 ? V_MIN_POS : V_MAX_POS)
+    #define V_HOME_POS TERN(V_HOME_TO_MIN, V_MIN_POS, V_MAX_POS)
   #endif
 #endif
 #if HAS_W_AXIS
   #ifdef MANUAL_W_HOME_POS
     #define W_HOME_POS MANUAL_W_HOME_POS
   #else
-    #define W_HOME_POS (W_HOME_DIR < 0 ? W_MIN_POS : W_MAX_POS)
+    #define W_HOME_POS TERN(W_HOME_TO_MIN, W_MIN_POS, W_MAX_POS)
   #endif
 #endif
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -920,7 +920,7 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
       #endif
-      #if HAS_Z_AXIS && USE_ZMIN_PLUG
+      #if (HAS_Z_AXIS && USE_ZMIN_PLUG)
         else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
       #endif
       G38_did_trigger = true;

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -920,7 +920,7 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
       #endif
-      #if BOTH(HAS_Z_AXIS, USE_ZMIN_PLUG)
+      #if BOTH(HAS_Z_AXIS, HAS_Z_MIN)
         else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
       #endif
       G38_did_trigger = true;

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -915,14 +915,22 @@ void Endstops::update() {
   #if HAS_G38_PROBE // TODO (DerAndere): Add support for HAS_I_AXIS
     // For G38 moves check the probe's pin for ALL movement
     if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) == TERN1(G38_PROBE_AWAY, (G38_move < 4))) {
-             if (stepper.axis_is_moving(X_AXIS)) { _ENDSTOP_HIT(X, TERN(X_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(X_AXIS); }
+      G38_did_trigger = true;
+      #if HAS_X_AXIS
+        const bool xmoving = stepper.axis_is_moving(X_AXIS);
+      #endif
       #if HAS_Y_AXIS
-        else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
+        const bool ymoving = stepper.axis_is_moving(Y_AXIS);
       #endif
       #if HAS_Z_MIN
-        else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
+        const bool zmoving = stepper.axis_is_moving(Z_AXIS);
       #endif
-      G38_did_trigger = true;
+      TERN_(HAS_X_AXIS, if (xmoving) _ENDSTOP_HIT(X, TERN(X_HOME_TO_MIN, MIN, MAX)));
+      TERN_(HAS_Y_AXIS, if (ymoving) _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)));
+      TERN_(HAS_Z_MIN,  if (zmoving) _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)));
+      TERN_(HAS_X_AXIS, if (xmoving) planner.endstop_triggered(X_AXIS));
+      TERN_(HAS_Y_AXIS, if (ymoving) planner.endstop_triggered(Y_AXIS));
+      TERN_(HAS_Z_MIN,  if (zmoving) planner.endstop_triggered(Z_AXIS));
     }
   #endif
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -922,15 +922,18 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         const bool ymoving = stepper.axis_is_moving(Y_AXIS);
       #endif
-      #if HAS_Z_MIN
+      #if HAS_Z_AXIS
         const bool zmoving = stepper.axis_is_moving(Z_AXIS);
       #endif
-      TERN_(HAS_X_AXIS, if (xmoving) _ENDSTOP_HIT(X, TERN(X_HOME_TO_MIN, MIN, MAX)));
-      TERN_(HAS_Y_AXIS, if (ymoving) _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)));
-      TERN_(HAS_Z_MIN,  if (zmoving) _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)));
-      TERN_(HAS_X_AXIS, if (xmoving) planner.endstop_triggered(X_AXIS));
-      TERN_(HAS_Y_AXIS, if (ymoving) planner.endstop_triggered(Y_AXIS));
-      TERN_(HAS_Z_MIN,  if (zmoving) planner.endstop_triggered(Z_AXIS));
+      #if HAS_X_AXIS
+        if (xmoving) { _ENDSTOP_HIT(X, ENDSTOP); planner.endstop_triggered(X_AXIS); }
+      #endif
+      #if HAS_Y_AXIS
+        if (ymoving) { _ENDSTOP_HIT(Y, ENDSTOP); planner.endstop_triggered(Y_AXIS); }
+      #endif
+      #if HAS_Z_AXIS
+        if (zmoving) { _ENDSTOP_HIT(Z, ENDSTOP); planner.endstop_triggered(Z_AXIS); }
+      #endif
     }
   #endif
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -916,24 +916,10 @@ void Endstops::update() {
     // For G38 moves check the probe's pin for ALL movement
     if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) == TERN1(G38_PROBE_AWAY, (G38_move < 4))) {
       G38_did_trigger = true;
-      #if HAS_X_AXIS
-        const bool xmoving = stepper.axis_is_moving(X_AXIS);
-      #endif
-      #if HAS_Y_AXIS
-        const bool ymoving = stepper.axis_is_moving(Y_AXIS);
-      #endif
-      #if HAS_Z_AXIS
-        const bool zmoving = stepper.axis_is_moving(Z_AXIS);
-      #endif
-      #if HAS_X_AXIS
-        if (xmoving) { _ENDSTOP_HIT(X, ENDSTOP); planner.endstop_triggered(X_AXIS); }
-      #endif
-      #if HAS_Y_AXIS
-        if (ymoving) { _ENDSTOP_HIT(Y, ENDSTOP); planner.endstop_triggered(Y_AXIS); }
-      #endif
-      #if HAS_Z_AXIS
-        if (zmoving) { _ENDSTOP_HIT(Z, ENDSTOP); planner.endstop_triggered(Z_AXIS); }
-      #endif
+      #define _G38_SET(Q) | (stepper.axis_is_moving(_AXIS(Q)) << _AXIS(Q))
+      #define _G38_RESP(Q) if (moving[_AXIS(Q)]) { _ENDSTOP_HIT(Q, ENDSTOP); planner.endstop_triggered(_AXIS(Q)); }
+      const Flags<NUM_AXES> moving = { value_t(NUM_AXES)(0 MAIN_AXIS_MAP(_G38_SET)) };
+      MAIN_AXIS_MAP(_G38_RESP);
     }
   #endif
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -920,7 +920,7 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
       #endif
-      #if HAS_Z_AXIS
+      #if HAS_Z_AXIS && USE_ZMIN_PLUG
         else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
       #endif
       G38_did_trigger = true;

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -913,7 +913,7 @@ void Endstops::update() {
   #endif
 
   #if HAS_G38_PROBE // TODO (DerAndere): Add support for HAS_I_AXIS
-    // For G38 moves check the probes pin for ALL movement
+    // For G38 moves check the probe's pin for ALL movement
     if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) == TERN1(G38_PROBE_AWAY, (G38_move < 4))) {
       G38_did_trigger = true;
       #define _G38_SET(Q) | (stepper.axis_is_moving(_AXIS(Q)) << _AXIS(Q))

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -920,7 +920,7 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
       #endif
-      #if (HAS_Z_AXIS && USE_ZMIN_PLUG)
+      #if BOTH(HAS_Z_AXIS, USE_ZMIN_PLUG)
         else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
       #endif
       G38_did_trigger = true;

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -920,7 +920,7 @@ void Endstops::update() {
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }
       #endif
-      #if BOTH(HAS_Z_AXIS, HAS_Z_MIN)
+      #if HAS_Z_MIN
         else if (stepper.axis_is_moving(Z_AXIS)) { _ENDSTOP_HIT(Z, TERN(Z_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Z_AXIS); }
       #endif
       G38_did_trigger = true;

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -913,9 +913,8 @@ void Endstops::update() {
   #endif
 
   #if HAS_G38_PROBE // TODO (DerAndere): Add support for HAS_I_AXIS
-    #define _G38_OPEN_STATE TERN(G38_PROBE_AWAY, (G38_move >= 4), LOW)
     // For G38 moves check the probe's pin for ALL movement
-    if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) != _G38_OPEN_STATE) {
+    if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) == TERN1(G38_PROBE_AWAY, (G38_move < 4))) {
              if (stepper.axis_is_moving(X_AXIS)) { _ENDSTOP_HIT(X, TERN(X_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(X_AXIS); }
       #if HAS_Y_AXIS
         else if (stepper.axis_is_moving(Y_AXIS)) { _ENDSTOP_HIT(Y, TERN(Y_HOME_TO_MIN, MIN, MAX)); planner.endstop_triggered(Y_AXIS); }

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -913,7 +913,7 @@ void Endstops::update() {
   #endif
 
   #if HAS_G38_PROBE // TODO (DerAndere): Add support for HAS_I_AXIS
-    // For G38 moves check the probe's pin for ALL movement
+    // For G38 moves check the probes pin for ALL movement
     if (G38_move && TEST_ENDSTOP(_ENDSTOP(Z, TERN(USES_Z_MIN_PROBE_PIN, MIN_PROBE, MIN))) == TERN1(G38_PROBE_AWAY, (G38_move < 4))) {
       G38_did_trigger = true;
       #define _G38_SET(Q) | (stepper.axis_is_moving(_AXIS(Q)) << _AXIS(Q))


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

This PR makes it possible to enable and use G38 commands on a printer without minimum Z axis endstops. 

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

To test this PR, it requires having a 3d printer with a probe. 

### Benefits

<!-- What does this PR fix or improve? -->

This allows G38 to work when there isn't a minimum Z axis endstop. This change is important because of:
- Freedom. When using tools, such as Octoprint, wouldn't it be nice to have plugins be possible that can probe a board position with G38? G30 sort of works, but it has extra safety stuff which we don't always want. Eg when probing the top of a print we don't want Marlin to detect that the probe was activated too early and shut off the printer. 
- Machines without Z axis endstops make sense when we have a probe. This PR makes this possible to do this AND enable G38. 

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

[Configuration.tar.gz](https://github.com/MarlinFirmware/Marlin/files/11241324/Configuration.tar.gz)

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

https://github.com/MarlinFirmware/Marlin/issues/22722

