### PR TITLE
Added support for two custom boards based on STM32F1 and ESP32

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -391,6 +391,7 @@
 #define BOARD_PANDA_PI_V29            5066  // Panda Pi V2.9 - Standalone (STM32F103RC)
 #define BOARD_SOVOL_V131              5067  // Sovol V1.3.1 (GD32F103RET6)
 #define BOARD_TRIGORILLA_V006         5068  // Trigorilla V0.0.6 (GD32F103RE)
+#define BOARD_KEDI_CONTROLLER_V1_2    5069  // EDUTRONICS Kedi Controller V1.2 (STM32F103RC)
 
 //
 // ARM Cortex-M4F
@@ -479,6 +480,7 @@
 #define BOARD_PANDA_M4                7007  // Panda_M4
 #define BOARD_MKS_TINYBEE             7008  // MKS TinyBee based on ESP32 (with I2S stepper stream)
 #define BOARD_ENWI_ESPNP              7009  // enwi ESPNP based on ESP32 (with I2S stepper stream)
+#define BOARD_GODI_CONTROLLER_V1_0    7010  // Godi Controller based on ESP32 32-Bit V1.0
 
 //
 // SAMD51 ARM Cortex-M4

--- a/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
+++ b/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
@@ -1,0 +1,141 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Godi Controller 32-Bit V1.0 pin assignments
+ *
+ * 3D printer control board based on the ESP32 microcontroller.
+ * Supports 4 stepper drivers, heated bed, single hotend.
+ */
+
+#include "env_validate.h"
+
+#if EXTRUDERS > 1 || E_STEPPERS > 1
+  #error "Godi Controller only supports 1 E stepper."
+#elif HAS_MULTI_HOTEND
+  #error "Godi Controller only supports 1 hotend / E stepper."
+#endif
+
+#define BOARD_INFO_NAME       "Godi Controller 32-Bit V1.0"
+
+//
+// Disable I2S stepper stream, by default
+//
+#undef I2S_STEPPER_STREAM
+#undef I2S_WS
+#undef I2S_BCK
+#undef I2S_DATA
+
+//
+// Limit Switches
+//
+#define X_STOP_PIN                            34
+#define Y_STOP_PIN                            35
+#define Z_STOP_PIN                            15
+
+//
+// Steppers
+//
+#define X_STEP_PIN                            27
+#define X_DIR_PIN                             26
+#define X_ENABLE_PIN                          25
+
+#define Y_STEP_PIN                            33
+#define Y_DIR_PIN                             32
+#define Y_ENABLE_PIN                X_ENABLE_PIN
+
+#define Z_STEP_PIN                            14
+#define Z_DIR_PIN                             12
+#define Z_ENABLE_PIN                X_ENABLE_PIN
+
+#define E0_STEP_PIN                           16
+#define E0_DIR_PIN                            17
+#define E0_ENABLE_PIN               X_ENABLE_PIN
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                            36  // Analog Input
+#define TEMP_BED_PIN                          39  // Analog Input
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                           4
+#define FAN0_PIN                              13
+#define HEATER_BED_PIN                         2
+
+//
+// MicroSD card
+//
+#define SD_MOSI_PIN                           23
+#define SD_MISO_PIN                           19
+#define SD_SCK_PIN                            18
+#define SDSS                                   5
+#define USES_SHARED_SPI                           // SPI is shared by SD card with TMC SPI drivers
+
+#if HAS_TMC_UART
+  //
+  // TMC2209 stepper drivers
+  //
+
+  //
+  // Hardware serial 1
+  //
+  #define X_HARDWARE_SERIAL              Serial1
+  #define Y_HARDWARE_SERIAL              Serial1
+  #define Z_HARDWARE_SERIAL              Serial1
+  #define E0_HARDWARE_SERIAL             Serial1
+
+  #define TMC_BAUD_RATE 115200
+#endif
+
+/**
+ * Hardware serial pins
+ *
+ * Override these pins in Configuration.h or Configuration_adv.h if needed.
+ *
+ * Note: Serial2 can be defined using HARDWARE_SERIAL2_RX and HARDWARE_SERIAL2_TX
+ *       but Godi Controller 32-Bit does not have enough spare pins for such reassignment.
+ */
+#ifndef HARDWARE_SERIAL1_RX
+  #define HARDWARE_SERIAL1_RX                 21
+#endif
+#ifndef HARDWARE_SERIAL1_TX
+  #define HARDWARE_SERIAL1_TX                 22
+#endif
+
+//
+// Heaters / Fans
+//
+
+#if EITHER(EDUTRONICS_12864OLED_SH1106, EDUTRONICS_12864OLED_SSD1306)
+  #define LCDSCREEN_NAME "EDUTRONICS 12864 OLED"
+  #define BTN_EN2                             1
+  #define BTN_EN1                             3
+  #define BTN_ENC                             0
+  #define BEEPER_PIN                          -1
+  #define KILL_PIN                            -1
+  #define DOGLCD_SDA                          21  // SDA
+  #define DOGLCD_SCL                          22  // SCL
+#endif // OLED 128x64

