### PR TITLE
fix pro_ui delay boot loop issue.

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1235,7 +1235,7 @@ void HMI_Init() {
       DWINUI::Draw_Icon(ICON_Bar, 15, 260);
       DWIN_Draw_Rectangle(1, HMI_data.Background_Color, t, 260, 257, 280);
       DWIN_UpdateLCD();
-      delay((BOOTSCREEN_TIMEOUT) / 22);
+      safe_delay(millis_t((BOOTSCREEN_TIMEOUT) / 22));
     }
   #endif
   HMI_SetLanguage();


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/commit/4528fde7f9255eb90fc9b9a44e35a04efb764742 PRO_UI causes a boot loop

The issue is the delay. originally delay(50) is now delay((BOOTSCREEN_TIMEOUT) / 22);
The default BOOTSCREEN_TIMEOUT in Configuration_adv.h is 4000 resulting in a float (181.818181818) and causing a watchdog timeout.

Added a millis_t type conversion and used safe_delay and the issue is resolved.

### Requirements

PRO_UI

### Benefits

Works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/25786