### PR TITLE
Bugfix: G12 not working as expected since #25666

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2408,7 +2408,7 @@
   // Default pattern to use when 'P' is not provided to G12. One of the enabled options above.
   #define NOZZLE_CLEAN_DEFAULT_PATTERN 0
 
-  #define NOZZLE_CLEAN_STROKES   12   // Default number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES     12   // Default number of pattern repetitions
 
   #if ENABLED(NOZZLE_CLEAN_PATTERN_ZIGZAG)
     #define NOZZLE_CLEAN_TRIANGLES  3   // Default number of triangles

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2408,9 +2408,7 @@
   // Default pattern to use when 'P' is not provided to G12. One of the enabled options above.
   #define NOZZLE_CLEAN_DEFAULT_PATTERN 0
 
-  #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
-    #define NOZZLE_CLEAN_STROKES   12   // Default number of pattern repetitions
-  #endif
+  #define NOZZLE_CLEAN_STROKES   12   // Default number of pattern repetitions
 
   #if ENABLED(NOZZLE_CLEAN_PATTERN_ZIGZAG)
     #define NOZZLE_CLEAN_TRIANGLES  3   // Default number of triangles

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2408,7 +2408,7 @@
   // Default pattern to use when 'P' is not provided to G12. One of the enabled options above.
   #define NOZZLE_CLEAN_DEFAULT_PATTERN 0
 
-  #if ENABLED(NOZZLE_CLEAN_PATTERN_LINE)
+  #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
     #define NOZZLE_CLEAN_STROKES   12   // Default number of pattern repetitions
   #endif
 

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -65,13 +65,13 @@ void GcodeSuite::G12() {
     #endif
   );
   const uint8_t objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES)),
-		strokes = (
-      #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
-        parser.ushortval('S', NOZZLE_CLEAN_STROKES)
-      #else
-        0
-      #endif
-		);
+                strokes = (
+                  #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
+                    parser.ushortval('S', NOZZLE_CLEAN_STROKES)
+                  #else
+                    0
+                  #endif
+                );
   const float radius = TERN0(NOZZLE_CLEAN_PATTERN_CIRCLE, parser.linearval('R', NOZZLE_CLEAN_CIRCLE_RADIUS));
 
   const bool seenxyz = parser.seen("XYZ");

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -64,14 +64,8 @@ void GcodeSuite::G12() {
       NOZZLE_CLEAN_DEFAULT_PATTERN
     #endif
   );
-  const uint8_t objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES)),
-                strokes = (
-                  #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
-                    parser.ushortval('S', NOZZLE_CLEAN_STROKES)
-                  #else
-                    0
-                  #endif
-                );
+  const uint8_t strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
+	              objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES));
   const float radius = TERN0(NOZZLE_CLEAN_PATTERN_CIRCLE, parser.linearval('R', NOZZLE_CLEAN_CIRCLE_RADIUS));
 
   const bool seenxyz = parser.seen("XYZ");

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -65,7 +65,7 @@ void GcodeSuite::G12() {
     #endif
   );
   const uint8_t strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
-	              objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES));
+                objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES));
   const float radius = TERN0(NOZZLE_CLEAN_PATTERN_CIRCLE, parser.linearval('R', NOZZLE_CLEAN_CIRCLE_RADIUS));
 
   const bool seenxyz = parser.seen("XYZ");

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -64,8 +64,14 @@ void GcodeSuite::G12() {
       NOZZLE_CLEAN_DEFAULT_PATTERN
     #endif
   );
-  const uint8_t strokes = TERN0(NOZZLE_CLEAN_PATTERN_LINE, parser.ushortval('S', NOZZLE_CLEAN_STROKES)),
-                objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES));
+  const uint8_t objects = TERN0(NOZZLE_CLEAN_PATTERN_ZIGZAG, parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES)),
+		strokes = (
+      #if EITHER(NOZZLE_CLEAN_PATTERN_LINE, NOZZLE_CLEAN_PATTERN_ZIGZAG)
+        parser.ushortval('S', NOZZLE_CLEAN_STROKES)
+      #else
+        0
+      #endif
+		);
   const float radius = TERN0(NOZZLE_CLEAN_PATTERN_CIRCLE, parser.linearval('R', NOZZLE_CLEAN_CIRCLE_RADIUS));
 
   const bool seenxyz = parser.seen("XYZ");

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -230,10 +230,9 @@ Nozzle nozzle;
     }
     if (!TEST(cleans, Z_AXIS)) start[arrPos].z = end[arrPos].z = current_position.z;
 