--- a/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
+++ b/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -33,7 +33,7 @@
 #if EXTRUDERS > 1 || E_STEPPERS > 1
   #error "Godi Controller only supports 1 E stepper."
 #elif HAS_MULTI_HOTEND
-  #error "Godi Controller only supports 1 hotend / E stepper."
+  #error "Godi Controller only supports 1 hotend."
 #endif
 
 #define BOARD_INFO_NAME       "Godi Controller 32-Bit V1.0"
@@ -131,11 +131,11 @@
 
 #if EITHER(EDUTRONICS_12864OLED_SH1106, EDUTRONICS_12864OLED_SSD1306)
   #define LCDSCREEN_NAME "EDUTRONICS 12864 OLED"
-  #define BTN_EN2                             1
-  #define BTN_EN1                             3
-  #define BTN_ENC                             0
+  #define BTN_EN2                              1
+  #define BTN_EN1                              3
+  #define BTN_ENC                              0
   #define BEEPER_PIN                          -1
   #define KILL_PIN                            -1
   #define DOGLCD_SDA                          21  // SDA
   #define DOGLCD_SCL                          22  // SCL
-#endif // OLED 128x64
+#endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -689,7 +689,7 @@
 #elif MB(TRIGORILLA_V006)
   #include "gd32f1/pins_TRIGORILLA_V006.h"      // GD32F103                               env:trigorilla_v006
 #elif MB(KEDI_CONTROLLER_V1_2)
-  #include "stm32f1/pins_KEDI_CONTROLLER_V1_2.h"// STM32F1                                env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
+  #include "stm32f1/pins_KEDI_CONTROLLER_V1_2.h" // STM32F1                               env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -688,6 +688,8 @@
   #include "gd32f1/pins_SOVOL_V131.h"           // GD32F1                                 env:GD32F103RET6_sovol_maple
 #elif MB(TRIGORILLA_V006)
   #include "gd32f1/pins_TRIGORILLA_V006.h"      // GD32F103                               env:trigorilla_v006
+#elif MB(KEDI_CONTROLLER_V1_2)
+  #include "stm32f1/pins_KEDI_CONTROLLER_V1_2.h"// STM32F1                                env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 
 //
 // ARM Cortex-M4F
@@ -838,6 +840,8 @@
   #include "esp32/pins_MKS_TINYBEE.h"           // ESP32                                  env:mks_tinybee
 #elif MB(ENWI_ESPNP)
   #include "esp32/pins_ENWI_ESPNP.h"            // ESP32                                  env:esp32
+#elif MB(GODI_CONTROLLER_V1_0)
+  #include "esp32/pins_GODI_CONTROLLER_V1_0.h"  // ESP32                                  env:godi_esp32
 
 //
 // Adafruit Grand Central M4 (SAMD51 ARM Cortex-M4)

--- a/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -68,15 +68,14 @@
 #define E0_DIR_PIN                          PB0
 #define E0_ENABLE_PIN                       PC4
 
-
 // Special Drivers
 
 // L6470 or L6474 on SPI
