### PR TITLE
remove incorrect fan_pin MKS_ROBIN_NANO_V1_3_F4

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V1_3_F4.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V1_3_F4.h
@@ -40,6 +40,4 @@
   //#define FLASH_EEPROM_EMULATION                // Use Flash-based EEPROM emulation
 #endif
 
-#define LED_PIN                             PB1
-
 #include "../stm32f1/pins_MKS_ROBIN_NANO_common.h"


### PR DESCRIPTION
### Description

Issue with fan reported on MKS_ROBIN_NANO_V1_3_F4
Reporter also noticed that led_pin was set to same IO pin incorectly.

removed led_pin from Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V1_3_F4.h
No led on circuit diagrams. PB1 is confirmed to be a fan

### Requirements

MKS_ROBIN_NANO_V1_3_F4

### Benefits

Extruder fan works as expected

### Configurations

https://github.com/MarlinFirmware/Marlin/files/11486955/configuration.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/25837
