### PR TITLE
Multi Part Cooling Fans With M106 & M107 

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3383,6 +3383,10 @@
 // duty cycle is attained.
 //#define SOFT_PWM_DITHER
 
+//Use Additional Pwn fan headers for partcooling allowing up to 3 total part cooling fans that are controlled thru M106 & M107
+//#define EXTRA_PARTCOOLER_FAN1 //Also use Fan1 for part cooling 
+//#define EXTRA_PARTCOOLER_FAN2 //Also use Fan2 for part cooling
+
 // @section extras
 
 // Support for the BariCUDA Paste Extruder

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3384,8 +3384,9 @@
 //#define SOFT_PWM_DITHER
 
 //Use Additional Pwn fan headers for partcooling allowing up to 3 total part cooling fans that are controlled thru M106 & M107
-//#define EXTRA_PARTCOOLER_FAN1 //Also use Fan1 for part cooling 
-//#define EXTRA_PARTCOOLER_FAN2 //Also use Fan2 for part cooling
+//#define EXTRA_PARTCOOLER_FAN1 //Also use Fan1 for part cooling (Dual)
+//#define EXTRA_PARTCOOLER_FAN2 //Also use Fan2 for part cooling (Tri)
+//#define EXTRA_PARTCOOLER_FAN3 //Also use Fan3 for part cooling (Quad)
 
 // @section extras
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3383,7 +3383,7 @@
 // duty cycle is attained.
 //#define SOFT_PWM_DITHER
 
-//Use Additional Pwn fan headers for partcooling allowing up to 3 total part cooling fans that are controlled thru M106 & M107
+//Use Additional Pwn fan headers for partcooling allowing up to 4 total part cooling fans that are controlled thru M106 & M107
 //#define EXTRA_PARTCOOLER_FAN1 //Also use Fan1 for part cooling (Dual)
 //#define EXTRA_PARTCOOLER_FAN2 //Also use Fan2 for part cooling (Tri)
 //#define EXTRA_PARTCOOLER_FAN3 //Also use Fan3 for part cooling (Quad)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3383,11 +3383,6 @@
 // duty cycle is attained.
 //#define SOFT_PWM_DITHER
 
-//Use Additional Pwn fan headers for partcooling allowing up to 4 total part cooling fans that are controlled thru M106 & M107
-//#define EXTRA_PARTCOOLER_FAN1 //Also use Fan1 for part cooling (Dual)
-//#define EXTRA_PARTCOOLER_FAN2 //Also use Fan2 for part cooling (Tri)
-//#define EXTRA_PARTCOOLER_FAN3 //Also use Fan3 for part cooling (Quad)
-
 // @section extras
 
 // Support for the BariCUDA Paste Extruder

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -660,11 +660,11 @@
 #endif
 
 /**
- * Use of the PWM fans for multi part cooling fans 2-4 total
+ * Assign more PWM fans for part cooling, synchronized with Fan 0
  */
-//#define REDUNDANT_PART_COOLING_FAN 1  // Index of the fan to sync with FAN 0.
-#if ENABLED (REDUNDANT_PART_COOLING_FAN)
-//#define EXTRA_PART_COOLING 2  // add 1-2 additional part cooling fans
+//#define REDUNDANT_PART_COOLING_FAN 1  // Index of the first fan to synchronize with Fan 0
+#ifdef REDUNDANT_PART_COOLING_FAN
+  //#define NUM_REDUNDANT_FANS 1        // Number of sequential fans to synchronize with Fan 0
 #endif
 
 // @section extruder

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -660,9 +660,12 @@
 #endif
 
 /**
- * Use one of the PWM fans as a redundant part-cooling fan
+ * Use of the PWM fans for multi part cooling fans 2-4 total
  */
