### PR TITLE
Undefine "disable other extruder" when just 1 E stepper

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -681,8 +681,8 @@
 
 #endif
 
-// No inactive extruders with SWITCHING_NOZZLE or Průša MMU1
-#if HAS_SWITCHING_NOZZLE || HAS_PRUSA_MMU1
+// No inactive extruders with SWITCHING_NOZZLE or Průša MMU1 or just 1 E stepper is mounted
+#if HAS_SWITCHING_NOZZLE || HAS_PRUSA_MMU1 || E_STEPPERS < 2
   #undef DISABLE_OTHER_EXTRUDERS
 #endif
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -681,7 +681,7 @@
 
 #endif
 
-// No inactive extruders with SWITCHING_NOZZLE or Průša MMU1 or just 1 E stepper is mounted
+// No inactive extruders with SWITCHING_NOZZLE or Průša MMU1 or just 1 E stepper exists
 #if HAS_SWITCHING_NOZZLE || HAS_PRUSA_MMU1 || E_STEPPERS < 2
   #undef DISABLE_OTHER_EXTRUDERS
 #endif


### PR DESCRIPTION
When there is just 1 E_STEPPER it has no sense to keep code and memory to "disable other extruders" since there is no "others"