### PR TITLE
Improve config editor compatibility

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3374,8 +3374,8 @@
 // affecting heaters, and the fan if FAN_SOFT_PWM is enabled.
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
-// :[1,2,3,4,5,6,7]
-//#define SOFT_PWM_SCALE 1
+// :[0,1,2,3,4,5,6,7]
+#define SOFT_PWM_SCALE 0
 
 // If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
 // be used to mitigate the associated resolution loss. If enabled,

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3374,8 +3374,8 @@
 // affecting heaters, and the fan if FAN_SOFT_PWM is enabled.
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
-// :[0,1,2,3,4,5,6,7]
-#define SOFT_PWM_SCALE 0
+// :[1,2,3,4,5,6,7]
+//#define SOFT_PWM_SCALE 1
 
 // If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
 // be used to mitigate the associated resolution loss. If enabled,

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -3479,6 +3479,10 @@ void Temperature::isr() {
 
   static int8_t temp_count = -1;
   static ADCSensorState adc_sensor_state = StartupDelay;
+
+  #ifndef SOFT_PWM_SCALE
+    #define SOFT_PWM_SCALE 0
+  #endif
   static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
 
   // Avoid multiple loads of pwm_count

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -41,10 +41,6 @@
   #include "../feature/fancheck.h"
 #endif
 
-#ifndef SOFT_PWM_SCALE
-  #define SOFT_PWM_SCALE 0
-#endif
-
 #define HOTEND_INDEX TERN(HAS_MULTI_HOTEND, e, 0)
 #define E_NAME TERN_(HAS_MULTI_HOTEND, e)
 


### PR DESCRIPTION
Undefined SOFT_PWM_SCALE is automatically set by code to 0.
Since new editor configurator, when value is 0, shows parameter as enabled and when from editor you disable such parameter it add a double /, why not to disable it by default? and remove 0 as valid value?