### PR TITLE
Add melzi creality ender2 board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -191,12 +191,13 @@
 #define BOARD_MELZI_V2                1503  // Melzi V2
 #define BOARD_MELZI_MAKR3D            1504  // Melzi with ATmega1284 (MaKr3d version)
 #define BOARD_MELZI_CREALITY          1505  // Melzi Creality3D (for CR-10 etc)
-#define BOARD_MELZI_MALYAN            1506  // Melzi Malyan M150
-#define BOARD_MELZI_TRONXY            1507  // Tronxy X5S
-#define BOARD_STB_11                  1508  // STB V1.1
-#define BOARD_AZTEEG_X1               1509  // Azteeg X1
-#define BOARD_ANET_10                 1510  // Anet 1.0 (Melzi clone)
-#define BOARD_ZMIB_V2                 1511  // ZoneStar ZMIB V2
+#define BOARD_MELZI_CREALITY_ENDER2   1506  // Melzi Creality3D (for Ender-2)
+#define BOARD_MELZI_MALYAN            1507  // Melzi Malyan M150
+#define BOARD_MELZI_TRONXY            1508  // Tronxy X5S
+#define BOARD_STB_11                  1509  // STB V1.1
+#define BOARD_AZTEEG_X1               1510  // Azteeg X1
+#define BOARD_ANET_10                 1511  // Anet 1.0 (Melzi clone)
+#define BOARD_ZMIB_V2                 1512  // ZoneStar ZMIB V2
 
 //
 // Other ATmega644P, ATmega644, ATmega1284P

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -372,6 +372,8 @@
   #include "sanguino/pins_MELZI_MAKR3D.h"       // ATmega644P, ATmega1284P                env:sanguino1284p_optimized env:sanguino1284p env:sanguino644p
 #elif MB(MELZI_CREALITY)
   #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi_optiboot_optimized env:melzi_optiboot env:melzi_optimized env:melzi
