### PR TITLE
add missing board to env:STM32F103RE_creality_smartPro

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -135,16 +135,6 @@ debug_tool                  = jlink
 upload_protocol             = jlink
 
 #
-# Trigorilla V0.0.6 (GD32F103)
-#  modified version of env:STM32F103RE_creality
-#
-[env:trigorilla_v006]
-extends                     = STM32F103Rx_creality
-board                       = genericSTM32F103RE
-board_build.offset          = 0x8000
-board_upload.offset_address = 0x08008000
-
-#
 # Creality (STM32F103Rx)
 # With custom upload to SD via Marlin with binary protocol.
 # Requires Marlin with BINARY_FILE_TRANSFER already installed on the target board.
@@ -176,10 +166,18 @@ board   = genericSTM32F103RE
 # Creality 512K (STM32F103RE) for new 64KiB bootloader (CR-10 Smart Pro printer)
 #
 [env:STM32F103RE_creality_smartPro]
-extends                     = STM32F103Rx_creality
-board                       = genericSTM32F103RE
+extends                     = env:STM32F103RE_creality
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
+
+#
+# Trigorilla V0.0.6 (GD32F103)
+#  modified version of env:STM32F103RE_creality
+#
+[env:trigorilla_v006]
+extends                     = env:STM32F103RE_creality
+board_build.offset          = 0x8000
+board_upload.offset_address = 0x08008000
 
 #
 # Creality 256K (STM32F103RC)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -177,6 +177,7 @@ board   = genericSTM32F103RE
 #
 [env:STM32F103RE_creality_smartPro]
 extends                     = STM32F103Rx_creality
+board                       = genericSTM32F103RE
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
 

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -229,54 +229,7 @@ platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${env:STM32F103RE_btt.build_flags}
                     -DUSE_USB_FS -DUSBD_IRQ_PRIO=5
                     -DUSBD_IRQ_SUBPRIO=6 -DUSBD_USE_CDC_MSC
-build_unflags     = ${stm32_variant.build_unflags} -DUSBD_USE_CDC
-
-#
-# FLSUN QQS Pro (STM32F103VET6)
-# board Hispeedv1
-#
-[env:flsun_hispeedv1]
-extends                     = stm32_variant
-board                       = genericSTM32F103VE
-board_build.variant         = MARLIN_F103Vx
-board_build.encrypt_mks     = Robin_mini.bin
-board_build.offset          = 0x7000
-board_upload.offset_address = 0x08007000
-build_flags                 = ${stm32_variant.build_flags}
-                              -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
-                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
-build_unflags               = ${stm32_variant.build_unflags}
-                              -DUSBCON -DUSBD_USE_CDC
-
-[mks_robin_nano_v1v2_common]
-extends                     = stm32_variant
-board                       = genericSTM32F103VE
-board_build.variant         = MARLIN_F103Vx
-board_build.encrypt_mks     = Robin_nano35.bin
-board_build.offset          = 0x7000
-board_upload.offset_address = 0x08007000
-debug_tool                  = stlink
-upload_protocol             = stlink
-
-#
-# MKS Robin Nano V1.2 and V2
-#
-[env:mks_robin_nano_v1v2]
-extends                     = mks_robin_nano_v1v2_common
-build_flags                 = ${stm32_variant.build_flags}
-                              -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
-                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
-build_unflags               = ${stm32_variant.build_unflags}
-                              -DUSBCON -DUSBD_USE_CDC
-
-#
-# MKS/ZNP Robin Nano V1.2 and V2 with native USB modification
-#
-[env:mks_robin_nano_v1v2_usbmod]
-extends                     = mks_robin_nano_v1v2_common
-build_flags                 = ${common_stm32.build_flags}
-                              -DMCU_STM32F103VE -DSS_TIMER=4
-                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+build_unflags     = ${env:STM32F103RE_btt.build_unflags} -DUSBD_USE_CDC
 
 #
 # Mingda MPX_ARM_MINI
@@ -314,17 +267,63 @@ board_upload.offset_address = 0x08005000
 build_flags                 = ${stm32_variant.build_flags} -DSS_TIMER=4
 
 #
-# MKS Robin Mini (STM32F103VET6)
+# (STM32F103VE_robin)
 #
