### PR TITLE
Fix issue 25718  ui.quick_feedback() error

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1424,6 +1424,13 @@ void MarlinUI::init() {
 
   #endif // HAS_ENCODER_ACTION
 
+  #if HAS_SOUND
+    void MarlinUI::completion_feedback(const bool good/*=true*/) {
+      TERN_(HAS_TOUCH_SLEEP, wakeup_screen()); // Wake up on rotary encoder click...
+      if (good) OKAY_BUZZ(); else ERR_BUZZ();
+    }
+  #endif
+
 #endif // HAS_WIRED_LCD
 
 #if HAS_STATUS_MESSAGE

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -521,9 +521,12 @@ public:
 
     static void update() {}
     static void kill_screen(FSTR_P const, FSTR_P const) {}
+
+  #endif
+
+  #if !HAS_WIRED_LCD
     static void quick_feedback(const bool=true) {}
     static void completion_feedback(const bool=true) {}
-
   #endif
 
   #if ENABLED(SDSUPPORT)

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -494,11 +494,6 @@ public:
 
       static void status_screen();
 
-    #else
-
-      static void quick_feedback(const bool=true) {}
-      static void completion_feedback(const bool=true) {}
-
     #endif
 
     #if HAS_MARLINUI_U8GLIB
@@ -526,6 +521,8 @@ public:
 
     static void update() {}
     static void kill_screen(FSTR_P const, FSTR_P const) {}
+    static void quick_feedback(const bool=true) {}
+    static void completion_feedback(const bool=true) {}
 
   #endif
 

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -271,13 +271,6 @@ void scroll_screen(const uint8_t limit, const bool is_menu) {
     encoderTopLine = encoderLine;
 }
 
-#if HAS_SOUND
-  void MarlinUI::completion_feedback(const bool good/*=true*/) {
-    TERN_(HAS_TOUCH_SLEEP, wakeup_screen()); // Wake up on rotary encoder click...
-    if (good) OKAY_BUZZ(); else ERR_BUZZ();
-  }
-#endif
-
 #if HAS_LINE_TO_Z
 
   void line_to_z(const_float_t z) {


### PR DESCRIPTION
### Description

Commit https://github.com/MarlinFirmware/Marlin/commit/9a1c02591ba4c3d5b41f4c64edd819ea1860b75b amongst other things seem to have attempted to make the following functions always available, eliminating the need to test before calling them
 ui.quick_feedback
 ui.completion_feedback

Unfortunately it seem the empty version of these functions where added to the wrong part of the code so it doesnt work as inteneded. The functions are undefined when needed

Move functions to correct locations.

### Requirements

A build without a lcd

### Benefits

Builds as expected

### Configurations

https://github.com/MarlinFirmware/Marlin/files/11288672/Configuration.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25718
https://github.com/MarlinFirmware/Marlin/issues/25692