### PR TITLE
fix ENDER2 STOCKDISPLAY on MELZI_CREALITY

### DIFF
--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -44,21 +44,21 @@
   #define BOARD_ST7920_DELAY_2               125
   #define BOARD_ST7920_DELAY_3               125
 #endif
-/*
- *            EXP1                  EXP1 as ENDER2 STOCKDISPLAY           EXP1 as CR10 STOCKDISPLAY
- *           ------                            ------                               ------
- *      D27 | 1  2 | D16                  SCK | 1  2 | BTN_E            BEEPER_PIN | 1  2 | BTN_ENC
- *      D11 | 3  4 | RESET            BTN_EN1 | 3  4 | RESET               BTN_EN1 | 3  4 | RESET
- *      D10   5  6 | D30              BTN_EN2   5  6 | LCD_A0              BTN_EN2   5  6 | LCD_D4 (ST9720 CLK)
- *      D28 | 7  8 | D17               LCD_CS | 7  8 | MOSI     (ST9720 CS) LCD_RS | 7  8 | LCD_EN (ST9720 DAT)
- *      GND | 9 10 | 5V                   GND | 9 10 | 5V                      GND | 9 10 | 5V
- *           ------                            ------                               ------
- */
 
+/**
+ *       EXP1          EXP1 as ENDER2 STOCKDISPLAY           EXP1 as CR10 STOCKDISPLAY
+ *      ------                    ------                               ------
+ * D27 | 1  2 | D16          SCK | 1  2 | BTN_E            BEEPER_PIN | 1  2 | BTN_ENC
+ * D11 | 3  4 | RESET    BTN_EN1 | 3  4 | RESET               BTN_EN1 | 3  4 | RESET
+ * D10   5  6 | D30      BTN_EN2   5  6 | LCD_A0              BTN_EN2   5  6 | LCD_D4 (ST9720 CLK)
+ * D28 | 7  8 | D17       LCD_CS | 7  8 | MOSI     (ST9720 CS) LCD_RS | 7  8 | LCD_EN (ST9720 DAT)
+ * GND | 9 10 | 5V           GND | 9 10 | 5V                      GND | 9 10 | 5V
+ *      ------                    ------                               ------
+ */
 #define EXP1_01_PIN                           27
 #define EXP1_02_PIN                           16
 #define EXP1_03_PIN                           11
-#define EXP1_04_PIN                           -1  // hardware reset line
+#define EXP1_04_PIN                           -1  // RESET
 #define EXP1_05_PIN                           10
 #define EXP1_06_PIN                           30
 #define EXP1_07_PIN                           28

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -44,53 +44,71 @@
   #define BOARD_ST7920_DELAY_2               125
   #define BOARD_ST7920_DELAY_3               125
 #endif
+/*
+ *            EXP1                  EXP1 as ENDER2 STOCKDISPLAY           EXP1 as CR10 STOCKDISPLAY
+ *           ------                            ------                               ------
+ *      D27 | 1  2 | D16                  SCK | 1  2 | BTN_E            BEEPER_PIN | 1  2 | BTN_ENC
+ *      D11 | 3  4 | RESET            BTN_EN1 | 3  4 | RESET               BTN_EN1 | 3  4 | RESET
+ *      D10   5  6 | D30              BTN_EN2   5  6 | LCD_A0              BTN_EN2   5  6 | LCD_D4 (ST9720 CLK)
+ *      D28 | 7  8 | D17               LCD_CS | 7  8 | MOSI     (ST9720 CS) LCD_RS | 7  8 | LCD_EN (ST9720 DAT)
+ *      GND | 9 10 | 5V                   GND | 9 10 | 5V                      GND | 9 10 | 5V
+ *           ------                            ------                               ------
+ */
+
+#define EXP1_01_PIN                           27
+#define EXP1_02_PIN                           16
+#define EXP1_03_PIN                           11
+#define EXP1_04_PIN                           -1  // hardware reset line
+#define EXP1_05_PIN                           10
+#define EXP1_06_PIN                           30
+#define EXP1_07_PIN                           28
+#define EXP1_08_PIN                           17
 
 //
 // LCD / Controller
 //
 #if ANY(MKS_MINI_12864, CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