+#elif MB(MELZI_CREALITY_ENDER2)
+  #include "sanguino/pins_MELZI_CREALITY_E2.h"  // ATmega1284P                            env:melzi_optiboot_optimized env:melzi_optiboot env:melzi_optimized env:melzi
 #elif MB(MELZI_MALYAN)
   #include "sanguino/pins_MELZI_MALYAN.h"       // ATmega644P, ATmega1284P                env:sanguino1284p_optimized env:sanguino1284p env:sanguino644p
 #elif MB(MELZI_TRONXY)

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY_E2.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY_E2.h
@@ -1,0 +1,113 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Melzi (Creality) pin assignments
+ * Schematic: https://green-candy.osdn.jp/external/MarlinFW/board_schematics/Melzi%20(Creality)/CR-10%20Schematic.pdf
+ * Origin: https://github.com/Creality3DPrinting/CR10-Melzi-1.1.2/blob/master/Circuit%20diagram/Motherboard/CR-10%20Schematic.pdf
+ * ATmega1284P
+ *
+ * The Creality board needs a bootloader installed before Marlin can be uploaded.
+ * If you don't have a chip programmer you can use a spare Arduino plus a few
+ * electronic components to write the bootloader.
+ *
+ * See https://www.instructables.com/id/Burn-Arduino-Bootloader-with-Arduino-MEGA/
+ *
+ * Schematic: https://bit.ly/2XOnsWb
+ */
+
+#define BOARD_INFO_NAME "Melzi Ender 2 (Creality)"
+
+/*
+ * Connectors.
+ *                                              FAN1     LASER     K-FAN   B-MOT(A6) E-TEMP(A7)  CHECK         AVR ISP
+ *                                           --------- --------- --------- --------- --------- ---------      ----------
+ *  J11(Power Switch)                        |12V GND| |12V  D4| |12V  D4| |GND D25| |GND D24| |D29 GND|      |MISO  5V|
+ *  ------                                   --------- --------- --------- --------- --------- ---------      |SCK MOSI|
+ *  |V-IN|(Regulator)       BED     HOT-END     FAN2      OFF     X-STOP    Y-STOP    Z-STOP                  |RST  GND|
+ *  |GND |               --------- --------- --------- --------- --------- --------- ---------                ----------
+ *  |12V |               |12V D12| |12V D13| |12V GND| |D27 D17| |GND D18| |GND D19| |GND D20|
+ *  ------               --------- --------- --------- --------- --------- --------- ---------
+ *
+ *
+ *                EXP1                  EXP1 as ENDER2 STOCKDISPLAY           EXP1 as CR10 STOCKDISPLAY
+ *               ------                            ------                               ------
+ * (AVR_SCK) D7 | 1  2 | D16                  SCK | 1  2 | BTN_E            BEEPER_PIN | 1  2 | BTN_ENC
+ *          D11 | 3  4 | RESET            BTN_EN1 | 3  4 | RESET               BTN_EN1 | 3  4 | RESET
+ *          D10   5  6 | D30              BTN_EN2   5  6 | LCD_A0              BTN_EN2   5  6 | LCD_D4 (ST9720 CLK)
+ *          D28 | 7  8 | D5 (AVR_MOSI)     LCD_CS | 7  8 | MOSI     (ST9720 CS) LCD_RS | 7  8 | LCD_EN (ST9720 DAT)
+ *          GND | 9 10 | 5V                   GND | 9 10 | 5V                      GND | 9 10 | 5V
+ *               ------                            ------                               ------
+ */
+
+#define EXP1_01_PIN                 7
+#define EXP1_02_PIN                16
+#define EXP1_03_PIN                11
+#define EXP1_04_PIN                -1  // hardware reset line
+#define EXP1_05_PIN                10
+#define EXP1_06_PIN                30
+#define EXP1_07_PIN                28
+#define EXP1_08_PIN                 5
+
+//
+// LCD / Controller
+//
+#if EITHER(CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #if ENABLED(SDSUPPORT)
+      #error "Cannot have SDSUPPORT with CR10_STOCKDISPLAY on this motherboard." // Hardware SDCARD SCK and MOSI pins are reallocated.
+    #endif
+    #define LCD_PINS_RS                  EXP1_07_PIN  // ST9720 CS
+    #define LCD_PINS_EN                  EXP1_08_PIN  // ST9720 DAT
+    #define LCD_PINS_D4                  EXP1_06_PIN  // ST9720 CLK
+    #define BEEPER_PIN                   EXP1_01_PIN
+  #elif ENABLED(ENDER2_STOCKDISPLAY)
+    #define DOGLCD_CS                    EXP1_07_PIN
+    #define DOGLCD_A0                    EXP1_06_PIN
+  #endif
+  #define BTN_ENC                        EXP1_02_PIN
+  #define BTN_EN1                        EXP1_03_PIN
+  #define BTN_EN2                        EXP1_05_PIN
+  #define LCD_PINS_DEFINED
+#endif
+
+#define LCD_SDSS                               31  // Controller's SD card
+
+#include "pins_MELZI.h" // ... SANGUINOLOLU_12 ... SANGUINOLOLU_11
+
+#if ENABLED(BLTOUCH)
+  #ifndef SERVO0_PIN
+    #define SERVO0_PIN                        27
+  #endif
+  #if SERVO0_PIN == BEEPER_PIN
+    #undef BEEPER_PIN
+  #endif
+#elif HAS_FILAMENT_SENSOR
+  #ifndef FIL_RUNOUT_PIN
+    #define FIL_RUNOUT_PIN                    27
+  #endif
+  #if FIL_RUNOUT_PIN == BEEPER_PIN
+    #undef BEEPER_PIN
+  #endif
+#endif
+

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY_E2.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY_E2.h
@@ -21,21 +21,6 @@
  */
 #pragma once
 
-/**
- * Melzi (Creality) pin assignments
- * Schematic: https://green-candy.osdn.jp/external/MarlinFW/board_schematics/Melzi%20(Creality)/CR-10%20Schematic.pdf
- * Origin: https://github.com/Creality3DPrinting/CR10-Melzi-1.1.2/blob/master/Circuit%20diagram/Motherboard/CR-10%20Schematic.pdf
- * ATmega1284P
- *
- * The Creality board needs a bootloader installed before Marlin can be uploaded.
- * If you don't have a chip programmer you can use a spare Arduino plus a few
- * electronic components to write the bootloader.
- *
- * See https://www.instructables.com/id/Burn-Arduino-Bootloader-with-Arduino-MEGA/
- *
- * Schematic: https://bit.ly/2XOnsWb
- */
-
 #define BOARD_INFO_NAME "Melzi Ender 2 (Creality)"
 
 /*
@@ -60,14 +45,14 @@
  *               ------                            ------                               ------
  */
 