-#if HAS_DRIVER(L6470) || HAS_DRIVER(L6474) // Shared with SPI on EXP2
-    #define L6470_CHAIN_SCK_PIN                      PB3
-    #define L6470_CHAIN_MISO_PIN                     PB4
-    #define L6470_CHAIN_MOSI_PIN                     PB5
-    #define L6470_CHAIN_SS_PIN                     	 PA15
+#if HAS_DRIVER(L6470) || HAS_DRIVER(L6474)        // Shared with SPI on EXP2
+    #define L6470_CHAIN_SCK_PIN             PB3
+    #define L6470_CHAIN_MISO_PIN            PB4
+    #define L6470_CHAIN_MOSI_PIN            PB5
+    #define L6470_CHAIN_SS_PIN              PA15
 	#define ENABLE_RESET_L64XX_CHIPS
 #endif
 
@@ -97,48 +96,46 @@
 // CS Pins (One pin for each driver)
 #if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC2160) || HAS_DRIVER(TMC2660) || HAS_DRIVER(TMC5130) || HAS_DRIVER(TMC5160)
  #ifndef X_CS_PIN
-  #define X_CS_PIN	                    PC10
+  #define X_CS_PIN                          PC10
  #endif
  #ifndef Y_CS_PIN
-  #define Y_CS_PIN	                    PC11
+  #define Y_CS_PIN                          PC11
  #endif
  #ifndef Z_CS_PIN
-  #define Z_CS_PIN	                    PC12
+  #define Z_CS_PIN                          PC12
  #endif
  #ifndef E0_CS_PIN
-  #define E0_CS_PIN	                    PC14
+  #define E0_CS_PIN                         PC14
  #endif
 #endif
-
 
 // TMC2208 or TMC2209 on UART
 #if HAS_DRIVER(TMC2208) || HAS_DRIVER(TMC2209)
 
 // UART Pins (Single pin for both RX & TX)
  #ifndef X_PIN_UART
-  #define X_PIN_UART					PC10
+  #define X_PIN_UART                        PC10
  #endif
  #ifndef Y_PIN_UART
-  #define Y_PIN_UART					PC11
+  #define Y_PIN_UART                        PC11
  #endif
  #ifndef Z_PIN_UART
-  #define Z_PIN_UART					PC12
+  #define Z_PIN_UART                        PC12
  #endif
  #ifndef E0_PIN_UART
-  #define E0_PIN_UART					PC14
+  #define E0_PIN_UART                       PC14
  #endif
 
 // Configurating Pins
-#define X_SERIAL_TX_PIN X_PIN_UART
-#define X_SERIAL_RX_PIN X_PIN_UART
-#define Y_SERIAL_TX_PIN Y_PIN_UART
-#define Y_SERIAL_RX_PIN Y_PIN_UART
-#define Z_SERIAL_TX_PIN Z_PIN_UART
-#define Z_SERIAL_RX_PIN Z_PIN_UART
-#define E0_SERIAL_TX_PIN E0_PIN_UART
-#define E0_SERIAL_RX_PIN E0_PIN_UART
+#define X_SERIAL_TX_PIN               X_PIN_UART
+#define X_SERIAL_RX_PIN               X_PIN_UART
+#define Y_SERIAL_TX_PIN               Y_PIN_UART
+#define Y_SERIAL_RX_PIN               Y_PIN_UART
+#define Z_SERIAL_TX_PIN               Z_PIN_UART
+#define Z_SERIAL_RX_PIN               Z_PIN_UART
+#define E0_SERIAL_TX_PIN             E0_PIN_UART
+#define E0_SERIAL_RX_PIN             E0_PIN_UART
 #endif
-
 
 //
 // Heaters / Fans
@@ -298,4 +295,3 @@
 #endif
 #define ONBOARD_SPI_DEVICE                     1  // SPI1
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
-

