### PR TITLE
Fix ui.quick_feedback() error in G26

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -322,7 +322,7 @@ typedef struct {
 
       if (bed_temp > 25) {
         LCD_MESSAGE_MAX(MSG_G26_HEATING_BED);
-        ui.quick_feedback();
+        TERN_(HAS_MARLINUI_MENU, ui.quick_feedback());
         TERN_(HAS_MARLINUI_MENU, ui.capture());
         thermalManager.setTargetBed(bed_temp);
 
@@ -339,7 +339,7 @@ typedef struct {
 
     // Start heating the active nozzle
     LCD_MESSAGE_MAX(MSG_G26_HEATING_NOZZLE);
-    ui.quick_feedback();
+    TERN_(HAS_MARLINUI_MENU, ui.quick_feedback());
     thermalManager.setTargetHotend(hotend_temp, active_extruder);
 
     // Wait for the temperature to stabilize
@@ -347,7 +347,7 @@ typedef struct {
       return G26_ERR;
 
     ui.reset_status();
-    ui.completion_feedback();
+    TERN_(HAS_MARLINUI_MENU, ui.completion_feedback());
 
     return G26_OK;
   }
@@ -400,7 +400,7 @@ typedef struct {
     #endif
     {
       LCD_MESSAGE_MAX(MSG_G26_FIXED_LENGTH);
-      ui.quick_feedback();
+      TERN_(HAS_MARLINUI_MENU, ui.quick_feedback());
       destination = current_position;
       destination.e += prime_length;
       prepare_internal_move_to_destination(fr_slow_e);


### PR DESCRIPTION


### Description

Fix for the following compilation errors due to missing TERN statements.

```
src/gcode/bedlevel/G26.cpp:329:12: error: ‘class MarlinUI’ has no member named ‘quick_feedback’
         ui.quick_feedback();
            ^
src/gcode/bedlevel/G26.cpp:346:8: error: ‘class MarlinUI’ has no member named ‘quick_feedback’
     ui.quick_feedback();
        ^
src/gcode/bedlevel/G26.cpp:354:8: error: ‘class MarlinUI’ has no member named ‘completion_feedback’
     ui.completion_feedback();
        ^
src/gcode/bedlevel/G26.cpp: In member function ‘bool<anonymous struct>::prime_nozzle()’:
src/gcode/bedlevel/G26.cpp:407:10: error: ‘class MarlinUI’ has no member named ‘quick_feedback’
       ui.quick_feedback();
          ^
make: *** [Makefile:1008: applet/src/gcode/bedlevel/G26.o] Error 1
```