### PR TITLE
update goto_edit_screen Initial encoder value data size

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -138,7 +138,7 @@ void MenuEditItemBase::goto_edit_screen(
   void * const ev,        // Edit value pointer
   const int32_t minv,     // Encoder minimum
   const int32_t maxv,     // Encoder maximum
-  const uint16_t ep,      // Initial encoder value
+  const uint32_t ep,      // Initial encoder value
   const screenFunc_t cs,  // MenuItem_type::draw_edit_screen => MenuEditItemBase::edit()
   const screenFunc_t cb,  // Callback after edit
   const bool le           // Flag to call cb() during editing

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -168,7 +168,7 @@ class MenuEditItemBase : public MenuItemBase {
       void * const ev,        // Edit value pointer
       const int32_t minv,     // Encoder minimum
       const int32_t maxv,     // Encoder maximum
-      const uint16_t ep,      // Initial encoder value
+      const uint32_t ep,      // Initial encoder value
       const screenFunc_t cs,  // MenuItem_type::draw_edit_screen => MenuEditItemBase::edit()
       const screenFunc_t cb,  // Callback after edit
       const bool le           // Flag to call cb() during editing


### PR DESCRIPTION
### Description

This fixes issue https://github.com/MarlinFirmware/Marlin/issues/23849

If you have a large number of steps/mm (a common example is 1600 for Z)
If you use the advanced menu|edit steps/mm. On the menu screen this shows 1600, but the instant you enter the menu to edit the value, 1600 changes to a much smaller number.

<img src="https://user-images.githubusercontent.com/58139092/237391388-6ba53e88-bea1-44ac-84e6-7e139cb2cdf9.gif">


Found that goto_edit_screen  ep was being overflowed

Upgraded from uint16_t to uint32_t  and the issue is resolved.

### Requirements

128x64 LCD 
Marlin menu.

### Benefits

Steps/mm edit menu works as expected on larger numbers.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25806
https://github.com/MarlinFirmware/Marlin/issues/23849