### PR TITLE
🧑‍💻 Misc. TFT code cleanup

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -302,7 +302,7 @@ uint16_t getTickDiff(const uint16_t curTick, const uint16_t lastTick) {
   return (TICK_CYCLE) * (lastTick <= curTick ? (curTick - lastTick) : (0xFFFFFFFF - lastTick + curTick));
 }
 
-static bool get_point(int16_t *x, int16_t *y) {
+static bool get_point(int16_t * const x, int16_t * const y) {
   if (!touch.getRawPoint(x, y)) return false;
 
   #if ENABLED(TOUCH_SCREEN_CALIBRATION)

--- a/Marlin/src/lcd/tft/tft.h
+++ b/Marlin/src/lcd/tft/tft.h
@@ -77,8 +77,8 @@ class TFT {
     static void fill(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color) { queue.fill(x, y, width, height, color); }
     static void canvas(uint16_t x, uint16_t y, uint16_t width, uint16_t height) { queue.canvas(x, y, width, height); }
     static void set_background(uint16_t color) { queue.set_background(color); }
-    static void add_text(uint16_t x, uint16_t y, uint16_t color, TFT_String tft_string, uint16_t maxWidth = 0) { queue.add_text(x, y, color, tft_string.string(), maxWidth); }
-    static void add_text(uint16_t x, uint16_t y, uint16_t color, const char *string, uint16_t maxWidth = 0) { queue.add_text(x, y, color, string, maxWidth); }
+    static void add_text(const uint16_t x, const uint16_t y, const uint16_t color, TFT_String tft_string, uint16_t maxWidth = 0) { queue.add_text(x, y, color, tft_string.string(), maxWidth); }
+    static void add_text(const uint16_t x, const uint16_t y, const uint16_t color, const char *string, uint16_t maxWidth = 0) { queue.add_text(x, y, color, string, maxWidth); }
     static void add_image(int16_t x, int16_t y, MarlinImage image, uint16_t *colors) { queue.add_image(x, y, image, colors); }
     static void add_image(int16_t x, int16_t y, MarlinImage image, uint16_t color_main = COLOR_WHITE, uint16_t color_background = COLOR_BACKGROUND, uint16_t color_shadow = COLOR_BLACK) { queue.add_image(x, y, image, color_main,  color_background, color_shadow); }
     static void add_bar(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color) { queue.add_bar(x, y, width, height, color); }

--- a/Marlin/src/lcd/tft/tft_queue.cpp
+++ b/Marlin/src/lcd/tft/tft_queue.cpp
@@ -208,14 +208,14 @@ void TFT_Queue::set_background(uint16_t color) {
 
 #define QUEUE_SAFETY_FREE_SPACE 100
 
-void TFT_Queue::handle_queue_overflow(uint16_t sizeNeeded) {
+void TFT_Queue::handle_queue_overflow(const uint16_t sizeNeeded) {
   if (uintptr_t(end_of_queue) + sizeNeeded + (QUEUE_SAFETY_FREE_SPACE) - uintptr_t(queue) >= TFT_QUEUE_SIZE) {
     end_of_queue = queue;
     ((parametersCanvasText_t *)last_parameter)->nextParameter = end_of_queue;
   }
 }
 
-void TFT_Queue::add_text(uint16_t x, uint16_t y, uint16_t color, const uint8_t *string, uint16_t maxWidth) {
+void TFT_Queue::add_text(const uint16_t x, const uint16_t y, const uint16_t color, const uint8_t *string, uint16_t maxWidth) {
   handle_queue_overflow(sizeof(parametersCanvasText_t) + maxWidth);
   parametersCanvas_t *task_parameters = (parametersCanvas_t *)(((uint8_t *)last_task) + sizeof(queueTask_t));
   parametersCanvasText_t *parameters = (parametersCanvasText_t *)end_of_queue;
@@ -247,7 +247,7 @@ void TFT_Queue::add_text(uint16_t x, uint16_t y, uint16_t color, const uint8_t *
   task_parameters->count++;
 }
 
-void TFT_Queue::add_text(uint16_t x, uint16_t y, uint16_t color, const uint16_t *string, uint16_t maxWidth) {
+void TFT_Queue::add_text(const uint16_t x, const uint16_t y, const uint16_t color, const uint16_t *string, uint16_t maxWidth) {
   handle_queue_overflow(sizeof(parametersCanvasText_t) + maxWidth);
   parametersCanvas_t *task_parameters = (parametersCanvas_t *)(((uint8_t *)last_task) + sizeof(queueTask_t));
   parametersCanvasText_t *parameters = (parametersCanvasText_t *)end_of_queue;

--- a/Marlin/src/lcd/tft/tft_queue.h
+++ b/Marlin/src/lcd/tft/tft_queue.h
@@ -129,7 +129,7 @@ class TFT_Queue {
     static void finish_sketch();
     static void fill(queueTask_t *task);
     static void canvas(queueTask_t *task);
-    static void handle_queue_overflow(uint16_t sizeNeeded);
+    static void handle_queue_overflow(const uint16_t sizeNeeded);
 
   public:
     static void reset();
@@ -140,9 +140,9 @@ class TFT_Queue {
     static void fill(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color);
     static void canvas(uint16_t x, uint16_t y, uint16_t width, uint16_t height);
     static void set_background(uint16_t color);
-    static void add_text(uint16_t x, uint16_t y, uint16_t color, const uint16_t *string, uint16_t maxWidth);
-    static void add_text(uint16_t x, uint16_t y, uint16_t color, const uint8_t *string, uint16_t maxWidth);
-    static void add_text(uint16_t x, uint16_t y, uint16_t color, const char *string, uint16_t maxWidth) {
+    static void add_text(const uint16_t x, const uint16_t y, const uint16_t color, const uint16_t *string, uint16_t maxWidth);
+    static void add_text(const uint16_t x, const uint16_t y, const uint16_t color, const uint8_t *string, uint16_t maxWidth);
+    static void add_text(const uint16_t x, const uint16_t y, const uint16_t color, const char *string, uint16_t maxWidth) {
       add_text(x, y, color, (uint8_t *)string, maxWidth);
     }
 

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -63,7 +63,7 @@ void Touch::init() {
   enable();
 }
 
-void Touch::add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, intptr_t data) {
+void Touch::add_control(const TouchControlType type, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, voidFunc_t func) {
   if (controls_count == MAX_CONTROLS) return;
 
   controls[controls_count].type = type;
@@ -71,7 +71,7 @@ void Touch::add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t 
   controls[controls_count].y = y;
   controls[controls_count].width = width;
   controls[controls_count].height = height;
-  controls[controls_count].data = data;
+  controls[controls_count].func = func;
   controls_count++;
 }
 
@@ -244,11 +244,11 @@ void Touch::touch(touch_control_t *control) {
     #endif
 
     case MOVE_AXIS:
-      ui.goto_screen((screenFunc_t)ui.move_axis_screen);
+      ui.goto_screen(ui.move_axis_screen);
       break;
 
     // TODO: TOUCH could receive data to pass to the callback
-    case BUTTON: ((screenFunc_t)control->data)(); break;
+    case BUTTON: (*control->func)(); break;
 
     default: break;
   }
@@ -263,7 +263,7 @@ void Touch::hold(touch_control_t *control, millis_t delay) {
   ui.refresh();
 }
 
-bool Touch::get_point(int16_t *x, int16_t *y) {
+bool Touch::get_point(int16_t * const x, int16_t * const y) {
   #if ENABLED(TFT_TOUCH_DEVICE_XPT2046)
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
       bool is_touched = (touch_calibration.calibration.orientation == TOUCH_PORTRAIT ? io.getRawPoint(y, x) : io.getRawPoint(x, y));
@@ -320,13 +320,13 @@ bool MarlinUI::touch_pressed() {
   return touch.is_clicked();
 }
 
-void add_control(uint16_t x, uint16_t y, TouchControlType control_type, intptr_t data, MarlinImage image, bool is_enabled, uint16_t color_enabled, uint16_t color_disabled) {
+void add_control(uint16_t x, uint16_t y, TouchControlType control_type, screenFunc_t func, MarlinImage image, bool is_enabled, uint16_t color_enabled, uint16_t color_disabled) {
   uint16_t width = Images[image].width;
   uint16_t height = Images[image].height;
   tft.canvas(x, y, width, height);
   tft.add_image(0, 0, image, is_enabled ? color_enabled : color_disabled);
   if (is_enabled)
-    touch.add_control(control_type, x, y, width, height, data);
+    touch.add_control(control_type, x, y, width, height, func);
 }
 
 #endif // TOUCH_SCREEN

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -69,11 +69,11 @@ enum TouchControlType : uint16_t {
   BUTTON,
 };
 
-typedef void (*screenFunc_t)();
+typedef void (*voidFunc_t)();
 
-void add_control(uint16_t x, uint16_t y, TouchControlType control_type, intptr_t data, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED);
+void add_control(uint16_t x, uint16_t y, TouchControlType control_type, voidFunc_t func, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED);
 inline void add_control(uint16_t x, uint16_t y, TouchControlType control_type, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, control_type, 0, image, is_enabled, color_enabled, color_disabled); }
-inline void add_control(uint16_t x, uint16_t y, screenFunc_t screen, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, MENU_SCREEN, (intptr_t)screen, image, is_enabled, color_enabled, color_disabled); }
+inline void add_control(uint16_t x, uint16_t y, voidFunc_t screen, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, MENU_SCREEN, screen, image, is_enabled, color_enabled, color_disabled); }
 
 typedef struct __attribute__((__packed__)) {
   TouchControlType type;
@@ -81,7 +81,7 @@ typedef struct __attribute__((__packed__)) {
   uint16_t y;
   uint16_t width;
   uint16_t height;
-  intptr_t data;
+  voidFunc_t func;
 } touch_control_t;
 
 #define MAX_CONTROLS        16
@@ -107,7 +107,7 @@ class Touch {
     static millis_t next_touch_ms, time_to_hold, repeat_delay, touch_time;
     static TouchControlType touch_control_type;
 
-    static bool get_point(int16_t *x, int16_t *y);
+    static bool get_point(int16_t * const x, int16_t * const y);
     static void touch(touch_control_t *control);
     static void hold(touch_control_t *control, millis_t delay = 0);
 
@@ -131,7 +131,7 @@ class Touch {
       static void sleepTimeout();
       static void wakeUp();
     #endif
-    static void add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, intptr_t data = 0);
+    static void add_control(const TouchControlType type, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, voidFunc_t func=nullptr);
 };
 
 extern Touch touch;

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -118,23 +118,23 @@ void MarlinUI::draw_kill_screen() {
   tft.queue.sync();
 }
 
-void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
+void draw_heater_status(const uint16_t x, const uint16_t y, const int8_t heater) {
   MarlinImage image = imgHotEnd;
   uint16_t Color;
   celsius_t currentTemperature, targetTemperature;
 
-  if (Heater >= 0) { // HotEnd
-    currentTemperature = thermalManager.wholeDegHotend(Heater);
-    targetTemperature = thermalManager.degTargetHotend(Heater);
+  if (heater >= 0) { // HotEnd
+    currentTemperature = thermalManager.wholeDegHotend(heater);
+    targetTemperature = thermalManager.degTargetHotend(heater);
   }
   #if HAS_HEATED_BED
-    else if (Heater == H_BED) {
+    else if (heater == H_BED) {
       currentTemperature = thermalManager.wholeDegBed();
       targetTemperature = thermalManager.degTargetBed();
     }
   #endif
   #if HAS_TEMP_CHAMBER
-    else if (Heater == H_CHAMBER) {
+    else if (heater == H_CHAMBER) {
       currentTemperature = thermalManager.wholeDegChamber();
       #if HAS_HEATED_CHAMBER
         targetTemperature = thermalManager.degTargetChamber();
@@ -144,36 +144,36 @@ void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
     }
   #endif
   #if HAS_TEMP_COOLER
-    else if (Heater == H_COOLER) {
+    else if (heater == H_COOLER) {
       currentTemperature = thermalManager.wholeDegCooler();
       targetTemperature = TERN(HAS_COOLER, thermalManager.degTargetCooler(), ABSOLUTE_ZERO);
     }
   #endif
   else return;
 
-  TERN_(TOUCH_SCREEN, if (targetTemperature >= 0) touch.add_control(HEATER, x, y, 80, 120, Heater));
+  TERN_(TOUCH_SCREEN, if (targetTemperature >= 0) touch.add_control(HEATER, x, y, 80, 120, heater));
   tft.canvas(x, y, 80, 120);
   tft.set_background(COLOR_BACKGROUND);
 
   Color = currentTemperature < 0 ? COLOR_INACTIVE : COLOR_COLD;
 
-  if (Heater >= 0) { // HotEnd
+  if (heater >= 0) { // HotEnd
     if (currentTemperature >= 50) Color = COLOR_HOTEND;
   }
   #if HAS_HEATED_BED
-    else if (Heater == H_BED) {
+    else if (heater == H_BED) {
       if (currentTemperature >= 50) Color = COLOR_HEATED_BED;
       image = targetTemperature > 0 ? imgBedHeated : imgBed;
     }
   #endif
   #if HAS_TEMP_CHAMBER
-    else if (Heater == H_CHAMBER) {
+    else if (heater == H_CHAMBER) {
       if (currentTemperature >= 50) Color = COLOR_CHAMBER;
       image = targetTemperature > 0 ? imgChamberHeated : imgChamber;
     }
   #endif
   #if HAS_TEMP_COOLER
-    else if (Heater == H_COOLER) {
+    else if (heater == H_COOLER) {
       if (currentTemperature <= 26) Color = COLOR_COLD;
       if (currentTemperature > 26) Color = COLOR_RED;
       image = targetTemperature > 26 ? imgCoolerHot : imgCooler;
@@ -195,7 +195,7 @@ void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
   }
 }
 
-void draw_fan_status(uint16_t x, uint16_t y, const bool blink) {
+void draw_fan_status(const uint16_t x, const uint16_t y, const bool blink) {
   TERN_(TOUCH_SCREEN, touch.add_control(FAN, x, y, 80, 120));
   tft.canvas(x, y, 80, 120);
   tft.set_background(COLOR_BACKGROUND);
@@ -568,7 +568,7 @@ void MenuItem_confirm::draw_select_screen(FSTR_P const yes, FSTR_P const no, con
       add_control(GRID_OFFSET_X + CONTROL_OFFSET,                   GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET,      UBL, - ENCODER_STEPS_PER_MENU_ITEM, imgLeft);
       add_control(GRID_OFFSET_X + GRID_WIDTH - CONTROL_OFFSET - 32, GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET,      UBL,   ENCODER_STEPS_PER_MENU_ITEM, imgRight);
       add_control(320, GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET, CLICK, imgLeveling);
-      add_control(224, TFT_HEIGHT - 34, BACK, imgBack);
+      add_control(224, TFT_HEIGHT - FONT_LINE_HEIGHT, BACK, imgBack);
     #endif
   }
 #endif // AUTO_BED_LEVELING_UBL
@@ -581,36 +581,6 @@ void MenuItem_confirm::draw_select_screen(FSTR_P const yes, FSTR_P const no, con
   #include "../../module/probe.h"
 #endif
 
-#define Z_SELECTION_Z 1
-#define Z_SELECTION_Z_PROBE -1
-
-struct MotionAxisState {
-  xy_int_t xValuePos, yValuePos, zValuePos, eValuePos, stepValuePos, zTypePos, eNamePos;
-  float currentStepSize = 10.0;
-  int z_selection = Z_SELECTION_Z;
-  uint8_t e_selection = 0;
-  bool blocked = false;
-  char message[32];
-};
-
-MotionAxisState motionAxisState;
-
-#define BTN_WIDTH 64
-#define BTN_HEIGHT 52
-#define X_MARGIN 20
-#define Y_MARGIN 15
-
-static void quick_feedback() {
-  #if HAS_CHIRP
-    ui.chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-    #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
-      for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
-    #elif HAS_MARLINUI_MENU
-      delay(10);
-    #endif
-  #endif
-}
-
 #define CUR_STEP_VALUE_WIDTH 104
 static void drawCurStepValue() {
   tft_string.set(ftostr52sp(motionAxisState.currentStepSize));
@@ -620,35 +590,11 @@ static void drawCurStepValue() {
   tft.add_text(tft_string.center(CUR_STEP_VALUE_WIDTH), 0, COLOR_AXIS_HOMED, tft_string);
 }
 
-static void drawCurZSelection() {
-  tft_string.set('Z');
-  tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y, tft_string.width(), 34);
-  tft.set_background(COLOR_BACKGROUND);
-  tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-  tft.queue.sync();
-  tft_string.set(F("Offset"));
-  tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y + 34, tft_string.width(), 34);
-  tft.set_background(COLOR_BACKGROUND);
-  if (motionAxisState.z_selection == Z_SELECTION_Z_PROBE) {
-    tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-  }
-}
-
-static void drawCurESelection() {
-  tft.canvas(motionAxisState.eNamePos.x, motionAxisState.eNamePos.y, BTN_WIDTH, BTN_HEIGHT);
-  tft.set_background(COLOR_BACKGROUND);
-  tft_string.set('E');
-  tft.add_text(0, 0, E_BTN_COLOR , tft_string);
-  tft.add_text(tft_string.width(), 0, E_BTN_COLOR, ui8tostr3rj(motionAxisState.e_selection));
-}
-
-static void drawMessage(PGM_P const msg) {
-  tft.canvas(X_MARGIN, TFT_HEIGHT - Y_MARGIN - 34, TFT_HEIGHT / 2, 34);
+void drawMessage(PGM_P const msg) {
+  tft.canvas(X_MARGIN, TFT_HEIGHT - Y_MARGIN - FONT_LINE_HEIGHT, TFT_HEIGHT / 2, FONT_LINE_HEIGHT);
   tft.set_background(COLOR_BACKGROUND);
   tft.add_text(0, 0, COLOR_YELLOW, msg);
 }
-
-static void drawMessage(FSTR_P const fmsg) { drawMessage(FTOP(fmsg)); }
 
 static void drawAxisValue(const AxisEnum axis) {
   const float value = (
@@ -670,7 +616,7 @@ static void drawAxisValue(const AxisEnum axis) {
   tft.add_text(0, 0, color, tft_string);
 }
 
-static void moveAxis(const AxisEnum axis, const int8_t direction) {
+void moveAxis(const AxisEnum axis, const int8_t direction) {
   quick_feedback();
 
   if (axis == E_AXIS && thermalManager.tooColdToExtrude(motionAxisState.e_selection)) {
@@ -750,15 +696,6 @@ static void moveAxis(const AxisEnum axis, const int8_t direction) {
   drawAxisValue(axis);
 }
 
-static void e_plus()  { moveAxis(E_AXIS, 1);  }
-static void e_minus() { moveAxis(E_AXIS, -1); }
-static void x_minus() { moveAxis(X_AXIS, -1); }
-static void x_plus()  { moveAxis(X_AXIS, 1);  }
-static void y_plus()  { moveAxis(Y_AXIS, 1);  }
-static void y_minus() { moveAxis(Y_AXIS, -1); }
-static void z_plus()  { moveAxis(Z_AXIS, 1);  }
-static void z_minus() { moveAxis(Z_AXIS, -1); }
-
 #if ENABLED(TOUCH_SCREEN)
   static void e_select() {
     if (++motionAxisState.e_selection >= EXTRUDERS)
@@ -803,7 +740,7 @@ static void disable_steppers() {
   queue.inject(F("M84"));
 }
 
-static void drawBtn(int x, int y, const char *label, intptr_t data, MarlinImage img, uint16_t bgColor, bool enabled = true) {
+static void drawBtn(int x, int y, const char *label, voidFunc_t func, MarlinImage img, uint16_t bgColor, bool enabled = true) {
   uint16_t width = Images[imgBtn52Rounded].width,
            height = Images[imgBtn52Rounded].height;
 
@@ -823,7 +760,7 @@ static void drawBtn(int x, int y, const char *label, intptr_t data, MarlinImage 
     tft.add_image(0, 0, img, bgColor, COLOR_BACKGROUND, COLOR_DARKGREY);
   }
 
-  TERN_(TOUCH_SCREEN, if (enabled) touch.add_control(BUTTON, x, y, width, height, data));
+  TERN_(TOUCH_SCREEN, if (enabled) touch.add_control(BUTTON, x, y, width, height, func));
 }
 
 void MarlinUI::move_axis_screen() {
@@ -845,11 +782,11 @@ void MarlinUI::move_axis_screen() {
   // ROW 1 -> E- Y- CurY Z+
   int x = X_MARGIN, y = Y_MARGIN, spacing = 0;
 
-  drawBtn(x, y, "E+", (intptr_t)e_plus, imgUp, E_BTN_COLOR, !busy);
+  drawBtn(x, y, "E+", e_plus, imgUp, E_BTN_COLOR, !busy);
 
   spacing = (TFT_WIDTH - X_MARGIN * 2 - 3 * BTN_WIDTH) / 2;
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Y+", (intptr_t)y_plus, imgUp, Y_BTN_COLOR, !busy);
+  drawBtn(x, y, "Y+", y_plus, imgUp, Y_BTN_COLOR, !busy);
 
   // Cur Y
   x += BTN_WIDTH;
@@ -858,7 +795,7 @@ void MarlinUI::move_axis_screen() {
   drawAxisValue(Y_AXIS);
 
   x += spacing;
-  drawBtn(x, y, "Z+", (intptr_t)z_plus, imgUp, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
+  drawBtn(x, y, "Z+", z_plus, imgUp, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
 
   // ROW 2 -> "Ex"  X-  HOME X+  "Z"
   y += BTN_HEIGHT + (TFT_HEIGHT - Y_MARGIN * 2 - 4 * BTN_HEIGHT) / 3;
@@ -868,24 +805,24 @@ void MarlinUI::move_axis_screen() {
   motionAxisState.eNamePos.x = x;
   motionAxisState.eNamePos.y = y;
   drawCurESelection();
-  TERN_(TOUCH_SCREEN, if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, BTN_HEIGHT, (intptr_t)e_select));
+  TERN_(TOUCH_SCREEN, if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, BTN_HEIGHT, e_select));
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "X-", (intptr_t)x_minus, imgLeft, X_BTN_COLOR, !busy);
+  drawBtn(x, y, "X-", x_minus, imgLeft, X_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing; //imgHome is 64x64
-  TERN_(TOUCH_SCREEN, add_control(TFT_WIDTH / 2 - Images[imgHome].width / 2, y - (Images[imgHome].width - BTN_HEIGHT) / 2, BUTTON, (intptr_t)do_home, imgHome, !busy));
+  TERN_(TOUCH_SCREEN, add_control(TFT_WIDTH / 2 - Images[imgHome].width / 2, y - (Images[imgHome].width - BTN_HEIGHT) / 2, BUTTON, do_home, imgHome, !busy));
 
   x += BTN_WIDTH + spacing;
   uint16_t xplus_x = x;
-  drawBtn(x, y, "X+", (intptr_t)x_plus, imgRight, X_BTN_COLOR, !busy);
+  drawBtn(x, y, "X+", x_plus, imgRight, X_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing;
   motionAxisState.zTypePos.x = x;
   motionAxisState.zTypePos.y = y;
   drawCurZSelection();
   #if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
-    if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, 34 * 2, (intptr_t)z_select);
+    if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, FONT_LINE_HEIGHT * 2, z_select);
   #endif
 
   // ROW 3 -> E- CurX Y-  Z-
@@ -893,7 +830,7 @@ void MarlinUI::move_axis_screen() {
   x = X_MARGIN;
   spacing = (TFT_WIDTH - X_MARGIN * 2 - 3 * BTN_WIDTH) / 2;
 
-  drawBtn(x, y, "E-", (intptr_t)e_minus, imgDown, E_BTN_COLOR, !busy);
+  drawBtn(x, y, "E-", e_minus, imgDown, E_BTN_COLOR, !busy);
 
   // Cur E
   motionAxisState.eValuePos.x = x;
@@ -906,10 +843,10 @@ void MarlinUI::move_axis_screen() {
   drawAxisValue(X_AXIS);
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Y-", (intptr_t)y_minus, imgDown, Y_BTN_COLOR, !busy);
+  drawBtn(x, y, "Y-", y_minus, imgDown, Y_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Z-", (intptr_t)z_minus, imgDown, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
+  drawBtn(x, y, "Z-", z_minus, imgDown, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
 
   // Cur Z
   motionAxisState.zValuePos.x = x;
@@ -923,11 +860,11 @@ void MarlinUI::move_axis_screen() {
   motionAxisState.stepValuePos.y = y;
   if (!busy) {
     drawCurStepValue();
-    TERN_(TOUCH_SCREEN, touch.add_control(BUTTON, motionAxisState.stepValuePos.x, motionAxisState.stepValuePos.y, CUR_STEP_VALUE_WIDTH, BTN_HEIGHT, (intptr_t)step_size));
+    TERN_(TOUCH_SCREEN, touch.add_control(BUTTON, motionAxisState.stepValuePos.x, motionAxisState.stepValuePos.y, CUR_STEP_VALUE_WIDTH, BTN_HEIGHT, step_size));
   }
 
   // aligned with x+
-  drawBtn(xplus_x, TFT_HEIGHT - Y_MARGIN - BTN_HEIGHT, "off", (intptr_t)disable_steppers, imgCancel, COLOR_WHITE, !busy);
+  drawBtn(xplus_x, TFT_HEIGHT - Y_MARGIN - BTN_HEIGHT, "off", disable_steppers, imgCancel, COLOR_WHITE, !busy);
 
   TERN_(TOUCH_SCREEN, add_control(TFT_WIDTH - X_MARGIN - BTN_WIDTH, y, BACK, imgBack));
 }

--- a/Marlin/src/lcd/tft/ui_1024x600.h
+++ b/Marlin/src/lcd/tft/ui_1024x600.h
@@ -46,4 +46,9 @@
 
 #define FONT_LINE_HEIGHT      34
 
+#define BTN_WIDTH  64
+#define BTN_HEIGHT 52
+#define X_MARGIN   20
+#define Y_MARGIN   15
+
 #include "tft_font.h"

--- a/Marlin/src/lcd/tft/ui_320x240.h
+++ b/Marlin/src/lcd/tft/ui_320x240.h
@@ -46,4 +46,9 @@
 
 #define FONT_LINE_HEIGHT      24
 
+#define BTN_WIDTH  48
+#define BTN_HEIGHT 39
+#define X_MARGIN   15
+#define Y_MARGIN   11
+
 #include "tft_font.h"

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -49,9 +49,9 @@ void MarlinUI::tft_idle() {
   #if ENABLED(TOUCH_SCREEN)
     if (TERN0(HAS_TOUCH_SLEEP, lcd_sleep_task())) return;
     if (draw_menu_navigation) {
-      add_control(104, TFT_HEIGHT - 34, PAGE_UP, imgPageUp, encoderTopLine > 0);
-      add_control(344, TFT_HEIGHT - 34, PAGE_DOWN, imgPageDown, encoderTopLine + LCD_HEIGHT < screen_items);
-      add_control(224, TFT_HEIGHT - 34, BACK, imgBack);
+      add_control(104, TFT_HEIGHT - FONT_LINE_HEIGHT, PAGE_UP, imgPageUp, encoderTopLine > 0);
+      add_control(344, TFT_HEIGHT - FONT_LINE_HEIGHT, PAGE_DOWN, imgPageDown, encoderTopLine + LCD_HEIGHT < screen_items);
+      add_control(224, TFT_HEIGHT - FONT_LINE_HEIGHT, BACK, imgBack);
       draw_menu_navigation = false;
     }
   #endif
@@ -118,23 +118,23 @@ void MarlinUI::draw_kill_screen() {
   tft.queue.sync();
 }
 
-void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
+void draw_heater_status(const uint16_t x, const uint16_t y, const int8_t heater) {
   MarlinImage image = imgHotEnd;
   uint16_t Color;
   celsius_t currentTemperature, targetTemperature;
 
-  if (Heater >= 0) { // HotEnd
-    currentTemperature = thermalManager.wholeDegHotend(Heater);
-    targetTemperature = thermalManager.degTargetHotend(Heater);
+  if (heater >= 0) { // HotEnd
+    currentTemperature = thermalManager.wholeDegHotend(heater);
+    targetTemperature = thermalManager.degTargetHotend(heater);
   }
   #if HAS_HEATED_BED
-    else if (Heater == H_BED) {
+    else if (heater == H_BED) {
       currentTemperature = thermalManager.wholeDegBed();
       targetTemperature = thermalManager.degTargetBed();
     }
   #endif
   #if HAS_TEMP_CHAMBER
-    else if (Heater == H_CHAMBER) {
+    else if (heater == H_CHAMBER) {
       currentTemperature = thermalManager.wholeDegChamber();
       #if HAS_HEATED_CHAMBER
         targetTemperature = thermalManager.degTargetChamber();
@@ -144,36 +144,36 @@ void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
     }
   #endif
   #if HAS_TEMP_COOLER
-    else if (Heater == H_COOLER) {
+    else if (heater == H_COOLER) {
       currentTemperature = thermalManager.wholeDegCooler();
       targetTemperature = TERN(HAS_COOLER, thermalManager.degTargetCooler(), ABSOLUTE_ZERO);
     }
   #endif
   else return;
 
-  TERN_(TOUCH_SCREEN, if (targetTemperature >= 0) touch.add_control(HEATER, x, y, 80, 120, Heater));
+  TERN_(TOUCH_SCREEN, if (targetTemperature >= 0) touch.add_control(HEATER, x, y, 80, 120, heater));
   tft.canvas(x, y, 80, 120);
   tft.set_background(COLOR_BACKGROUND);
 
   Color = currentTemperature < 0 ? COLOR_INACTIVE : COLOR_COLD;
 
-  if (Heater >= 0) { // HotEnd
+  if (heater >= 0) { // HotEnd
     if (currentTemperature >= 50) Color = COLOR_HOTEND;
   }
   #if HAS_HEATED_BED
-    else if (Heater == H_BED) {
+    else if (heater == H_BED) {
       if (currentTemperature >= 50) Color = COLOR_HEATED_BED;
       image = targetTemperature > 0 ? imgBedHeated : imgBed;
     }
   #endif
   #if HAS_TEMP_CHAMBER
-    else if (Heater == H_CHAMBER) {
+    else if (heater == H_CHAMBER) {
       if (currentTemperature >= 50) Color = COLOR_CHAMBER;
       image = targetTemperature > 0 ? imgChamberHeated : imgChamber;
     }
   #endif
   #if HAS_TEMP_COOLER
-    else if (Heater == H_COOLER) {
+    else if (heater == H_COOLER) {
       if (currentTemperature <= 26) Color = COLOR_COLD;
       if (currentTemperature > 26) Color = COLOR_RED;
       image = targetTemperature > 26 ? imgCoolerHot : imgCooler;
@@ -195,7 +195,7 @@ void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater) {
   }
 }
 
-void draw_fan_status(uint16_t x, uint16_t y, const bool blink) {
+void draw_fan_status(const uint16_t x, const uint16_t y, const bool blink) {
   TERN_(TOUCH_SCREEN, touch.add_control(FAN, x, y, 80, 120));
   tft.canvas(x, y, 80, 120);
   tft.set_background(COLOR_BACKGROUND);
@@ -549,7 +549,7 @@ void MenuItem_confirm::draw_select_screen(FSTR_P const yes, FSTR_P const no, con
       add_control(GRID_OFFSET_X + CONTROL_OFFSET,                   GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET,      UBL, -(ENCODER_STEPS_PER_MENU_ITEM), imgLeft);
       add_control(GRID_OFFSET_X + GRID_WIDTH - CONTROL_OFFSET - 32, GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET,      UBL,   ENCODER_STEPS_PER_MENU_ITEM, imgRight);
       add_control(320, GRID_OFFSET_Y + GRID_HEIGHT + CONTROL_OFFSET, CLICK, imgLeveling);
-      add_control(224, TFT_HEIGHT - 34, BACK, imgBack);
+      add_control(224, TFT_HEIGHT - FONT_LINE_HEIGHT, BACK, imgBack);
     #endif
   }
 #endif // AUTO_BED_LEVELING_UBL
@@ -562,36 +562,6 @@ void MenuItem_confirm::draw_select_screen(FSTR_P const yes, FSTR_P const no, con
   #include "../../module/probe.h"
 #endif
 
-#define Z_SELECTION_Z 1
-#define Z_SELECTION_Z_PROBE -1
-
-struct MotionAxisState {
-  xy_int_t xValuePos, yValuePos, zValuePos, eValuePos, stepValuePos, zTypePos, eNamePos;
-  float currentStepSize = 10.0;
-  int z_selection = Z_SELECTION_Z;
-  uint8_t e_selection = 0;
-  bool blocked = false;
-  char message[32];
-};
-
-MotionAxisState motionAxisState;
-
-#define BTN_WIDTH 64
-#define BTN_HEIGHT 52
-#define X_MARGIN 20
-#define Y_MARGIN 15
-
-static void quick_feedback() {
-  #if HAS_CHIRP
-    ui.chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-    #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
-      for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
-    #elif HAS_MARLINUI_MENU
-      delay(10);
-    #endif
-  #endif
-}
-
 #define CUR_STEP_VALUE_WIDTH 104
 static void drawCurStepValue() {
   tft_string.set(ftostr52sp(motionAxisState.currentStepSize));
@@ -601,35 +571,11 @@ static void drawCurStepValue() {
   tft.add_text(tft_string.center(CUR_STEP_VALUE_WIDTH), 0, COLOR_AXIS_HOMED, tft_string);
 }
 
-static void drawCurZSelection() {
-  tft_string.set('Z');
-  tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y, tft_string.width(), 34);
-  tft.set_background(COLOR_BACKGROUND);
-  tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-  tft.queue.sync();
-  tft_string.set(F("Offset"));
-  tft.canvas(motionAxisState.zTypePos.x, motionAxisState.zTypePos.y + 34, tft_string.width(), 34);
-  tft.set_background(COLOR_BACKGROUND);
-  if (motionAxisState.z_selection == Z_SELECTION_Z_PROBE) {
-    tft.add_text(0, 0, Z_BTN_COLOR, tft_string);
-  }
-}
-
-static void drawCurESelection() {
-  tft.canvas(motionAxisState.eNamePos.x, motionAxisState.eNamePos.y, BTN_WIDTH, BTN_HEIGHT);
-  tft.set_background(COLOR_BACKGROUND);
-  tft_string.set('E');
-  tft.add_text(0, 0, E_BTN_COLOR , tft_string);
-  tft.add_text(tft_string.width(), 0, E_BTN_COLOR, ui8tostr3rj(motionAxisState.e_selection));
-}
-
-static void drawMessage(PGM_P const msg) {
-  tft.canvas(X_MARGIN, TFT_HEIGHT - Y_MARGIN - 34, TFT_HEIGHT / 2, 34);
+void drawMessage(PGM_P const msg) {
+  tft.canvas(X_MARGIN, TFT_HEIGHT - Y_MARGIN - FONT_LINE_HEIGHT, TFT_HEIGHT / 2, FONT_LINE_HEIGHT);
   tft.set_background(COLOR_BACKGROUND);
   tft.add_text(0, 0, COLOR_YELLOW, msg);
 }
-
-static void drawMessage(FSTR_P const fmsg) { drawMessage(FTOP(fmsg)); }
 
 static void drawAxisValue(const AxisEnum axis) {
   const float value = (
@@ -651,7 +597,7 @@ static void drawAxisValue(const AxisEnum axis) {
   tft.add_text(0, 0, color, tft_string);
 }
 
-static void moveAxis(const AxisEnum axis, const int8_t direction) {
+void moveAxis(const AxisEnum axis, const int8_t direction) {
   quick_feedback();
 
   if (axis == E_AXIS && thermalManager.tooColdToExtrude(motionAxisState.e_selection)) {
@@ -731,15 +677,6 @@ static void moveAxis(const AxisEnum axis, const int8_t direction) {
   drawAxisValue(axis);
 }
 
-static void e_plus()  { moveAxis(E_AXIS, 1);  }
-static void e_minus() { moveAxis(E_AXIS, -1); }
-static void x_minus() { moveAxis(X_AXIS, -1); }
-static void x_plus()  { moveAxis(X_AXIS, 1);  }
-static void y_plus()  { moveAxis(Y_AXIS, 1);  }
-static void y_minus() { moveAxis(Y_AXIS, -1); }
-static void z_plus()  { moveAxis(Z_AXIS, 1);  }
-static void z_minus() { moveAxis(Z_AXIS, -1); }
-
 #if ENABLED(TOUCH_SCREEN)
   static void e_select() {
     if (++motionAxisState.e_selection >= EXTRUDERS)
@@ -784,7 +721,7 @@ static void disable_steppers() {
   queue.inject(F("M84"));
 }
 
-static void drawBtn(int x, int y, const char *label, intptr_t data, MarlinImage img, uint16_t bgColor, bool enabled = true) {
+static void drawBtn(int x, int y, const char *label, voidFunc_t func, MarlinImage img, uint16_t bgColor, bool enabled = true) {
   uint16_t width = Images[imgBtn52Rounded].width,
            height = Images[imgBtn52Rounded].height;
 
@@ -804,7 +741,7 @@ static void drawBtn(int x, int y, const char *label, intptr_t data, MarlinImage 
     tft.add_image(0, 0, img, bgColor, COLOR_BACKGROUND, COLOR_DARKGREY);
   }
 
-  TERN_(HAS_TFT_XPT2046, if (enabled) touch.add_control(BUTTON, x, y, width, height, data));
+  TERN_(HAS_TFT_XPT2046, if (enabled) touch.add_control(BUTTON, x, y, width, height, func));
 }
 
 void MarlinUI::move_axis_screen() {
@@ -826,11 +763,11 @@ void MarlinUI::move_axis_screen() {
   // ROW 1 -> E- Y- CurY Z+
   int x = X_MARGIN, y = Y_MARGIN, spacing = 0;
 
-  drawBtn(x, y, "E+", (intptr_t)e_plus, imgUp, E_BTN_COLOR, !busy);
+  drawBtn(x, y, "E+", e_plus, imgUp, E_BTN_COLOR, !busy);
 
   spacing = (TFT_WIDTH - X_MARGIN * 2 - 3 * BTN_WIDTH) / 2;
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Y+", (intptr_t)y_plus, imgUp, Y_BTN_COLOR, !busy);
+  drawBtn(x, y, "Y+", y_plus, imgUp, Y_BTN_COLOR, !busy);
 
   // Cur Y
   x += BTN_WIDTH;
@@ -839,7 +776,7 @@ void MarlinUI::move_axis_screen() {
   drawAxisValue(Y_AXIS);
 
   x += spacing;
-  drawBtn(x, y, "Z+", (intptr_t)z_plus, imgUp, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
+  drawBtn(x, y, "Z+", z_plus, imgUp, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
 
   // ROW 2 -> "Ex"  X-  HOME X+  "Z"
   y += BTN_HEIGHT + (TFT_HEIGHT - Y_MARGIN * 2 - 4 * BTN_HEIGHT) / 3;
@@ -849,24 +786,24 @@ void MarlinUI::move_axis_screen() {
   motionAxisState.eNamePos.x = x;
   motionAxisState.eNamePos.y = y;
   drawCurESelection();
-  TERN_(HAS_TFT_XPT2046, if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, BTN_HEIGHT, (intptr_t)e_select));
+  TERN_(HAS_TFT_XPT2046, if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, BTN_HEIGHT, e_select));
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "X-", (intptr_t)x_minus, imgLeft, X_BTN_COLOR, !busy);
+  drawBtn(x, y, "X-", x_minus, imgLeft, X_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing; //imgHome is 64x64
-  TERN_(HAS_TFT_XPT2046, add_control(TFT_WIDTH / 2 - Images[imgHome].width / 2, y - (Images[imgHome].width - BTN_HEIGHT) / 2, BUTTON, (intptr_t)do_home, imgHome, !busy));
+  TERN_(HAS_TFT_XPT2046, add_control(TFT_WIDTH / 2 - Images[imgHome].width / 2, y - (Images[imgHome].width - BTN_HEIGHT) / 2, BUTTON, do_home, imgHome, !busy));
 
   x += BTN_WIDTH + spacing;
   uint16_t xplus_x = x;
-  drawBtn(x, y, "X+", (intptr_t)x_plus, imgRight, X_BTN_COLOR, !busy);
+  drawBtn(x, y, "X+", x_plus, imgRight, X_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing;
   motionAxisState.zTypePos.x = x;
   motionAxisState.zTypePos.y = y;
   drawCurZSelection();
   #if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
-    if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, 34 * 2, (intptr_t)z_select);
+    if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, FONT_LINE_HEIGHT * 2, z_select);
   #endif
 
   // ROW 3 -> E- CurX Y-  Z-
@@ -874,7 +811,7 @@ void MarlinUI::move_axis_screen() {
   x = X_MARGIN;
   spacing = (TFT_WIDTH - X_MARGIN * 2 - 3 * BTN_WIDTH) / 2;
 
-  drawBtn(x, y, "E-", (intptr_t)e_minus, imgDown, E_BTN_COLOR, !busy);
+  drawBtn(x, y, "E-", e_minus, imgDown, E_BTN_COLOR, !busy);
 
   // Cur E
   motionAxisState.eValuePos.x = x;
@@ -887,10 +824,10 @@ void MarlinUI::move_axis_screen() {
   drawAxisValue(X_AXIS);
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Y-", (intptr_t)y_minus, imgDown, Y_BTN_COLOR, !busy);
+  drawBtn(x, y, "Y-", y_minus, imgDown, Y_BTN_COLOR, !busy);
 
   x += BTN_WIDTH + spacing;
-  drawBtn(x, y, "Z-", (intptr_t)z_minus, imgDown, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
+  drawBtn(x, y, "Z-", z_minus, imgDown, Z_BTN_COLOR, !busy || ENABLED(BABYSTEP_ZPROBE_OFFSET)); //only enabled when not busy or have baby step
 
   // Cur Z
   motionAxisState.zValuePos.x = x;
@@ -904,11 +841,11 @@ void MarlinUI::move_axis_screen() {
   motionAxisState.stepValuePos.y = y;
   if (!busy) {
     drawCurStepValue();
-    TERN_(HAS_TFT_XPT2046, touch.add_control(BUTTON, motionAxisState.stepValuePos.x, motionAxisState.stepValuePos.y, CUR_STEP_VALUE_WIDTH, BTN_HEIGHT, (intptr_t)step_size));
+    TERN_(HAS_TFT_XPT2046, touch.add_control(BUTTON, motionAxisState.stepValuePos.x, motionAxisState.stepValuePos.y, CUR_STEP_VALUE_WIDTH, BTN_HEIGHT, step_size));
   }
 
   // aligned with x+
-  drawBtn(xplus_x, TFT_HEIGHT - Y_MARGIN - BTN_HEIGHT, "off", (intptr_t)disable_steppers, imgCancel, COLOR_WHITE, !busy);
+  drawBtn(xplus_x, TFT_HEIGHT - Y_MARGIN - BTN_HEIGHT, "off", disable_steppers, imgCancel, COLOR_WHITE, !busy);
 
   TERN_(HAS_TFT_XPT2046, add_control(TFT_WIDTH - X_MARGIN - BTN_WIDTH, y, BACK, imgBack));
 }

--- a/Marlin/src/lcd/tft/ui_480x320.h
+++ b/Marlin/src/lcd/tft/ui_480x320.h
@@ -63,4 +63,9 @@
 
 #define MENU_LINE_HEIGHT      (MENU_ITEM_HEIGHT + 2)
 
+#define BTN_WIDTH  64
+#define BTN_HEIGHT 52
+#define X_MARGIN   20
+#define Y_MARGIN   15
+
 #include "tft_font.h"

--- a/Marlin/src/lcd/tft/ui_common.h
+++ b/Marlin/src/lcd/tft/ui_common.h
@@ -45,11 +45,31 @@
   #error "Unsupported display resolution!"
 #endif
 
-void draw_heater_status(uint16_t x, uint16_t y, const int8_t Heater);
-void draw_fan_status(uint16_t x, uint16_t y, const bool blink);
+typedef void (*voidFunc_t)();
 
-void menu_line(const uint8_t row, uint16_t color=COLOR_BACKGROUND);
-void menu_item(const uint8_t row, bool sel = false);
+void draw_heater_status(const uint16_t x, const uint16_t y, const int8_t heater);
+void draw_fan_status(const uint16_t x, const uint16_t y, const bool blink);
+
+void drawMessage(PGM_P const msg);
+inline void drawMessage(FSTR_P const fmsg) { drawMessage(FTOP(fmsg)); }
+
+void quick_feedback();
+
+void drawCurZSelection();
+void drawCurESelection();
+
+void moveAxis(const AxisEnum axis, const int8_t direction);
+inline void e_plus()  { moveAxis(E_AXIS,  1); }
+inline void e_minus() { moveAxis(E_AXIS, -1); }
+inline void x_minus() { moveAxis(X_AXIS, -1); }
+inline void x_plus()  { moveAxis(X_AXIS,  1); }
+inline void y_plus()  { moveAxis(Y_AXIS,  1); }
+inline void y_minus() { moveAxis(Y_AXIS, -1); }
+inline void z_plus()  { moveAxis(Z_AXIS,  1); }
+inline void z_minus() { moveAxis(Z_AXIS, -1); }
+
+void menu_line(const uint8_t row, const uint16_t color=COLOR_BACKGROUND);
+void menu_item(const uint8_t row, const bool sel=false);
 
 #if HAS_TOUCH_SLEEP
   bool lcd_sleep_task();
@@ -86,3 +106,17 @@ void menu_item(const uint8_t row, bool sel = false);
   #define ITEM_FAN        2
   #define ITEMS_COUNT     3
 #endif
+
+#define Z_SELECTION_Z 1
+#define Z_SELECTION_Z_PROBE -1
+
+struct MotionAxisState {
+  xy_int_t xValuePos, yValuePos, zValuePos, eValuePos, stepValuePos, zTypePos, eNamePos;
+  float currentStepSize = 10.0;
+  int z_selection = Z_SELECTION_Z;
+  uint8_t e_selection = 0;
+  bool blocked = false;
+  char message[32];
+};
+
+extern MotionAxisState motionAxisState;


### PR DESCRIPTION
- Move some common functions to `ui_common.*`
- Use font height define for some position / size.
- Split up `types.h` into base types and dependent types.
- Use a `typedef` for `void` functions used by TFT controls.
- Apply `const` and lowercase a heater parameter name.