### PR TITLE
no x axis followup 

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -824,7 +824,9 @@ public:
     el bits;
     // x, y, z ... e0, e1, e2 ... hx, hy, hz
     struct {
-      bool NUM_AXIS_LIST(x:1, y:1, z:1, i:1, j:1, k:1, u:1, v:1, w:1);
+      #if HAS_X_AXIS
+        bool NUM_AXIS_LIST(x:1, y:1, z:1, i:1, j:1, k:1, u:1, v:1, w:1);
+      #endif
       #define _EN_ITEM(N) bool e##N:1;
       REPEAT(EXTRUDERS,_EN_ITEM)
       #undef _EN_ITEM
@@ -834,7 +836,9 @@ public:
     };
     // X, Y, Z ... E0, E1, E2 ... HX, HY, HZ
     struct {
-      bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
+      #if HAS_X_AXIS
+        bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
+      #endif
       #define _EN_ITEM(N) bool E##N:1;
       REPEAT(EXTRUDERS,_EN_ITEM)
       #undef _EN_ITEM

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -824,7 +824,7 @@ public:
     el bits;
     // x, y, z ... e0, e1, e2 ... hx, hy, hz
     struct {
-      #if HAS_X_AXIS
+      #if NUM_AXES
         bool NUM_AXIS_LIST(x:1, y:1, z:1, i:1, j:1, k:1, u:1, v:1, w:1);
       #endif
       #define _EN_ITEM(N) bool e##N:1;
@@ -836,7 +836,7 @@ public:
     };
     // X, Y, Z ... E0, E1, E2 ... HX, HY, HZ
     struct {
-      #if HAS_X_AXIS
+      #if NUM_AXES
         bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
       #endif
       #define _EN_ITEM(N) bool E##N:1;

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -73,7 +73,9 @@ typedef struct {
   union {
     ena_mask_t bits;
     struct {
-      bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
+      #if HAS_X_AXIS
+        bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
+      #endif
       #if E_STATES
         bool LIST_N(E_STATES, E0:1, E1:1, E2:1, E3:1, E4:1, E5:1, E6:1, E7:1);
       #endif

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -73,7 +73,7 @@ typedef struct {
   union {
     ena_mask_t bits;
     struct {
-      #if HAS_X_AXIS
+      #if NUM_AXES
         bool NUM_AXIS_LIST(X:1, Y:1, Z:1, I:1, J:1, K:1, U:1, V:1, W:1);
       #endif
       #if E_STATES

--- a/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
@@ -80,17 +80,6 @@
 //
 // Steppers
 //
-#define X_ENABLE_PIN                        -1
-#define X_STEP_PIN                          PA10  // Unused. Assigned so Marlin will compile
-#define X_DIR_PIN                           -1
-
-#define Y_ENABLE_PIN                        -1
-#define Y_STEP_PIN                          PA10  // Unused. Assigned so Marlin will compile
-#define Y_DIR_PIN                           -1
-
-#define Z_ENABLE_PIN                        -1
-#define Z_STEP_PIN                          PA10  // Unused. Assigned so Marlin will compile
-#define Z_DIR_PIN                           -1
 
 #define E0_ENABLE_PIN                       PD2
 #define E0_STEP_PIN                         PD0


### PR DESCRIPTION
### Description

Attempts to build with only a E fails on `bool NUM_AXIS_LIST(x:1, y:1, z:1, i:1, j:1, k:1, u:1, v:1, w:1);` when there are none.
enclosed in a #if block

Also remove fake X,Y and Z stepper pins from pins_BTT_EBB42_V1_1.h

### Requirements

system with only E axis 

### Benefits

Builds as expected

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/11439392/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/25418
