### PR TITLE
Fix UBL_HILBERT_CURVE on BOARD_MKS_TINYBEE

### DIFF
--- a/Marlin/src/feature/bedlevel/hilbert_curve.cpp
+++ b/Marlin/src/feature/bedlevel/hilbert_curve.cpp
@@ -28,8 +28,8 @@
 
 constexpr int8_t  to_fix(int8_t  v) { return v * 2; }
 constexpr int8_t  to_int(int8_t  v) { return v / 2; }
-constexpr uint8_t   log2(uint8_t n) { return (n > 1) ? 1 + log2(n >> 1) : 0; }
-constexpr uint8_t  order(uint8_t n) { return uint8_t(log2(n - 1)) + 1; }
+constexpr uint8_t   log2(uint8_t n) { return (n > 1) ? 1 + log2(uint8_t(n >> 1)) : 0; }
+constexpr uint8_t  order(uint8_t n) { return uint8_t(log2(uint8_t(n - 1))) + 1; }
 constexpr uint8_t ord = order(_MAX(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y));
 constexpr uint8_t dim = _BV(ord);
 


### PR DESCRIPTION
### Description

UBL_HILBERT_CURVE fails to compile on BOARD_MKS_TINYBEE 
Error "Marlin/src/feature/bedlevel/hilbert_curve.cpp:31:71: error: call of overloaded 'log2(int)' is ambiguous" 

Explicitly defined the typres

### Requirements
```cpp
#define MOTHERBOARD BOARD_MKS_TINYBEE
#define FIX_MOUNTED_PROBE
#define AUTO_BED_LEVELING_UBL
#define UBL_HILBERT_CURVE
#define Z_SAFE_HOMING
#define EEPROM_SETTINGS
```
### Benefits

Compiles as expected

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/25870