### PR TITLE
fix Anycubic PlayTune issue 25721

### DIFF
--- a/Marlin/src/lcd/extui/anycubic/Tunes.h
+++ b/Marlin/src/lcd/extui/anycubic/Tunes.h
@@ -61,7 +61,7 @@ n_END=10000 // end of tune marker
 
 namespace Anycubic {
 
-  void PlayTune(const uint8_t beeperPin, const uint16_t *tune, const uint8_t speed);
+  void PlayTune(const uint16_t *tune, const uint8_t speed);
 
   // Only uncomment the tunes you are using to save memory
   // This will help you write tunes!

--- a/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
@@ -40,8 +40,8 @@ using namespace ExtUI;
 
 namespace Anycubic {
 
-  FileList  FileNavigator::filelist;                          // Instance of the Marlin file API
-  char      FileNavigator::currentfoldername[];               // Current folder path
+  FileList  FileNavigator::filelist;                            // Instance of the Marlin file API
+  char      FileNavigator::currentfoldername[MAX_PATH_LEN + 1]; // Current folder path
   uint16_t  FileNavigator::lastindex;
   uint8_t   FileNavigator::folderdepth;
   uint16_t  FileNavigator::currentindex;                      // override the panel request

--- a/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/FileNavigator.cpp
@@ -41,7 +41,7 @@ using namespace ExtUI;
 namespace Anycubic {
 
   FileList  FileNavigator::filelist;                          // Instance of the Marlin file API
-  char      FileNavigator::currentfoldername[MAX_PATH_LEN];   // Current folder path
+  char      FileNavigator::currentfoldername[];               // Current folder path
   uint16_t  FileNavigator::lastindex;
   uint8_t   FileNavigator::folderdepth;
   uint16_t  FileNavigator::currentindex;                      // override the panel request


### PR DESCRIPTION
### Description

After https://github.com/MarlinFirmware/Marlin/pull/25690 Anycubic shared code Marlin no longer compiles
PlayTune was changed from 3 parameters to 2, but the definition was missed.  

### Requirements

Anycubic LCD

### Benefits

Builds as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25721
https://github.com/MarlinFirmware/Marlin/pull/25690 