--- a/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
@@ -1,0 +1,301 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "env_validate.h"
+
+#define BOARD_INFO_NAME "Kedi Controller 32-Bit V1.2"
+
+//#define DISABLE_DEBUG
+#define DISABLE_JTAG
+
+// Ignore temp readings during development.
+//#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
+
+#if EITHER(NO_EEPROM_SELECTED, FLASH_EEPROM_EMULATION)
+  #define FLASH_EEPROM_EMULATION
+  #define EEPROM_PAGE_SIZE     (0x800U)           // 2KB
+  #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
+  #define MARLIN_EEPROM_SIZE    EEPROM_PAGE_SIZE  // 2KB
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN                           PC2
+#define X_MAX_PIN                           PA2
+#define Y_MIN_PIN                           PC1
+#define Y_MAX_PIN                           PA1
+#define Z_MIN_PIN                           PC0
+#define Z_MAX_PIN                           PC3
+
+//
+// Steppers
+//
+
+#define X_STEP_PIN                          PC6
+#define X_DIR_PIN                           PC7
+#define X_ENABLE_PIN                        PB15
+
+#define Y_STEP_PIN                          PB13
+#define Y_DIR_PIN                           PB14
+#define Y_ENABLE_PIN                        PB12
+
+#define Z_STEP_PIN                          PB10
+#define Z_DIR_PIN                           PB11
+#define Z_ENABLE_PIN                        PB2
+
+#define E0_STEP_PIN                         PC5
+#define E0_DIR_PIN                          PB0
+#define E0_ENABLE_PIN                       PC4
+
+
+// Special Drivers
+
+// L6470 or L6474 on SPI
+#if HAS_DRIVER(L6470) || HAS_DRIVER(L6474) // Shared with SPI on EXP2
+    #define L6470_CHAIN_SCK_PIN                      PB3
+    #define L6470_CHAIN_MISO_PIN                     PB4
+    #define L6470_CHAIN_MOSI_PIN                     PB5
+    #define L6470_CHAIN_SS_PIN                     	 PA15
+	#define ENABLE_RESET_L64XX_CHIPS
+#endif
+
+// TMC2130 on SPI
+//  SPI Pins (Shared for all drivers)
+#if ENABLED(TMC_USE_SW_SPI)                       // Shared with EXP2
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK                      PB3
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO                     PB4
+  #endif
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI                     PB5
+  #endif
+#endif
+
+// CS Pins (One pin for each driver)
+#if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC2160) || HAS_DRIVER(TMC2660) || HAS_DRIVER(TMC5130) || HAS_DRIVER(TMC5160)
+ #ifndef X_CS_PIN
+  #define X_CS_PIN	                    PC10
+ #endif
+ #ifndef Y_CS_PIN
+  #define Y_CS_PIN	                    PC11
+ #endif
+ #ifndef Z_CS_PIN
+  #define Z_CS_PIN	                    PC12
+ #endif
+ #ifndef E0_CS_PIN
+  #define E0_CS_PIN	                    PC14
+ #endif
+#endif
+
+
+// TMC2208 or TMC2209 on UART
+#if HAS_DRIVER(TMC2208) || HAS_DRIVER(TMC2209)
+
+// UART Pins (Single pin for both RX & TX)
+ #ifndef X_PIN_UART
+  #define X_PIN_UART					PC10
+ #endif
+ #ifndef Y_PIN_UART
+  #define Y_PIN_UART					PC11
+ #endif
+ #ifndef Z_PIN_UART
+  #define Z_PIN_UART					PC12
+ #endif
+ #ifndef E0_PIN_UART
+  #define E0_PIN_UART					PC14
+ #endif
+
+// Configurating Pins
+#define X_SERIAL_TX_PIN X_PIN_UART
+#define X_SERIAL_RX_PIN X_PIN_UART
+#define Y_SERIAL_TX_PIN Y_PIN_UART
+#define Y_SERIAL_RX_PIN Y_PIN_UART
+#define Z_SERIAL_TX_PIN Z_PIN_UART
+#define Z_SERIAL_RX_PIN Z_PIN_UART
+#define E0_SERIAL_TX_PIN E0_PIN_UART
+#define E0_SERIAL_RX_PIN E0_PIN_UART
+#endif
+
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PA8
+#define FAN0_PIN                            PC8
+#define HEATER_BED_PIN                      PC9
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN                        PB1   // Analog Input
+#define TEMP_0_PIN                          PA0   // Analog Input
+
+/**                ------                                    ------
+ *  (BEEPER) PC10 |10  9 | PC11 (BTN_ENC)        (MISO) PB4 |10  9 | PB3   (SCK)
+ *  (LCD_EN) PB6  | 8  7 | PC12  (LCD_RS)     (BTN_EN1) PD2 | 8  7 | PA15  (SD_SS)
+ *  (LCD_D4) PC13   6  5 | PB7   (LCD_D5)     (BTN_EN2) PB8   6  5 | PB5   (MOSI)
+ *  (LCD_D6) PC15 | 4  3 | PC14  (LCD_D7)   (SD_DETECT) PB9 | 4  3 | RESET
+ *            GND | 2  1 | 5V                           GND | 2  1 | --
+ *                 ------                                    ------
+ *                  EXP1                                      EXP2
+ */
+#define EXP1_03_PIN                         PC14
+#define EXP1_04_PIN                         PC15
+#define EXP1_05_PIN                         PB7
+#define EXP1_06_PIN                         PC13
+#define EXP1_07_PIN                         PC12
+#define EXP1_08_PIN                         PB6
+#define EXP1_09_PIN                         PC11
+#define EXP1_10_PIN                         PC10
+
+#define EXP2_03_PIN                         -1    // RESET
+#define EXP2_04_PIN                         PB9
+#define EXP2_05_PIN                         PB5
+#define EXP2_06_PIN                         PB8
+#define EXP2_07_PIN                         PA15
+#define EXP2_08_PIN                         PD2
+#define EXP2_09_PIN                         PB3
+#define EXP2_10_PIN                         PB4
+
+//
+// LCD / Controller
+//
+#if HAS_WIRED_LCD
+  #define BEEPER_PIN                 EXP1_10_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #define LCD_PINS_RS              EXP1_04_PIN
+
+    #define BTN_EN1                  EXP1_08_PIN
+    #define BTN_EN2                  EXP1_06_PIN
+
+    #define LCD_PINS_ENABLE          EXP1_03_PIN
+    #define LCD_PINS_D4              EXP1_05_PIN
+
+  #elif IS_TFTGLCD_PANEL
+
+    #undef BEEPER_PIN
+    #undef BTN_ENC
+
+    #if ENABLED(TFTGLCD_PANEL_SPI)
+      #define TFTGLCD_CS             EXP2_08_PIN
+    #endif
+
+    #define SD_DETECT_PIN            EXP2_04_PIN
+
+  #else
+
+    #define LCD_PINS_RS              EXP1_07_PIN
+
+    #define BTN_EN1                  EXP2_08_PIN
+    #define BTN_EN2                  EXP2_06_PIN
+
+    #define LCD_PINS_ENABLE          EXP1_08_PIN
+
+    #if ENABLED(FYSETC_MINI_12864)
+
+      #define LCD_BACKLIGHT_PIN             -1
+      #define LCD_RESET_PIN          EXP1_06_PIN
+      #define DOGLCD_A0              EXP1_07_PIN
+      #define DOGLCD_CS              EXP1_08_PIN
+      #define DOGLCD_SCK             EXP2_09_PIN
+      #define DOGLCD_MOSI            EXP2_05_PIN
+
+      #define FORCE_SOFT_SPI                      // SPI MODE3
+
+      #define LED_PIN                EXP1_05_PIN   // red pwm
+      //#define LED_PIN              EXP1_04_PIN  // green
+      //#define LED_PIN              EXP1_03_PIN  // blue
+
+      //#if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+      //  #ifndef RGB_LED_R_PIN
+      //    #define RGB_LED_R_PIN    EXP1_05_PIN
+      //  #endif
+      //  #ifndef RGB_LED_G_PIN
+      //    #define RGB_LED_G_PIN    EXP1_04_PIN
+      //  #endif
+      //  #ifndef RGB_LED_B_PIN
+      //    #define RGB_LED_B_PIN    EXP1_03_PIN
+      //  #endif
+      //#elif ENABLED(FYSETC_MINI_12864_2_1)
+      //  #define NEOPIXEL_PIN       EXP1_05_PIN
+      //#endif
+
+    #else                                         // !FYSETC_MINI_12864
+
+      #define LCD_PINS_D4            EXP1_06_PIN
+      #if IS_ULTIPANEL
+        #define LCD_PINS_D5          EXP1_05_PIN
+        #define LCD_PINS_D6          EXP1_04_PIN
+        #define LCD_PINS_D7          EXP1_03_PIN
+
+        #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+          #define BTN_ENC_EN         LCD_PINS_D7  // Detect the presence of the encoder
+        #endif
+
+      #endif
+
+    #endif // !FYSETC_MINI_12864
+
+    // Alter timing for graphical display
+    #if IS_U8GLIB_ST7920
+      #define BOARD_ST7920_DELAY_1           125
+      #define BOARD_ST7920_DELAY_2           125
+      #define BOARD_ST7920_DELAY_3           125
+    #endif
+
+  #endif
+
+#endif // HAS_WIRED_LCD
+
+//
+// SD Card
+//
+
+// By default the onboard SD is enabled.
+// Change SDCARD_CONNECTION from 'ONBOARD' to 'LCD' for an external (LCD module) SD
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
+#if SD_CONNECTION_IS(LCD)
+  #define SPI_DEVICE                           3
+  #define SD_DETECT_PIN              EXP2_04_PIN
+  #define SD_SCK_PIN                 EXP2_09_PIN
+  #define SD_MISO_PIN                EXP2_10_PIN
+  #define SD_MOSI_PIN                EXP2_05_PIN
+  #define SD_SS_PIN                  EXP2_07_PIN
+#elif SD_CONNECTION_IS(ONBOARD)
+  #define SD_DETECT_PIN                     PA3
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+  #define SD_SS_PIN                         PA4
+#endif
+#define ONBOARD_SPI_DEVICE                     1  // SPI1
+#define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
+

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -44,5 +44,5 @@ board_build.partitions = default_8MB.csv
 [env:godi_esp32]
 extends                = env:esp32
 board_build.partitions = Marlin/src/HAL/ESP32/esp32.csv
