### PR TITLE
🐛 Fix Z_AFTER_HOMING when 0 and Z_HOME_POS is not 0

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -195,7 +195,7 @@ public:
   #endif
   static void move_z_after_probing(const float z=Z_AFTER_PROBING) {
     DEBUG_SECTION(mzah, "move_z_after_probing", DEBUGGING(LEVELING));
-    if (z != 0) do_z_clearance(z, true, true); // Move down still permitted
+    if (z != Z_HOME_POS) do_z_clearance(z, true, true); // Move down still permitted
   }
   static void move_z_after_homing() {
     DEBUG_SECTION(mzah, "move_z_after_homing", DEBUGGING(LEVELING));


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

`Z_AFTER_HOMING` no longer functions when it has a value of `0` and the printer does not home to `0`.

For example, my printer homes its Z axis to `-1`. With `Z_AFTER_HOMING 0`, the z axis should move *up* 1 mm to 0 after homing.

After commit 4e73fdd this no longer happens. This is because the new implementation of `move_z_after_probing`, which is called by `move_z_after_homing`, assumes that Z = 0 is always home. Instead, it should check against `Z_HOME_POS`.

### Requirements

Any configuration with a `Z_AFTER_HOMING` value of 0 and `Z_HOME_POS` value that is not 0.

### Benefits

`Z_AFTER_HOMING` functions properly.

### Configurations

see above, but my Ender 3 v2 with Octopus 1.1 board config is below:
[ender 3 v2 octopus.zip](https://github.com/MarlinFirmware/Marlin/files/11250698/ender.3.v2.octopus.zip)


### Related Issues

This may be related to or affecting some of the behavior in #25631