### PR TITLE
`pin_is_protected` not defined in pins/pinsDebug.h

### DIFF
--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -25,7 +25,7 @@
 #if ENABLED(PINS_DEBUGGING)
 
 #include "../gcode.h"
-#include "../../MarlinCore.h" // for pin_is_protected
+#include "../../MarlinCore.h" // for pin_is_protected, wait_for_user
 #include "../../pins/pinsDebug.h"
 #include "../../module/endstops.h"
 

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -25,7 +25,6 @@
 #if ENABLED(DIRECT_PIN_CONTROL)
 
 #include "../gcode.h"
-#include "../../MarlinCore.h" // for pin_is_protected
 
 #if HAS_FAN
   #include "../../module/temperature.h"
@@ -37,6 +36,8 @@
   #define INPUT_ANALOG INPUT_ANALOG
   #define OUTPUT_OPEN_DRAIN OUTPUT_OPEN_DRAIN
 #endif
+
+bool pin_is_protected(const pin_t pin);
 
 void protected_pin_err() {
   SERIAL_ERROR_MSG(STR_ERR_PROTECTED_PIN);

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -169,11 +169,12 @@ const PinInfo pin_array[] PROGMEM = {
 };
 
 #include HAL_PATH(.., pinsDebug.h)  // get the correct support file for this CPU
-#include "../MarlinCore.h"
 
 #ifndef M43_NEVER_TOUCH
   #define M43_NEVER_TOUCH(Q) false
 #endif
+
+bool pin_is_protected(const pin_t pin);
 
 static void print_input_or_output(const bool isout) {
   SERIAL_ECHOF(isout ? F("Output ") : F("Input  "));

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -169,6 +169,7 @@ const PinInfo pin_array[] PROGMEM = {
 };
 
 #include HAL_PATH(.., pinsDebug.h)  // get the correct support file for this CPU
+#include "../MarlinCore.h"
 
 #ifndef M43_NEVER_TOUCH
   #define M43_NEVER_TOUCH(Q) false


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
no real error after compiling, but the red squiggly lines appear and says "identifier 'pin_is_protected' is undefined"

so adding `#include "../MarlinCore.h"` to line 172 solves that.