-#define EXP1_01_PIN                 7
-#define EXP1_02_PIN                16
-#define EXP1_03_PIN                11
-#define EXP1_04_PIN                -1  // hardware reset line
-#define EXP1_05_PIN                10
-#define EXP1_06_PIN                30
-#define EXP1_07_PIN                28
-#define EXP1_08_PIN                 5
+#define EXP1_01_PIN                            7
+#define EXP1_02_PIN                           16
+#define EXP1_03_PIN                           11
+#define EXP1_04_PIN                           -1  // hardware reset line
+#define EXP1_05_PIN                           10
+#define EXP1_06_PIN                           30
+#define EXP1_07_PIN                           28
+#define EXP1_08_PIN                            5
 
 //
 // LCD / Controller
@@ -77,21 +62,21 @@
     #if ENABLED(SDSUPPORT)
       #error "Cannot have SDSUPPORT with CR10_STOCKDISPLAY on this motherboard." // Hardware SDCARD SCK and MOSI pins are reallocated.
     #endif
-    #define LCD_PINS_RS                  EXP1_07_PIN  // ST9720 CS
-    #define LCD_PINS_EN                  EXP1_08_PIN  // ST9720 DAT
-    #define LCD_PINS_D4                  EXP1_06_PIN  // ST9720 CLK
-    #define BEEPER_PIN                   EXP1_01_PIN
+    #define LCD_PINS_RS              EXP1_07_PIN  // ST9720 CS
+    #define LCD_PINS_EN              EXP1_08_PIN  // ST9720 DAT
+    #define LCD_PINS_D4              EXP1_06_PIN  // ST9720 CLK
+    #define BEEPER_PIN               EXP1_01_PIN
   #elif ENABLED(ENDER2_STOCKDISPLAY)
-    #define DOGLCD_CS                    EXP1_07_PIN
-    #define DOGLCD_A0                    EXP1_06_PIN
+    #define DOGLCD_CS                EXP1_07_PIN
+    #define DOGLCD_A0                EXP1_06_PIN
   #endif
-  #define BTN_ENC                        EXP1_02_PIN
-  #define BTN_EN1                        EXP1_03_PIN
-  #define BTN_EN2                        EXP1_05_PIN
+  #define BTN_ENC                    EXP1_02_PIN
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_05_PIN
   #define LCD_PINS_DEFINED
 #endif
 
-#define LCD_SDSS                               31  // Controller's SD card
+#define LCD_SDSS                              31  // Controller's SD card
 
 #include "pins_MELZI.h" // ... SANGUINOLOLU_12 ... SANGUINOLOLU_11
 
@@ -110,4 +95,3 @@
     #undef BEEPER_PIN
   #endif
 #endif
-


### PR DESCRIPTION
### Description

I recently obtained the motherboard and ENDER2_STOCKDISPLAY from a old Ender 2 that had been scrapped.

This is the Controller (there are no board name or version labels)

![ender_2_mini_39757b84-5b22-4e4b-a74f-8e14a4f68883_1200x_2nd](https://user-images.githubusercontent.com/530024/235132483-f30d772a-cd4c-4e88-9258-3a16267c268f.jpg)

Current example configs for the Ender2 use BOARD_MELZI_CREALITY, while this is close there are several key differences. The obvious being it has a lot more plugs, and the less obvious, different IO pins on the LCD connector EXP1.
I don't know if there are different versions of Ender2 with different motherboards.  So I dont know if the example config should be updated. 

I created a new motherboard BOARD_MELZI_CREALITY_ENDER2 for this board. Including documenting all the connector pins. 
  
### Requirements

Using this motherboard

### Benefits

Pins are correct, in particular CR10_STOCKDISPLAY works as expected. (with limitations that you cannot also use onboard sdcard)

