### PR TITLE
Consider const_float_t obsolete

### DIFF
--- a/Marlin/src/HAL/AVR/fastio.cpp
+++ b/Marlin/src/HAL/AVR/fastio.cpp
@@ -241,7 +241,7 @@ uint8_t extDigitalRead(const int8_t pin) {
  *
  * DC values -1.0 to 1.0. Negative duty cycle inverts the pulse.
  */
-uint16_t set_pwm_frequency_hz(const_float_t hz, const float dca, const float dcb, const float dcc) {
+uint16_t set_pwm_frequency_hz(const float hz, const float dca, const float dcb, const float dcc) {
   float count = 0;
   if (hz > 0 && (dca || dcb || dcc)) {
     count = float(F_CPU) / hz;            // 1x prescaler, TOP for 16MHz base freq.

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -99,7 +99,7 @@ void SERIAL_WARN_START()  { SERIAL_ECHO(F("Warning:")); }
 
 void SERIAL_ECHO_SP(uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR(' '); }
 
-void serial_offset(const_float_t v, const uint8_t sp/*=0*/) {
+void serial_offset(const float v, const uint8_t sp/*=0*/) {
   if (v == 0 && sp == 1)
     SERIAL_CHAR(' ');
   else if (v > 0 || (v == 0 && sp == 2))
@@ -121,7 +121,7 @@ void print_bin(uint16_t val) {
   }
 }
 
-void _print_xyz(NUM_AXIS_ARGS_(const_float_t) FSTR_P const prefix) {
+void _print_xyz(NUM_AXIS_ARGS_(const float) FSTR_P const prefix) {
   if (prefix) SERIAL_ECHO(prefix);
   #if NUM_AXES
     SERIAL_ECHOPGM_P(NUM_AXIS_PAIRED_LIST(
@@ -132,12 +132,12 @@ void _print_xyz(NUM_AXIS_ARGS_(const_float_t) FSTR_P const prefix) {
   #endif
 }
 
-void print_xyz(NUM_AXIS_ARGS_(const_float_t) FSTR_P const prefix/*=nullptr*/, FSTR_P const suffix/*=nullptr*/) {
+void print_xyz(NUM_AXIS_ARGS_(const float) FSTR_P const prefix/*=nullptr*/, FSTR_P const suffix/*=nullptr*/) {
   _print_xyz(NUM_AXIS_LIST_(x, y, z, i, j, k, u, v, w) prefix);
   if (suffix) SERIAL_ECHO(suffix); else SERIAL_EOL();
 }
 
-void print_xyze(LOGICAL_AXIS_ARGS_(const_float_t) FSTR_P const prefix/*=nullptr*/, FSTR_P const suffix/*=nullptr*/) {
+void print_xyze(LOGICAL_AXIS_ARGS_(const float) FSTR_P const prefix/*=nullptr*/, FSTR_P const suffix/*=nullptr*/) {
   _print_xyz(NUM_AXIS_LIST_(x, y, z, i, j, k, u, v, w) prefix);
   #if HAS_EXTRUDERS
     SERIAL_ECHOPGM_P(SP_E_STR, e);

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -236,16 +236,16 @@ void SERIAL_ECHO_SP(uint8_t count);
 inline FSTR_P const ON_OFF(const bool onoff) { return onoff ? F("ON") : F("OFF"); }
 inline FSTR_P const TRUE_FALSE(const bool tf) { return tf ? F("true") : F("false"); }
 
-void serial_offset(const_float_t v, const uint8_t sp=0); // For v==0 draw space (sp==1) or plus (sp==2)
+void serial_offset(const float v, const uint8_t sp=0); // For v==0 draw space (sp==1) or plus (sp==2)
 
 void print_bin(const uint16_t val);
 
-void print_xyz(NUM_AXIS_ARGS_(const_float_t) FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr);
+void print_xyz(NUM_AXIS_ARGS_(const float) FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr);
 inline void print_xyz(const xyz_pos_t &xyz, FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr) {
   print_xyz(NUM_AXIS_ELEM_(xyz) prefix, suffix);
 }
 
-void print_xyze(LOGICAL_AXIS_ARGS_(const_float_t) FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr);
+void print_xyze(LOGICAL_AXIS_ARGS_(const float) FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr);
 inline void print_xyze(const xyze_pos_t &xyze, FSTR_P const prefix=nullptr, FSTR_P const suffix=nullptr) {
   print_xyze(LOGICAL_AXIS_ELEM_LC_(xyze) prefix, suffix);
 }

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -363,17 +363,6 @@ typedef uint16_t raw_adc_t;
 typedef int16_t celsius_t;
 typedef float celsius_float_t;
 
-//
-// On AVR pointers are only 2 bytes so use 'const float &' for 'const float'
-//
-#ifdef __AVR__
-  typedef const float & const_float_t;
-#else
-  typedef const float const_float_t;
-#endif
-typedef const_float_t const_feedRate_t;
-typedef const_float_t const_celsius_float_t;
-
 // Type large enough to count leveling grid points
 typedef IF<TERN0(ABL_USES_GRID, (GRID_MAX_POINTS > 255)), uint16_t, uint8_t>::type grid_count_t;
 

--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -54,12 +54,12 @@ void Babystep::step_axis(const AxisEnum axis) {
   }
 }
 
-void Babystep::add_mm(const AxisEnum axis, const_float_t mm) {
+void Babystep::add_mm(const AxisEnum axis, const float mm) {
   add_steps(axis, mm * planner.settings.axis_steps_per_mm[axis]);
 }
 
 #if ENABLED(BD_SENSOR)
-  void Babystep::set_mm(const AxisEnum axis, const_float_t mm) {
+  void Babystep::set_mm(const AxisEnum axis, const float mm) {
     //if (DISABLED(BABYSTEP_WITHOUT_HOMING) && axis_should_home(axis)) return;
     const int16_t distance = mm * planner.settings.axis_steps_per_mm[axis];
     accum = distance; // Count up babysteps for the UI

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -61,7 +61,7 @@ public:
 
   static bool can_babystep(const AxisEnum axis);
   static void add_steps(const AxisEnum axis, const int16_t distance);
-  static void add_mm(const AxisEnum axis, const_float_t mm);
+  static void add_mm(const AxisEnum axis, const float mm);
 
   #if ENABLED(EP_BABYSTEPPING)
     // Step Z for M293 / M294
@@ -79,7 +79,7 @@ public:
   #endif // EP_BABYSTEPPING
 
   #if ENABLED(BD_SENSOR)
-    static void set_mm(const AxisEnum axis, const_float_t mm);
+    static void set_mm(const AxisEnum axis, const float mm);
   #endif
 
   static bool has_steps() {

--- a/Marlin/src/feature/backlash.h
+++ b/Marlin/src/feature/backlash.h
@@ -81,10 +81,10 @@ public:
     static void set_correction(const float v) { set_correction_uint8(_MAX(0, _MIN(1.0, v)) * all_on + 0.5f); }
     static float get_correction() { return float(get_correction_uint8()) / all_on; }
     static void set_distance_mm(const AxisEnum axis, const float v);
-    static float get_distance_mm(const AxisEnum axis) {return distance_mm[axis];}
+    static float get_distance_mm(const AxisEnum axis) { return distance_mm[axis]; }
     #ifdef BACKLASH_SMOOTHING_MM
       static void set_smoothing_mm(const float v);
-      static float get_smoothing_mm() {return smoothing_mm;}
+      static float get_smoothing_mm() { return smoothing_mm; }
     #endif
   #endif
 

--- a/Marlin/src/feature/bedlevel/abl/bbl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/bbl.cpp
@@ -229,7 +229,7 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
     ) * 0.5f;
   }
 
-  float LevelingBilinear::virt_2cmr(const uint8_t x, const uint8_t y, const_float_t tx, const_float_t ty) {
+  float LevelingBilinear::virt_2cmr(const uint8_t x, const uint8_t y, const float tx, const float ty) {
     float row[4], column[4];
     for (uint8_t i = 0; i < 4; ++i) {
       for (uint8_t j = 0; j < 4; ++j) {
@@ -369,7 +369,7 @@ float LevelingBilinear::get_z_correction(const xy_pos_t &raw) {
    * Prepare a bilinear-leveled linear move on Cartesian,
    * splitting the move where it crosses grid borders.
    */
-  void LevelingBilinear::line_to_destination(const_feedRate_t scaled_fr_mm_s, uint16_t x_splits, uint16_t y_splits) {
+  void LevelingBilinear::line_to_destination(const feedRate_t scaled_fr_mm_s, uint16_t x_splits, uint16_t y_splits) {
     // Get current and destination cells for this line
     xy_int_t c1 { CELL_INDEX(x, current_position.x), CELL_INDEX(y, current_position.y) },
              c2 { CELL_INDEX(x, destination.x), CELL_INDEX(y, destination.y) };

--- a/Marlin/src/feature/bedlevel/abl/bbl.h
+++ b/Marlin/src/feature/bedlevel/abl/bbl.h
@@ -45,7 +45,7 @@ private:
 
     static float virt_coord(const uint8_t x, const uint8_t y);
     static float virt_cmr(const float p[4], const uint8_t i, const float t);
-    static float virt_2cmr(const uint8_t x, const uint8_t y, const_float_t tx, const_float_t ty);
+    static float virt_2cmr(const uint8_t x, const uint8_t y, const float tx, const float ty);
     static void subdivide_mesh();
   #endif
 
@@ -63,7 +63,7 @@ public:
   static constexpr float get_z_offset() { return 0.0f; }
 
   #if IS_CARTESIAN && DISABLED(SEGMENT_LEVELED_MOVES)
-    static void line_to_destination(const_feedRate_t scaled_fr_mm_s, uint16_t x_splits=0xFFFF, uint16_t y_splits=0xFFFF);
+    static void line_to_destination(const feedRate_t scaled_fr_mm_s, uint16_t x_splits=0xFFFF, uint16_t y_splits=0xFFFF);
   #endif
 };
 

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -91,7 +91,7 @@ TemporaryBedLevelingState::TemporaryBedLevelingState(const bool enable) : saved(
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-  void set_z_fade_height(const_float_t zfh, const bool do_report/*=true*/) {
+  void set_z_fade_height(const float zfh, const bool do_report/*=true*/) {
 
     if (planner.z_fade_height == zfh) return;
 

--- a/Marlin/src/feature/bedlevel/bedlevel.h
+++ b/Marlin/src/feature/bedlevel/bedlevel.h
@@ -38,7 +38,7 @@ void set_bed_leveling_enabled(const bool enable=true);
 void reset_bed_level();
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-  void set_z_fade_height(const_float_t zfh, const bool do_report=true);
+  void set_z_fade_height(const float zfh, const bool do_report=true);
 #endif
 
 #if ANY(MESH_BED_LEVELING, PROBE_MANUALLY)

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -61,7 +61,7 @@
      * Prepare a mesh-leveled linear move in a Cartesian setup,
      * splitting the move where it crosses mesh borders.
      */
-    void mesh_bed_leveling::line_to_destination(const_feedRate_t scaled_fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
+    void mesh_bed_leveling::line_to_destination(const feedRate_t scaled_fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
       // Get current and destination cells for this line
       xy_uint8_t scel = cell_indexes(current_position), ecel = cell_indexes(destination);
       NOMORE(scel.x, GRID_MAX_CELLS_X - 1);

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
@@ -55,7 +55,7 @@ public:
 
   static bool mesh_is_valid() { return has_mesh(); }
 
-  static void set_z(const int8_t px, const int8_t py, const_float_t z) { z_values[px][py] = z; }
+  static void set_z(const int8_t px, const int8_t py, const float z) { z_values[px][py] = z; }
 
   static void zigzag(const int8_t index, int8_t &px, int8_t &py) {
     px = index % (GRID_MAX_POINTS_X);
@@ -63,7 +63,7 @@ public:
     if (py & 1) px = (GRID_MAX_POINTS_X) - 1 - px; // Zig zag
   }
 
-  static void set_zigzag_z(const int8_t index, const_float_t z) {
+  static void set_zigzag_z(const int8_t index, const float z) {
     int8_t px, py;
     zigzag(index, px, py);
     set_z(px, py, z);
@@ -72,33 +72,33 @@ public:
   static float get_mesh_x(const uint8_t i) { return index_to_xpos[i]; }
   static float get_mesh_y(const uint8_t i) { return index_to_ypos[i]; }
 
-  static uint8_t cell_index_x(const_float_t x) {
+  static uint8_t cell_index_x(const float x) {
     int8_t cx = (x - (MESH_MIN_X)) * RECIPROCAL(MESH_X_DIST);
     return constrain(cx, 0, GRID_MAX_CELLS_X - 1);
   }
-  static uint8_t cell_index_y(const_float_t y) {
+  static uint8_t cell_index_y(const float y) {
     int8_t cy = (y - (MESH_MIN_Y)) * RECIPROCAL(MESH_Y_DIST);
     return constrain(cy, 0, GRID_MAX_CELLS_Y - 1);
   }
-  static xy_uint8_t cell_indexes(const_float_t x, const_float_t y) {
+  static xy_uint8_t cell_indexes(const float x, const float y) {
     return { cell_index_x(x), cell_index_y(y) };
   }
   static xy_uint8_t cell_indexes(const xy_pos_t &xy) { return cell_indexes(xy.x, xy.y); }
 
-  static int8_t probe_index_x(const_float_t x) {
+  static int8_t probe_index_x(const float x) {
     int8_t px = (x - (MESH_MIN_X) + 0.5f * (MESH_X_DIST)) * RECIPROCAL(MESH_X_DIST);
     return WITHIN(px, 0, (GRID_MAX_POINTS_X) - 1) ? px : -1;
   }
-  static int8_t probe_index_y(const_float_t y) {
+  static int8_t probe_index_y(const float y) {
     int8_t py = (y - (MESH_MIN_Y) + 0.5f * (MESH_Y_DIST)) * RECIPROCAL(MESH_Y_DIST);
     return WITHIN(py, 0, (GRID_MAX_POINTS_Y) - 1) ? py : -1;
   }
-  static xy_int8_t probe_indexes(const_float_t x, const_float_t y) {
+  static xy_int8_t probe_indexes(const float x, const float y) {
     return { probe_index_x(x), probe_index_y(y) };
   }
   static xy_int8_t probe_indexes(const xy_pos_t &xy) { return probe_indexes(xy.x, xy.y); }
 
-  static float calc_z0(const_float_t a0, const_float_t a1, const_float_t z1, const_float_t a2, const_float_t z2) {
+  static float calc_z0(const float a0, const float a1, const float z1, const float a2, const float z2) {
     const float delta_z = (z2 - z1) / (a2 - a1),
                 delta_a = a0 - a1;
     return z1 + delta_a * delta_z;
@@ -118,7 +118,7 @@ public:
   }
 
   #if IS_CARTESIAN && DISABLED(SEGMENT_LEVELED_MOVES)
-    static void line_to_destination(const_feedRate_t scaled_fr_mm_s, uint8_t x_splits=0xFF, uint8_t y_splits=0xFF);
+    static void line_to_destination(const feedRate_t scaled_fr_mm_s, uint8_t x_splits=0xFF, uint8_t y_splits=0xFF);
   #endif
 };
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -102,7 +102,7 @@ void unified_bed_leveling::invalidate() {
   set_all_mesh_points_to_value(NAN);
 }
 
-void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
+void unified_bed_leveling::set_all_mesh_points_to_value(const float value) {
   GRID_LOOP(x, y) {
     z_values[x][y] = value;
     TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, value));
@@ -115,7 +115,7 @@ void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
   constexpr int16_t Z_STEPS_NAN = INT16_MAX;
 
   void unified_bed_leveling::set_store_from_mesh(const bed_mesh_t &in_values, mesh_store_t &stored_values) {
-    auto z_to_store = [](const_float_t z) {
+    auto z_to_store = [](const float z) {
       if (isnan(z)) return Z_STEPS_NAN;
       const int32_t z_scaled = TRUNC(z * mesh_store_scaling);
       if (z_scaled == Z_STEPS_NAN || !WITHIN(z_scaled, INT16_MIN, INT16_MAX))

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -67,10 +67,10 @@ private:
   static G29_parameters_t param;
 
   #if IS_NEWPANEL
-    static void move_z_with_encoder(const_float_t multiplier);
+    static void move_z_with_encoder(const float multiplier);
     static float measure_point_with_encoder();
     static float measure_business_card_thickness();
-    static void manually_probe_remaining_mesh(const xy_pos_t&, const_float_t, const_float_t, const bool) __O0;
+    static void manually_probe_remaining_mesh(const xy_pos_t&, const float, const float, const bool) __O0;
     static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) __O0;
   #endif
 
@@ -101,13 +101,13 @@ public:
   static mesh_index_pair find_furthest_invalid_mesh_point() __O0;
   static void reset();
   static void invalidate();
-  static void set_all_mesh_points_to_value(const_float_t value);
-  static void adjust_mesh_to_mean(const bool cflag, const_float_t value);
+  static void set_all_mesh_points_to_value(const float value);
+  static void adjust_mesh_to_mean(const bool cflag, const float value);
   static bool sanity_check();
   static void smart_fill_mesh();
 
   static void G29() __O0;                           // O0 for no optimization
-  static void smart_fill_wlsf(const_float_t ) __O2; // O2 gives smaller code than Os on A2560
+  static void smart_fill_wlsf(const float ) __O2; // O2 gives smaller code than Os on A2560
 
   static int8_t storage_slot;
 
@@ -130,42 +130,42 @@ public:
 
   unified_bed_leveling();
 
-  FORCE_INLINE static void set_z(const int8_t px, const int8_t py, const_float_t z) { z_values[px][py] = z; }
+  FORCE_INLINE static void set_z(const int8_t px, const int8_t py, const float z) { z_values[px][py] = z; }
 
-  static int8_t cell_index_x_raw(const_float_t x) {
+  static int8_t cell_index_x_raw(const float x) {
     return FLOOR((x - (MESH_MIN_X)) * RECIPROCAL(MESH_X_DIST));
   }
 
-  static int8_t cell_index_y_raw(const_float_t y) {
+  static int8_t cell_index_y_raw(const float y) {
     return FLOOR((y - (MESH_MIN_Y)) * RECIPROCAL(MESH_Y_DIST));
   }
 
-  static bool cell_index_x_valid(const_float_t x) {
+  static bool cell_index_x_valid(const float x) {
     return WITHIN(cell_index_x_raw(x), 0, GRID_MAX_CELLS_X - 1);
   }
 
-  static bool cell_index_y_valid(const_float_t y) {
+  static bool cell_index_y_valid(const float y) {
     return WITHIN(cell_index_y_raw(y), 0, GRID_MAX_CELLS_Y - 1);
   }
 
-  static uint8_t cell_index_x(const_float_t x) {
+  static uint8_t cell_index_x(const float x) {
     return constrain(cell_index_x_raw(x), 0, GRID_MAX_CELLS_X - 1);
   }
 
-  static uint8_t cell_index_y(const_float_t y) {
+  static uint8_t cell_index_y(const float y) {
     return constrain(cell_index_y_raw(y), 0, GRID_MAX_CELLS_Y - 1);
   }
 
-  static xy_uint8_t cell_indexes(const_float_t x, const_float_t y) {
+  static xy_uint8_t cell_indexes(const float x, const float y) {
     return { cell_index_x(x), cell_index_y(y) };
   }
   static xy_uint8_t cell_indexes(const xy_pos_t &xy) { return cell_indexes(xy.x, xy.y); }
 
-  static int8_t closest_x_index(const_float_t x) {
+  static int8_t closest_x_index(const float x) {
     const int8_t px = (x - (MESH_MIN_X) + (MESH_X_DIST) * 0.5) * RECIPROCAL(MESH_X_DIST);
     return WITHIN(px, 0, (GRID_MAX_POINTS_X) - 1) ? px : -1;
   }
-  static int8_t closest_y_index(const_float_t y) {
+  static int8_t closest_y_index(const float y) {
     const int8_t py = (y - (MESH_MIN_Y) + (MESH_Y_DIST) * 0.5) * RECIPROCAL(MESH_Y_DIST);
     return WITHIN(py, 0, (GRID_MAX_POINTS_Y) - 1) ? py : -1;
   }
@@ -188,7 +188,7 @@ public:
    *  It is fairly expensive with its 4 floating point additions and 2 floating point
    *  multiplications.
    */
-  FORCE_INLINE static float calc_z0(const_float_t a0, const_float_t a1, const_float_t z1, const_float_t a2, const_float_t z2) {
+  FORCE_INLINE static float calc_z0(const float a0, const float a1, const float z1, const float a2, const float z2) {
     return z1 + (z2 - z1) * (a0 - a1) / (a2 - a1);
   }
 
@@ -202,7 +202,7 @@ public:
    * z_correction_for_x_on_horizontal_mesh_line is an optimization for
    * the case where the printer is making a vertical line that only crosses horizontal mesh lines.
    */
-  static float z_correction_for_x_on_horizontal_mesh_line(const_float_t rx0, const int x1_i, const int yi) {
+  static float z_correction_for_x_on_horizontal_mesh_line(const float rx0, const int x1_i, const int yi) {
     if (!WITHIN(x1_i, 0, (GRID_MAX_POINTS_X) - 1) || !WITHIN(yi, 0, (GRID_MAX_POINTS_Y) - 1)) {
 
       if (DEBUGGING(LEVELING)) {
@@ -225,7 +225,7 @@ public:
   //
   // See comments above for z_correction_for_x_on_horizontal_mesh_line
   //
-  static float z_correction_for_y_on_vertical_mesh_line(const_float_t ry0, const int xi, const int y1_i) {
+  static float z_correction_for_y_on_vertical_mesh_line(const float ry0, const int xi, const int y1_i) {
     if (!WITHIN(xi, 0, (GRID_MAX_POINTS_X) - 1) || !WITHIN(y1_i, 0, (GRID_MAX_POINTS_Y) - 1)) {
 
       if (DEBUGGING(LEVELING)) {
@@ -251,7 +251,7 @@ public:
    * Z-Height at both ends. Then it does a linear interpolation of these heights based
    * on the Y position within the cell.
    */
-  static float get_z_correction(const_float_t rx0, const_float_t ry0) {
+  static float get_z_correction(const float rx0, const float ry0) {
     const int8_t cx = cell_index_x(rx0), cy = cell_index_y(ry0); // return values are clamped
 
     /**
@@ -295,9 +295,9 @@ public:
   }
 
   #if UBL_SEGMENTED
-    static bool line_to_destination_segmented(const_feedRate_t scaled_fr_mm_s);
+    static bool line_to_destination_segmented(const feedRate_t scaled_fr_mm_s);
   #else
-    static void line_to_destination_cartesian(const_feedRate_t scaled_fr_mm_s, const uint8_t e);
+    static void line_to_destination_cartesian(const feedRate_t scaled_fr_mm_s, const uint8_t e);
   #endif
 
   static bool mesh_is_valid() {

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -716,7 +716,7 @@ void unified_bed_leveling::G29() {
  * G29 P5 C<value> : Adjust Mesh To Mean (and subtract the given offset).
  *                   Find the mean average and shift the mesh to center on that value.
  */
-void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const_float_t offset) {
+void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const float offset) {
   float sum = 0;
   uint8_t n = 0;
   GRID_LOOP(x, y)
@@ -870,7 +870,7 @@ void set_message_with_feedback(FSTR_P const fstr) {
     return false;
   }
 
-  void unified_bed_leveling::move_z_with_encoder(const_float_t multiplier) {
+  void unified_bed_leveling::move_z_with_encoder(const float multiplier) {
     ui.wait_for_release();
     while (!ui.button_pressed()) {
       idle();
@@ -953,7 +953,7 @@ void set_message_with_feedback(FSTR_P const fstr) {
    *          Move to INVALID points and
    *          NOTE: Blocks the G-code queue and captures Marlin UI during use.
    */
-  void unified_bed_leveling::manually_probe_remaining_mesh(const xy_pos_t &pos, const_float_t z_clearance, const_float_t thick, const bool do_ubl_mesh_map) {
+  void unified_bed_leveling::manually_probe_remaining_mesh(const xy_pos_t &pos, const float z_clearance, const float thick, const bool do_ubl_mesh_map) {
     ui.capture();
     TERN_(EXTENSIBLE_UI, ExtUI::onLevelingStart());
 
@@ -1661,10 +1661,10 @@ void unified_bed_leveling::smart_fill_mesh() {
        */
       #if ENABLED(VALIDATE_MESH_TILT)
         auto d_from = []{ DEBUG_ECHOPGM("D from "); };
-        auto normed = [&](const xy_pos_t &pos, const_float_t zadd) {
+        auto normed = [&](const xy_pos_t &pos, const float zadd) {
           return normal.x * pos.x + normal.y * pos.y + zadd;
         };
-        auto debug_pt = [](const int num, const xy_pos_t &pos, const_float_t zadd) {
+        auto debug_pt = [](const int num, const xy_pos_t &pos, const float zadd) {
           d_from();
           DEBUG_ECHOLN(F("Point "), num, C(':'), p_float_t(normed(pos, zadd), 6), F("   Z error = "), p_float_t(zadd - get_z_correction(pos), 6));
         };
@@ -1685,7 +1685,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 #endif // HAS_BED_PROBE
 
 #if ENABLED(UBL_G29_P31)
-  void unified_bed_leveling::smart_fill_wlsf(const_float_t weight_factor) {
+  void unified_bed_leveling::smart_fill_wlsf(const float weight_factor) {
 
     // For each undefined mesh point, compute a distance-weighted least squares fit
     // from all the originally populated mesh points, weighted toward the point

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -47,7 +47,7 @@
   //       corners of cells. To fix the issue, simply check if the start/end of the line
   //       is very close to a cell boundary in advance and don't split the line there.
 
-  void unified_bed_leveling::line_to_destination_cartesian(const_feedRate_t scaled_fr_mm_s, const uint8_t extruder) {
+  void unified_bed_leveling::line_to_destination_cartesian(const feedRate_t scaled_fr_mm_s, const uint8_t extruder) {
     /**
      * Much of the nozzle movement will be within the same cell. So we will do as little computation
      * as possible to determine if this is the case. If this move is within the same cell, we will
@@ -351,7 +351,7 @@
    * Returns true if did NOT move, false if moved (requires current_position update).
    */
 
-  bool __O2 unified_bed_leveling::line_to_destination_segmented(const_feedRate_t scaled_fr_mm_s) {
+  bool __O2 unified_bed_leveling::line_to_destination_segmented(const feedRate_t scaled_fr_mm_s) {
 
     if (!position_is_reachable(destination))  // fail if moving outside reachable boundary
       return true;                            // did not move, so current_position still accurate

--- a/Marlin/src/feature/encoder_i2c.h
+++ b/Marlin/src/feature/encoder_i2c.h
@@ -188,7 +188,7 @@ class I2CPositionEncoder {
     FORCE_INLINE void set_ec_method(const byte method) { ecMethod = method; }
 
     FORCE_INLINE float get_ec_threshold() { return ecThreshold; }
-    FORCE_INLINE void set_ec_threshold(const_float_t newThreshold) { ecThreshold = newThreshold; }
+    FORCE_INLINE void set_ec_threshold(const float newThreshold) { ecThreshold = newThreshold; }
 
     FORCE_INLINE int get_encoder_ticks_mm() {
       switch (type) {

--- a/Marlin/src/feature/filwidth.h
+++ b/Marlin/src/feature/filwidth.h
@@ -78,7 +78,7 @@ public:
   static void update_measured_mm() { measured_mm = raw_to_mm(); }
 
   // Update ring buffer used to delay filament measurements
-  static void advance_e(const_float_t e_move) {
+  static void advance_e(const float e_move) {
 
     // Increment counters with the E distance
     e_count += e_move;

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -283,7 +283,7 @@ void Max7219::set(const uint8_t line, const uint8_t bits) {
   }
 
   // Draw a float with a decimal point and optional digits
-  void Max7219::print(const uint8_t start, const_float_t value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false) {
+  void Max7219::print(const uint8_t start, const float value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false) {
     if (pre_size) print(start, value, pre_size, leadzero, !!post_size);
     if (post_size) {
       const int16_t after = ABS(value) * (10 ^ post_size);

--- a/Marlin/src/feature/max7219.h
+++ b/Marlin/src/feature/max7219.h
@@ -166,7 +166,7 @@ public:
     // Draw an integer with optional leading zeros and optional decimal point
     void print(const uint8_t start, int16_t value, uint8_t size, const bool leadzero=false, bool dec=false);
     // Draw a float with a decimal point and optional digits
-    void print(const uint8_t start, const_float_t value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false);
+    void print(const uint8_t start, const float value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false);
   #endif
 
   // Set a single LED by XY coordinate

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -166,7 +166,7 @@ void Mixer::refresh_collector(const float proportion/*=1.0*/, const uint8_t t/*=
 
   float Mixer::prev_z; // = 0
 
-  void Mixer::update_gradient_for_z(const_float_t z) {
+  void Mixer::update_gradient_for_z(const float z) {
     if (z == prev_z) return;
     prev_z = z;
 

--- a/Marlin/src/feature/mixing.h
+++ b/Marlin/src/feature/mixing.h
@@ -174,9 +174,9 @@ class Mixer {
     static float prev_z;
 
     // Update the current mix from the gradient for a given Z
-    static void update_gradient_for_z(const_float_t z);
+    static void update_gradient_for_z(const float z);
     static void update_gradient_for_planner_z();
-    static void gradient_control(const_float_t z) {
+    static void gradient_control(const float z) {
       if (gradient.enabled) {
         if (z >= gradient.end_z)
           T(gradient.end_vtool);

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -96,7 +96,7 @@ struct E_Step {
   feedRate_t feedRate;  //!< feed rate in mm/s
 };
 
-inline void unscaled_mmu2_e_move(const float &dist, const feedRate_t fr_mm_s, const bool sync=true) {
+inline void unscaled_mmu2_e_move(const float dist, const feedRate_t fr_mm_s, const bool sync=true) {
   current_position.e += dist / planner.e_factor[active_extruder];
   line_to_current_position(fr_mm_s);
   if (sync) planner.synchronize();

--- a/Marlin/src/feature/mmu3/mmu3_marlin.h
+++ b/Marlin/src/feature/mmu3/mmu3_marlin.h
@@ -33,10 +33,10 @@ namespace MMU3 {
   // - Unify implementation among MK3 and Buddy FW
   // - Enable unit testing of MMU top layer
 
-  void extruder_move(const_float_t distance, const_float_t feedRate_mm_s, const bool sync=true);
-  void extruder_schedule_turning(const_float_t feedRate_mm_s);
+  void extruder_move(const float distance, const float feedRate_mm_s, const bool sync=true);
+  void extruder_schedule_turning(const float feedRate_mm_s);
 
-  float move_raise_z(const_float_t delta);
+  float move_raise_z(const float delta);
 
   void planner_abort_queued_moves();
   void planner_synchronize();

--- a/Marlin/src/feature/mmu3/mmu3_marlin1.cpp
+++ b/Marlin/src/feature/mmu3/mmu3_marlin1.cpp
@@ -49,13 +49,13 @@ namespace MMU3 {
     planner_synchronize();
   }
 
-  void extruder_move(const_float_t delta, const_float_t feedRate_mm_s, const bool sync/*=true*/) {
+  void extruder_move(const float delta, const float feedRate_mm_s, const bool sync/*=true*/) {
     current_position.e += delta / planner.e_factor[active_extruder];
     planner_line_to_current_position(feedRate_mm_s);
     if (sync) planner.synchronize();
   }
 
-  float move_raise_z(const_float_t delta) {
+  float move_raise_z(const float delta) {
     //return raise_z(delta);
     xyze_pos_t current_position_before = current_position;
     do_z_clearance_by(delta);

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -188,10 +188,8 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
  *
  * Returns 'true' if load was completed, 'false' for abort
  */
-bool load_filament(const_float_t slow_load_length/*=0*/, const_float_t fast_load_length/*=0*/, const_float_t purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
-                   const bool show_lcd/*=false*/, const bool pause_for_user/*=false*/,
-                   const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
-                   DXC_ARGS
+bool load_filament(const float slow_load_length/*=0*/, const float fast_load_length/*=0*/, const float purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
+  const bool show_lcd/*=false*/, const bool pause_for_user/*=false*/, const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/ DXC_ARGS
 ) {
   DEBUG_SECTION(lf, "load_filament", true);
   DEBUG_ECHOLNPGM("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " showlcd:", show_lcd, " pauseforuser:", pause_for_user, " pausemode:", mode DXC_SAY);
@@ -344,10 +342,10 @@ inline void disable_active_extruder() {
  *
  * Returns 'true' if unload was completed, 'false' for abort
  */
-bool unload_filament(const_float_t unload_length, const bool show_lcd/*=false*/,
+bool unload_filament(const float unload_length, const bool show_lcd/*=false*/,
                      const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
                      #if ALL(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)
-                       , const_float_t mix_multiplier/*=1.0*/
+                       , const float mix_multiplier/*=1.0*/
                      #endif
 ) {
   DEBUG_SECTION(uf, "unload_filament", true);
@@ -418,7 +416,7 @@ bool unload_filament(const_float_t unload_length, const bool show_lcd/*=false*/,
  */
 uint8_t did_pause_print = 0;
 
-bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool show_lcd/*=false*/, const_float_t unload_length/*=0*/ DXC_ARGS) {
+bool pause_print(const float retract, const xyz_pos_t &park_point, const bool show_lcd/*=false*/, const float unload_length/*=0*/ DXC_ARGS) {
   DEBUG_SECTION(pp, "pause_print", true);
   DEBUG_ECHOLNPGM("... park.x:", park_point.x, " y:", park_point.y, " z:", park_point.z, " unloadlen:", unload_length, " showlcd:", show_lcd DXC_SAY);
 
@@ -639,9 +637,9 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
  * - Resume the current SD print job, if any
  */
 void resume_print(
-  const_float_t   slow_load_length/*=0*/,
-  const_float_t   fast_load_length/*=0*/,
-  const_float_t   purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/,
+  const float   slow_load_length/*=0*/,
+  const float   fast_load_length/*=0*/,
+  const float   purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/,
   const int8_t    max_beep_count/*=0*/,
   const celsius_t targetTemp/*=0*/,
   const bool      show_lcd/*=true*/,

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -91,10 +91,10 @@ extern uint8_t did_pause_print;
 
 // Pause the print. If unload_length is set, do a Filament Unload
 bool pause_print(
-  const_float_t   retract,                                    // (mm) Retraction length
+  const float     retract,                                    // (mm) Retraction length
   const xyz_pos_t &park_point,                                // Parking XY Position and Z Raise
   const bool      show_lcd=false,                             // Set LCD status messages?
-  const_float_t   unload_length=0                             // (mm) Filament Change Unload Length - 0 to skip
+  const float     unload_length=0                             // (mm) Filament Change Unload Length - 0 to skip
   DXC_PARAMS                                                  // Dual-X-Carriage extruder index
 );
 
@@ -105,9 +105,9 @@ void wait_for_confirmation(
 );
 
 void resume_print(
-  const_float_t   slow_load_length=0,                         // (mm) Slow Load Length for finishing move
-  const_float_t   fast_load_length=0,                         // (mm) Fast Load Length for initial move
-  const_float_t   purge_length=ADVANCED_PAUSE_PURGE_LENGTH,   // (mm) Purge length
+  const float     slow_load_length=0,                         // (mm) Slow Load Length for finishing move
+  const float     fast_load_length=0,                         // (mm) Fast Load Length for initial move
+  const float     purge_length=ADVANCED_PAUSE_PURGE_LENGTH,   // (mm) Purge length
   const int8_t    max_beep_count=0,                           // Beep alert for attention
   const celsius_t targetTemp=0,                               // (°C) A target temperature for the hotend
   const bool      show_lcd=true,                              // Set LCD status messages?
@@ -116,9 +116,9 @@ void resume_print(
 );
 
 bool load_filament(
-  const_float_t   slow_load_length=0,                         // (mm) Slow Load Length for finishing move
-  const_float_t   fast_load_length=0,                         // (mm) Fast Load Length for initial move
-  const_float_t   purge_length=0,                             // (mm) Purge length
+  const float     slow_load_length=0,                         // (mm) Slow Load Length for finishing move
+  const float     fast_load_length=0,                         // (mm) Fast Load Length for initial move
+  const float     purge_length=0,                             // (mm) Purge length
   const int8_t    max_beep_count=0,                           // Beep alert for attention
   const bool      show_lcd=false,                             // Set LCD status messages?
   const bool      pause_for_user=false,                       // Pause for user before returning?
@@ -127,11 +127,11 @@ bool load_filament(
 );
 
 bool unload_filament(
-  const_float_t   unload_length,                              // (mm) Filament Unload Length - 0 to skip
+  const float     unload_length,                              // (mm) Filament Unload Length - 0 to skip
   const bool      show_lcd=false,                             // Set LCD status messages?
   const PauseMode mode=PAUSE_MODE_PAUSE_PRINT                 // Pause Mode to apply
   #if ALL(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)
-    , const_float_t mix_multiplier=1.0f                       // Extrusion multiplier (for a Mixing Extruder)
+    , const float mix_multiplier=1.0f                         // Extrusion multiplier (for a Mixing Extruder)
   #endif
 );
 

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -270,7 +270,7 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
 
   #if ENABLED(BACKUP_POWER_SUPPLY)
 
-    void PrintJobRecovery::retract_and_lift(const_float_t zraise) {
+    void PrintJobRecovery::retract_and_lift(const float zraise) {
       #if POWER_LOSS_RETRACT_LEN || POWER_LOSS_ZRAISE
 
         gcode.set_relative_mode(true);  // Use relative coordinates

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -237,7 +237,7 @@ class PrintJobRecovery {
     static void write();
 
     #if ENABLED(BACKUP_POWER_SUPPLY)
-      static void retract_and_lift(const_float_t zraise);
+      static void retract_and_lift(const float zraise);
     #endif
 
     #if PIN_EXISTS(POWER_LOSS) || ENABLED(DEBUG_POWER_LOSS_RECOVERY)

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -104,12 +104,12 @@ void ProbeTempComp::print_offsets() {
   #endif
 }
 
-void ProbeTempComp::prepare_new_calibration(const_float_t init_meas_z) {
+void ProbeTempComp::prepare_new_calibration(const float init_meas_z) {
   calib_idx = 0;
   init_measurement = init_meas_z;
 }
 
-void ProbeTempComp::push_back_new_measurement(const TempSensorID tsi, const_float_t meas_z) {
+void ProbeTempComp::push_back_new_measurement(const TempSensorID tsi, const float meas_z) {
   if (calib_idx >= cali_info[tsi].measurements) return;
   sensor_z_offsets[tsi][calib_idx++] = static_cast<int16_t>((meas_z - init_measurement) * 1000.0f);
 }
@@ -186,7 +186,7 @@ void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const celsius
   };
 
   // Interpolate Z based on a temperature being within a given range
-  auto linear_interp = [](const_float_t x, xy_float_t p1, xy_float_t p2) {
+  auto linear_interp = [](const float x, xy_float_t p1, xy_float_t p2) {
     //   zoffs1 +      zoffset_per_toffset      *  toffset
     return p1.y + (p2.y - p1.y) / (p2.x - p1.x) * (x - p1.x);
   };

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -84,8 +84,8 @@ class ProbeTempComp {
     }
     static bool set_offset(const TempSensorID tsi, const uint8_t idx, const int16_t offset);
     static void print_offsets();
-    static void prepare_new_calibration(const_float_t init_meas_z);
-    static void push_back_new_measurement(const TempSensorID tsi, const_float_t meas_z);
+    static void prepare_new_calibration(const float init_meas_z);
+    static void push_back_new_measurement(const TempSensorID tsi, const float meas_z);
     static bool finish_calibration(const TempSensorID tsi);
     static void set_enabled(const bool ena) { enabled = ena; }
 

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -123,12 +123,12 @@ class TFilamentMonitor : public FilamentMonitorBase {
         response.filament_motion_present(extruder);
       }
       static float& motion_distance() { return response.motion_distance_mm; }
-      static void set_motion_distance(const_float_t mm) { response.motion_distance_mm = mm; }
+      static void set_motion_distance(const float mm) { response.motion_distance_mm = mm; }
     #endif
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       static float& runout_distance() { return response.runout_distance_mm; }
-      static void set_runout_distance(const_float_t mm) { response.runout_distance_mm = mm; }
+      static void set_runout_distance(const float mm) { response.runout_distance_mm = mm; }
     #endif
 
     // Handle a block completion. RunoutResponseDelayed uses this to

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -54,7 +54,7 @@ class SpindleLaser {
 public:
   static CutterMode cutter_mode;
 
-  static constexpr uint8_t pct_to_ocr(const_float_t pct) { return uint8_t(PCT_TO_PWM(pct)); }
+  static constexpr uint8_t pct_to_ocr(const float pct) { return uint8_t(PCT_TO_PWM(pct)); }
 
   // cpower = configured values (e.g., SPEED_POWER_MAX)
   // Convert configured power range to a percentage

--- a/Marlin/src/feature/x_twist.cpp
+++ b/Marlin/src/feature/x_twist.cpp
@@ -53,7 +53,7 @@ void XATC::print_points() {
   SERIAL_EOL();
 }
 
-float lerp(const_float_t t, const_float_t a, const_float_t b) { return a + t * (b - a); }
+float lerp(const float t, const float a, const float b) { return a + t * (b - a); }
 
 float XATC::compensation(const xy_pos_t &raw) {
   if (!enabled) return 0;

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -170,7 +170,7 @@ float g26_random_deviation = 0.0;
 
 #endif
 
-void move_to(const_float_t rx, const_float_t ry, const_float_t z, const_float_t e_delta) {
+void move_to(const float rx, const float ry, const float z, const float e_delta) {
   static float last_z = -999.99;
 
   const xy_pos_t dest = { rx, ry };
@@ -196,7 +196,7 @@ void move_to(const_float_t rx, const_float_t ry, const_float_t z, const_float_t 
   prepare_internal_move_to_destination(fr_mm_s);
 }
 
-void move_to(const xyz_pos_t &where, const_float_t de) { move_to(where.x, where.y, where.z, de); }
+void move_to(const xyz_pos_t &where, const float de) { move_to(where.x, where.y, where.z, de); }
 
 typedef struct {
   float extrusion_multiplier  = EXTRUSION_MULTIPLIER,

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -87,7 +87,7 @@ void ac_cleanup() {
   TERN_(HAS_BED_PROBE, probe.use_probing_tool(false));
 }
 
-void print_signed_float(FSTR_P const prefix, const_float_t f) {
+void print_signed_float(FSTR_P const prefix, const float f) {
   SERIAL_ECHO(F("  "), prefix, C(':'));
   serial_offset(f);
 }

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -323,7 +323,7 @@ void GcodeSuite::G34() {
         msg.echoln();
         ui.set_status(msg);
 
-        auto decreasing_accuracy = [](const_float_t v1, const_float_t v2) {
+        auto decreasing_accuracy = [](const float v1, const float v2) {
           if (v1 < v2 * 0.7f) {
             SERIAL_ECHOLNPGM("Decreasing Accuracy Detected.");
             LCD_MESSAGE(MSG_DECREASING_ACCURACY);

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -124,7 +124,7 @@ void GcodeSuite::M48() {
         max = -99999.9, // Largest value sampled so far
         sample_set[n_samples];  // Storage for sampled values
 
-  auto dev_report = [](const bool verbose, const_float_t mean, const_float_t sigma, const_float_t min, const_float_t max, const bool final=false) {
+  auto dev_report = [](const bool verbose, const float mean, const float sigma, const float min, const float max, const bool final=false) {
     if (verbose) {
       SERIAL_ECHOPGM("Mean: ", p_float_t(mean, 6));
       if (!final) SERIAL_ECHOPGM(" Sigma: ", p_float_t(sigma, 6));

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -47,7 +47,7 @@
   #endif
 
   #ifdef PHOTO_RETRACT_MM
-    inline void e_move_m240(const float length, const_feedRate_t fr_mm_s) {
+    inline void e_move_m240(const float length, const feedRate_t fr_mm_s) {
       if (length && thermalManager.hotEnoughToExtrude(active_extruder))
         unscaled_e_move(length, fr_mm_s);
     }

--- a/Marlin/src/gcode/feature/mixing/M166.cpp
+++ b/Marlin/src/gcode/feature/mixing/M166.cpp
@@ -33,7 +33,7 @@ inline void echo_mix() {
   SERIAL_ECHOPGM(" (", mixer.mix[0], "%|", mixer.mix[1], "%)");
 }
 
-inline void echo_zt(const int t, const_float_t z) {
+inline void echo_zt(const int t, const float z) {
   mixer.update_mix_from_vtool(t);
   SERIAL_ECHOPGM_P(SP_Z_STR, z, SP_T_STR, t);
   echo_mix();

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -90,7 +90,7 @@ void GcodeSuite::M701() {
       tool_change(target_extruder);
   #endif
 
-  auto move_z_by = [](const_float_t zdist) {
+  auto move_z_by = [](const float zdist) {
     if (zdist) {
       destination = current_position;
       destination.z += zdist;

--- a/Marlin/src/gcode/host/M360.cpp
+++ b/Marlin/src/gcode/host/M360.cpp
@@ -49,7 +49,7 @@ struct ProgStr {
   constexpr explicit operator bool() const { return ptr != nullptr; }
 };
 
-static void config_prefix(ProgStr name, ProgStr pref=nullptr, int8_t ind=-1) {
+static void config_prefix(ProgStr name, ProgStr pref=nullptr, const int8_t ind=-1) {
   SERIAL_ECHOPGM("Config:");
   if (pref) SERIAL_ECHOPGM_P(static_cast<PGM_P>(pref));
   if (ind >= 0) { SERIAL_ECHO(ind); SERIAL_CHAR(':'); }
@@ -57,15 +57,16 @@ static void config_prefix(ProgStr name, ProgStr pref=nullptr, int8_t ind=-1) {
 }
 
 template<typename T>
-static void config_line(ProgStr name, const T val, ProgStr pref=nullptr, int8_t ind=-1) {
+static void config_line(ProgStr name, const T val, ProgStr pref=nullptr, const int8_t ind=-1) {
   config_prefix(name, pref, ind);
   SERIAL_ECHOLN(val);
 }
 
 template<typename T>
-static void config_line_e(int8_t e, ProgStr name, const T val) {
+static void config_line_e(const int8_t e, ProgStr name, const T val) {
   config_line(name, val, PSTR("Extr."), e + 1);
 }
+
 /**
  * M360: Report Firmware configuration
  *       in RepRapFirmware-compatible format

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -35,7 +35,7 @@
 
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
 
-  FORCE_INLINE void mod_probe_offset(const_float_t offs) {
+  FORCE_INLINE void mod_probe_offset(const float offs) {
     if (TERN1(BABYSTEP_HOTEND_Z_OFFSET, active_extruder == 0)) {
       probe.offset.z += offs;
       SERIAL_ECHO_MSG(STR_PROBE_OFFSET " " STR_Z, probe.offset.z);

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -301,8 +301,8 @@ public:
   // Units modes: Inches, Fahrenheit, Kelvin
 
   #if ENABLED(INCH_MODE_SUPPORT)
-    static float mm_to_linear_unit(const_float_t mm)     { return mm / linear_unit_factor; }
-    static float mm_to_volumetric_unit(const_float_t mm) { return mm / (volumetric_enabled ? volumetric_unit_factor : linear_unit_factor); }
+    static float mm_to_linear_unit(const float mm)     { return mm / linear_unit_factor; }
+    static float mm_to_volumetric_unit(const float mm) { return mm / (volumetric_enabled ? volumetric_unit_factor : linear_unit_factor); }
 
     // Init linear units by constructor
     GCodeParser() { set_input_linear_units(LINEARUNIT_MM); }
@@ -324,16 +324,16 @@ public:
       return linear_unit_factor;
     }
 
-    static float linear_value_to_mm(const_float_t v)                  { return v * linear_unit_factor; }
+    static float linear_value_to_mm(const float v)                  { return v * linear_unit_factor; }
     static float axis_value_to_mm(const AxisEnum axis, const float v) { return v * axis_unit_factor(axis); }
     static float per_axis_value(const AxisEnum axis, const float v)   { return v / axis_unit_factor(axis); }
 
   #else
 
-    static constexpr float mm_to_linear_unit(const_float_t mm)     { return mm; }
-    static constexpr float mm_to_volumetric_unit(const_float_t mm) { return mm; }
+    static constexpr float mm_to_linear_unit(const float mm)     { return mm; }
+    static constexpr float mm_to_volumetric_unit(const float mm) { return mm; }
 
-    static constexpr float linear_value_to_mm(const_float_t v)             { return v; }
+    static constexpr float linear_value_to_mm(const float v)               { return v; }
     static constexpr float axis_value_to_mm(const AxisEnum, const float v) { return v; }
     static constexpr float per_axis_value(const AxisEnum, const float v)   { return v; }
 
@@ -420,17 +420,17 @@ public:
   void unknown_command_warning();
 
   // Provide simple value accessors with default option
-  static char*     stringval(const char c, char * const dval=nullptr) { return seenval(c) ? value_string()   : dval; }
+  static char*     stringval(const char c, char * const dval=nullptr) { return seenval(c) ? value_string()     : dval; }
   static float     floatval(const char c, const float dval=0.0)   { return seenval(c) ? value_float()        : dval; }
-  static bool      boolval(const char c, const bool dval=false)   { return seenval(c) ? value_bool()         : (seen(c) ? true : dval); }
-  static uint8_t   byteval(const char c, const uint8_t dval=0)    { return seenval(c) ? value_byte()         : dval; }
-  static int16_t   intval(const char c, const int16_t dval=0)     { return seenval(c) ? value_int()          : dval; }
-  static uint16_t  ushortval(const char c, const uint16_t dval=0) { return seenval(c) ? value_ushort()       : dval; }
-  static int32_t   longval(const char c, const int32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
-  static uint32_t  ulongval(const char c, const uint32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
+  static bool      boolval(const char c, const bool dval=false)     { return seenval(c) ? value_bool()         : (seen(c) ? true : dval); }
+  static uint8_t   byteval(const char c, const uint8_t dval=0)      { return seenval(c) ? value_byte()         : dval; }
+  static int16_t   intval(const char c, const int16_t dval=0)       { return seenval(c) ? value_int()          : dval; }
+  static uint16_t  ushortval(const char c, const uint16_t dval=0)   { return seenval(c) ? value_ushort()       : dval; }
+  static int32_t   longval(const char c, const int32_t dval=0)      { return seenval(c) ? value_long()         : dval; }
+  static uint32_t  ulongval(const char c, const uint32_t dval=0)    { return seenval(c) ? value_ulong()        : dval; }
   static float     linearval(const char c, const float dval=0)    { return seenval(c) ? value_linear_units() : dval; }
   static float     axisunitsval(const char c, const AxisEnum a, const float dval=0)
-                                                                         { return seenval(c) ? value_axis_units(a)  : dval; }
+                                                                       { return seenval(c) ? value_axis_units(a)  : dval; }
   static celsius_t celsiusval(const char c, const celsius_t dval=0)    { return seenval(c) ? value_celsius() : dval; }
   static feedRate_t feedrateval(const char c, const feedRate_t dval=0) { return seenval(c) ? value_feedrate() : dval; }
 

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -3676,7 +3676,7 @@ void hmiAdvSet() {
     dwinUpdateLCD();
   }
 
-  void hmiHomeOffN(const AxisEnum axis, float &posScaled, const_float_t lo, const_float_t hi) {
+  void hmiHomeOffN(const AxisEnum axis, float &posScaled, const float lo, const float hi) {
     EncoderState encoder_diffState = encoderReceiveAnalyze();
     if (encoder_diffState == ENCODER_DIFF_NO) return;
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -454,7 +454,7 @@ void JyersDWIN::clearScreen(const uint8_t e/*=3*/) {
   if (e == 4) dwinDrawRectangle(1, COLOR_BG_BLACK, 0, 31, DWIN_WIDTH, DWIN_HEIGHT); // Clear Popup Area
 }
 
-void JyersDWIN::drawFloat(const_float_t value, const uint8_t row, const bool selected/*=false*/, const uint8_t minunit/*=10*/) {
+void JyersDWIN::drawFloat(const float value, const uint8_t row, const bool selected/*=false*/, const uint8_t minunit/*=10*/) {
   const uint8_t digits = (uint8_t)floor(log10(abs(value))) + log10(minunit) + (minunit > 1);
   const uint16_t bColor = selected ? COLOR_SELECT : COLOR_BG_BLACK;
   const uint16_t xpos = 240 - (digits * 8);
@@ -4812,7 +4812,7 @@ void JyersDWIN::confirmControl() {
 // In-Menu Value Modification
 //
 
-void JyersDWIN::setupValue(const_float_t value, const_float_t min, const_float_t max, const_float_t unit, const uint8_t type) {
+void JyersDWIN::setupValue(const float value, const float min, const float max, const float unit, const uint8_t type) {
   if (TERN0(PIDTEMP, valuepointer == &thermalManager.temp_hotend[0].pid.Ki) || TERN0(PIDTEMPBED, valuepointer == &thermalManager.temp_bed.pid.Ki))
     tempvalue = unscalePID_i(value) * unit;
   else if (TERN0(PIDTEMP, valuepointer == &thermalManager.temp_hotend[0].pid.Kd) || TERN0(PIDTEMPBED, valuepointer == &thermalManager.temp_bed.pid.Kd))
@@ -4828,32 +4828,32 @@ void JyersDWIN::setupValue(const_float_t value, const_float_t min, const_float_t
   drawFloat(tempvalue / unit, selection - scrollpos, true, valueunit);
 }
 
-void JyersDWIN::modifyValue(float &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(float &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 0);
 }
-void JyersDWIN::modifyValue(uint8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(uint8_t &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 1);
 }
-void JyersDWIN::modifyValue(uint16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(uint16_t &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 2);
 }
-void JyersDWIN::modifyValue(int16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(int16_t &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 3);
 }
-void JyersDWIN::modifyValue(uint32_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(uint32_t &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 4);
 }
-void JyersDWIN::modifyValue(int8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()/*=nullptr*/) {
+void JyersDWIN::modifyValue(int8_t &value, const float min, const float max, const float unit, void (*f)()/*=nullptr*/) {
   valuepointer = &value;
   funcpointer = f;
   setupValue((float)value, min, max, unit, 5);

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.h
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.h
@@ -173,7 +173,7 @@ public:
   static constexpr const char * const preheat_modes[3] = { "Both", "Hotend", "Bed" };
 
   static void clearScreen(const uint8_t e=3);
-  static void drawFloat(const_float_t value, const uint8_t row, const bool selected=false, const uint8_t minunit=10);
+  static void drawFloat(const float value, const uint8_t row, const bool selected=false, const uint8_t minunit=10);
   static void drawOption(const uint8_t value, const char * const * options, const uint8_t row, const bool selected=false, const bool color=false);
   static uint16_t getColor(const uint8_t color, const uint16_t original, const bool light=false);
   static void drawCheckbox(const uint8_t row, const bool value);
@@ -219,13 +219,13 @@ public:
   static void popupControl();
   static void confirmControl();
 
-  static void setupValue(const_float_t value, const_float_t min, const_float_t max, const_float_t unit, const uint8_t type);
-  static void modifyValue(float &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(uint8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(uint16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(int16_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(uint32_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
-  static void modifyValue(int8_t &value, const_float_t min, const_float_t max, const_float_t unit, void (*f)()=nullptr);
+  static void setupValue(const float value, const float min, const float max, const float unit, const uint8_t type);
+  static void modifyValue(float &value, const float min, const float max, const float unit, void (*f)()=nullptr);
+  static void modifyValue(uint8_t &value, const float min, const float max, const float unit, void (*f)()=nullptr);
+  static void modifyValue(uint16_t &value, const float min, const float max, const float unit, void (*f)()=nullptr);
+  static void modifyValue(int16_t &value, const float min, const float max, const float unit, void (*f)()=nullptr);
+  static void modifyValue(uint32_t &value, const float min, const float max, const float unit, void (*f)()=nullptr);
+  static void modifyValue(int8_t &value, const float min, const float max, const float unit, void (*f)()=nullptr);
   static void modifyOption(const uint8_t value, const char * const * options, const uint8_t max);
 
   static void updateStatus(const char * const text);

--- a/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_status_480x272.cpp
@@ -108,7 +108,7 @@ void _draw_axis_value(const AxisEnum axis, const char *value, const bool blink, 
 
 #if ENABLED(LCD_SHOW_E_TOTAL)
 
-  void _draw_e_value(const_float_t value, const uint16_t x, const uint16_t y) {
+  void _draw_e_value(const float value, const uint16_t x, const uint16_t y) {
     const uint8_t scale = value >= 100000.0f ? 10 : 1; // show cm after 99,999mm
     const bool e_redraw = !ui.did_first_redraw || old_is_printing != print_job_timer.isRunning();
 

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1567,7 +1567,7 @@ void dwinLevelingDone() {
 }
 
 #if HAS_MESH
-  void dwinMeshUpdate(const int8_t cpos, const int8_t tpos, const_float_t zval) {
+  void dwinMeshUpdate(const int8_t cpos, const int8_t tpos, const float zval) {
     ui.set_status(
       &MString<32>(GET_TEXT_F(MSG_PROBING_POINT), ' ', cpos, '/', tpos, F(" Z="), p_float_t(zval, 2))
     );
@@ -2169,7 +2169,7 @@ void autoHome() { queue.inject_P(G28_STR); }
   void applyZOffset() { TERN_(EEPROM_SETTINGS, settings.save()); }
   void liveZOffset() {
     #if ANY(BABYSTEP_ZPROBE_OFFSET, JUST_BABYSTEP)
-      const_float_t step_zoffset = round((menuData.value / 100.0f) * planner.settings.axis_steps_per_mm[Z_AXIS]) - babystep.accum;
+      const float step_zoffset = round((menuData.value / 100.0f) * planner.settings.axis_steps_per_mm[Z_AXIS]) - babystep.accum;
       if (BABYSTEP_ALLOWED()) babystep.add_steps(Z_AXIS, step_zoffset);
     #endif
   }

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -288,7 +288,7 @@ void dwinCheckStatusMessage();
 void dwinHomingStart();
 void dwinHomingDone();
 #if HAS_MESH
-  void dwinMeshUpdate(const int8_t cpos, const int8_t tpos, const_float_t zval);
+  void dwinMeshUpdate(const int8_t cpos, const int8_t tpos, const float zval);
 #endif
 void dwinLevelingStart();
 void dwinLevelingDone();

--- a/Marlin/src/lcd/e3v2/proui/plot.cpp
+++ b/Marlin/src/lcd/e3v2/proui/plot.cpp
@@ -45,7 +45,7 @@ Plot plot;
 
 Plot::PlotData Plot::data;
 
-void Plot::draw(const frame_rect_t &frame, const_celsius_float_t max, const_celsius_float_t ref/*=0*/) {
+void Plot::draw(const frame_rect_t &frame, const celsius_float_t max, const celsius_float_t ref/*=0*/) {
   data.graphframe = frame;
   data.graphpoints = 0;
   data.scale = frame.h / max;
@@ -58,7 +58,7 @@ void Plot::draw(const frame_rect_t &frame, const_celsius_float_t max, const_cels
   dwinDrawHLine(COLOR_RED, frame.x, data.r, frame.w);
 }
 
-void Plot::update(const_celsius_float_t value) {
+void Plot::update(const celsius_float_t value) {
   if (!data.scale) return;
   const uint16_t y = LROUND((data.y2) - value * data.scale);
   if (data.graphpoints < data.graphframe.w) {

--- a/Marlin/src/lcd/e3v2/proui/plot.h
+++ b/Marlin/src/lcd/e3v2/proui/plot.h
@@ -32,8 +32,8 @@
 
 class Plot {
 public:
-  static void draw(const frame_rect_t &frame, const_celsius_float_t max, const_celsius_float_t ref=0);
-  static void update(const_celsius_float_t value);
+  static void draw(const frame_rect_t &frame, const celsius_float_t max, const celsius_float_t ref=0);
+  static void update(const celsius_float_t value);
 
 private:
   static struct PlotData {

--- a/Marlin/src/lcd/e3v2/proui/proui_extui.cpp
+++ b/Marlin/src/lcd/e3v2/proui/proui_extui.cpp
@@ -163,7 +163,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       const int16_t idx = ypos * (GRID_MAX_POINTS_X) + xpos;
       dwinMeshUpdate(_MIN(idx, GRID_MAX_POINTS), int(GRID_MAX_POINTS), zval);
       dwinRedrawScreen();

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
@@ -137,7 +137,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
@@ -127,7 +127,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
@@ -140,7 +140,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }

--- a/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
@@ -153,7 +153,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSRxHandler.cpp
@@ -34,14 +34,14 @@
 #include "../../../module/stepper.h"
 
 void DGUSRxHandler::printSpeedPercentage(DGUS_VP &vp, void *data) {
-  const_float_t feedratePercentage = dgus.fromFixedPoint<int16_t, const_float_t, 0>(Endianness::fromBE_P<int16_t>(data));
+  const float feedratePercentage = dgus.fromFixedPoint<int16_t, const float, 0>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setFeedrate_percent(feedratePercentage);
 }
 
 void DGUSRxHandler::zOffset(DGUS_VP &vp, void *data) {
-  const_float_t zoffset = dgus.fromFixedPoint<int16_t, const_float_t, 2>(Endianness::fromBE_P<int16_t>(data));
-  const_float_t currentzOffset = ExtUI::getZOffset_mm();
-  const_float_t zStepsPerMm = ExtUI::getAxisSteps_per_mm(ExtUI::Z);
+  const float zoffset = dgus.fromFixedPoint<int16_t, const float, 2>(Endianness::fromBE_P<int16_t>(data));
+  const float currentzOffset = ExtUI::getZOffset_mm();
+  const float zStepsPerMm = ExtUI::getAxisSteps_per_mm(ExtUI::Z);
   int16_t zStepsDiff = zStepsPerMm * (zoffset - currentzOffset);
 
   ExtUI::babystepAxis_steps(zStepsDiff, ExtUI::Z);
@@ -49,33 +49,33 @@ void DGUSRxHandler::zOffset(DGUS_VP &vp, void *data) {
 }
 
 void DGUSRxHandler::extruderTargetTemp(DGUS_VP &vp, void *data) {
-  const_float_t temperature = dgus.fromFixedPoint<int16_t, const_float_t, 0>(Endianness::fromBE_P<int16_t>(data));
+  const float temperature = dgus.fromFixedPoint<int16_t, const float, 0>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setTargetTemp_celsius(temperature, ExtUI::H0);
 }
 
 void DGUSRxHandler::bedTargetTemp(DGUS_VP &vp, void *data) {
-  const_float_t temperature = dgus.fromFixedPoint<int16_t, const_float_t, 0>(Endianness::fromBE_P<int16_t>(data));
+  const float temperature = dgus.fromFixedPoint<int16_t, const float, 0>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setTargetTemp_celsius(temperature, ExtUI::BED);
 }
 
 void DGUSRxHandler::axis_X(DGUS_VP &vp, void *data) {
-  const_float_t axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
+  const float axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setAxisPosition_mm(axisValue, ExtUI::X);
 }
 
 void DGUSRxHandler::axis_Y(DGUS_VP &vp, void *data) {
-  const_float_t axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
+  const float axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setAxisPosition_mm(axisValue, ExtUI::Y);
 }
 
 void DGUSRxHandler::axis_Z(DGUS_VP &vp, void *data) {
-  const_float_t axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
+  const float axisValue = dgus.fromFixedPoint<int16_t, float, 1>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setAxisPosition_mm(axisValue, ExtUI::Z);
 }
 
 void DGUSRxHandler::extrudeLength(DGUS_VP &vp, void *data) {
-  const_float_t length = dgus.fromFixedPoint<int16_t, const_float_t, 1>(Endianness::fromBE_P<int16_t>(data));
-  const_float_t currentPosition = ExtUI::getAxisPosition_mm(ExtUI::E0);
+  const float length = dgus.fromFixedPoint<int16_t, const float, 1>(Endianness::fromBE_P<int16_t>(data));
+  const float currentPosition = ExtUI::getAxisPosition_mm(ExtUI::E0);
 
   #if HAS_FILAMENT_SENSOR
     if (ExtUI::getFilamentRunoutEnabled() && ExtUI::getFilamentRunoutState()) {
@@ -87,8 +87,8 @@ void DGUSRxHandler::extrudeLength(DGUS_VP &vp, void *data) {
 }
 
 void DGUSRxHandler::retractLength(DGUS_VP &vp, void *data) {
-  const_float_t length = dgus.fromFixedPoint<int16_t, const_float_t, 1>(Endianness::fromBE_P<int16_t>(data));
-  const_float_t currentPosition = ExtUI::getAxisPosition_mm(ExtUI::E0);
+  const float length = dgus.fromFixedPoint<int16_t, const float, 1>(Endianness::fromBE_P<int16_t>(data));
+  const float currentPosition = ExtUI::getAxisPosition_mm(ExtUI::E0);
 
   #if HAS_FILAMENT_SENSOR
     if (ExtUI::getFilamentRunoutEnabled() && ExtUI::getFilamentRunoutState()) {
@@ -138,7 +138,7 @@ void DGUSRxHandler::setLanguage(DGUS_VP &vp, void *data) {
 #endif // PIDTEMPBED
 
 void DGUSRxHandler::fanSpeed(DGUS_VP &vp, void *data) {
-  const_float_t percentage = dgus.fromFixedPoint<int16_t, float, 0>(Endianness::fromBE_P<int16_t>(data));
+  const float percentage = dgus.fromFixedPoint<int16_t, float, 0>(Endianness::fromBE_P<int16_t>(data));
   ExtUI::setTargetFan_percent(percentage, ExtUI::FAN0);
 }
 

--- a/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
@@ -148,7 +148,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       screen.meshUpdate(xpos, ypos);
     }
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const probe_state_t state) { }

--- a/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
@@ -140,7 +140,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       screen.meshUpdate(xpos, ypos);
     }
 

--- a/Marlin/src/lcd/extui/example/example.cpp
+++ b/Marlin/src/lcd/extui/example/example.cpp
@@ -132,7 +132,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
@@ -159,7 +159,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t x, const int8_t y, const_float_t val) {
+    void onMeshUpdate(const int8_t x, const int8_t y, const float val) {
       BedMeshViewScreen::onMeshUpdate(x, y, val);
     }
     void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) {

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
@@ -389,7 +389,7 @@ class CommandProcessor : public CLCD::CommandFifo {
       return *this;
     }
 
-    FORCEDINLINE CommandProcessor& icon(int16_t x, int16_t y, int16_t w, int16_t h, const FTDI::bitmap_info_t& info, const float scale = 1) {
+    FORCEDINLINE CommandProcessor& icon(int16_t x, int16_t y, int16_t w, int16_t h, const FTDI::bitmap_info_t& info, const float scale=1) {
       using namespace FTDI;
       cmd(BEGIN(BITMAPS));
       if (scale != 1) {

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
@@ -136,7 +136,7 @@ void BaseMoveAxisScreen::raiseZtoTop() {
   setAxisPosition_mm(Z_MAX_POS - 5, Z, homing_feedrate.z);
 }
 
-float BaseMoveAxisScreen::getManualFeedrate(const uint8_t axis, const_float_t increment_mm) {
+float BaseMoveAxisScreen::getManualFeedrate(const uint8_t axis, const float increment_mm) {
   // Compute feedrate so that the tool lags the adjuster when it is
   // being held down, this allows enough margin for the planner to
   // connect segments and even out the motion.
@@ -144,12 +144,12 @@ float BaseMoveAxisScreen::getManualFeedrate(const uint8_t axis, const_float_t in
   return min(MMM_TO_MMS(max_manual_feedrate[axis]), ABS(increment_mm * (TOUCH_REPEATS_PER_SECOND) * 0.80f));
 }
 
-void BaseMoveAxisScreen::setManualFeedrate(const ExtUI::axis_t axis, const_float_t increment_mm) {
+void BaseMoveAxisScreen::setManualFeedrate(const ExtUI::axis_t axis, const float increment_mm) {
   ExtUI::setFeedrate_mm_s(getManualFeedrate(X_AXIS + (axis - ExtUI::X), increment_mm));
 }
 
 #if HAS_EXTRUDERS
-  void BaseMoveAxisScreen::setManualFeedrate(const ExtUI::extruder_t, const_float_t increment_mm) {
+  void BaseMoveAxisScreen::setManualFeedrate(const ExtUI::extruder_t, const float increment_mm) {
     ExtUI::setFeedrate_mm_s(getManualFeedrate(E_AXIS, increment_mm));
   }
 #endif

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.h
@@ -32,11 +32,11 @@ struct MoveAxisScreenData {
 
 class BaseMoveAxisScreen : public BaseNumericAdjustmentScreen {
   private:
-    static float getManualFeedrate(const uint8_t axis, const_float_t increment_mm);
+    static float getManualFeedrate(const uint8_t axis, const float increment_mm);
   public:
     static void raiseZtoTop();
-    static void setManualFeedrate(const ExtUI::axis_t, const_float_t increment_mm);
-    static void setManualFeedrate(const ExtUI::extruder_t, const_float_t increment_mm);
+    static void setManualFeedrate(const ExtUI::axis_t, const float increment_mm);
+    static void setManualFeedrate(const ExtUI::extruder_t, const float increment_mm);
 
     static void onEntry();
     static bool onTouchHeld(const uint8_t tag);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/string_format.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/string_format.cpp
@@ -35,7 +35,7 @@
 /**
  * Formats a temperature string (e.g. "100°C")
  */
-void format_temp(char *str, const_celsius_float_t t1) {
+void format_temp(char *str, const celsius_float_t t1) {
   #ifdef TOUCH_UI_LCD_TEMP_PRECISION
     char num1[7];
     dtostrf(t1, 4 + TOUCH_UI_LCD_TEMP_PRECISION, TOUCH_UI_LCD_TEMP_PRECISION, num1);
@@ -48,7 +48,7 @@ void format_temp(char *str, const_celsius_float_t t1) {
 /**
  * Formats a temperature string for an idle heater (e.g. "100 °C / idle")
  */
-void format_temp_and_idle(char *str, const_celsius_float_t t1) {
+void format_temp_and_idle(char *str, const celsius_float_t t1) {
   #ifdef TOUCH_UI_LCD_TEMP_PRECISION
     char num1[7];
     dtostrf(t1, 4 + TOUCH_UI_LCD_TEMP_PRECISION, TOUCH_UI_LCD_TEMP_PRECISION, num1);
@@ -61,7 +61,7 @@ void format_temp_and_idle(char *str, const_celsius_float_t t1) {
 /**
  * Formats a temperature string for an active heater (e.g. "100 / 200°C")
  */
-void format_temp_and_temp(char *str, const_celsius_float_t t1, const_celsius_float_t t2) {
+void format_temp_and_temp(char *str, const celsius_float_t t1, const celsius_float_t t2) {
   #ifdef TOUCH_UI_LCD_TEMP_PRECISION
     char num1[7], num2[7];
     dtostrf(t1, 4 + TOUCH_UI_LCD_TEMP_PRECISION, TOUCH_UI_LCD_TEMP_PRECISION, num1);
@@ -75,7 +75,7 @@ void format_temp_and_temp(char *str, const_celsius_float_t t1, const_celsius_flo
 /**
  * Formats a temperature string for a material (e.g. "100°C (PLA)")
  */
-void format_temp_and_material(char *str, const_celsius_float_t t1, const char *material) {
+void format_temp_and_material(char *str, const celsius_float_t t1, const char *material) {
   #ifdef TOUCH_UI_LCD_TEMP_PRECISION
     char num1[7];
     dtostrf(t1, 4 + TOUCH_UI_LCD_TEMP_PRECISION, TOUCH_UI_LCD_TEMP_PRECISION, num1);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/string_format.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/string_format.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-void format_temp(char *str, const_celsius_float_t t1);
-void format_temp_and_idle(char *str, const_celsius_float_t t1);
-void format_temp_and_temp(char *str, const_celsius_float_t t1, const_celsius_float_t t2);
-void format_temp_and_material(char *str, const_celsius_float_t t1, const char *material);
+void format_temp(char *str, const celsius_float_t t1);
+void format_temp_and_idle(char *str, const celsius_float_t t1);
+void format_temp_and_temp(char *str, const celsius_float_t t1, const celsius_float_t t2);
+void format_temp_and_material(char *str, const celsius_float_t t1, const char *material);
 void format_position(char *str, float p, uint8_t decimals = 1);
 void format_position(char *str, float x, float y, float z);

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
@@ -366,7 +366,7 @@ void onPostprocessSettings() {}
 #if HAS_MESH
   void onMeshUpdate(const int8_t xpos, const int8_t ypos, probe_state_t state) {}
 
-  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
+  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
     if (waitway == 3)
       if (isPositionKnown() && (getActualTemp_celsius(BED) >= (getTargetTemp_celsius(BED) - 1)))
         rts.sendData(ExchangePageBase + 64, ExchangepageAddr);

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
@@ -554,7 +554,7 @@ void RTS::sendData(const char c, const uint32_t addr, const uint8_t cmd/*=VarAdd
   sendData();
 }
 
-void RTS::sendData(const_float_t f, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {
+void RTS::sendData(const float f, const uint32_t addr, const uint8_t cmd/*=VarAddr_W*/) {
   int16_t n = f;
   if (cmd == VarAddr_W) {
     snddat.data[0] = n;

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.h
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.h
@@ -228,7 +228,7 @@ class RTS {
     static void sendData(char,          const uint32_t, const uint8_t=VarAddr_W);
     static void sendData(int,           const uint32_t, const uint8_t=VarAddr_W);
     static void sendData(unsigned long, const uint32_t, const uint8_t=VarAddr_W);
-    static void sendData(const_float_t, const uint32_t, const uint8_t=VarAddr_W);
+    static void sendData(const float, const uint32_t, const uint8_t=VarAddr_W);
 
     static void sendData(uint8_t * const str, const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData((char *)str, addr, cmd); }
     static void sendData(const unsigned int n, uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(int(n), addr, cmd); }

--- a/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
@@ -187,7 +187,7 @@ namespace ExtUI {
   #endif
 
   #if HAS_MESH
-    void onMeshUpdate(const int8_t, const int8_t, const_float_t) {}
+    void onMeshUpdate(const int8_t, const int8_t, const float) {}
     void onMeshUpdate(const int8_t, const int8_t, const ExtUI::probe_state_t) {}
   #endif
 

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -337,7 +337,7 @@ namespace ExtUI {
     return epos;
   }
 
-  void setAxisPosition_mm(const_float_t position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const float position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
     // Get motion limit from software endstops, if any
     float min, max;
     soft_endstop.get_manual_axis_limits((AxisEnum)axis, min, max);
@@ -355,7 +355,7 @@ namespace ExtUI {
     line_to_current_position(feedrate ?: manual_feedrate_mm_s[axis]);
   }
 
-  void setAxisPosition_mm(const_float_t position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const float position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
     setActiveTool(extruder, true);
 
     current_position.e = position;
@@ -470,7 +470,7 @@ namespace ExtUI {
       };
     }
 
-    void setAxisCurrent_mA(const_float_t mA, const axis_t axis) {
+    void setAxisCurrent_mA(const float mA, const axis_t axis) {
       switch (axis) {
         case X:  TERN_(X_IS_TRINAMIC,  stepperX.rms_current(constrain(mA, 400, 1500))); break;
         case Y:  TERN_(Y_IS_TRINAMIC,  stepperY.rms_current(constrain(mA, 400, 1500))); break;
@@ -490,7 +490,7 @@ namespace ExtUI {
       };
     }
 
-    void setAxisCurrent_mA(const_float_t mA, const extruder_t extruder) {
+    void setAxisCurrent_mA(const float mA, const extruder_t extruder) {
       switch (extruder) {
         case E0: TERN_(E0_IS_TRINAMIC, stepperE0.rms_current(constrain(mA, 400, 1500))); break;
         case E1: TERN_(E1_IS_TRINAMIC, stepperE1.rms_current(constrain(mA, 400, 1500))); break;
@@ -524,7 +524,7 @@ namespace ExtUI {
       }
     }
 
-    void setTMCBumpSensitivity(const_float_t value, const axis_t axis) {
+    void setTMCBumpSensitivity(const float value, const axis_t axis) {
       switch (axis) {
         case X: TERN_(X_SENSORLESS, stepperX.homing_threshold(value)); break;
         case Y: TERN_(Y_SENSORLESS, stepperY.homing_threshold(value)); break;
@@ -560,12 +560,12 @@ namespace ExtUI {
   }
 
   #if ENABLED(EDITABLE_STEPS_PER_UNIT)
-    void setAxisSteps_per_mm(const_float_t value, const axis_t axis) {
+    void setAxisSteps_per_mm(const float value, const axis_t axis) {
       planner.settings.axis_steps_per_mm[axis] = value;
       planner.refresh_positioning();
     }
 
-    void setAxisSteps_per_mm(const_float_t value, const extruder_t extruder) {
+    void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
       UNUSED(extruder);
       planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)] = value;
       planner.refresh_positioning();
@@ -599,11 +599,11 @@ namespace ExtUI {
     return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
-  void setAxisMaxAcceleration_mm_s2(const_float_t value, const axis_t axis) {
+  void setAxisMaxAcceleration_mm_s2(const float value, const axis_t axis) {
     planner.set_max_acceleration((AxisEnum)axis, value);
   }
 
-  void setAxisMaxAcceleration_mm_s2(const_float_t value, const extruder_t extruder) {
+  void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
     UNUSED(extruder);
     planner.set_max_acceleration(E_AXIS_N(extruder - E0), value);
   }
@@ -616,7 +616,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm()                 { return runout.runout_distance(); }
-      void setFilamentRunoutDistance_mm(const_float_t value) { runout.set_runout_distance(constrain(value, 0, 999)); }
+      void setFilamentRunoutDistance_mm(const float value) { runout.set_runout_distance(constrain(value, 0, 999)); }
     #endif
   #endif
 
@@ -629,7 +629,7 @@ namespace ExtUI {
 
     #if CASELIGHT_USES_BRIGHTNESS
       float getCaseLightBrightness_percent()                 { return ui8_to_percent(caselight.brightness); }
-      void setCaseLightBrightness_percent(const_float_t value) {
+      void setCaseLightBrightness_percent(const float value) {
          caselight.brightness = map(constrain(value, 0, 100), 0, 100, 0, 255);
          caselight.update_brightness();
       }
@@ -646,7 +646,7 @@ namespace ExtUI {
       return (extruder < EXTRUDERS) ? planner.get_advance_k(E_INDEX_N(extruder - E0)) : 0;
     }
 
-    void setLinearAdvance_mm_mm_s(const_float_t value, const extruder_t extruder) {
+    void setLinearAdvance_mm_mm_s(const float value, const extruder_t extruder) {
       if (extruder < EXTRUDERS)
         planner.set_advance_k(constrain(value, 0, 10), E_INDEX_N(extruder - E0));
     }
@@ -674,7 +674,7 @@ namespace ExtUI {
 
     float getJunctionDeviation_mm() { return planner.junction_deviation_mm; }
 
-    void setJunctionDeviation_mm(const_float_t value) {
+    void setJunctionDeviation_mm(const float value) {
       planner.junction_deviation_mm = constrain(value, 0.001, 0.3);
       TERN_(LIN_ADVANCE, planner.recalculate_max_e_jerk());
     }
@@ -682,8 +682,8 @@ namespace ExtUI {
   #else
     float getAxisMaxJerk_mm_s(const axis_t axis) { return planner.max_jerk[axis]; }
     float getAxisMaxJerk_mm_s(const extruder_t) { return planner.max_jerk.e; }
-    void setAxisMaxJerk_mm_s(const_float_t value, const axis_t axis) { planner.set_max_jerk((AxisEnum)axis, value); }
-    void setAxisMaxJerk_mm_s(const_float_t value, const extruder_t) { planner.set_max_jerk(E_AXIS, value); }
+    void setAxisMaxJerk_mm_s(const float value, const axis_t axis) { planner.set_max_jerk((AxisEnum)axis, value); }
+    void setAxisMaxJerk_mm_s(const float value, const extruder_t) { planner.set_max_jerk(E_AXIS, value); }
   #endif
 
   #if ENABLED(DUAL_X_CARRIAGE)
@@ -711,9 +711,9 @@ namespace ExtUI {
   void setFlow_percent(const int16_t flow, const extruder_t extr) { planner.set_flow(extr, flow); }
   void setMinFeedrate_mm_s(const feedRate_t fr)       { planner.settings.min_feedrate_mm_s = fr; }
   void setMinTravelFeedrate_mm_s(const feedRate_t fr) { planner.settings.min_travel_feedrate_mm_s = fr; }
-  void setPrintingAcceleration_mm_s2(const_float_t acc) { planner.settings.acceleration = acc; }
-  void setRetractAcceleration_mm_s2(const_float_t acc) { planner.settings.retract_acceleration = acc; }
-  void setTravelAcceleration_mm_s2(const_float_t acc)  { planner.settings.travel_acceleration = acc; }
+  void setPrintingAcceleration_mm_s2(const float acc) { planner.settings.acceleration = acc; }
+  void setRetractAcceleration_mm_s2(const float acc) { planner.settings.retract_acceleration = acc; }
+  void setTravelAcceleration_mm_s2(const float acc)  { planner.settings.travel_acceleration = acc; }
 
   #if ENABLED(BABYSTEPPING)
 
@@ -780,7 +780,7 @@ namespace ExtUI {
      * Converts a mm displacement to a number of whole number of
      * steps that is at least mm long.
      */
-    int16_t mmToWholeSteps(const_float_t mm, const axis_t axis) {
+    int16_t mmToWholeSteps(const float mm, const axis_t axis) {
       const float steps = mm / planner.mm_per_step[axis];
       return steps > 0 ? CEIL(steps) : FLOOR(steps);
     }
@@ -803,7 +803,7 @@ namespace ExtUI {
     );
   }
 
-  void setZOffset_mm(const_float_t value) {
+  void setZOffset_mm(const float value) {
     #if HAS_BED_PROBE
       if (WITHIN(value, PROBE_OFFSET_ZMIN, PROBE_OFFSET_ZMAX))
         probe.offset.z = value;
@@ -821,7 +821,7 @@ namespace ExtUI {
       return hotend_offset[extruder - E0][axis];
     }
 
-    void setNozzleOffset_mm(const_float_t value, const axis_t axis, const extruder_t extruder) {
+    void setNozzleOffset_mm(const float value, const axis_t axis, const extruder_t extruder) {
       if (extruder - E0 >= HOTENDS) return;
       hotend_offset[extruder - E0][axis] = value;
     }
@@ -840,21 +840,21 @@ namespace ExtUI {
 
   #if HAS_BED_PROBE
     float getProbeOffset_mm(const axis_t axis) { return probe.offset.pos[axis]; }
-    void setProbeOffset_mm(const_float_t val, const axis_t axis) { probe.offset.pos[axis] = val; }
+    void setProbeOffset_mm(const float val, const axis_t axis) { probe.offset.pos[axis] = val; }
     probe_limits_t getBedProbeLimits() { return probe_limits_t({ probe.min_x(), probe.min_y(), probe.max_x(), probe.max_y() }); }
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t axis)       { return backlash.get_distance_mm((AxisEnum)axis); }
-    void setAxisBacklash_mm(const_float_t value, const axis_t axis)
+    void setAxisBacklash_mm(const float value, const axis_t axis)
                                                       { backlash.set_distance_mm((AxisEnum)axis, constrain(value,0,5)); }
 
     float getBacklashCorrection_percent()             { return backlash.get_correction() * 100.0f; }
-    void setBacklashCorrection_percent(const_float_t value) { backlash.set_correction(constrain(value, 0, 100) / 100.0f); }
+    void setBacklashCorrection_percent(const float value) { backlash.set_correction(constrain(value, 0, 100) / 100.0f); }
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm()                 { return backlash.get_smoothing_mm(); }
-      void setBacklashSmoothing_mm(const_float_t value) { backlash.set_smoothing_mm(constrain(value, 0, 999)); }
+      void setBacklashSmoothing_mm(const float value) { backlash.set_smoothing_mm(constrain(value, 0, 999)); }
     #endif
   #endif
 
@@ -873,14 +873,14 @@ namespace ExtUI {
 
       bed_mesh_t& getMeshArray() { return bedlevel.z_values; }
       float getMeshPoint(const xy_uint8_t &pos) { return bedlevel.z_values[pos.x][pos.y]; }
-      void setMeshPoint(const xy_uint8_t &pos, const_float_t zoff) {
+      void setMeshPoint(const xy_uint8_t &pos, const float zoff) {
         if (WITHIN(pos.x, 0, (GRID_MAX_POINTS_X) - 1) && WITHIN(pos.y, 0, (GRID_MAX_POINTS_Y) - 1)) {
           bedlevel.z_values[pos.x][pos.y] = zoff;
           TERN_(ABL_BILINEAR_SUBDIVISION, bedlevel.refresh_bed_level());
         }
       }
 
-      void moveToMeshPoint(const xy_uint8_t &pos, const_float_t z) {
+      void moveToMeshPoint(const xy_uint8_t &pos, const float z) {
         #if ANY(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
           REMEMBER(fr, feedrate_mm_s);
           const float x_target = MESH_MIN_X + pos.x * (MESH_X_DIST),
@@ -931,7 +931,7 @@ namespace ExtUI {
     float getPID_Ki(const extruder_t tool) { return thermalManager.temp_hotend[tool].pid.i(); }
     float getPID_Kd(const extruder_t tool) { return thermalManager.temp_hotend[tool].pid.d(); }
 
-    void setPID(const_float_t p, const_float_t i, const_float_t d, extruder_t tool) {
+    void setPID(const float p, const float i, const float d, extruder_t tool) {
       thermalManager.setPID(uint8_t(tool), p, i, d);
     }
 
@@ -945,7 +945,7 @@ namespace ExtUI {
     float getBedPID_Ki() { return thermalManager.temp_bed.pid.i(); }
     float getBedPID_Kd() { return thermalManager.temp_bed.pid.d(); }
 
-    void setBedPID(const_float_t p, const_float_t i, const_float_t d) {
+    void setBedPID(const float p, const float i, const float d) {
       thermalManager.temp_bed.pid.set(p, i, d);
     }
 
@@ -969,7 +969,7 @@ namespace ExtUI {
     return firmware_name;
   }
 
-  void setTargetTemp_celsius(const_float_t inval, const heater_t heater) {
+  void setTargetTemp_celsius(const float inval, const heater_t heater) {
     float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
@@ -994,7 +994,7 @@ namespace ExtUI {
     }
   }
 
-  void setTargetTemp_celsius(const_float_t inval, const extruder_t extruder) {
+  void setTargetTemp_celsius(const float inval, const extruder_t extruder) {
     float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
@@ -1006,7 +1006,7 @@ namespace ExtUI {
     #endif
   }
 
-  void setTargetFan_percent(const_float_t value, const fan_t fan) {
+  void setTargetFan_percent(const float value, const fan_t fan) {
     #if HAS_FAN
       if (fan < FAN_COUNT)
         thermalManager.set_fan_speed(fan - FAN0, map(constrain(value, 0, 100), 0, 100, 0, 255));
@@ -1016,7 +1016,7 @@ namespace ExtUI {
     #endif
   }
 
-  void setFeedrate_percent(const_float_t value) { feedrate_percentage = constrain(value, 10, 500); }
+  void setFeedrate_percent(const float value) { feedrate_percentage = constrain(value, 10, 500); }
 
   void coolDown() { thermalManager.cooldown(); }
 

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -158,11 +158,11 @@ namespace ExtUI {
   #if HAS_TRINAMIC_CONFIG
     float getAxisCurrent_mA(const axis_t);
     float getAxisCurrent_mA(const extruder_t);
-    void  setAxisCurrent_mA(const_float_t, const axis_t);
-    void  setAxisCurrent_mA(const_float_t, const extruder_t);
+    void  setAxisCurrent_mA(const float, const axis_t);
+    void  setAxisCurrent_mA(const float, const extruder_t);
 
      int getTMCBumpSensitivity(const axis_t);
-    void setTMCBumpSensitivity(const_float_t, const axis_t);
+    void setTMCBumpSensitivity(const float, const axis_t);
   #endif
 
   // Actual and target accessors, by Heater ID, Extruder ID, Fan ID
@@ -245,10 +245,10 @@ namespace ExtUI {
       // Mesh data, utilities, events
       bed_mesh_t& getMeshArray();
       float getMeshPoint(const xy_uint8_t &pos);
-      void setMeshPoint(const xy_uint8_t &pos, const_float_t zval);
-      void moveToMeshPoint(const xy_uint8_t &pos, const_float_t z);
-      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval);
-      inline void onMeshUpdate(const xy_int8_t &pos, const_float_t zval) { onMeshUpdate(pos.x, pos.y, zval); }
+      void setMeshPoint(const xy_uint8_t &pos, const float zval);
+      void moveToMeshPoint(const xy_uint8_t &pos, const float z);
+      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval);
+      inline void onMeshUpdate(const xy_int8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
       typedef enum : uint8_t {
         G29_START,        // Prior to start of probe
@@ -288,31 +288,31 @@ namespace ExtUI {
   #endif
 
   // Temperature Control
-  void setTargetTemp_celsius(const_float_t, const heater_t);
-  void setTargetTemp_celsius(const_float_t, const extruder_t);
-  void setTargetFan_percent(const_float_t, const fan_t);
+  void setTargetTemp_celsius(const float, const heater_t);
+  void setTargetTemp_celsius(const float, const extruder_t);
+  void setTargetFan_percent(const float, const fan_t);
   void coolDown();
 
   // Motion Control
-  void setAxisPosition_mm(const_float_t, const axis_t, const feedRate_t=0);
-  void setAxisPosition_mm(const_float_t, const extruder_t, const feedRate_t=0);
+  void setAxisPosition_mm(const float, const axis_t, const feedRate_t=0);
+  void setAxisPosition_mm(const float, const extruder_t, const feedRate_t=0);
 
   // Planner Control
   #if ENABLED(EDITABLE_STEPS_PER_UNIT)
-    void setAxisSteps_per_mm(const_float_t, const axis_t);
-    void setAxisSteps_per_mm(const_float_t, const extruder_t);
+    void setAxisSteps_per_mm(const float, const axis_t);
+    void setAxisSteps_per_mm(const float, const extruder_t);
   #endif
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const axis_t);
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const extruder_t);
-  void setAxisMaxAcceleration_mm_s2(const_float_t, const axis_t);
-  void setAxisMaxAcceleration_mm_s2(const_float_t, const extruder_t);
+  void setAxisMaxAcceleration_mm_s2(const float, const axis_t);
+  void setAxisMaxAcceleration_mm_s2(const float, const extruder_t);
   void setFeedrate_mm_s(const feedRate_t);
   void setMinFeedrate_mm_s(const feedRate_t);
   void setMinTravelFeedrate_mm_s(const feedRate_t);
-  void setPrintingAcceleration_mm_s2(const_float_t);
-  void setRetractAcceleration_mm_s2(const_float_t);
-  void setTravelAcceleration_mm_s2(const_float_t);
-  void setFeedrate_percent(const_float_t);
+  void setPrintingAcceleration_mm_s2(const float);
+  void setRetractAcceleration_mm_s2(const float);
+  void setTravelAcceleration_mm_s2(const float);
+  void setFeedrate_percent(const float);
   void setFlow_percent(const int16_t, const extruder_t);
 
   // Waiting for User Interaction
@@ -328,7 +328,7 @@ namespace ExtUI {
   #if ENABLED(LIN_ADVANCE)
     // Linear Advance Control
     float getLinearAdvance_mm_mm_s(const extruder_t);
-    void setLinearAdvance_mm_mm_s(const_float_t, const extruder_t);
+    void setLinearAdvance_mm_mm_s(const float, const extruder_t);
   #endif
 
   #if HAS_SHAPING
@@ -341,12 +341,12 @@ namespace ExtUI {
   // JD or Jerk Control
   #if HAS_JUNCTION_DEVIATION
     float getJunctionDeviation_mm();
-    void setJunctionDeviation_mm(const_float_t);
+    void setJunctionDeviation_mm(const float);
   #else
     float getAxisMaxJerk_mm_s(const axis_t);
     float getAxisMaxJerk_mm_s(const extruder_t);
-    void setAxisMaxJerk_mm_s(const_float_t, const axis_t);
-    void setAxisMaxJerk_mm_s(const_float_t, const extruder_t);
+    void setAxisMaxJerk_mm_s(const float, const axis_t);
+    void setAxisMaxJerk_mm_s(const float, const extruder_t);
   #endif
 
   // Tool Changing
@@ -356,7 +356,7 @@ namespace ExtUI {
 
   // Babystepping (axis, probe offset)
   #if ENABLED(BABYSTEPPING)
-    int16_t mmToWholeSteps(const_float_t mm, const axis_t axis);
+    int16_t mmToWholeSteps(const float mm, const axis_t axis);
     float mmFromWholeSteps(int16_t steps, const axis_t axis);
 
     bool babystepAxis_steps(const int16_t steps, const axis_t axis);
@@ -366,32 +366,32 @@ namespace ExtUI {
   // Hotend Offsets
   #if HAS_HOTEND_OFFSET
     float getNozzleOffset_mm(const axis_t, const extruder_t);
-    void setNozzleOffset_mm(const_float_t, const axis_t, const extruder_t);
+    void setNozzleOffset_mm(const float, const axis_t, const extruder_t);
     void normalizeNozzleOffset(const axis_t axis);
   #endif
 
   // The Probe Z Offset
   float getZOffset_mm();
-  void setZOffset_mm(const_float_t);
+  void setZOffset_mm(const float);
 
   // The Probe XYZ Offset
   #if HAS_BED_PROBE
     float getProbeOffset_mm(const axis_t);
-    void setProbeOffset_mm(const_float_t, const axis_t);
+    void setProbeOffset_mm(const float, const axis_t);
     probe_limits_t getBedProbeLimits();
   #endif
 
   // Backlash Control
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t);
-    void setAxisBacklash_mm(const_float_t, const axis_t);
+    void setAxisBacklash_mm(const float, const axis_t);
 
     float getBacklashCorrection_percent();
-    void setBacklashCorrection_percent(const_float_t);
+    void setBacklashCorrection_percent(const float);
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm();
-      void setBacklashSmoothing_mm(const_float_t);
+      void setBacklashSmoothing_mm(const float);
     #endif
   #endif
 
@@ -404,7 +404,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm();
-      void setFilamentRunoutDistance_mm(const_float_t);
+      void setFilamentRunoutDistance_mm(const float);
     #endif
   #endif
 
@@ -415,7 +415,7 @@ namespace ExtUI {
 
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
       float getCaseLightBrightness_percent();
-      void setCaseLightBrightness_percent(const_float_t);
+      void setCaseLightBrightness_percent(const float);
     #endif
   #endif
 
@@ -430,7 +430,7 @@ namespace ExtUI {
     float getPID_Kp(const extruder_t);
     float getPID_Ki(const extruder_t);
     float getPID_Kd(const extruder_t);
-    void setPID(const_float_t, const_float_t, const_float_t, extruder_t);
+    void setPID(const float, const float, const float, extruder_t);
     void startPIDTune(const celsius_t, extruder_t);
   #endif
 
@@ -439,7 +439,7 @@ namespace ExtUI {
     float getBedPID_Kp();
     float getBedPID_Ki();
     float getBedPID_Kd();
-    void setBedPID(const_float_t, const_float_t, const_float_t);
+    void setBedPID(const float, const float, const float);
     void startBedPIDTune(const celsius_t);
   #endif
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1996,7 +1996,7 @@ uint8_t expand_u8str_P(char * const outstr, PGM_P const ptpl, const int8_t ind, 
   }
 
   #if ANY(BABYSTEP_GFX_OVERLAY, MESH_EDIT_GFX_OVERLAY)
-    void MarlinUI::zoffset_overlay(const_float_t zvalue) {
+    void MarlinUI::zoffset_overlay(const float zvalue) {
       // Determine whether the user is raising or lowering the nozzle.
       static int8_t dir;
       static float old_zvalue;

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -170,7 +170,7 @@ typedef bool (*statusResetFunc_t)();
     static float axis_value(const AxisEnum axis) {
       return NATIVE_TO_LOGICAL(processing ? destination[axis] : SUM_TERN(IS_KINEMATIC, current_position[axis], offset), axis);
     }
-    static bool apply_diff(const AxisEnum axis, const_float_t diff, const_float_t min, const_float_t max) {
+    static bool apply_diff(const AxisEnum axis, const float diff, const float min, const float max) {
       #if IS_KINEMATIC
         float &valref = offset;
         const float rmin = min - current_position[axis], rmax = max - current_position[axis];
@@ -618,7 +618,7 @@ public:
 
     #if ANY(BABYSTEP_GFX_OVERLAY, MESH_EDIT_GFX_OVERLAY)
       static void zoffset_overlay(const int8_t dir);
-      static void zoffset_overlay(const_float_t zvalue);
+      static void zoffset_overlay(const float zvalue);
     #endif
 
     static void draw_kill_screen();
@@ -734,7 +734,7 @@ public:
     #endif
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      static void ubl_mesh_edit_start(const_float_t initial);
+      static void ubl_mesh_edit_start(const float initial);
       static float ubl_mesh_value();
     #endif
 

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -295,7 +295,7 @@ void scroll_screen(const uint8_t limit, const bool is_menu) {
 
 #if HAS_LINE_TO_Z
 
-  void line_to_z(const_float_t z) {
+  void line_to_z(const float z) {
     current_position.z = z;
     line_to_current_position(manual_feedrate_mm_s.z);
   }

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -225,7 +225,7 @@ void _lcd_draw_homing();
 #define HAS_LINE_TO_Z ANY(DELTA, PROBE_MANUALLY, MESH_BED_LEVELING, LCD_BED_TRAMMING)
 
 #if HAS_LINE_TO_Z
-  void line_to_z(const_float_t z);
+  void line_to_z(const float z);
 #endif
 
 #if ENABLED(PROBE_OFFSET_WIZARD)

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -88,7 +88,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
     ui.goto_screen(_lcd_calibrate_homing);
   }
 
-  void _goto_tower_a(const_float_t a) {
+  void _goto_tower_a(const float a) {
     float dcr = PRINTABLE_RADIUS - PROBING_MARGIN;
     TERN_(HAS_PROBE_XY_OFFSET, dcr -= HYPOT(probe.offset_xy.x, probe.offset_xy.y));
     TERN_(HAS_DELTA_SENSORLESS_PROBING, dcr *= sensorless_radius_factor);

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -114,7 +114,7 @@ void lcd_move_axis(const AxisEnum axis) {
 
 #if ANY(PROBE_OFFSET_WIZARD, X_AXIS_TWIST_COMPENSATION)
 
-  void _goto_manual_move_z(const_float_t scale) {
+  void _goto_manual_move_z(const float scale) {
     ui.manual_move.menu_scale = scale;
     ui.goto_screen([]{ lcd_move_axis(Z_AXIS); });
   }
@@ -129,7 +129,7 @@ void lcd_move_axis(const AxisEnum axis) {
   #define FINE_MANUAL_MOVE 0.025
 #endif
 
-void _goto_manual_move(const_float_t scale) {
+void _goto_manual_move(const float scale) {
   ui.defer_status_screen();
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(ui.manual_move.screen_ptr);

--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -39,13 +39,13 @@
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
 
-void _goto_manual_move_z(const_float_t);
+void _goto_manual_move_z(const float);
 
 // Global storage - TODO: Keep wizard/process data in a 'ui.scratch' union.
 float z_offset_backup, calculated_z_offset, z_offset_ref;
 
 // "Done" - Set the offset, re-enable leveling, go back to the previous screen.
-void set_offset_and_go_back(const_float_t z) {
+void set_offset_and_go_back(const float z) {
   probe.offset.z = z;
   SET_SOFT_ENDSTOP_LOOSE(false);
   TERN_(HAS_LEVELING, set_bed_leveling_enabled(menu_leveling_was_active));

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -95,7 +95,7 @@ void _lcd_mesh_fine_tune(FSTR_P const fmsg) {
 // Init mesh editing and go to the fine tuning screen (bedlevel.fine_tune_mesh)
 // To capture encoder events UBL will also call ui.capture and ui.release.
 //
-void MarlinUI::ubl_mesh_edit_start(const_float_t initial) {
+void MarlinUI::ubl_mesh_edit_start(const float initial) {
   TERN_(HAS_GRAPHICAL_TFT, clear_for_drawing());
   mesh_edit_accumulator = initial;
   goto_screen([]{ _lcd_mesh_fine_tune(GET_TEXT_F(MSG_MESH_EDIT_Z)); });

--- a/Marlin/src/lcd/menu/menu_x_twist.cpp
+++ b/Marlin/src/lcd/menu/menu_x_twist.cpp
@@ -41,7 +41,7 @@
   #include "../tft/touch.h"
 #endif
 
-void _goto_manual_move_z(const_float_t);
+void _goto_manual_move_z(const float);
 
 float measured_z, z_offset;
 

--- a/Marlin/src/lcd/sovol_rts/sovol_rts.h
+++ b/Marlin/src/lcd/sovol_rts/sovol_rts.h
@@ -283,7 +283,7 @@ class RTS {
 
     static void sendData(const uint8_t str[], const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData((char *)str, addr, cmd); }
     static void sendData(const uint16_t n,    const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(int16_t(n), addr, cmd); }
-    static void sendData(const_float_t n,     const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(int16_t(n), addr, cmd); } //was originally int16 ?
+    static void sendData(const float n,     const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(int16_t(n), addr, cmd); } //was originally int16 ?
     static void sendData(const int32_t n,     const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(uint32_t(n), addr, cmd); }
     static void sendData(const int n,         const uint32_t addr, const uint8_t cmd=VarAddr_W) { sendData(int16_t(n), addr, cmd); }
 

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -138,7 +138,7 @@ SPISettings MAX31865::spiConfig = SPISettings(
  * @param ref_res   The resistance of the reference resistor, in ohms.
  * @param wire_res  The resistance of the wire connecting the sensor to the RTD, in ohms.
  */
-void MAX31865::begin(max31865_numwires_t wires, const_float_t zero_res, const_float_t ref_res, const_float_t wire_res) {
+void MAX31865::begin(max31865_numwires_t wires, const float zero_res, const float ref_res, const float wire_res) {
   resNormalizer = 100.0f / zero_res;  // reciprocal of resistance, scaled by 100
   refRes = ref_res;
   wireRes = wire_res;

--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -153,7 +153,7 @@ public:
              int8_t spi_clk);
   #endif
 
-  void begin(max31865_numwires_t wires, const_float_t zero_res, const_float_t ref_res, const_float_t wire_res);
+  void begin(max31865_numwires_t wires, const float zero_res, const float ref_res, const float wire_res);
 
   uint8_t readFault();
   void clearFault();

--- a/Marlin/src/libs/least_squares_fit.h
+++ b/Marlin/src/libs/least_squares_fit.h
@@ -47,7 +47,7 @@ inline void incremental_LSF_reset(struct linear_fit_data *lsf) {
   memset(lsf, 0, sizeof(linear_fit_data));
 }
 
-inline void incremental_WLSF(struct linear_fit_data *lsf, const_float_t x, const_float_t y, const_float_t z, const_float_t w) {
+inline void incremental_WLSF(struct linear_fit_data *lsf, const float x, const float y, const float z, const float w) {
   // weight each accumulator by factor w, including the "number" of samples
   // (analogous to calling inc_LSF twice with same values to weight it by 2X)
   const float wx = w * x, wy = w * y, wz = w * z;
@@ -63,11 +63,11 @@ inline void incremental_WLSF(struct linear_fit_data *lsf, const_float_t x, const
   lsf->max_absx = _MAX(ABS(wx), lsf->max_absx);
   lsf->max_absy = _MAX(ABS(wy), lsf->max_absy);
 }
-inline void incremental_WLSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const_float_t z, const_float_t w) {
+inline void incremental_WLSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const float z, const float w) {
   incremental_WLSF(lsf, pos.x, pos.y, z, w);
 }
 
-inline void incremental_LSF(struct linear_fit_data *lsf, const_float_t x, const_float_t y, const_float_t z) {
+inline void incremental_LSF(struct linear_fit_data *lsf, const float x, const float y, const float z) {
   lsf->xbar += x;
   lsf->ybar += y;
   lsf->zbar += z;
@@ -80,7 +80,7 @@ inline void incremental_LSF(struct linear_fit_data *lsf, const_float_t x, const_
   lsf->max_absy = _MAX(ABS(y), lsf->max_absy);
   lsf->N += 1.0;
 }
-inline void incremental_LSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const_float_t z) {
+inline void incremental_LSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const float z) {
   incremental_LSF(lsf, pos.x, pos.y, z);
 }
 

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -133,7 +133,7 @@ Nozzle nozzle;
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const_float_t radius) {
+    void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const float radius) {
       if (strokes == 0) return;
 
       #if ENABLED(NOZZLE_CLEAN_GOBACK)
@@ -162,7 +162,7 @@ Nozzle nozzle;
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t pattern, const uint8_t strokes, const_float_t radius, const uint8_t objects, const uint8_t cleans) {
+  void Nozzle::clean(const uint8_t pattern, const uint8_t strokes, const float radius, const uint8_t objects, const uint8_t cleans) {
     xyz_pos_t start[HOTENDS] = NOZZLE_CLEAN_START_POINT, end[HOTENDS] = NOZZLE_CLEAN_END_POINT;
     #if ENABLED(NOZZLE_CLEAN_PATTERN_CIRCLE)
       xyz_pos_t middle[HOTENDS] = NOZZLE_CLEAN_CIRCLE_MIDDLE;
@@ -246,7 +246,7 @@ Nozzle nozzle;
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
   #if HAS_Z_AXIS
-    float Nozzle::park_mode_0_height(const_float_t park_z) {
+    float Nozzle::park_mode_0_height(const float park_z) {
       // Apply a minimum raise, if specified. Use park.z as a minimum height instead.
       return _MAX(park_z,                       // Minimum height over 0 based on input
         _MIN(Z_MAX_POS,                         // Maximum height is fixed

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -62,7 +62,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const_float_t radius) __Os;
+    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const float radius) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
@@ -77,13 +77,13 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t pattern, const uint8_t strokes, const_float_t radius, const uint8_t objects, const uint8_t cleans) __Os;
+    static void clean(const uint8_t pattern, const uint8_t strokes, const float radius, const uint8_t objects, const uint8_t cleans) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
   #if ENABLED(NOZZLE_PARK_FEATURE)
 
-    static float park_mode_0_height(const_float_t park_z) __Os;
+    static float park_mode_0_height(const float park_z) __Os;
     static void park(const uint8_t z_action, const xyz_pos_t &park=NOZZLE_PARK_POINT) __Os;
 
   #endif

--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -181,7 +181,7 @@ const char* i16tostr4signrj(const int16_t i) {
 }
 
 // Convert unsigned float to string with 1.1 format
-const char* ftostr11ns(const_float_t f) {
+const char* ftostr11ns(const float f) {
   const long i = UINTFLOAT(f, 1);
   conv[5] = DIGIMOD(i, 10);
   conv[6] = '.';
@@ -190,7 +190,7 @@ const char* ftostr11ns(const_float_t f) {
 }
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr12ns(const_float_t f) {
+const char* ftostr12ns(const float f) {
   const long i = UINTFLOAT(f, 2);
   conv[4] = DIGIMOD(i, 100);
   conv[5] = '.';
@@ -200,7 +200,7 @@ const char* ftostr12ns(const_float_t f) {
 }
 
 // Convert unsigned float to string with 12.3 format
-const char* ftostr31ns(const_float_t f) {
+const char* ftostr31ns(const float f) {
   const long i = UINTFLOAT(f, 1);
   conv[4] = DIGIMOD(i, 100);
   conv[5] = DIGIMOD(i, 10);
@@ -210,7 +210,7 @@ const char* ftostr31ns(const_float_t f) {
 }
 
 // Convert unsigned float to string with 123.4 format
-const char* ftostr41ns(const_float_t f) {
+const char* ftostr41ns(const float f) {
   const long i = UINTFLOAT(f, 1);
   conv[3] = DIGIMOD(i, 1000);
   conv[4] = DIGIMOD(i, 100);
@@ -221,7 +221,7 @@ const char* ftostr41ns(const_float_t f) {
 }
 
 // Convert float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
-const char* ftostr42_52(const_float_t f) {
+const char* ftostr42_52(const float f) {
   if (f <= -10 || f >= 100) return ftostr52(f); // -23.45 / 123.45
   long i = INTFLOAT(f, 2);
   conv[3] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 1000));
@@ -233,7 +233,7 @@ const char* ftostr42_52(const_float_t f) {
 }
 
 // Convert float to fixed-length string with 023.45 / -23.45 format
-const char* ftostr52(const_float_t f) {
+const char* ftostr52(const float f) {
   long i = INTFLOAT(f, 2);
   conv[2] = MINUSOR(i, DIGIMOD(i, 10000));
   conv[3] = DIGIMOD(i, 1000);
@@ -245,7 +245,7 @@ const char* ftostr52(const_float_t f) {
 }
 
 // Convert float to fixed-length string with 12.345 / _2.345 / -2.345 or -23.45 / 123.45 format
-const char* ftostr53_63(const_float_t f) {
+const char* ftostr53_63(const float f) {
   if (f <= -10 || f >= 100) return ftostr63(f); // -23.456 / 123.456
   long i = INTFLOAT(f, 3);
   conv[2] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 10000));
@@ -258,7 +258,7 @@ const char* ftostr53_63(const_float_t f) {
 }
 
 // Convert float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr63(const_float_t f) {
+const char* ftostr63(const float f) {
   long i = INTFLOAT(f, 3);
   conv[1] = MINUSOR(i, DIGIMOD(i, 100000));
   conv[2] = DIGIMOD(i, 10000);
@@ -273,7 +273,7 @@ const char* ftostr63(const_float_t f) {
 #if ENABLED(LCD_DECIMAL_SMALL_XY)
 
   // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
-  const char* ftostr4sign(const_float_t f) {
+  const char* ftostr4sign(const float f) {
     const int i = INTFLOAT(f, 1);
     if (!WITHIN(i, -99, 999)) return i16tostr4signrj((int)f);
     const bool neg = i < 0;
@@ -290,7 +290,7 @@ const char* ftostr63(const_float_t f) {
 //
 // Convert float to fixed-length string with +/- and a single decimal place
 //
-inline const char* ftostrX1sign(const_float_t f, const int index) {
+inline const char* ftostrX1sign(const float f, const int index) {
   long i = INTFLOAT(f, 1);
   conv[index] = MINUSOR(i, '+');
   switch (index + 1) {
@@ -306,18 +306,18 @@ inline const char* ftostrX1sign(const_float_t f, const int index) {
 }
 
 // Convert float to fixed-length string with +12.3 / -12.3 format
-const char* ftostr31sign(const_float_t f) { return ftostrX1sign(f, 3); }
+const char* ftostr31sign(const float f) { return ftostrX1sign(f, 3); }
 
 // Convert float to fixed-length string with +123.4 / -123.4 format
-const char* ftostr41sign(const_float_t f) { return ftostrX1sign(f, 2); }
+const char* ftostr41sign(const float f) { return ftostrX1sign(f, 2); }
 
 // Convert float to fixed-length string with +1234.5 / +1234.5 format
-const char* ftostr51sign(const_float_t f) { return ftostrX1sign(f, 1); }
+const char* ftostr51sign(const float f) { return ftostrX1sign(f, 1); }
 
 //
 // Convert float to string with +/ /- and 3 decimal places
 //
-inline const char* ftostrX3sign(const_float_t f, const int index, char plus/*=' '*/) {
+inline const char* ftostrX3sign(const float f, const int index, char plus/*=' '*/) {
   long i = INTFLOAT(f, 3);
   conv[index] = i ? MINUSOR(i, plus) : ' ';
   switch (index + 1) {
@@ -333,13 +333,13 @@ inline const char* ftostrX3sign(const_float_t f, const int index, char plus/*=' 
 }
 
 // Convert float to string (6 chars) with -1.234 / _0.000 / +1.234 format
-const char* ftostr43sign(const_float_t f, char plus/*=' '*/) { return ftostrX3sign(f, 2, plus); }
+const char* ftostr43sign(const float f, char plus/*=' '*/) { return ftostrX3sign(f, 2, plus); }
 
 // Convert float to string (7 chars) with -12.345 / _00.000 / +12.345 format
-const char* ftostr53sign(const_float_t f, char plus/*=' '*/) { return ftostrX3sign(f, 1, plus); }
+const char* ftostr53sign(const float f, char plus/*=' '*/) { return ftostrX3sign(f, 1, plus); }
 
 // Convert float to string (7 chars) with -1.2345 / _0.0000 / +1.2345 format
-const char* ftostr54sign(const_float_t f, char plus/*=' '*/) {
+const char* ftostr54sign(const float f, char plus/*=' '*/) {
   long i = INTFLOAT(f, 4);
   conv[1] = i ? MINUSOR(i, plus) : ' ';
   conv[2] = DIGIMOD(i, 10000);
@@ -352,13 +352,13 @@ const char* ftostr54sign(const_float_t f, char plus/*=' '*/) {
 }
 
 // Convert unsigned float to rj string with 12345 format
-const char* ftostr5rj(const_float_t f) {
+const char* ftostr5rj(const float f) {
   const long i = UINTFLOAT(f, 0);
   return ui16tostr5rj(i);
 }
 
 // Convert signed float to string with +123.45 format
-const char* ftostr52sign(const_float_t f) {
+const char* ftostr52sign(const float f) {
   long i = INTFLOAT(f, 2);
   conv[1] = MINUSOR(i, '+');
   conv[2] = DIGIMOD(i, 10000);
@@ -371,7 +371,7 @@ const char* ftostr52sign(const_float_t f) {
 }
 
 // Convert unsigned float to string with a single digit precision
-inline const char* ftostrX1rj(const_float_t f, const int index=1) {
+inline const char* ftostrX1rj(const float f, const int index=1) {
   const long i = UINTFLOAT(f, 1);
   switch (index) {
     case 0: conv[0] = RJDIGIT(i, 1000000);
@@ -387,19 +387,19 @@ inline const char* ftostrX1rj(const_float_t f, const int index=1) {
 }
 
 // Convert unsigned float to string with _2.3 / 12.3 format
-const char* ftostr31rj(const_float_t f) { return ftostrX1rj(f, 7 - 3); }
+const char* ftostr31rj(const float f) { return ftostrX1rj(f, 7 - 3); }
 
 // Convert unsigned float to string with __3.4 / _23.4 / 123.4 format
-const char* ftostr41rj(const_float_t f) { return ftostrX1rj(f, 7 - 4); }
+const char* ftostr41rj(const float f) { return ftostrX1rj(f, 7 - 4); }
 
 // Convert unsigned float to string with ___4.5 / __34.5 / _234.5 / 1234.5 format
-const char* ftostr51rj(const_float_t f) { return ftostrX1rj(f, 7 - 5); }
+const char* ftostr51rj(const float f) { return ftostrX1rj(f, 7 - 5); }
 
 // Convert unsigned float to string with ____5.6 / ___45.6 / __345.6 / _2345.6 / 12345.6 format
-const char* ftostr61rj(const_float_t f) { return ftostrX1rj(f, 7 - 6); }
+const char* ftostr61rj(const float f) { return ftostrX1rj(f, 7 - 6); }
 
 // Convert unsigned float to string with two digit precision
-inline const char* ftostrX2rj(const_float_t f, const int index=1) {
+inline const char* ftostrX2rj(const float f, const int index=1) {
   const long i = UINTFLOAT(f, 2);
   switch (index) {
     case 0: conv[0] = RJDIGIT(i, 1000000);
@@ -415,22 +415,22 @@ inline const char* ftostrX2rj(const_float_t f, const int index=1) {
 }
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr32rj(const_float_t f) { return ftostrX2rj(f, 4); }
+const char* ftostr32rj(const float f) { return ftostrX2rj(f, 4); }
 
 // Convert unsigned float to string with _2.34, 12.34 format
-const char* ftostr42rj(const_float_t f) { return ftostrX2rj(f, 3); }
+const char* ftostr42rj(const float f) { return ftostrX2rj(f, 3); }
 
 // Convert unsigned float to string with __3.45, _23.45, 123.45 format
-const char* ftostr52rj(const_float_t f) { return ftostrX2rj(f, 2); }
+const char* ftostr52rj(const float f) { return ftostrX2rj(f, 2); }
 
 // Convert unsigned float to string with ___4.56, __34.56, _234.56, 1234.56 format
-const char* ftostr62rj(const_float_t f) { return ftostrX2rj(f, 1); }
+const char* ftostr62rj(const float f) { return ftostrX2rj(f, 1); }
 
 // Convert unsigned float to string with ____5.67, ___45.67, __345.67, _2345.67, 12345.67 format
-const char* ftostr72rj(const_float_t f) { return ftostrX2rj(f, 0); }
+const char* ftostr72rj(const float f) { return ftostrX2rj(f, 0); }
 
 // Convert float to space-padded string with -_23.4_ format
-const char* ftostr52sp(const_float_t f) {
+const char* ftostr52sp(const float f) {
   long i = INTFLOAT(f, 2);
   uint8_t dig;
   conv[1] = MINUSOR(i, ' ');
@@ -461,7 +461,7 @@ const char* utostr3(const uint16_t x) {
 }
 
 // Convert float to space-padded string with 1.23, 12.34, 123.45 format
-const char* ftostr52sprj(const_float_t f) {
+const char* ftostr52sprj(const float f) {
   long i = INTFLOAT(f, 2);
   LIMIT(i, -99999, 99999);            // cap to -999.99 - 999.99 range
   if (WITHIN(i, -999, 999)) {         // -9.99 - 9.99 range

--- a/Marlin/src/libs/numtostr.h
+++ b/Marlin/src/libs/numtostr.h
@@ -63,105 +63,105 @@ const char* i16tostr3left(const int16_t xx);
 const char* i16tostr4signrj(const int16_t x);
 
 // Convert unsigned float to string with 1.2 format
-const char* ftostr11ns(const_float_t x);
+const char* ftostr11ns(const float x);
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr12ns(const_float_t x);
+const char* ftostr12ns(const float x);
 
 // Convert unsigned float to string with 12.3 format
-const char* ftostr31ns(const_float_t x);
+const char* ftostr31ns(const float x);
 
 // Convert unsigned float to string with 123.4 format
-const char* ftostr41ns(const_float_t x);
+const char* ftostr41ns(const float x);
 
 // Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
-const char* ftostr42_52(const_float_t x);
+const char* ftostr42_52(const float x);
 
 // Convert signed float to fixed-length string with 023.45 / -23.45 format
-const char* ftostr52(const_float_t x);
+const char* ftostr52(const float x);
 
 // Convert signed float to fixed-length string with 12.345 / -2.345 or 023.456 / -23.456 format
-const char* ftostr53_63(const_float_t x);
+const char* ftostr53_63(const float x);
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr63(const_float_t x);
+const char* ftostr63(const float x);
 
 // Convert signed float to fixed-length string with +12.3 / -12.3 format
-const char* ftostr31sign(const_float_t x);
+const char* ftostr31sign(const float x);
 
 // Convert signed float to fixed-length string with +123.4 / -123.4 format
-const char* ftostr41sign(const_float_t x);
+const char* ftostr41sign(const float x);
 
 // Convert signed float to fixed-length string with +1234.5 / +1234.5 format
-const char* ftostr51sign(const_float_t x);
+const char* ftostr51sign(const float x);
 
 // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
-const char* ftostr43sign(const_float_t x, char plus=' ');
+const char* ftostr43sign(const float x, char plus=' ');
 
 // Convert signed float to string (7 chars) with -12.345 / _00.000 / +12.345 format
-const char* ftostr53sign(const_float_t x, char plus=' ');
+const char* ftostr53sign(const float x, char plus=' ');
 
 // Convert signed float to string (5 digit) with -1.2345 / _0.0000 / +1.2345 format
-const char* ftostr54sign(const_float_t x, char plus=' ');
+const char* ftostr54sign(const float x, char plus=' ');
 
 // Convert unsigned float to rj string with 12345 format
-const char* ftostr5rj(const_float_t x);
+const char* ftostr5rj(const float x);
 
 // Convert signed float to fixed-length string with +12.3 / -12.3 format
-const char* ftostr31sign(const_float_t x);
+const char* ftostr31sign(const float x);
 
 // Convert signed float to fixed-length string with +123.4 / -123.4 format
-const char* ftostr41sign(const_float_t x);
+const char* ftostr41sign(const float x);
 
 // Convert signed float to fixed-length string with +1234.5 format
-const char* ftostr51sign(const_float_t x);
+const char* ftostr51sign(const float x);
 
 // Convert signed float to space-padded string with -_23.4_ format
-const char* ftostr52sp(const_float_t x);
+const char* ftostr52sp(const float x);
 
 // Convert signed float to string with +123.45 format
-const char* ftostr52sign(const_float_t x);
+const char* ftostr52sign(const float x);
 
 // Convert unsigned float to string with _2.3 / 12.3 format
-const char* ftostr31rj(const_float_t x);
+const char* ftostr31rj(const float x);
 
 // Convert unsigned float to string with __3.4 / _23.4 / 123.4 format
-const char* ftostr41rj(const_float_t x);
+const char* ftostr41rj(const float x);
 
 // Convert unsigned float to string with ___4.5 / __34.5 / _234.5 / 1234.5 format
-const char* ftostr51rj(const_float_t x);
+const char* ftostr51rj(const float x);
 
 // Convert unsigned float to string with ____5.6 / ___45.6 / __345.6 / _2345.6 / 12345.6 format
-const char* ftostr61rj(const_float_t x);
+const char* ftostr61rj(const float x);
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr32rj(const_float_t f);
+const char* ftostr32rj(const float f);
 
 // Convert unsigned float to string with _2.34, 12.34 format
-const char* ftostr42rj(const_float_t f);
+const char* ftostr42rj(const float f);
 
 // Convert unsigned float to string with __3.45, _23.45, 123.45 format
-const char* ftostr52rj(const_float_t f);
+const char* ftostr52rj(const float f);
 
 // Convert unsigned float to string with ___4.56, __34.56, _234.56, 1234.56 format
-const char* ftostr62rj(const_float_t f);
+const char* ftostr62rj(const float f);
 
 // Convert unsigned float to string with ____5.67, ___45.67, __345.67, _2345.67, 12345.67 format
-const char* ftostr72rj(const_float_t x);
+const char* ftostr72rj(const float x);
 
 // Convert signed float to rj string with 123 or -12 format
-FORCE_INLINE const char* ftostr3rj(const_float_t x) { return i16tostr3rj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
+FORCE_INLINE const char* ftostr3rj(const float x) { return i16tostr3rj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
 
 #if ENABLED(LCD_DECIMAL_SMALL_XY)
   // Convert signed float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
-  const char* ftostr4sign(const_float_t fx);
+  const char* ftostr4sign(const float fx);
 #else
   // Convert signed float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
-  FORCE_INLINE const char* ftostr4sign(const_float_t x) { return i16tostr4signrj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
+  FORCE_INLINE const char* ftostr4sign(const float x) { return i16tostr4signrj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
 #endif
 
 // Convert unsigned int to string 1, 12, 123 format, capped at 999
 const char* utostr3(const uint16_t x);
 
 // Convert signed float to space-padded string with 1.23, 12.34, 123.45 format
-const char* ftostr52sprj(const_float_t f);
+const char* ftostr52sprj(const float f);

--- a/Marlin/src/libs/vector_3.h
+++ b/Marlin/src/libs/vector_3.h
@@ -49,7 +49,7 @@ struct vector_3 {
     struct { float x, y, z; };
     float pos[3];
   };
-  vector_3(const_float_t _x, const_float_t _y, const_float_t _z) : x(_x), y(_y), z(_z) {}
+  vector_3(const float _x, const float _y, const float _z) : x(_x), y(_y), z(_z) {}
   vector_3(const xy_float_t   &in) { TERN_(HAS_X_AXIS, x = in.x); TERN_(HAS_Y_AXIS, y = in.y); }
   vector_3(const xyz_float_t  &in) { TERN_(HAS_X_AXIS, x = in.x); TERN_(HAS_Y_AXIS, y = in.y); TERN_(HAS_Z_AXIS, z = in.z); }
   vector_3(const xyze_float_t &in) { TERN_(HAS_X_AXIS, x = in.x); TERN_(HAS_Y_AXIS, y = in.y); TERN_(HAS_Z_AXIS, z = in.z); }

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -162,7 +162,7 @@ float delta_safe_distance_from_top() {
  *
  * The result is stored in the cartes[] array.
  */
-void forward_kinematics(const_float_t z1, const_float_t z2, const_float_t z3) {
+void forward_kinematics(const float z1, const float z2, const float z3) {
   // Create a vector in old coordinates along x axis of new coordinate
   const float p12[3] = { delta_tower[B_AXIS].x - delta_tower[A_AXIS].x, delta_tower[B_AXIS].y - delta_tower[A_AXIS].y, z2 - z1 },
 

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -116,7 +116,7 @@ void refresh_delta_clip_start_height();
  *
  * The result is stored in the cartes[] array.
  */
-void forward_kinematics(const_float_t z1, const_float_t z2, const_float_t z3);
+void forward_kinematics(const float z1, const float z2, const float z3);
 
 FORCE_INLINE void forward_kinematics(const abc_float_t &point) {
   forward_kinematics(point.a, point.b, point.c);

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -227,7 +227,7 @@ void FTMotion::loop() {
 #if HAS_FTM_SHAPING
 
   // Refresh the gains used by shaping functions.
-  void FTMotion::AxisShaping::set_axis_shaping_A(const ftMotionShaper_t shaper, const_float_t zeta, const_float_t vtol) {
+  void FTMotion::AxisShaping::set_axis_shaping_A(const ftMotionShaper_t shaper, const float zeta, const float vtol) {
 
     const float K = exp(-zeta * M_PI / sqrt(1.f - sq(zeta))),
                 K2 = sq(K),
@@ -327,7 +327,7 @@ void FTMotion::loop() {
   }
 
   // Refresh the indices used by shaping functions.
-  void FTMotion::AxisShaping::set_axis_shaping_N(const ftMotionShaper_t shaper, const_float_t f, const_float_t zeta) {
+  void FTMotion::AxisShaping::set_axis_shaping_N(const ftMotionShaper_t shaper, const float f, const float zeta) {
     // Note that protections are omitted for DBZ and for index exceeding array length.
     const float df = sqrt ( 1.f - sq(zeta) );
     switch (shaper) {

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -185,8 +185,8 @@ class FTMotion {
         uint32_t Ni[5];                   // Shaping time index vector.
         uint32_t max_i;                   // Vector length for the selected shaper.
 
-        void set_axis_shaping_N(const ftMotionShaper_t shaper, const_float_t f, const_float_t zeta);    // Sets the gains used by shaping functions.
-        void set_axis_shaping_A(const ftMotionShaper_t shaper, const_float_t zeta, const_float_t vtol); // Sets the indices used by shaping functions.
+        void set_axis_shaping_N(const ftMotionShaper_t shaper, const float f, const float zeta);    // Sets the gains used by shaping functions.
+        void set_axis_shaping_A(const ftMotionShaper_t shaper, const float zeta, const float vtol); // Sets the indices used by shaping functions.
 
       } axis_shaping_t;
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -629,7 +629,7 @@ void report_current_position_projected() {
 
 #if IS_KINEMATIC
 
-  bool position_is_reachable(const_float_t rx, const_float_t ry, const float inset/*=0*/) {
+  bool position_is_reachable(const float rx, const float ry, const float inset/*=0.0f*/) {
 
     bool can_reach;
 
@@ -680,7 +680,7 @@ void report_current_position_projected() {
 #else // CARTESIAN
 
   // Return true if the given position is within the machine bounds.
-  bool position_is_reachable(TERN_(HAS_X_AXIS, const_float_t rx) OPTARG(HAS_Y_AXIS, const_float_t ry)) {
+  bool position_is_reachable(TERN_(HAS_X_AXIS, const float rx) OPTARG(HAS_Y_AXIS, const float ry)) {
     if (TERN0(HAS_Y_AXIS, !COORDINATE_OKAY(ry, Y_MIN_POS - fslop, Y_MAX_POS + fslop))) return false;
     #if ENABLED(DUAL_X_CARRIAGE)
       if (active_extruder)
@@ -802,12 +802,12 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
  * Move the planner to the current position from wherever it last moved
  * (or from wherever it has been told it is located).
  */
-void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
+void line_to_current_position(const feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
   planner.buffer_line(current_position, fr_mm_s);
 }
 
 #if HAS_EXTRUDERS
-  void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
+  void unscaled_e_move(const float length, const feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
@@ -820,7 +820,7 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
   /**
    * Buffer a fast move without interpolation. Set current_position to destination
    */
-  void prepare_fast_move_to_destination(const_feedRate_t scaled_fr_mm_s/*=MMS_SCALED(feedrate_mm_s)*/) {
+  void prepare_fast_move_to_destination(const feedRate_t scaled_fr_mm_s/*=MMS_SCALED(feedrate_mm_s)*/) {
     if (DEBUGGING(LEVELING)) DEBUG_POS("prepare_fast_move_to_destination", destination);
 
     #if UBL_SEGMENTED
@@ -842,7 +842,7 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
  *  - Move at normal speed regardless of feedrate percentage.
  *  - Extrude the specified length regardless of flow percentage.
  */
-void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
+void _internal_move_to_destination(const feedRate_t fr_mm_s/*=0.0f*/
   OPTARG(IS_KINEMATIC, const bool is_fast/*=false*/)
 ) {
   REMEMBER(fr, feedrate_mm_s);
@@ -858,8 +858,8 @@ void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
 
 #if SECONDARY_AXES
 
-  void secondary_axis_moves(SECONDARY_AXIS_ARGS_LC(const_float_t), const_feedRate_t fr_mm_s) {
-    auto move_one = [&](const AxisEnum a, const_float_t p) {
+  void secondary_axis_moves(SECONDARY_AXIS_ARGS_LC(const float), const feedRate_t fr_mm_s) {
+    auto move_one = [&](const AxisEnum a, const float p) {
       const feedRate_t fr = fr_mm_s ?: homing_feedrate(a);
       current_position[a] = p; line_to_current_position(fr);
     };
@@ -880,7 +880,7 @@ void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
  * - Delta may lower Z first to get into the free motion zone.
  * - Before returning, wait for the planner buffer to empty.
  */
-void do_blocking_move_to(NUM_AXIS_ARGS_(const_float_t) const_feedRate_t fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(NUM_AXIS_ARGS_(const float) const feedRate_t fr_mm_s/*=0.0f*/) {
   DEBUG_SECTION(log_move, "do_blocking_move_to", DEBUGGING(LEVELING));
   #if NUM_AXES
     if (DEBUGGING(LEVELING)) DEBUG_XYZ("> ", NUM_AXIS_ARGS_LC());
@@ -973,20 +973,20 @@ void do_blocking_move_to(NUM_AXIS_ARGS_(const_float_t) const_feedRate_t fr_mm_s/
   planner.synchronize();
 }
 
-void do_blocking_move_to(const xy_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xy_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(NUM_AXIS_LIST_(raw.x, raw.y, current_position.z,
                                     current_position.i, current_position.j, current_position.k,
                                     current_position.u, current_position.v, current_position.w) fr_mm_s);
 }
-void do_blocking_move_to(const xyz_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xyz_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(NUM_AXIS_ELEM_(raw) fr_mm_s);
 }
-void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xyze_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(NUM_AXIS_ELEM_(raw) fr_mm_s);
 }
 
 #if HAS_X_AXIS
-  void do_blocking_move_to_x(const_float_t rx, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_x(const float rx, const feedRate_t fr_mm_s/*=0.0*/) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_blocking_move_to_x(", rx, ", ", fr_mm_s, ")");
     do_blocking_move_to(
       NUM_AXIS_LIST_(rx, current_position.y, current_position.z,
@@ -998,7 +998,7 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
 #endif
 
 #if HAS_Y_AXIS
-  void do_blocking_move_to_y(const_float_t ry, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_y(const float ry, const feedRate_t fr_mm_s/*=0.0*/) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_blocking_move_to_y(", ry, ", ", fr_mm_s, ")");
     do_blocking_move_to(
       NUM_AXIS_LIST_(current_position.x, ry, current_position.z,
@@ -1007,7 +1007,7 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
       fr_mm_s
     );
   }
-  void do_blocking_move_to_xy(const_float_t rx, const_float_t ry, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_xy(const float rx, const float ry, const feedRate_t fr_mm_s/*=0.0*/) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_blocking_move_to_xy(", rx, ", ", ry, ", ", fr_mm_s, ")");
     do_blocking_move_to(
       NUM_AXIS_LIST_(rx, ry, current_position.z,
@@ -1016,17 +1016,17 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
       fr_mm_s
     );
   }
-  void do_blocking_move_to_xy(const xy_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xy(const xy_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to_xy(raw.x, raw.y, fr_mm_s);
   }
 #endif
 
 #if HAS_Z_AXIS
-  void do_blocking_move_to_z(const_float_t rz, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_z(const float rz, const feedRate_t fr_mm_s/*=0.0*/) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_blocking_move_to_z(", rz, ", ", fr_mm_s, ")");
     do_blocking_move_to_xy_z(current_position, rz, fr_mm_s);
   }
-  void do_blocking_move_to_xy_z(const xy_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xy_z(const xy_pos_t &raw, const float z, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, z,
                     current_position.i, current_position.j, current_position.k,
@@ -1042,7 +1042,7 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
    *  - If lowering is not allowed then skip a downward move
    *  - Execute the move at the probing (or homing) feedrate
    */
-  void do_z_clearance(const_float_t zclear, const bool with_probe/*=true*/, const bool lower_allowed/*=false*/) {
+  void do_z_clearance(const float zclear, const bool with_probe/*=true*/, const bool lower_allowed/*=false*/) {
     UNUSED(with_probe);
     float zdest = zclear;
     TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest -= probe.offset.z);
@@ -1051,7 +1051,7 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
     if ((!lower_allowed && zdest < current_position.z) || zdest == current_position.z) return;
     do_blocking_move_to_z(zdest, TERN(HAS_BED_PROBE, z_probe_fast_mm_s, homing_feedrate(Z_AXIS)));
   }
-  void do_z_clearance_by(const_float_t zclear) {
+  void do_z_clearance_by(const float zclear) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_z_clearance_by(", zclear, ")");
     do_z_clearance(current_position.z + zclear, false);
   }
@@ -1074,73 +1074,73 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
 #endif // HAS_Z_AXIS
 
 #if HAS_I_AXIS
-  void do_blocking_move_to_xyz_i(const xyze_pos_t &raw, const_float_t i, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyz_i(const xyze_pos_t &raw, const float i, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, i, raw.j, raw.k, raw.u, raw.v, raw.w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_i(const_float_t ri, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_i(const float ri, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyz_i(current_position, ri, fr_mm_s);
   }
 #endif
 
 #if HAS_J_AXIS
-  void do_blocking_move_to_xyzi_j(const xyze_pos_t &raw, const_float_t j, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyzi_j(const xyze_pos_t &raw, const float j, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, raw.i, j, raw.k, raw.u, raw.v, raw.w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_j(const_float_t rj, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_j(const float rj, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyzi_j(current_position, rj, fr_mm_s);
   }
 #endif
 
 #if HAS_K_AXIS
-  void do_blocking_move_to_xyzij_k(const xyze_pos_t &raw, const_float_t k, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyzij_k(const xyze_pos_t &raw, const float k, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, raw.i, raw.j, k, raw.u, raw.v, raw.w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_k(const_float_t rk, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_k(const float rk, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyzij_k(current_position, rk, fr_mm_s);
   }
 #endif
 
 #if HAS_U_AXIS
-  void do_blocking_move_to_xyzijk_u(const xyze_pos_t &raw, const_float_t u, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyzijk_u(const xyze_pos_t &raw, const float u, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, raw.i, raw.j, raw.k, u, raw.v, raw.w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_u(const_float_t ru, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_u(const float ru, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyzijk_u(current_position, ru, fr_mm_s);
   }
 #endif
 
 #if HAS_V_AXIS
-  void do_blocking_move_to_xyzijku_v(const xyze_pos_t &raw, const_float_t v, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyzijku_v(const xyze_pos_t &raw, const float v, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, raw.i, raw.j, raw.k, raw.u, v, raw.w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_v(const_float_t rv, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_v(const float rv, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyzijku_v(current_position, rv, fr_mm_s);
   }
 #endif
 
 #if HAS_W_AXIS
-  void do_blocking_move_to_xyzijkuv_w(const xyze_pos_t &raw, const_float_t w, const_feedRate_t fr_mm_s/*=0.0f*/) {
+  void do_blocking_move_to_xyzijkuv_w(const xyze_pos_t &raw, const float w, const feedRate_t fr_mm_s/*=0.0f*/) {
     do_blocking_move_to(
       NUM_AXIS_LIST_(raw.x, raw.y, raw.z, raw.i, raw.j, raw.k, raw.u, raw.v, w)
       fr_mm_s
     );
   }
-  void do_blocking_move_to_w(const_float_t rw, const_feedRate_t fr_mm_s/*=0.0*/) {
+  void do_blocking_move_to_w(const float rw, const feedRate_t fr_mm_s/*=0.0*/) {
     do_blocking_move_to_xyzijkuv_w(current_position, rw, fr_mm_s);
   }
 #endif
@@ -1633,7 +1633,7 @@ float get_move_distance(const xyze_pos_t &diff OPTARG(HAS_ROTATIONAL_AXES, bool 
      * small incremental moves. This allows the planner to
      * apply more detailed bed leveling to the full move.
      */
-    inline void segmented_line_to_destination(const_feedRate_t fr_mm_s, const float segment_size=LEVELED_SEGMENT_LENGTH) {
+    inline void segmented_line_to_destination(const feedRate_t fr_mm_s, const float segment_size=LEVELED_SEGMENT_LENGTH) {
 
       const xyze_float_t diff = destination - current_position;
 
@@ -2856,7 +2856,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
   /**
    * Set the home offset for an axis.
    */
-  void set_home_offset(const AxisEnum axis, const_float_t v) {
+  void set_home_offset(const AxisEnum axis, const float v) {
     home_offset[axis] = v;
   }
 #endif

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -338,24 +338,24 @@ void sync_plan_position();
  * Move the planner to the current position from wherever it last moved
  * (or from wherever it has been told it is located).
  */
-void line_to_current_position(const_feedRate_t fr_mm_s=feedrate_mm_s);
+void line_to_current_position(const feedRate_t fr_mm_s=feedrate_mm_s);
 
 #if HAS_EXTRUDERS
-  void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s);
+  void unscaled_e_move(const float length, const feedRate_t fr_mm_s);
 #endif
 
 void prepare_line_to_destination();
 
-void _internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f OPTARG(IS_KINEMATIC, const bool is_fast=false));
+void _internal_move_to_destination(const feedRate_t fr_mm_s=0.0f OPTARG(IS_KINEMATIC, const bool is_fast=false));
 
-inline void prepare_internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f) {
+inline void prepare_internal_move_to_destination(const feedRate_t fr_mm_s=0.0f) {
   _internal_move_to_destination(fr_mm_s);
 }
 
 #if IS_KINEMATIC
-  void prepare_fast_move_to_destination(const_feedRate_t scaled_fr_mm_s=MMS_SCALED(feedrate_mm_s));
+  void prepare_fast_move_to_destination(const feedRate_t scaled_fr_mm_s=MMS_SCALED(feedrate_mm_s));
 
-  inline void prepare_internal_fast_move_to_destination(const_feedRate_t fr_mm_s=0.0f) {
+  inline void prepare_internal_fast_move_to_destination(const feedRate_t fr_mm_s=0.0f) {
     _internal_move_to_destination(fr_mm_s, true);
   }
 #endif
@@ -363,56 +363,56 @@ inline void prepare_internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f) 
 /**
  * Blocking movement and shorthand functions
  */
-void do_blocking_move_to(NUM_AXIS_ARGS_(const_float_t) const_feedRate_t fr_mm_s=0.0f);
-void do_blocking_move_to(const xy_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
-void do_blocking_move_to(const xyz_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
-void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(NUM_AXIS_ARGS_(const float) const feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xy_pos_t &raw, const feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xyz_pos_t &raw, const feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xyze_pos_t &raw, const feedRate_t fr_mm_s=0.0f);
 
 #if HAS_X_AXIS
-  void do_blocking_move_to_x(const_float_t rx, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_x(const float rx, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_Y_AXIS
-  void do_blocking_move_to_y(const_float_t ry, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_y(const float ry, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_Z_AXIS
-  void do_blocking_move_to_z(const_float_t rz, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_z(const float rz, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_I_AXIS
-  void do_blocking_move_to_i(const_float_t ri, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyz_i(const xyze_pos_t &raw, const_float_t i, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_i(const float ri, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyz_i(const xyze_pos_t &raw, const float i, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_J_AXIS
-  void do_blocking_move_to_j(const_float_t rj, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyzi_j(const xyze_pos_t &raw, const_float_t j, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_j(const float rj, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyzi_j(const xyze_pos_t &raw, const float j, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_K_AXIS
-  void do_blocking_move_to_k(const_float_t rk, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyzij_k(const xyze_pos_t &raw, const_float_t k, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_k(const float rk, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyzij_k(const xyze_pos_t &raw, const float k, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_U_AXIS
-  void do_blocking_move_to_u(const_float_t ru, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyzijk_u(const xyze_pos_t &raw, const_float_t u, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_u(const float ru, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyzijk_u(const xyze_pos_t &raw, const float u, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_V_AXIS
-  void do_blocking_move_to_v(const_float_t rv, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyzijku_v(const xyze_pos_t &raw, const_float_t v, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_v(const float rv, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyzijku_v(const xyze_pos_t &raw, const float v, const feedRate_t fr_mm_s=0.0f);
 #endif
 #if HAS_W_AXIS
-  void do_blocking_move_to_w(const_float_t rw, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xyzijkuv_w(const xyze_pos_t &raw, const_float_t w, const_feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_w(const float rw, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xyzijkuv_w(const xyze_pos_t &raw, const float w, const feedRate_t fr_mm_s=0.0f);
 #endif
 
 #if HAS_Y_AXIS
-  void do_blocking_move_to_xy(const_float_t rx, const_float_t ry, const_feedRate_t fr_mm_s=0.0f);
-  void do_blocking_move_to_xy(const xy_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
-  FORCE_INLINE void do_blocking_move_to_xy(const xyz_pos_t &raw, const_feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
-  FORCE_INLINE void do_blocking_move_to_xy(const xyze_pos_t &raw, const_feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
+  void do_blocking_move_to_xy(const float rx, const float ry, const feedRate_t fr_mm_s=0.0f);
+  void do_blocking_move_to_xy(const xy_pos_t &raw, const feedRate_t fr_mm_s=0.0f);
+  FORCE_INLINE void do_blocking_move_to_xy(const xyz_pos_t &raw, const feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
+  FORCE_INLINE void do_blocking_move_to_xy(const xyze_pos_t &raw, const feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
 #endif
 
 #if HAS_Z_AXIS
-  void do_blocking_move_to_xy_z(const xy_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f);
-  FORCE_INLINE void do_blocking_move_to_xy_z(const xyz_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
-  FORCE_INLINE void do_blocking_move_to_xy_z(const xyze_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
+  void do_blocking_move_to_xy_z(const xy_pos_t &raw, const float z, const feedRate_t fr_mm_s=0.0f);
+  FORCE_INLINE void do_blocking_move_to_xy_z(const xyz_pos_t &raw, const float z, const feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
+  FORCE_INLINE void do_blocking_move_to_xy_z(const xyze_pos_t &raw, const float z, const feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
 #endif
 
 void remember_feedrate_scaling_off();
@@ -426,8 +426,8 @@ void restore_feedrate_and_scaling();
       #define Z_POST_CLEARANCE Z_CLEARANCE_FOR_HOMING
     #endif
   #endif
-  void do_z_clearance(const_float_t zclear, const bool with_probe=true, const bool lower_allowed=false);
-  void do_z_clearance_by(const_float_t zclear);
+  void do_z_clearance(const float zclear, const bool with_probe=true, const bool lower_allowed=false);
+  void do_z_clearance_by(const float zclear);
   void do_move_after_z_homing();
   inline void do_z_post_clearance() { do_z_clearance(Z_POST_CLEARANCE); }
 #else
@@ -569,16 +569,16 @@ void home_if_needed(const bool keeplev=false);
   #endif
 
   // Return true if the given point is within the printable area
-  bool position_is_reachable(const_float_t rx, const_float_t ry, const float inset=0);
+  bool position_is_reachable(const float rx, const float ry, const float inset=0.0f);
 
-  inline bool position_is_reachable(const xy_pos_t &pos, const float inset=0) {
+  inline bool position_is_reachable(const xy_pos_t &pos, const float inset=0.0f) {
     return position_is_reachable(pos.x, pos.y, inset);
   }
 
 #else
 
   // Return true if the given position is within the machine bounds.
-  bool position_is_reachable(TERN_(HAS_X_AXIS, const_float_t rx) OPTARG(HAS_Y_AXIS, const_float_t ry));
+  bool position_is_reachable(TERN_(HAS_X_AXIS, const float rx) OPTARG(HAS_Y_AXIS, const float ry));
   inline bool position_is_reachable(const xy_pos_t &pos) {
     return position_is_reachable(TERN_(HAS_X_AXIS, pos.x) OPTARG(HAS_Y_AXIS, pos.y));
   }
@@ -636,7 +636,7 @@ void home_if_needed(const bool keeplev=false);
 #endif
 
 #if HAS_HOME_OFFSET
-  void set_home_offset(const AxisEnum axis, const_float_t v);
+  void set_home_offset(const AxisEnum axis, const float v);
 #endif
 
 //

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -799,7 +799,7 @@ block_t* Planner::get_future_block(const uint8_t offset) {
  * NOT BUSY and it is marked as RECALCULATE. That WARRANTIES the Stepper ISR
  * is not and will not use the block while we modify it.
  */
-void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t entry_speed, const_float_t exit_speed) {
+void Planner::calculate_trapezoid_for_block(block_t * const block, const float entry_speed, const float exit_speed) {
 
   const float spmm = block->steps_per_mm;
   uint32_t initial_rate = entry_speed ? LROUND(entry_speed * spmm) : block->initial_rate,
@@ -1006,7 +1006,7 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
 
 // The kernel called by recalculate() when scanning the plan from last to first entry.
 // Returns true if it could increase the current block's entry speed.
-bool Planner::reverse_pass_kernel(block_t * const current, const block_t * const next, const_float_t safe_exit_speed_sqr) {
+bool Planner::reverse_pass_kernel(block_t * const current, const block_t * const next, const float safe_exit_speed_sqr) {
   // We need to recalculate only for the last block added or if next->entry_speed_sqr changed.
   if (!next || next->flag.recalculate) {
     // And only if we're not already at max entry speed.
@@ -1045,7 +1045,7 @@ bool Planner::reverse_pass_kernel(block_t * const current, const block_t * const
  * coarsely maximizes the entry speeds starting from last block.
  * Requires there's at least one block with flag.recalculate in the buffer.
  */
-void Planner::reverse_pass(const_float_t safe_exit_speed_sqr) {
+void Planner::reverse_pass(const float safe_exit_speed_sqr) {
   // Initialize block index to the last block in the planner buffer.
   // This last block will have flag.recalculate set.
   uint8_t block_index = prev_block_index(block_buffer_head);
@@ -1107,7 +1107,7 @@ void Planner::forward_pass_kernel(const block_t * const previous, block_t * cons
  * Do the forward pass and recalculate the trapezoid speed profiles for all blocks in the plan
  * according to entry/exit speeds.
  */
-void Planner::recalculate_trapezoids(const_float_t safe_exit_speed_sqr) {
+void Planner::recalculate_trapezoids(const float safe_exit_speed_sqr) {
   // Start with the block that's about to execute or is executing.
   uint8_t block_index = block_buffer_tail,
           head_block_index = block_buffer_head;
@@ -1182,7 +1182,7 @@ void Planner::recalculate_trapezoids(const_float_t safe_exit_speed_sqr) {
 }
 
 // Requires there's at least one block with flag.recalculate in the buffer
-void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
+void Planner::recalculate(const float safe_exit_speed_sqr) {
   reverse_pass(safe_exit_speed_sqr);
   // The forward pass is done as part of recalculate_trapezoids()
   recalculate_trapezoids(safe_exit_speed_sqr);
@@ -1421,7 +1421,7 @@ void Planner::check_axes_activity() {
    * This is the reciprocal of the circular cross-section area.
    * Return 1.0 with volumetric off or a diameter of 0.0.
    */
-  inline float calculate_volumetric_multiplier(const_float_t diameter) {
+  inline float calculate_volumetric_multiplier(const float diameter) {
     return (parser.volumetric_enabled && diameter) ? 1.0f / CIRCLE_AREA(diameter * 0.5f) : 1;
   }
 
@@ -2864,7 +2864,7 @@ void Planner::buffer_sync_block(const BlockFlagBit sync_flag/*=BLOCK_BIT_SYNC_PO
  */
 bool Planner::buffer_segment(const abce_pos_t &abce
   OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-  , const_feedRate_t fr_mm_s
+  , const feedRate_t fr_mm_s
   , const uint8_t extruder/*=active_extruder*/
   , const PlannerHints &hints/*=PlannerHints()*/
 ) {
@@ -2989,7 +2989,7 @@ bool Planner::buffer_segment(const abce_pos_t &abce
  * @param extruder  Optional target extruder (otherwise active_extruder)
  * @param hints     Optional parameters to aid planner calculations
  */
-bool Planner::buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s
+bool Planner::buffer_line(const xyze_pos_t &cart, const feedRate_t fr_mm_s
   , const uint8_t extruder/*=active_extruder*/
   , const PlannerHints &hints/*=PlannerHints()*/
 ) {
@@ -3215,7 +3215,7 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
   /**
    * Special setter for planner E position (also setting E stepper position).
    */
-  void Planner::set_e_position_mm(const_float_t e) {
+  void Planner::set_e_position_mm(const float e) {
     const uint8_t axis_index = E_AXIS_N(active_extruder);
     TERN_(DISTINCT_E_FACTORS, last_extruder = active_extruder);
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -435,7 +435,7 @@ struct PlannerHints {
                                       // False if no movement of the tool center point relative to the work piece occurs
                                       // (i.e. the tool rotates around the tool centerpoint)
   #endif
-  PlannerHints(const_float_t mm=0.0f) : millimeters(mm) {}
+  PlannerHints(const float mm=0.0f) : millimeters(mm) {}
 };
 
 class Planner {
@@ -527,7 +527,7 @@ class Planner {
 
     #if ENABLED(LIN_ADVANCE)
       static float extruder_advance_K[DISTINCT_E];
-      static void set_advance_k(const_float_t k, const uint8_t e=active_extruder) {
+      static void set_advance_k(const float k, const uint8_t e=active_extruder) {
         UNUSED(e);
         extruder_advance_K[E_INDEX_N(e)] = k;
         TERN_(SMOOTH_LIN_ADVANCE, extruder_advance_K_q27[E_INDEX_N(e)] = k * _BV32(27));
@@ -655,7 +655,7 @@ class Planner {
     #if ENABLED(CLASSIC_JERK)
       static void set_max_jerk(const AxisEnum axis, float inMaxJerkMMS);
     #else
-      static void set_max_jerk(const AxisEnum, const_float_t) {}
+      static void set_max_jerk(const AxisEnum, const float) {}
     #endif
 
     #if HAS_EXTRUDERS
@@ -709,7 +709,7 @@ class Planner {
         static void calculate_volumetric_extruder_limits();
       #endif
 
-      FORCE_INLINE static void set_filament_size(const uint8_t e, const_float_t v) {
+      FORCE_INLINE static void set_filament_size(const uint8_t e, const float v) {
         filament_size[e] = v;
         if (v > 0) volumetric_area_nominal = CIRCLE_AREA(v * 0.5); //TODO: should it be per extruder
         // make sure all extruders have some sane value for the filament size
@@ -720,7 +720,7 @@ class Planner {
     #endif
 
     #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-      FORCE_INLINE static void set_volumetric_extruder_limit(const uint8_t e, const_float_t v) {
+      FORCE_INLINE static void set_volumetric_extruder_limit(const uint8_t e, const float v) {
         volumetric_extruder_limit[e] = v;
         calculate_volumetric_extruder_limit(e);
       }
@@ -735,7 +735,7 @@ class Planner {
        *  Returns 1.0 if planner.z_fade_height is 0.0.
        *  Returns 0.0 if Z is past the specified 'Fade Height'.
        */
-      static float fade_scaling_factor_for_z(const_float_t rz) {
+      static float fade_scaling_factor_for_z(const float rz) {
         static float z_fade_factor = 1;
         if (!z_fade_height || rz <= 0) return 1;
         if (rz >= z_fade_height) return 0;
@@ -748,27 +748,27 @@ class Planner {
 
       FORCE_INLINE static void force_fade_recalc() { last_fade_z = -999.999f; }
 
-      FORCE_INLINE static void set_z_fade_height(const_float_t zfh) {
+      FORCE_INLINE static void set_z_fade_height(const float zfh) {
         z_fade_height = zfh > 0 ? zfh : 0;
         inverse_z_fade_height = RECIPROCAL(z_fade_height);
         force_fade_recalc();
       }
 
-      FORCE_INLINE static bool leveling_active_at_z(const_float_t rz) {
+      FORCE_INLINE static bool leveling_active_at_z(const float rz) {
         return !z_fade_height || rz < z_fade_height;
       }
 
     #else
 
-      FORCE_INLINE static float fade_scaling_factor_for_z(const_float_t) { return 1; }
+      FORCE_INLINE static float fade_scaling_factor_for_z(const float) { return 1; }
 
-      FORCE_INLINE static bool leveling_active_at_z(const_float_t) { return true; }
+      FORCE_INLINE static bool leveling_active_at_z(const float) { return true; }
 
     #endif
 
     #if ENABLED(SKEW_CORRECTION)
 
-      FORCE_INLINE static void skew(float &cx, float &cy, const_float_t cz) {
+      FORCE_INLINE static void skew(float &cx, float &cy, const float cz) {
         if (COORDINATE_OKAY(cx, X_MIN_POS + 1, X_MAX_POS) && COORDINATE_OKAY(cy, Y_MIN_POS + 1, Y_MAX_POS)) {
           const float sx = cx - cy * skew_factor.xy - cz * (skew_factor.xz - (skew_factor.xy * skew_factor.yz)),
                       sy = cy - cz * skew_factor.yz;
@@ -779,7 +779,7 @@ class Planner {
       }
       FORCE_INLINE static void skew(xyz_pos_t &raw) { skew(raw.x, raw.y, raw.z); }
 
-      FORCE_INLINE static void unskew(float &cx, float &cy, const_float_t cz) {
+      FORCE_INLINE static void unskew(float &cx, float &cy, const float cz) {
         if (COORDINATE_OKAY(cx, X_MIN_POS, X_MAX_POS) && COORDINATE_OKAY(cy, Y_MIN_POS, Y_MAX_POS)) {
           const float sx = cx + cy * skew_factor.xy + cz * skew_factor.xz,
                       sy = cy + cz * skew_factor.yz;
@@ -955,7 +955,7 @@ class Planner {
      */
     static bool buffer_segment(const abce_pos_t &abce
       OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
-      , const_feedRate_t fr_mm_s
+      , const feedRate_t fr_mm_s
       , const uint8_t extruder=active_extruder
       , const PlannerHints &hints=PlannerHints()
     );
@@ -974,7 +974,7 @@ class Planner {
      *
      * @return  false if no segment was queued due to cleaning, cold extrusion, full queue, etc...
      */
-    static bool buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s
+    static bool buffer_line(const xyze_pos_t &cart, const feedRate_t fr_mm_s
       , const uint8_t extruder=active_extruder
       , const PlannerHints &hints=PlannerHints()
     );
@@ -999,7 +999,7 @@ class Planner {
     static void set_position_mm(const xyze_pos_t &xyze);
 
     #if HAS_EXTRUDERS
-      static void set_e_position_mm(const_float_t e);
+      static void set_e_position_mm(const float e);
     #endif
 
     /**
@@ -1134,7 +1134,7 @@ class Planner {
      * to reach 'target_velocity_sqr' using 'acceleration' within a given
      * 'distance'.
      */
-    static float max_allowable_speed_sqr(const_float_t accel, const_float_t target_velocity_sqr, const_float_t distance) {
+    static float max_allowable_speed_sqr(const float accel, const float target_velocity_sqr, const float distance) {
       return target_velocity_sqr - 2 * accel * distance;
     }
 
@@ -1142,21 +1142,21 @@ class Planner {
       /**
        * Calculate the speed reached given initial speed, acceleration and distance
        */
-      static float final_speed(const_float_t initial_velocity, const_float_t accel, const_float_t distance) {
+      static float final_speed(const float initial_velocity, const float accel, const float distance) {
         return SQRT(sq(initial_velocity) + 2 * accel * distance);
       }
     #endif
 
-    static void calculate_trapezoid_for_block(block_t * const block, const_float_t entry_speed, const_float_t exit_speed);
+    static void calculate_trapezoid_for_block(block_t * const block, const float entry_speed, const float exit_speed);
 
-    static bool reverse_pass_kernel(block_t * const current, const block_t * const next, const_float_t safe_exit_speed_sqr);
+    static bool reverse_pass_kernel(block_t * const current, const block_t * const next, const float safe_exit_speed_sqr);
     static void forward_pass_kernel(const block_t * const previous, block_t * const current);
 
-    static void reverse_pass(const_float_t safe_exit_speed_sqr);
+    static void reverse_pass(const float safe_exit_speed_sqr);
 
-    static void recalculate_trapezoids(const_float_t safe_exit_speed_sqr);
+    static void recalculate_trapezoids(const float safe_exit_speed_sqr);
 
-    static void recalculate(const_float_t safe_exit_speed_sqr);
+    static void recalculate(const float safe_exit_speed_sqr);
 
     #if IS_KINEMATIC
       // Allow do_homing_move to access internal functions, such as buffer_segment.
@@ -1171,7 +1171,7 @@ class Planner {
         vector *= RSQRT(magnitude_sq);
       }
 
-      FORCE_INLINE static float limit_value_by_axis_maximum(const_float_t max_value, xyze_float_t &unit_vec) {
+      FORCE_INLINE static float limit_value_by_axis_maximum(const float max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
         LOOP_LOGICAL_AXES(idx) {
           if (unit_vec[idx]) {

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -43,7 +43,7 @@
 #define SIGMA 0.1f
 
 // Compute the linear interpolation between two real numbers.
-static inline float interp(const_float_t a, const_float_t b, const_float_t t) { return (1 - t) * a + t * b; }
+static inline float interp(const float a, const float b, const float t) { return (1 - t) * a + t * b; }
 
 /**
  * Compute a Bézier curve using the De Casteljau's algorithm (see
@@ -51,7 +51,7 @@ static inline float interp(const_float_t a, const_float_t b, const_float_t t) { 
  * easy to code and has good numerical stability (very important,
  * since Arduino works with limited precision real numbers).
  */
-static inline float eval_bezier(const_float_t a, const_float_t b, const_float_t c, const_float_t d, const_float_t t) {
+static inline float eval_bezier(const float a, const float b, const float c, const float d, const float t) {
   const float iab = interp(a, b, t),
               ibc = interp(b, c, t),
               icd = interp(c, d, t),
@@ -64,7 +64,7 @@ static inline float eval_bezier(const_float_t a, const_float_t b, const_float_t 
  * We approximate Euclidean distance with the sum of the coordinates
  * offset (so-called "norm 1"), which is quicker to compute.
  */
-static inline float dist1(const_float_t x1, const_float_t y1, const_float_t x2, const_float_t y2) { return ABS(x1 - x2) + ABS(y1 - y2); }
+static inline float dist1(const float x1, const float y1, const float x2, const float y2) { return ABS(x1 - x2) + ABS(y1 - y2); }
 
 /**
  * The algorithm for computing the step is loosely based on the one in Kig
@@ -109,7 +109,7 @@ void cubic_b_spline(
   const xyze_pos_t &position,       // current position
   const xyze_pos_t &target,         // target position
   const xy_pos_t (&offsets)[2],     // a pair of offsets
-  const_feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
+  const feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
   const uint8_t extruder
 ) {
   // Absolute first and second control points are recovered.

--- a/Marlin/src/module/planner_bezier.h
+++ b/Marlin/src/module/planner_bezier.h
@@ -33,6 +33,6 @@ void cubic_b_spline(
   const xyze_pos_t &position,       // current position
   const xyze_pos_t &target,         // target position
   const xy_pos_t (&offsets)[2],     // a pair of offsets
-  const_feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
+  const feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
   const uint8_t extruder
 );

--- a/Marlin/src/module/polar.cpp
+++ b/Marlin/src/module/polar.cpp
@@ -54,7 +54,7 @@ float absoluteAngle(float a) {
   return a;
 }
 
-void forward_kinematics(const_float_t r, const_float_t theta) {
+void forward_kinematics(const float r, const float theta) {
   const float absTheta = absoluteAngle(theta);
   float radius = r;
   if (polar_center_offset > 0.0) radius = SQRT( ABS( sq(r) - sq(-polar_center_offset) ) );

--- a/Marlin/src/module/polar.h
+++ b/Marlin/src/module/polar.h
@@ -30,7 +30,7 @@
 extern float segments_per_second;
 
 float absoluteAngle(float a);
-void forward_kinematics(const_float_t r, const_float_t theta);
+void forward_kinematics(const float r, const float theta);
 
 void inverse_kinematics(const xyz_pos_t &raw);
 void polar_report_positions();

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -613,7 +613,7 @@ bool Probe::set_deployed(const bool deploy, const bool no_return/*=false*/) {
  *
  * @return TRUE if the probe failed to trigger.
  */
-bool Probe::probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s) {
+bool Probe::probe_down_to_z(const float z, const feedRate_t fr_mm_s) {
   DEBUG_SECTION(log_probe, "Probe::probe_down_to_z", DEBUGGING(LEVELING));
 
   #if ALL(HAS_HEATED_BED, WAIT_FOR_BED_HEATER)
@@ -774,12 +774,12 @@ bool Probe::probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s) {
  *
  * @return The Z position of the bed at the current XY or NAN on error.
  */
-float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_point/*=Z_PROBE_LOW_POINT*/, const_float_t z_clearance/*=Z_TWEEN_SAFE_CLEARANCE*/) {
+float Probe::run_z_probe(const bool sanity_check/*=true*/, const float z_min_point/*=Z_PROBE_LOW_POINT*/, const float z_clearance/*=Z_TWEEN_SAFE_CLEARANCE*/) {
   DEBUG_SECTION(log_probe, "Probe::run_z_probe", DEBUGGING(LEVELING));
 
   const float zoffs = SUM_TERN(HAS_HOTEND_OFFSET, -offset.z, hotend_offset[active_extruder].z);
 
-  auto try_to_probe = [&](PGM_P const plbl, const_float_t z_probe_low_point, const feedRate_t fr_mm_s, const bool scheck) -> bool {
+  auto try_to_probe = [&](PGM_P const plbl, const float z_probe_low_point, const feedRate_t fr_mm_s, const bool scheck) -> bool {
     constexpr float error_tolerance = Z_PROBE_ERROR_TOLERANCE;
     if (DEBUGGING(LEVELING)) {
       DEBUG_ECHOPGM_P(plbl);
@@ -966,13 +966,13 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_p
  *
  */
 float Probe::probe_at_point(
-  const_float_t rx, const_float_t ry,
+  const float rx, const float ry,
   const ProbePtRaise raise_after,     // = PROBE_PT_NONE
   const uint8_t verbose_level,        // = 0
   const bool probe_relative,          // = true
   const bool sanity_check,            // = true
-  const_float_t z_min_point,          // = Z_PROBE_LOW_POINT
-  const_float_t z_clearance,          // = Z_TWEEN_SAFE_CLEARANCE
+  const float z_min_point,          // = Z_PROBE_LOW_POINT
+  const float z_clearance,          // = Z_TWEEN_SAFE_CLEARANCE
   const bool raise_after_is_rel       // = false
 ) {
   DEBUG_SECTION(log_probe, "Probe::probe_at_point", DEBUGGING(LEVELING));
@@ -1100,7 +1100,7 @@ float Probe::probe_at_point(
   /**
    * Set the sensorless Z offset
    */
-  void Probe::set_offset_sensorless_adj(const_float_t sz) {
+  void Probe::set_offset_sensorless_adj(const float sz) {
     DEBUG_SECTION(pso, "Probe::set_offset_sensorless_adj", true);
     if (test_sensitivity.x) offset_sensorless_adj.a = sz;
     if (test_sensitivity.y) offset_sensorless_adj.b = sz;

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -100,7 +100,7 @@ public:
       #if HAS_PROBE_XY_OFFSET
         // Return true if the both nozzle and the probe can reach the given point.
         // Note: This won't work on SCARA since the probe offset rotates with the arm.
-        static bool can_reach(const_float_t rx, const_float_t ry, const bool probe_relative=true) {
+        static bool can_reach(const float rx, const float ry, const bool probe_relative=true) {
           if (probe_relative) {
             return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y) // The nozzle can go where it needs to go?
                 && position_is_reachable(rx, ry, PROBING_MARGIN);            // Can the probe also go near there?
@@ -111,7 +111,7 @@ public:
           }
         }
       #else
-        static bool can_reach(const_float_t rx, const_float_t ry, const bool=true) {
+        static bool can_reach(const float rx, const float ry, const bool=true) {
           return position_is_reachable(rx, ry)
               && position_is_reachable(rx, ry, PROBING_MARGIN);
         }
@@ -119,7 +119,7 @@ public:
 
     #else // !IS_KINEMATIC
 
-      static bool obstacle_check(const_float_t rx, const_float_t ry) {
+      static bool obstacle_check(const float rx, const float ry) {
         #if ENABLED(AVOID_OBSTACLES)
           #ifdef OBSTACLE1
             constexpr float obst1[] = OBSTACLE1;
@@ -152,7 +152,7 @@ public:
        * Example: For a probe offset of -10,+10, then for the probe to reach 0,0 the
        *          nozzle must be be able to reach +10,-10.
        */
-      static bool can_reach(const_float_t rx, const_float_t ry, const bool probe_relative=true) {
+      static bool can_reach(const float rx, const float ry, const bool probe_relative=true) {
         if (probe_relative) {
           return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y)
               && COORDINATE_OKAY(rx, min_x() - fslop, max_x() + fslop)
@@ -172,14 +172,14 @@ public:
     #endif // !IS_KINEMATIC
 
     static float probe_at_point(
-      const_float_t      rx,
-      const_float_t      ry,
+      const float        rx,
+      const float        ry,
       const ProbePtRaise raise_after        = PROBE_PT_NONE,
       const uint8_t      verbose_level      = 0,
       const bool         probe_relative     = true,
       const bool         sanity_check       = true,
-      const_float_t      z_min_point        = Z_PROBE_LOW_POINT,
-      const_float_t      z_clearance        = Z_TWEEN_SAFE_CLEARANCE,
+      const float        z_min_point        = Z_PROBE_LOW_POINT,
+      const float        z_clearance        = Z_TWEEN_SAFE_CLEARANCE,
       const bool         raise_after_is_rel = false
     );
 
@@ -189,8 +189,8 @@ public:
       const uint8_t      verbose_level      = 0,
       const bool         probe_relative     = true,
       const bool         sanity_check       = true,
-      const_float_t      z_min_point        = Z_PROBE_LOW_POINT,
-      const_float_t      z_clearance        = Z_TWEEN_SAFE_CLEARANCE,
+      const float        z_min_point        = Z_PROBE_LOW_POINT,
+      const float        z_clearance        = Z_TWEEN_SAFE_CLEARANCE,
       const bool         raise_after_is_rel = false
     ) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check, z_min_point, z_clearance, raise_after_is_rel);
@@ -202,7 +202,7 @@ public:
 
     static bool set_deployed(const bool, const bool=false) { return false; }
 
-    static bool can_reach(const_float_t rx, const_float_t ry, const bool=true) { return position_is_reachable(TERN_(HAS_X_AXIS, rx) OPTARG(HAS_Y_AXIS, ry)); }
+    static bool can_reach(const float rx, const float ry, const bool=true) { return position_is_reachable(TERN_(HAS_X_AXIS, rx) OPTARG(HAS_Y_AXIS, ry)); }
 
   #endif // !HAS_BED_PROBE
 
@@ -356,14 +356,14 @@ public:
 
   // Basic functions for Sensorless Homing and Probing
   #if HAS_DELTA_SENSORLESS_PROBING
-    static void set_offset_sensorless_adj(const_float_t sz);
+    static void set_offset_sensorless_adj(const float sz);
     static void refresh_largest_sensorless_adj();
   #endif
 
 private:
   #if HAS_BED_PROBE
-    static bool probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s);
-    static float run_z_probe(const bool sanity_check=true, const_float_t z_min_point=Z_PROBE_LOW_POINT, const_float_t z_clearance=Z_TWEEN_SAFE_CLEARANCE);
+    static bool probe_down_to_z(const float z, const feedRate_t fr_mm_s);
+    static float run_z_probe(const bool sanity_check=true, const float z_min_point=Z_PROBE_LOW_POINT, const float z_clearance=Z_TWEEN_SAFE_CLEARANCE);
   #endif
 };
 

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -48,7 +48,7 @@ float segments_per_second = DEFAULT_SEGMENTS_PER_SECOND;
    * Maths and first version by QHARLEY.
    * Integrated into Marlin and slightly restructured by Joachim Cerny.
    */
-  void forward_kinematics(const_float_t a, const_float_t b) {
+  void forward_kinematics(const float a, const float b) {
     const float a_sin = sin(RADIANS(a)) * L1,
                 a_cos = cos(RADIANS(a)) * L1,
                 b_sin = sin(RADIANS(SUM_TERN(MP_SCARA, b, a))) * L2,
@@ -197,7 +197,7 @@ float segments_per_second = DEFAULT_SEGMENTS_PER_SECOND;
   }
 
   // Convert ABC inputs in degrees to XYZ outputs in mm
-  void forward_kinematics(const_float_t a, const_float_t b, const_float_t c) {
+  void forward_kinematics(const float a, const float b, const float c) {
     const float w = c - b,
                 r = L1 * cos(RADIANS(b)) + L2 * sin(RADIANS(w - (90 - b))),
                 x = r  * cos(RADIANS(a)),

--- a/Marlin/src/module/scara.h
+++ b/Marlin/src/module/scara.h
@@ -35,7 +35,7 @@ extern float segments_per_second;
                   L1_2 = FLOAT_SQ(L1), L1_2_2 = 2.0 * L1_2,
                   L2_2 = FLOAT_SQ(L2);
 
-  void forward_kinematics(const_float_t a, const_float_t b, const_float_t c);
+  void forward_kinematics(const float a, const float b, const float c);
   void home_TPARA();
 
 #else
@@ -44,7 +44,7 @@ extern float segments_per_second;
                   L1_2 = FLOAT_SQ(L1), L1_2_2 = 2.0 * L1_2,
                   L2_2 = FLOAT_SQ(L2);
 
-  void forward_kinematics(const_float_t a, const_float_t b);
+  void forward_kinematics(const float a, const float b);
 
 #endif
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3276,7 +3276,7 @@ void Stepper::init() {
    * Calculate a fixed point factor to apply to the signal and its echo
    * when shaping an axis.
    */
-  void Stepper::set_shaping_damping_ratio(const AxisEnum axis, const_float_t zeta) {
+  void Stepper::set_shaping_damping_ratio(const AxisEnum axis, const float zeta) {
     // From the damping ratio, get a factor that can be applied to advance_dividend for fixed-point maths.
     // For ZV, we use amplitudes 1/(1+K) and K/(1+K) where K = exp(-zeta * π / sqrt(1.0f - zeta * zeta))
     // which can be converted to 1:7 fixed point with an excellent fit with a 3rd-order polynomial.
@@ -3307,7 +3307,7 @@ void Stepper::init() {
     return -1;
   }
 
-  void Stepper::set_shaping_frequency(const AxisEnum axis, const_float_t freq) {
+  void Stepper::set_shaping_frequency(const AxisEnum axis, const float freq) {
     // enabling or disabling shaping whilst moving can result in lost steps
     planner.synchronize();
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -383,7 +383,7 @@ class Stepper {
 
     #if ENABLED(SMOOTH_LIN_ADVANCE)
       static float extruder_advance_tau[DISTINCT_E]; // Smoothing time; also the lookahead time of the smoother
-      static void set_advance_tau(const_float_t tau, const uint8_t e=active_extruder) {
+      static void set_advance_tau(const float tau, const uint8_t e=active_extruder) {
         const uint8_t i = E_INDEX_N(e);
         extruder_advance_tau[i] = tau;
         extruder_advance_tau_ticks[i] = tau * STEPPER_TIMER_RATE;
@@ -749,9 +749,9 @@ class Stepper {
     #endif
 
     #if HAS_ZV_SHAPING
-      static void set_shaping_damping_ratio(const AxisEnum axis, const_float_t zeta);
+      static void set_shaping_damping_ratio(const AxisEnum axis, const float zeta);
       static float get_shaping_damping_ratio(const AxisEnum axis);
-      static void set_shaping_frequency(const AxisEnum axis, const_float_t freq);
+      static void set_shaping_frequency(const AxisEnum axis, const float freq);
       static float get_shaping_frequency(const AxisEnum axis);
     #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1777,7 +1777,7 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
       #endif // !PID_OPENLOOP
     }
 
-    FORCE_INLINE void debug(const_celsius_float_t c, const_float_t pid_out, FSTR_P const name=nullptr, const int8_t index=-1) {
+    FORCE_INLINE void debug(const celsius_float_t c, const float pid_out, FSTR_P const name=nullptr, const int8_t index=-1) {
       if (TERN0(HAS_PID_DEBUG, thermalManager.pid_debug_flag)) {
         SERIAL_ECHO_START();
         if (name) SERIAL_ECHO(name);
@@ -3406,7 +3406,7 @@ void Temperature::init() {
    *
    * TODO: Embed the last 3 parameters during init, if not less optimal
    */
-  void Temperature::tr_state_machine_t::run(const_celsius_float_t current, const_celsius_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_float_t hysteresis_degc) {
+  void Temperature::tr_state_machine_t::run(const celsius_float_t current, const celsius_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_float_t hysteresis_degc) {
 
     #if HEATER_IDLE_HANDLER
       // Convert the given heater_id_t to an idle array index
@@ -4635,7 +4635,7 @@ void Temperature::isr() {
    *    Redundant: " R:nnn.nn /nnn.nn"
    *     With ADC: " T0:nnn.nn /nnn.nn (nnn.nn)"
    */
-  static void print_heater_state(const heater_id_t e, const_celsius_float_t c, const_celsius_float_t t
+  static void print_heater_state(const heater_id_t e, const celsius_float_t c, const celsius_float_t t
     OPTARG(SHOW_TEMP_ADC_VALUES, const float r)
   ) {
     char k;

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -399,9 +399,9 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
     float filament_heat_capacity_permm; // M306 H
     #if ENABLED(MPC_INCLUDE_FAN)
       float fan255_adjustment;          // M306 F
-      void applyFanAdjustment(const_float_t cf) { fan255_adjustment = cf - ambient_xfer_coeff_fan0; }
+      void applyFanAdjustment(const float cf) { fan255_adjustment = cf - ambient_xfer_coeff_fan0; }
     #else
-      void applyFanAdjustment(const_float_t) {}
+      void applyFanAdjustment(const float) {}
     #endif
     float fanCoefficient() { return SUM_TERN(MPC_INCLUDE_FAN, ambient_xfer_coeff_fan0, fan255_adjustment); }
   } MPC_t;
@@ -459,7 +459,7 @@ struct PIDHeaterInfo : public HeaterInfo {
           modeled_block_temp,
           modeled_sensor_temp;
     float fanCoefficient() { return mpc.fanCoefficient(); }
-    void applyFanAdjustment(const_float_t cf) { mpc.applyFanAdjustment(cf); }
+    void applyFanAdjustment(const float cf) { mpc.applyFanAdjustment(cf); }
   };
 #endif
 
@@ -1224,7 +1224,7 @@ class Temperature {
       // Update the temp manager when PID values change
       #if ENABLED(PIDTEMP)
         static void updatePID() { HOTEND_LOOP() temp_hotend[e].pid.reset(); }
-        static void setPID(const uint8_t hotend, const_float_t p, const_float_t i, const_float_t d) {
+        static void setPID(const uint8_t hotend, const float p, const float i, const float d) {
           #if ENABLED(PID_PARAMS_PER_HOTEND)
             temp_hotend[hotend].pid.set(p, i, d);
           #else
@@ -1425,7 +1425,7 @@ class Temperature {
           millis_t variance_timer = 0;
           celsius_float_t last_temp = 0.0, variance = 0.0;
         #endif
-        void run(const_celsius_float_t current, const_celsius_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_float_t hysteresis_degc);
+        void run(const celsius_float_t current, const celsius_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_float_t hysteresis_degc);
       } tr_state_machine_t;
 
       static tr_state_machine_t tr_state_machine[NR_HEATER_RUNAWAY];

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -940,7 +940,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
    *  current_position.e = e;
    *  sync_plan_position_e();
    */
-  void extruder_cutting_recover(const_float_t e) {
+  void extruder_cutting_recover(const float e) {
     if (too_cold(active_extruder)) return;
     const float dist = toolchange_settings.extra_resume + toolchange_settings.wipe_retract;
     DEBUG_ECHOLNPGM("Performing Cutting Recover | Distance: ", dist, " | Speed: ", MMM_TO_MMS(toolchange_settings.unretract_speed), "mm/s");


### PR DESCRIPTION
Since AVR has 16-bit pointers some calls and code size may be optimized using a `const float&` instead of a `const float`. Whether this makes a big difference in practice is yet to be widely tested, but this PR applies `const_float_t` for consistency anyway.