### PR TITLE
Further improvement to prevent potential LA related hang

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1578,7 +1578,7 @@ void Stepper::isr() {
           advance_isr();
           nextAdvanceISR = la_interval;
         }
-        else if (nextAdvanceISR == LA_ADV_NEVER)          // Start LA steps if necessary
+        else if (nextAdvanceISR > la_interval)            // Start/accelerate LA steps if necessary
           nextAdvanceISR = la_interval;
       #endif
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2169,7 +2169,8 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
   #ifdef CPU_32_BIT
 
     // A fast processor can just do integer division
-    return step_rate ? uint32_t(STEPPER_TIMER_RATE) / step_rate : HAL_TIMER_TYPE_MAX;
+    constexpr uint32_t min_step_rate = uint32_t(STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX;
+    return step_rate > min_step_rate ? uint32_t(STEPPER_TIMER_RATE) / step_rate : HAL_TIMER_TYPE_MAX;
 
   #else
 


### PR DESCRIPTION
### Description

#25557 fixed a problem where a division by zero in the 32 bit code for `Stepper::calc_timer_interval()` resulted in `la_interval == 0` which caused an infinite loop in the stepper ISR.

There remains a potential edge case where `Stepper::calc_timer_interval()` is passed a very low `step_rate` which results in a return value that is larger than can fit into `hal_timer_t`. In the very edgiest case it could even be a number that truncates to zero when converted to type `hal_timer_t`, also causing a hang. But even in the more general edge case it will result in a smaller value for `la_interval` than is correct.

This PR introduces an analogy to the 8 bit code which tests for `min_step_rate` and returns a fixed large number if `step_rate` is too small.

In addition, whilst working on this, I realised that if `la_interval` ends up being a large number (because `step_rate` is really low) then the E steps will freeze until `la_interval` has expired. But `step_rate` will only ever be really low momentarily (at the point where the E stepper reverses during a deceleration ramp due to linear advance). Long before `la_interval` has expired, it will receive a new, smaller value which should be honoured to avoid missed E steps. So there is a correction for this as well.

### Requirements

Enable `LIN_ADVANCE`.

### Benefits

Removes a potential edge case hang and potential lost E steps.

### Related Issues

#25553
#25557
