### PR TITLE
Fix for BTT_EBB42_V1.1 LTO compile issue

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
@@ -125,7 +125,8 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PA2   // "HE"
+#define HEATER_0_PIN                        PA2   // "HE" V1.1
+#define HEATER_1_PIN                        PB13  // "HE" V1.2
 #define FAN0_PIN                            PA0   // "FAN0"
 #define FAN1_PIN                            PA1   // "FAN1"
 

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -33,6 +33,7 @@ build_flags = -DPIN_WIRE_SCL=PB3 -DPIN_WIRE_SDA=PB4
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
+                              toolchain-gccarmnoneeabi @ 1.100301.220327
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -33,7 +33,7 @@ build_flags = -DPIN_WIRE_SCL=PB3 -DPIN_WIRE_SDA=PB4
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-                              toolchain-gccarmnoneeabi @ 1.100301.220327
+                              toolchain-gccarmnoneeabi@1.100301.220327
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->
This board benefits from Link Time Optimization due to the limited flash storage, however the default V9.2.1 toolchain from 2019 does not compile a binary that is able to run on the STM32G0B1CBT MCU used on this board. Updating the a later version of the gccarmnoneeabi toolchain (V10 or higher) works for all attempts at compiling and running marlin on the STM32G0B1CBT.

Without this fix the compiled binary does not start to run on the MCU, even though it throws no compile errors.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
Big Tree Tech EBB42(or 36) V1.1 or V1.2 using a STM32G0B1CBT MCU

### Benefits

<!-- What does this PR fix or improve? -->
Reduces the flash usage for a space constrained MCU allowing for more Marlin features to be compiled in whilst keeping features such as the splash screen with minimal issue, and also using the last page of flash for a virtual EEPROM. Its still scraping 98.4% memory usage after this, but wouldn't even fit without LTO.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
