### PR TITLE
rework ui displayed features

### DIFF
--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -228,25 +228,25 @@ void MarlinUI::draw_status_screen() {
   for (i = 0 ; i < ITEMS_COUNT; i++) {
     x = (TFT_WIDTH / ITEMS_COUNT - 80) / 2  + (TFT_WIDTH * i / ITEMS_COUNT);
     switch (i) {
-      #ifdef ITEM_E0
+      #if HAS_EXTRUDERS
         case ITEM_E0: draw_heater_status(x, y, H_E0); break;
       #endif
-      #ifdef ITEM_E1
+      #if HAS_MULTI_HOTEND
         case ITEM_E1: draw_heater_status(x, y, H_E1); break;
       #endif
-      #ifdef ITEM_E2
+      #if HOTENDS > 2
         case ITEM_E2: draw_heater_status(x, y, H_E2); break;
       #endif
-      #ifdef ITEM_BED
+      #if HAS_HEATED_BED
         case ITEM_BED: draw_heater_status(x, y, H_BED); break;
       #endif
-      #ifdef ITEM_CHAMBER
+      #if HAS_TEMP_CHAMBER
         case ITEM_CHAMBER: draw_heater_status(x, y, H_CHAMBER); break;
       #endif
-      #ifdef ITEM_COOLER
+      #if HAS_TEMP_COOLER
         case ITEM_COOLER: draw_heater_status(x, y, H_COOLER); break;
       #endif
-      #ifdef ITEM_FAN
+      #if HAS_FAN
         case ITEM_FAN: draw_fan_status(x, y, blink); break;
       #endif
     }

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -230,25 +230,25 @@ void MarlinUI::draw_status_screen() {
   for (i = 0 ; i < ITEMS_COUNT; i++) {
     x = (TFT_WIDTH / ITEMS_COUNT - 64) / 2  + (TFT_WIDTH * i / ITEMS_COUNT);
     switch (i) {
-      #ifdef ITEM_E0
+      #if HAS_EXTRUDERS
         case ITEM_E0: draw_heater_status(x, y, H_E0); break;
       #endif
-      #ifdef ITEM_E1
+      #if HAS_MULTI_HOTEND
         case ITEM_E1: draw_heater_status(x, y, H_E1); break;
       #endif
-      #ifdef ITEM_E2
+      #if HOTENDS > 2
         case ITEM_E2: draw_heater_status(x, y, H_E2); break;
       #endif
-      #ifdef ITEM_BED
+      #if HAS_HEATED_BED
         case ITEM_BED: draw_heater_status(x, y, H_BED); break;
       #endif
-      #ifdef ITEM_CHAMBER
+      #if HAS_TEMP_CHAMBER
         case ITEM_CHAMBER: draw_heater_status(x, y, H_CHAMBER); break;
       #endif
-      #ifdef ITEM_COOLER
+      #if HAS_TEMP_COOLER
         case ITEM_COOLER: draw_heater_status(x, y, H_COOLER); break;
       #endif
-      #ifdef ITEM_FAN
+      #if HAS_FAN
         case ITEM_FAN: draw_fan_status(x, y, blink); break;
       #endif
     }

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -228,25 +228,25 @@ void MarlinUI::draw_status_screen() {
   for (i = 0 ; i < ITEMS_COUNT; i++) {
     x = (TFT_WIDTH / ITEMS_COUNT - 80) / 2  + (TFT_WIDTH * i / ITEMS_COUNT);
     switch (i) {
-      #ifdef ITEM_E0
+      #if HAS_EXTRUDERS
         case ITEM_E0: draw_heater_status(x, y, H_E0); break;
       #endif
-      #ifdef ITEM_E1
+      #if HAS_MULTI_HOTEND
         case ITEM_E1: draw_heater_status(x, y, H_E1); break;
       #endif
-      #ifdef ITEM_E2
+      #if HOTENDS > 2
         case ITEM_E2: draw_heater_status(x, y, H_E2); break;
       #endif
-      #ifdef ITEM_BED
+      #if HAS_HEATED_BED
         case ITEM_BED: draw_heater_status(x, y, H_BED); break;
       #endif
-      #ifdef ITEM_CHAMBER
+      #if HAS_TEMP_CHAMBER
         case ITEM_CHAMBER: draw_heater_status(x, y, H_CHAMBER); break;
       #endif
-      #ifdef ITEM_COOLER
+      #if HAS_TEMP_COOLER
         case ITEM_COOLER: draw_heater_status(x, y, H_COOLER); break;
       #endif
-      #ifdef ITEM_FAN
+      #if HAS_FAN
         case ITEM_FAN: draw_fan_status(x, y, blink); break;
       #endif
     }

--- a/Marlin/src/lcd/tft/ui_common.h
+++ b/Marlin/src/lcd/tft/ui_common.h
@@ -57,90 +57,15 @@ void menu_item(const uint8_t row, bool sel = false);
 
 #define ABSOLUTE_ZERO     -273.15
 
-#if HAS_EXTRUDERS
-  #define ITEM_E0         0
-  #if HOTENDS > 1
-    #define ITEM_E1       1
-  #endif
+enum {
+  OPTITEM(HAS_EXTRUDERS, ITEM_E0)
+  OPTITEM(HAS_MULTI_HOTEND, ITEM_E1)
   #if HOTENDS > 2
-    #define ITEM_E2       2
+    ITEM_E2,
   #endif
-#endif
-
-#if HAS_HOTBED
-  #if defined(ITEM_E2)
-    #define ITEM_BED (ITEM_E2 + 1)
-  #elif defined(ITEM_E1)
-    #define ITEM_BED (ITEM_E1 + 1)
-  #elif defined(ITEM_E0)
-    #define ITEM_BED (ITEM_E0 + 1)
-  #else
-    #define ITEM_BED 0
-  #endif
-#endif
-
-#if HAS_TEMP_CHAMBER
-  #if defined(ITEM_BED)
-    #define ITEM_CHAMBER (ITEM_BED + 1)
-  #elif defined(ITEM_E2)
-    #define ITEM_CHAMBER (ITEM_E2 + 1)
-  #elif defined(ITEM_E1)
-    #define ITEM_CHAMBER (ITEM_E1 + 1)
-  #elif defined(ITEM_E0)
-    #define ITEM_CHAMBER (ITEM_E0 + 1)
-  #else
-    #define ITEM_CHAMBER 0
-  #endif
-#endif
-
-#if HAS_TEMP_COOLER
-  #if defined(ITEM_CHAMBER)
-    #define ITEM_COOLER (ITEM_CHAMBER + 1)
-  #elif defined(ITEM_BED)
-    #define ITEM_COOLER (ITEM_BED + 1)
-  #elif defined(ITEM_E2)
-    #define ITEM_COOLER (ITEM_E2 + 1)
-  #elif defined(ITEM_E1)
-    #define ITEM_COOLER (ITEM_E1 + 1)
-  #elif defined(ITEM_E0)
-    #define ITEM_COOLER (ITEM_E0 + 1)
-  #else
-    #define ITEM_COOLER 0
-  #endif
-#endif
-
-#if HAS_FAN
-  #if defined(ITEM_COOLER)
-    #define ITEM_FAN (ITEM_COOLER + 1)
-  #elif defined(ITEM_CHAMBER)
-    #define ITEM_FAN (ITEM_CHAMBER + 1)
-  #elif defined(ITEM_BED)
-    #define ITEM_FAN (ITEM_BED + 1)
-  #elif defined(ITEM_E2)
-    #define ITEM_FAN (ITEM_E2 + 1)
-  #elif defined(ITEM_E1)
-    #define ITEM_FAN (ITEM_E1 + 1)
-  #elif defined(ITEM_E0)
-    #define ITEM_FAN (ITEM_E0 + 1)
-  #else
-    #define ITEM_FAN 0
-  #endif
-#endif
-
-#if defined(ITEM_FAN)
-  #define ITEMS_COUNT (ITEM_FAN + 1)
-#elif defined(ITEM_COOLER)
-  #define ITEMS_COUNT (ITEM_COOLER + 1)
-#elif defined(ITEM_CHAMBER)
-  #define ITEMS_COUNT (ITEM_CHAMBER + 1)
-#elif defined(ITEM_BED)
-  #define ITEMS_COUNT (ITEM_BED + 1)
-#elif defined(ITEM_E2)
-  #define ITEMS_COUNT (ITEM_E2 + 1)
-#elif defined(ITEM_E1)
-  #define ITEMS_COUNT (ITEM_E1 + 1)
-#elif defined(ITEM_E0)
-  #define ITEMS_COUNT (ITEM_E0 + 1)
-#else
-  #define ITEMS_COUNT 0
-#endif
+  OPTITEM(HAS_HEATED_BED, ITEM_BED)
+  OPTITEM(HAS_TEMP_CHAMBER, ITEM_CHAMBER)
+  OPTITEM(HAS_TEMP_COOLER, ITEM_COOLER)
+  OPTITEM(HAS_FAN, ITEM_FAN)
+  ITEMS_COUNT
+};

--- a/Marlin/src/lcd/tft/ui_common.h
+++ b/Marlin/src/lcd/tft/ui_common.h
@@ -57,32 +57,90 @@ void menu_item(const uint8_t row, bool sel = false);
 
 #define ABSOLUTE_ZERO     -273.15
 
-#if HAS_TEMP_CHAMBER && HAS_MULTI_HOTEND
+#if HAS_EXTRUDERS
   #define ITEM_E0         0
-  #define ITEM_E1         1
-  #define ITEM_BED        2
-  #define ITEM_CHAMBER    3
-  #define ITEM_FAN        4
-  #define ITEMS_COUNT     5
-#elif HAS_TEMP_CHAMBER
-  #define ITEM_E0         0
-  #define ITEM_BED        1
-  #define ITEM_CHAMBER    2
-  #define ITEM_FAN        3
-  #define ITEMS_COUNT     4
-#elif HAS_TEMP_COOLER
-  #define ITEM_COOLER     0
-  #define ITEM_FAN        1
-  #define ITEMS_COUNT     2
-#elif HAS_MULTI_HOTEND
-  #define ITEM_E0         0
-  #define ITEM_E1         1
-  #define ITEM_BED        2
-  #define ITEM_FAN        3
-  #define ITEMS_COUNT     4
+  #if HOTENDS > 1
+    #define ITEM_E1       1
+  #endif
+  #if HOTENDS > 2
+    #define ITEM_E2       2
+  #endif
+#endif
+
+#if HAS_HOTBED
+  #if defined(ITEM_E2)
+    #define ITEM_BED (ITEM_E2 + 1)
+  #elif defined(ITEM_E1)
+    #define ITEM_BED (ITEM_E1 + 1)
+  #elif defined(ITEM_E0)
+    #define ITEM_BED (ITEM_E0 + 1)
+  #else
+    #define ITEM_BED 0
+  #endif
+#endif
+
+#if HAS_TEMP_CHAMBER
+  #if defined(ITEM_BED)
+    #define ITEM_CHAMBER (ITEM_BED + 1)
+  #elif defined(ITEM_E2)
+    #define ITEM_CHAMBER (ITEM_E2 + 1)
+  #elif defined(ITEM_E1)
+    #define ITEM_CHAMBER (ITEM_E1 + 1)
+  #elif defined(ITEM_E0)
+    #define ITEM_CHAMBER (ITEM_E0 + 1)
+  #else
+    #define ITEM_CHAMBER 0
+  #endif
+#endif
+
+#if HAS_TEMP_COOLER
+  #if defined(ITEM_CHAMBER)
+    #define ITEM_COOLER (ITEM_CHAMBER + 1)
+  #elif defined(ITEM_BED)
+    #define ITEM_COOLER (ITEM_BED + 1)
+  #elif defined(ITEM_E2)
+    #define ITEM_COOLER (ITEM_E2 + 1)
+  #elif defined(ITEM_E1)
+    #define ITEM_COOLER (ITEM_E1 + 1)
+  #elif defined(ITEM_E0)
+    #define ITEM_COOLER (ITEM_E0 + 1)
+  #else
+    #define ITEM_COOLER 0
+  #endif
+#endif
+
+#if HAS_FAN
+  #if defined(ITEM_COOLER)
+    #define ITEM_FAN (ITEM_COOLER + 1)
+  #elif defined(ITEM_CHAMBER)
+    #define ITEM_FAN (ITEM_CHAMBER + 1)
+  #elif defined(ITEM_BED)
+    #define ITEM_FAN (ITEM_BED + 1)
+  #elif defined(ITEM_E2)
+    #define ITEM_FAN (ITEM_E2 + 1)
+  #elif defined(ITEM_E1)
+    #define ITEM_FAN (ITEM_E1 + 1)
+  #elif defined(ITEM_E0)
+    #define ITEM_FAN (ITEM_E0 + 1)
+  #else
+    #define ITEM_FAN 0
+  #endif
+#endif
+
+#if defined(ITEM_FAN)
+  #define ITEMS_COUNT (ITEM_FAN + 1)
+#elif defined(ITEM_COOLER)
+  #define ITEMS_COUNT (ITEM_COOLER + 1)
+#elif defined(ITEM_CHAMBER)
+  #define ITEMS_COUNT (ITEM_CHAMBER + 1)
+#elif defined(ITEM_BED)
+  #define ITEMS_COUNT (ITEM_BED + 1)
+#elif defined(ITEM_E2)
+  #define ITEMS_COUNT (ITEM_E2 + 1)
+#elif defined(ITEM_E1)
+  #define ITEMS_COUNT (ITEM_E1 + 1)
+#elif defined(ITEM_E0)
+  #define ITEMS_COUNT (ITEM_E0 + 1)
 #else
-  #define ITEM_E0         0
-  #define ITEM_BED        1
-  #define ITEM_FAN        2
-  #define ITEMS_COUNT     3
+  #define ITEMS_COUNT 0
 #endif


### PR DESCRIPTION
### Description

Make UI display icons only when features enabled in order
`[E0 | E1 | E2 | HOTBED | CHAMBER | COOLER | FAN]`
When configuration is missing any of items (ex, no cooler and chamber), no icons will be displayed.

Ex, if device has 3 extruders and chamber, and no hotbed nor fan nor cooler, then this configuration will be set:

``` 
ITEM_E0      = 0
ITEM_E1      = 1
ITEM_E2      = 2
ITEM_CHAMBER = 3
ITEMS_COUNT  = 4
```

### Benefits

Automate icon selection depending on features enabled, exclude some cases when you need to configure it manually in `ui_common.h` in case of uncommon device.