-  #if EITHER(CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
-    #define LCD_PINS_RS                       28  // ST9720 CS
-    #define LCD_PINS_EN                       17  // ST9720 DAT
-    #define LCD_PINS_D4                       30  // ST9720 CLK
+  #if ENABLED(MKS_MINI_12864)
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! MKS_MINI_12864 on MELZI_CREALITY requires wiring modifications. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
+    #define DOGLCD_CS                EXP1_07_PIN
+    #define DOGLCD_A0                EXP1_06_PIN
+  #elif ENABLED(CR10_STOCKDISPLAY)
+    #define LCD_PINS_RS              EXP1_07_PIN  // ST9720 CS
+    #define LCD_PINS_EN              EXP1_08_PIN  // ST9720 DAT
+    #define LCD_PINS_D4              EXP1_06_PIN  // ST9720 CLK
+    #define BEEPER_PIN               EXP1_01_PIN
+  #elif ENABLED(ENDER2_STOCKDISPLAY)
+    #define DOGLCD_CS                EXP1_07_PIN
+    #define DOGLCD_A0                EXP1_06_PIN
+    #define DOGLCD_SCK               EXP1_01_PIN
+    #define DOGLCD_MOSI              EXP1_08_PIN
+    #define FORCE_SOFT_SPI
   #endif
-  #if EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
-    #define DOGLCD_CS                         28
-    #define DOGLCD_A0                         30
-  #endif
-
+  #define BTN_ENC                    EXP1_02_PIN
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_05_PIN
   #define LCD_SDSS                            31  // Controller's SD card
-
-  #define BTN_ENC                             16
-  #define BTN_EN1                             11
-  #define BTN_EN2                             10
-  #define BEEPER_PIN                          27
-
   #define LCD_PINS_DEFINED
-
 #endif
 
 #include "pins_MELZI.h" // ... SANGUINOLOLU_12 ... SANGUINOLOLU_11
 
 #if ENABLED(BLTOUCH)
   #ifndef SERVO0_PIN
-    #define SERVO0_PIN                        27
+    #define SERVO0_PIN                EXP1_01_PIN
   #endif
   #if SERVO0_PIN == BEEPER_PIN
     #undef BEEPER_PIN
   #endif
 #elif HAS_FILAMENT_SENSOR
   #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                    27
+    #define FIL_RUNOUT_PIN            EXP1_01_PIN
   #endif
   #if FIL_RUNOUT_PIN == BEEPER_PIN
     #undef BEEPER_PIN
   #endif
-#endif
-
-#if ENABLED(MINIPANEL)
-  #undef DOGLCD_CS
-  #define DOGLCD_CS                  LCD_PINS_RS
 #endif
 
 /**
@@ -139,14 +157,3 @@
   PIN:  30   Port: A1        LCD_PINS_D4                 Output = 1
   PIN:  31   Port: A0        SDSS                        Output = 1
 */
-
-/**
- *    EXP1 Connector                      EXP1 as CR10 STOCKDISPLAY
- *        ------                                      ------
- *   PA4 | 1  2 | PC0                     BEEPER_PIN | 1  2 | BTN_ENC
- *   PD3 | 3  4 | RESET                      BTN_EN1 | 3  4 | RESET
- *   PD2   5  6 | PA1                        BTN_EN2   5  6 | LCD_D4 (ST9720 CLK)
- *   PA3 | 7  8 | PC1             (ST9720 CS) LCD_RS | 7  8 | LCD_EN (ST9720 DAT)
- *   GND | 9 10 | 5V                             GND | 9 10 | 5V
- *        ------                                      ------
- */


### PR DESCRIPTION
### Description

Fulfills FR https://github.com/MarlinFirmware/Marlin/issues/20857

ENDER2_STOCKDISPLAY on a MELZI_CREALITY did not work.
This is due to some confusion over the ender2 melzi motherboard and the melzi creality v1.1.x
Ender 2 melzi Lcd port has hardware SCK and MOSI pins, MELZI_CREALITY does not.

Updated pins_MELZI_CREALITY.h

### Requirements
MELZI_CREALITY with ENDER2_STOCKDISPLAY

### Benefits

LCD work as expected.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/20857
https://github.com/MarlinFirmware/Marlin/pull/25754