### PR TITLE
USB host resets after USB drive removal on STM32 

### DIFF
--- a/Marlin/src/HAL/STM32/usb_host.cpp
+++ b/Marlin/src/HAL/STM32/usb_host.cpp
@@ -44,7 +44,7 @@ static void USBH_UserProcess(USBH_HandleTypeDef *phost, uint8_t id) {
       break;
     case HOST_USER_DISCONNECTION:
       //SERIAL_ECHOLNPGM("APPLICATION_DISCONNECT");
-      //usb.setUsbTaskState(USB_STATE_RUNNING);
+      usb.setUsbTaskState(USB_STATE_INIT);
       break;
     case HOST_USER_CLASS_ACTIVE:
       //SERIAL_ECHOLNPGM("APPLICATION_READY");


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

The USB host now resets when a USB drive is unplugged from a STM32 based board's native USB host port. Previously, the host state was not changed, and behavior was as if a device was connected, but data was not yet accessible; like a hard drive that took literally forever to spin up or "an SD card adapter [that] may not have an SD card in it yet."

In this state a USB status message was sent from the Sd2Card_FlashDrive class to the display and all serial ports every two seconds until a USB drive was connected or the printer restarted: "Waiting for media"

This PR modifies one line of code, uncommenting it and changing the set state to the correct one:

`//usb.setUsbTaskState(USB_STATE_RUNNING);` → `usb.setUsbTaskState(USB_STATE_INIT);`

The USB host now does something on disconnection, and send no messages other than a single disconnection alert.

While this stops the message spam, the STM32 USB host implementation seems very bare bones. Before this PR, the class could only change its state to one of its three (`USB_STATE_INIT`, `USB_STATE_ERROR`, and `USB_STATE_RUNNING`) and still can only handle two of the six states defined in the STM32 USB Host Library. I am currently ill equipped to make any significant changes to the standing implementation, but I also have not noticed any other errors that I can trace back to it. 

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Requires a STM32 based board with `USB_FLASH_DRIVE_SUPPORT` and `USE_OTG_USB_HOST` enabled. My board is a BigTreeTech SKR 2 (Rev. B, F429).

### Benefits

<!-- What does this PR fix or improve? -->

Stops the printer from displaying and sending "Waiting for media" at two second intervals after a USB drive is removed.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

The PR can be tested on the example config for the BIQU B1 SE and BIQU B1 SE Plus in the [MarlinFirmware/Configurations](https://github.com/MarlinFirmware/Configurations/tree/release-2.1.2/config/examples/BIQU) repository.

Another (outdated) configuration is the example in the [bigtreetech/SKR-2](https://github.com/bigtreetech/SKR-2/blob/master/Firmware/) repo.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

I just fixed the bug instead of reporting it, and I did not find any related issues.