-upload_speed     = 115200
-monitor_speed    = 115200
+upload_speed           = 115200
+monitor_speed          = 115200

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -40,3 +40,9 @@ monitor_speed          = 115200
 [env:mks_tinybee]
 extends                = env:esp32
 board_build.partitions = default_8MB.csv
+
+[env:godi_esp32]
+extends                = env:esp32
+board_build.partitions = Marlin/src/HAL/ESP32/esp32.csv
+upload_speed     = 115200
+monitor_speed    = 115200


### PR DESCRIPTION
### Description

Added support for two custom boards, Kedi Controller based on STM32F1 and Godi Controller based on ESP32

Hello,
We have created two custom boards for our students to get familiar with Marlin and 3D printing in advanced level.
We are submitting this pull request so that our students be able to just pick the correct board from Marlin firmware and don't have to go through all the hassles of adding the boards manually with each version. Thank you for you help.

Here are the pictures of our boards:
<img src="https://aktronics.net/wp-content/uploads/2023/05/Kedi_Controller_based_on_STM32F1.jpg"  alt="Kedi" width="30%"> <img src="https://aktronics.net/wp-content/uploads/2023/05/Godi_Controller_based_on_ESP32.jpg"  alt="Godi" width="30%">

### Requirements

This code require our custom boards.

### Benefits

It will help our students be able to use our boards with Marlşn Firmware without the need to adding them to newer version of marlin after every update.

### Configurations

Both boards works with default configurations but I have attached our test configurations and our marlin test folders:

Just the config files: [Marlin-Tested-with-Kedi-Godi-Controller-Just-Config-Files.zip](https://github.com/MarlinFirmware/Marlin/files/11429510/Marlin-Tested-with-Kedi-Godi-Controller-Just-Config-Files.zip)

Full marlin folder: [Marlin-Tested-with-Kedi-Godi-Controller.zip](https://aktronics.net/wp-content/uploads/2023/05/Marlin-Tested-with-Kedi-Godi-Controller.zip)

### Related Issues

There was no issues or error with our tests.