-    switch (pattern) {
-      default:
+    switch (pattern) { // no default clause as pattern is already validated
       #if ENABLED(NOZZLE_CLEAN_PATTERN_LINE)
-        case 0: stroke(start[arrPos], end[arrPos], strokes);
+        case 0: stroke(start[arrPos], end[arrPos], strokes); break;
       #endif
       #if ENABLED(NOZZLE_CLEAN_PATTERN_ZIGZAG)
         case 1: zigzag(start[arrPos], end[arrPos], strokes, objects); break;

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -46,7 +46,7 @@ Nozzle nozzle;
      * @param end xyz_pos_t defining the ending point
      * @param strokes number of strokes to execute
      */
-    void Nozzle::stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes) {
+    void Nozzle::stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t strokes) {
       #if ENABLED(NOZZLE_CLEAN_GOBACK)
         const xyz_pos_t oldpos = current_position;
       #endif
@@ -87,7 +87,7 @@ Nozzle nozzle;
      * @param strokes number of strokes to execute
      * @param objects number of triangles to do
      */
-    void Nozzle::zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes, const uint8_t &objects) {
+    void Nozzle::zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t strokes, const uint8_t objects) {
       const xy_pos_t diff = end - start;
       if (!diff.x || !diff.y) return;
 
@@ -135,7 +135,7 @@ Nozzle nozzle;
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const_float_t radius) {
+    void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const_float_t radius) {
       if (strokes == 0) return;
 
       #if ENABLED(NOZZLE_CLEAN_GOBACK)
@@ -164,7 +164,7 @@ Nozzle nozzle;
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const_float_t radius, const uint8_t &objects, const uint8_t cleans) {
+  void Nozzle::clean(const uint8_t pattern, const uint8_t strokes, const_float_t radius, const uint8_t objects, const uint8_t cleans) {
     xyz_pos_t start[HOTENDS] = NOZZLE_CLEAN_START_POINT, end[HOTENDS] = NOZZLE_CLEAN_END_POINT;
     #if ENABLED(NOZZLE_CLEAN_PATTERN_CIRCLE)
       xyz_pos_t middle[HOTENDS] = NOZZLE_CLEAN_CIRCLE_MIDDLE;

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -41,7 +41,7 @@ class Nozzle {
      * @param end xyz_pos_t defining the ending point
      * @param strokes number of strokes to execute
      */
-    static void stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes) __Os;
+    static void stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t strokes) __Os;
 
     /**
      * @brief Zig-zag clean pattern
@@ -52,7 +52,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param objects number of objects to create
      */
-    static void zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes, const uint8_t &objects) __Os;
+    static void zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t strokes, const uint8_t objects) __Os;
 
     /**
      * @brief Circular clean pattern
@@ -62,7 +62,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const_float_t radius) __Os;
+    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t strokes, const_float_t radius) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
@@ -77,7 +77,7 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const_float_t radius, const uint8_t &objects, const uint8_t cleans) __Os;
+    static void clean(const uint8_t pattern, const uint8_t strokes, const_float_t radius, const uint8_t objects, const uint8_t cleans) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 


### PR DESCRIPTION
### Description
Since #25666, G12 isn't behaving as it should. The code I submitted was changed a bit, causing the following issues:

* Cleaning the nozzle twice, once with the default pattern, once with the requested pattern
* Always using NOZZLE_CLEAN_STROKES for any pattern other than 0 (no parsing of S parameter)
* Only defining NOZZLE_CLEAN_STROKES when NOZZLE_CLEAN_PATTERN_LINE is enabled, though it's used in all patterns

### Requirements
No special requirements

### Benefits

Make G12 work as intended (according to documentation)

### Configurations
Configuration file change is in the pull request, no special config needed.

### Related Issues
Fixes changes/improvements made by thinkyhead in pull request #25666
