### PR TITLE
Fix MKS Gen L V1.0 MOSFET & FAN Pinmap (Artillery)

### DIFF
--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
@@ -38,10 +38,10 @@
 // Heaters / Fans
 //
 
-#define MOSFET_A_PIN                           9  // HE0
-#define MOSFET_B_PIN                           8  // HE1
-#define MOSFET_C_PIN                          10  // HBED
-#define FAN0_PIN                               7
+#define MOSFET_A_PIN                          10  // HE0					 
+#define MOSFET_B_PIN                           7  // HE1 or FAN Hotend Cooling
+#define MOSFET_C_PIN                           8  // HBED
+#define FAN0_PIN                               9  // FAN Part Cooling
 
 //
 // CS Pins wired to avoid conflict with the LCD


### PR DESCRIPTION
Correction of the MOSFET control pins
Heating Hotend, Hotbed working again

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Previous pinmap:

* MOSFET_A_PIN = H6 (signal HEATER_FAN)
* MOSFET_B_PIN = H5 (signal HEATER_BED)
* MOSFET_C_PIN = B4 (signal HEATER_E0)
* FAN0_PIN = H4 (signal HEATER_E1) 

New pinmap:

* MOSFET_A_PIN = B4 (signal HEATER_E0)
* MOSFET_B_PIN = H4 (signal HEATER_E1)
* MOSFET_C_PIN = H5 (signal HEATER_BED)
* FAN0_PIN = H6 (signal HEATER_FAN) 

=> correct according to Schematic


### Requirements

MKS Gen L V1.0

### Benefits

Correction of the MOSFET control pins
Heating Hotend, Hotbed working again

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/23478

Agreement with: quiret