-[env:mks_robin_mini]
+[STM32F103VE_robin]
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
-board_build.encrypt_mks     = Robin_mini.bin
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
-build_flags                 = ${stm32_variant.build_flags}
-                              -DMCU_STM32F103VE -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
+build_flags                 = ${stm32_variant.build_flags} -DMCU_STM32F103VE -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2 -DSS_TIMER=4
+
+[mks_robin_nano_v1v2_common]
+extends                     = STM32F103VE_robin
+board_build.encrypt_mks     = Robin_nano35.bin
+debug_tool                  = stlink
+upload_protocol             = stlink
+
+#
+# MKS/ZNP Robin Nano V1.2 and V2 with native USB modification
+#
+[env:mks_robin_nano_v1v2_usbmod]
+extends                     = mks_robin_nano_v1v2_common
+
+#
+# MKS Robin Nano V1.2 and V2
+#
+[env:mks_robin_nano_v1v2]
+extends                     = mks_robin_nano_v1v2_common
+build_flags                 = ${mks_robin_nano_v1v2_common.build_flags} -DENABLE_HWSERIAL3
+build_unflags               = ${mks_robin_nano_v1v2_common.build_unflags} -DUSBCON -DUSBD_USE_CDC
+
+#
+# MKS Robin Mini (STM32F103VET6)
+#
+[env:mks_robin_mini]
+extends                     = STM32F103VE_robin
+board_build.encrypt_mks     = Robin_mini.bin
+build_unflags               = ${STM32F103VE_robin.build_unflags} -DSS_TIMER=4
+
+#
+# MKS Robin E3p (STM32F103VET6)
+#  - LVGL UI
+#
+[env:mks_robin_e3p]
+extends                     = STM32F103VE_robin
+board_build.encrypt_mks     = Robin_e3p.bin
+debug_tool                  = jlink
+upload_protocol             = jlink
+
+#
+# FLSUN QQS Pro (STM32F103VET6)
+# Hispeedv1 Robin mini variant
+#
+[env:flsun_hispeedv1]
+extends                     = STM32F103VE_robin
+board_build.encrypt_mks     = Robin_mini.bin
+build_flags                 = ${STM32F103VE_robin.build_flags} -DENABLE_HWSERIAL3
+build_unflags               = ${STM32F103VE_robin.build_unflags} -DUSBCON -DUSBD_USE_CDC
 
 #
 # MKS Robin Lite/Lite2 (STM32F103RCT6)
@@ -350,23 +349,6 @@ board_build.encrypt_mks     = mksLite3.bin
 [env:mks_robin_pro]
 extends                 = env:mks_robin
 board_build.encrypt_mks = Robin_pro.bin
-
-#
-# MKS Robin E3p (STM32F103VET6)
-#  - LVGL UI
-#
-[env:mks_robin_e3p]
-extends                     = stm32_variant
-board                       = genericSTM32F103VE
-board_build.variant         = MARLIN_F103Vx
-board_build.encrypt_mks     = Robin_e3p.bin
-board_build.offset          = 0x7000
-board_upload.offset_address = 0x08007000
-build_flags                 = ${stm32_variant.build_flags}
-                              -DMCU_STM32F103VE -DSS_TIMER=4
-                              -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
-debug_tool                  = jlink
-upload_protocol             = jlink
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)


### PR DESCRIPTION
### Description

env:STM32F103RE_creality_smartPro does not define a board 

gives a long barely comprehensible error as follows: 
```
Error: Traceback (most recent call last):
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/__main__.py", line 102, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/cli.py", line 71, in invoke
    return super().invoke(ctx)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/run/cli.py", line 147, in cli
    process_env(
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/run/cli.py", line 204, in process_env
    result = {"env": name, "duration": time(), "succeeded": ep.process()}
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/run/processor.py", line 83, in process
    install_project_env_dependencies(
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/package/commands/install.py", line 131, in install_project_env_dependencies
    _install_project_env_platform(project_env, options),
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/package/commands/install.py", line 148, in _install_project_env_platform
    PlatformPackageManager().install(
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/package/manager/platform.py", line 60, in install
    p.configure_project_packages(project_env, project_targets)
  File "/home/redacted/.platformio/penv/lib/python3.10/site-packages/platformio/platform/base.py", line 184, in configure_project_packages
    self.configure_default_packages(options, targets or [])
  File "/home/redacted/.platformio/platforms/ststm32@12.1.1/platform.py", line 35, in configure_default_packages
    if board.startswith("portenta"):
AttributeError: 'NoneType' object has no attribute 'startswith'

```

The fix is to simply define the board 
Add missing board = genericSTM32F103RE

### Requirements

Minimal config 
#define MOTHERBOARD BOARD_CREALITY_V25S1
#define SERIAL_PORT 1
#define FAN_SOFT_PWM

default_envs = STM32F103RE_creality_smartPro

### Benefits

Builds as ecpected

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/24151