-//#define REDUNDANT_PART_COOLING_FAN 2  // Index of the fan to sync with FAN 0.
+//#define REDUNDANT_PART_COOLING_FAN 1  // Index of the fan to sync with FAN 0.
+#if ENABLED (REDUNDANT_PART_COOLING_FAN)
+//#define EXTRA_PART_COOLING 2  // add 1-2 additional part cooling fans
+#endif
 
 // @section extruder
 

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -98,6 +98,10 @@ void GcodeSuite::M106() {
   thermalManager.set_fan_speed(2, speed);
   #endif
 
+  #if ENABLED (EXTRA_PARTCOOLER_FAN3)
+  thermalManager.set_fan_speed(3, speed);
+  #endif
+
   TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
 
   if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
@@ -124,6 +128,9 @@ void GcodeSuite::M107() {
   thermalManager.set_fan_speed(2, 0);
   #endif
 
+  #if ENABLED (EXTRA_PARTCOOLER_FAN3)
+  thermalManager.set_fan_speed(3, 0);
+  #endif
 
   if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
     thermalManager.set_fan_speed(1 - pfan, 0);

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -89,17 +89,11 @@ void GcodeSuite::M106() {
 
   // Set speed, with constraint
   thermalManager.set_fan_speed(pfan, speed);
-  
-  #if ENABLED (EXTRA_PARTCOOLER_FAN1)
-  thermalManager.set_fan_speed(1, speed);
-  #endif
-
-  #if ENABLED (EXTRA_PARTCOOLER_FAN2)
-  thermalManager.set_fan_speed(2, speed);
-  #endif
-
-  #if ENABLED (EXTRA_PARTCOOLER_FAN3)
-  thermalManager.set_fan_speed(3, speed);
+   
+  #if EXTRA_PART_COOLING == 1
+  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 1, speed);
+  #elif EXTRA_PART_COOLING == 2
+  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 2, speed);
   #endif
 
   TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
@@ -119,19 +113,13 @@ void GcodeSuite::M107() {
   #endif
 
   thermalManager.set_fan_speed(pfan, 0);
+
+  #if EXTRA_PART_COOLING == 1
+  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 1, 0);
+  #elif EXTRA_PART_COOLING == 2
+  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 2, 0);
+  #endif
   
-  #if ENABLED (EXTRA_PARTCOOLER_FAN1)
-  thermalManager.set_fan_speed(1, 0);
-  #endif
-
-  #if ENABLED (EXTRA_PARTCOOLER_FAN2)
-  thermalManager.set_fan_speed(2, 0);
-  #endif
-
-  #if ENABLED (EXTRA_PARTCOOLER_FAN3)
-  thermalManager.set_fan_speed(3, 0);
-  #endif
-
   if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
     thermalManager.set_fan_speed(1 - pfan, 0);
 

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -89,6 +89,14 @@ void GcodeSuite::M106() {
 
   // Set speed, with constraint
   thermalManager.set_fan_speed(pfan, speed);
+  
+  #if ENABLED (EXTRA_PARTCOOLER_FAN1)
+  thermalManager.set_fan_speed(1, speed);
+  #endif
+
+  #if ENABLED (EXTRA_PARTCOOLER_FAN2)
+  thermalManager.set_fan_speed(2, speed);
+  #endif
 
   TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
 
@@ -107,6 +115,15 @@ void GcodeSuite::M107() {
   #endif
 
   thermalManager.set_fan_speed(pfan, 0);
+  
+  #if ENABLED (EXTRA_PARTCOOLER_FAN1)
+  thermalManager.set_fan_speed(1, 0);
+  #endif
+
+  #if ENABLED (EXTRA_PARTCOOLER_FAN2)
+  thermalManager.set_fan_speed(2, 0);
+  #endif
+
 
   if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
     thermalManager.set_fan_speed(1 - pfan, 0);

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -61,9 +61,7 @@
 void GcodeSuite::M106() {
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
-  #if REDUNDANT_PART_COOLING_FAN
-    if (pfan == REDUNDANT_PART_COOLING_FAN) return;
-  #endif
+  if (FAN_IS_REDUNDANT(pfan)) return;
 
   #if ENABLED(EXTRA_FAN_SPEED)
     const uint16_t t = parser.intval('T');
@@ -89,12 +87,6 @@ void GcodeSuite::M106() {
 
   // Set speed, with constraint
   thermalManager.set_fan_speed(pfan, speed);
-   
-  #if EXTRA_PART_COOLING == 1
-  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 1, speed);
-  #elif EXTRA_PART_COOLING == 2
-  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 2, speed);
-  #endif
 
   TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));
 
@@ -108,18 +100,10 @@ void GcodeSuite::M106() {
 void GcodeSuite::M107() {
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
-  #if REDUNDANT_PART_COOLING_FAN
-    if (pfan == REDUNDANT_PART_COOLING_FAN) return;
-  #endif
+  if (FAN_IS_REDUNDANT(pfan)) return;
 
   thermalManager.set_fan_speed(pfan, 0);
 
-  #if EXTRA_PART_COOLING == 1
-  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 1, 0);
-  #elif EXTRA_PART_COOLING == 2
-  thermalManager.set_fan_speed(REDUNDANT_PART_COOLING_FAN + 2, 0);
-  #endif
-  
   if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
     thermalManager.set_fan_speed(1 - pfan, 0);
 

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -1280,3 +1280,8 @@
   #define MULTISTEPPING_LIMIT 128
   #define MULTISTEPPING_LIMIT_WARNING 1
 #endif
+
+// One redundant cooling fan by default
+#if defined(REDUNDANT_PART_COOLING_FAN) && !defined(NUM_REDUNDANT_FANS)
+  #define NUM_REDUNDANT_FANS 1
+#endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1841,10 +1841,10 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 #endif
 
 #ifdef REDUNDANT_PART_COOLING_FAN
-  #if FAN_COUNT < 2
+  #if FAN_COUNT < 1
     #error "REDUNDANT_PART_COOLING_FAN requires a board with at least two PWM fans."
   #else
-    static_assert(WITHIN(REDUNDANT_PART_COOLING_FAN, 1, FAN_COUNT - 1), "REDUNDANT_PART_COOLING_FAN must be between 1 and " STRINGIFY(DECREMENT(FAN_COUNT)) ".");
+    static_assert(WITHIN(REDUNDANT_PART_COOLING_FAN, 1, FAN_COUNT), "REDUNDANT_PART_COOLING_FAN must be between 1 and " STRINGIFY(DECREMENT(FAN_COUNT)) ".");
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1841,10 +1841,12 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 #endif
 
 #ifdef REDUNDANT_PART_COOLING_FAN
-  #if FAN_COUNT < 1
+  #if FAN_COUNT < 2
     #error "REDUNDANT_PART_COOLING_FAN requires a board with at least two PWM fans."
-  #else
-    static_assert(WITHIN(REDUNDANT_PART_COOLING_FAN, 1, FAN_COUNT), "REDUNDANT_PART_COOLING_FAN must be between 1 and " STRINGIFY(DECREMENT(FAN_COUNT)) ".");
+  #elif !WITHIN(REDUNDANT_PART_COOLING_FAN, 1, FAN_COUNT - 1)
+    static_assert(false, "REDUNDANT_PART_COOLING_FAN must be between 1 and " STRINGIFY(DECREMENT(FAN_COUNT)) ".");
+  #elif !WITHIN(REDUNDANT_PART_COOLING_FAN + NUM_REDUNDANT_FANS - 1, 1, FAN_COUNT - 1)
+    #error "Not enough fans available for NUM_REDUNDANT_FANS."
   #endif
 #endif
 

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -580,10 +580,10 @@ class MenuItem_bool : public MenuEditItemBase {
   }while(0)
 
   #if FAN_COUNT > 1
-    #define FAN_EDIT_ITEMS(F) _FAN_EDIT_ITEMS(F,FAN_SPEED_N)
+    #define FAN_EDIT_ITEMS(F) _FAN_EDIT_ITEMS(F, FAN_SPEED_N)
   #endif
 
-  #define SNFAN(N) (ENABLED(SINGLENOZZLE_STANDBY_FAN) && !HAS_FAN##N && EXTRUDERS > N)
+  #define SNFAN(N) (ENABLED(SINGLENOZZLE_STANDBY_FAN) && !HAS_FAN##N && (N) < EXTRUDERS)
 
   #if SNFAN(1) || SNFAN(2) || SNFAN(3) || SNFAN(4) || SNFAN(5) || SNFAN(6) || SNFAN(7)
     #define DEFINE_SINGLENOZZLE_ITEM() \

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -221,40 +221,40 @@ void menu_temperature() {
 
     DEFINE_SINGLENOZZLE_ITEM();
 
-    #if HAS_FAN0
-      _FAN_EDIT_ITEMS(0,FIRST_FAN_SPEED);
+    #if FAN_IS_M106ABLE(0)
+      _FAN_EDIT_ITEMS(0, FIRST_FAN_SPEED);
     #endif
-    #if HAS_FAN1 && REDUNDANT_PART_COOLING_FAN != 1
+    #if FAN_IS_M106ABLE(1)
       FAN_EDIT_ITEMS(1);
     #elif SNFAN(1)
       singlenozzle_item(1);
     #endif
-    #if HAS_FAN2 && REDUNDANT_PART_COOLING_FAN != 2
+    #if FAN_IS_M106ABLE(2)
       FAN_EDIT_ITEMS(2);
     #elif SNFAN(2)
       singlenozzle_item(2);
     #endif
-    #if HAS_FAN3 && REDUNDANT_PART_COOLING_FAN != 3
+    #if FAN_IS_M106ABLE(3)
       FAN_EDIT_ITEMS(3);
     #elif SNFAN(3)
       singlenozzle_item(3);
     #endif
-    #if HAS_FAN4 && REDUNDANT_PART_COOLING_FAN != 4
+    #if FAN_IS_M106ABLE(4)
       FAN_EDIT_ITEMS(4);
     #elif SNFAN(4)
       singlenozzle_item(4);
     #endif
-    #if HAS_FAN5 && REDUNDANT_PART_COOLING_FAN != 5
+    #if FAN_IS_M106ABLE(5)
       FAN_EDIT_ITEMS(5);
     #elif SNFAN(5)
       singlenozzle_item(5);
     #endif
-    #if HAS_FAN6 && REDUNDANT_PART_COOLING_FAN != 6
+    #if FAN_IS_M106ABLE(6)
       FAN_EDIT_ITEMS(6);
     #elif SNFAN(6)
       singlenozzle_item(6);
     #endif
-    #if HAS_FAN7 && REDUNDANT_PART_COOLING_FAN != 7
+    #if FAN_IS_M106ABLE(7)
       FAN_EDIT_ITEMS(7);
     #elif SNFAN(7)
       singlenozzle_item(7);

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -153,40 +153,40 @@ void menu_tune() {
 
     DEFINE_SINGLENOZZLE_ITEM();
 
-    #if HAS_FAN0
-      _FAN_EDIT_ITEMS(0,FIRST_FAN_SPEED);
+    #if FAN_IS_M106ABLE(0)
+      _FAN_EDIT_ITEMS(0, FIRST_FAN_SPEED);
     #endif
-    #if HAS_FAN1 && REDUNDANT_PART_COOLING_FAN != 1
+    #if FAN_IS_M106ABLE(1)
       FAN_EDIT_ITEMS(1);
     #elif SNFAN(1)
       singlenozzle_item(1);
     #endif
-    #if HAS_FAN2 && REDUNDANT_PART_COOLING_FAN != 2
+    #if FAN_IS_M106ABLE(2)
       FAN_EDIT_ITEMS(2);
     #elif SNFAN(2)
       singlenozzle_item(2);
     #endif
-    #if HAS_FAN3 && REDUNDANT_PART_COOLING_FAN != 3
+    #if FAN_IS_M106ABLE(3)
       FAN_EDIT_ITEMS(3);
     #elif SNFAN(3)
       singlenozzle_item(3);
     #endif
-    #if HAS_FAN4 && REDUNDANT_PART_COOLING_FAN != 4
+    #if FAN_IS_M106ABLE(4)
       FAN_EDIT_ITEMS(4);
     #elif SNFAN(4)
       singlenozzle_item(4);
     #endif
-    #if HAS_FAN5 && REDUNDANT_PART_COOLING_FAN != 5
+    #if FAN_IS_M106ABLE(5)
       FAN_EDIT_ITEMS(5);
     #elif SNFAN(5)
       singlenozzle_item(5);
     #endif
-    #if HAS_FAN6 && REDUNDANT_PART_COOLING_FAN != 6
+    #if FAN_IS_M106ABLE(6)
       FAN_EDIT_ITEMS(6);
     #elif SNFAN(6)
       singlenozzle_item(6);
     #endif
-    #if HAS_FAN7 && REDUNDANT_PART_COOLING_FAN != 7
+    #if FAN_IS_M106ABLE(7)
       FAN_EDIT_ITEMS(7);
     #elif SNFAN(7)
       singlenozzle_item(7);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -467,8 +467,12 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
     if (fan >= FAN_COUNT) return;
 
     fan_speed[fan] = speed;
-    #if REDUNDANT_PART_COOLING_FAN
-      if (fan == 0) fan_speed[REDUNDANT_PART_COOLING_FAN] = speed;
+
+    #if NUM_REDUNDANT_FANS
+      if (fan == 0) {
+        for (uint8_t f = REDUNDANT_PART_COOLING_FAN; f < REDUNDANT_PART_COOLING_FAN + NUM_REDUNDANT_FANS; ++f)
+          thermalManager.set_fan_speed(f, 0);
+      }
     #endif
 
     TERN_(REPORT_FAN_CHANGE, report_fan_speed(fan));

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -44,6 +44,17 @@
 #define HOTEND_INDEX TERN(HAS_MULTI_HOTEND, e, 0)
 #define E_NAME TERN_(HAS_MULTI_HOTEND, e)
 
+#if HAS_FAN
+  #if NUM_REDUNDANT_FANS
+    #define FAN_IS_REDUNDANT(Q) WITHIN(Q, REDUNDANT_PART_COOLING_FAN, REDUNDANT_PART_COOLING_FAN + NUM_REDUNDANT_FANS - 1)
+  #else
+    #define FAN_IS_REDUNDANT(Q) false
+  #endif
+  #define FAN_IS_M106ABLE(Q) (HAS_FAN##Q && !FAN_IS_REDUNDANT(Q))
+#else
+  #define FAN_IS_M106ABLE(Q) false
+#endif
+
 // Element identifiers. Positive values are hotends. Negative values are other heaters or coolers.
 typedef enum : int_fast8_t {
   H_REDUNDANT = HID_REDUNDANT,


### PR DESCRIPTION
Expand M106 & M107 with the ability to use up to 3 pwm fans for part cooling and add defines to switch on/off.
I have encountered a need for this feature a number of times and feel its time it become available to everyone.

