### PR TITLE
🌐 Language CSV Import/Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ genpages.exe
 marlin_config.json
 mczip.h
 language*.csv
-csv-out/
+out-csv/
+out-language/
 *.gen
 *.sublime-workspace
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -546,7 +546,11 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
 
       TERN_(HOST_PROMPT_SUPPORT, hostui.prompt_do(PROMPT_USER_CONTINUE, GET_TEXT_F(MSG_HEATER_TIMEOUT), GET_TEXT_F(MSG_REHEAT)));
 
-      TERN_(EXTENSIBLE_UI, ExtUI::onUserConfirmRequired(GET_TEXT_F(MSG_HEATER_TIMEOUT)));
+      #if ENABLED(TOUCH_UI_FTDI_EVE)
+        ExtUI::onUserConfirmRequired(GET_TEXT_F(MSG_FTDI_HEATER_TIMEOUT));
+      #elif ENABLED(EXTENSIBLE_UI)
+        ExtUI::onUserConfirmRequired(GET_TEXT_F(MSG_HEATER_TIMEOUT));
+      #endif
 
       TERN_(HAS_RESUME_CONTINUE, wait_for_user_response(0, true)); // Wait for LCD click or M108
 

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -47,8 +47,8 @@ namespace GET_LANG(LCD_LANGUAGE) {
   #define _MSG_PREHEAT(N) \
     LSTR MSG_PREHEAT_##N                  = _UxGT("Preheat ") PREHEAT_## N ##_LABEL; \
     LSTR MSG_PREHEAT_## N ##_SETTINGS     = _UxGT("Preheat ") PREHEAT_## N ##_LABEL _UxGT(" Conf");
-  #if PREHEAT_COUNT > 3
-    REPEAT_S(4, PREHEAT_COUNT, _MSG_PREHEAT)
+  #if PREHEAT_COUNT > 1
+    REPEAT_S(2, INCREMENT(PREHEAT_COUNT), _MSG_PREHEAT)
   #endif
 }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
@@ -147,6 +147,8 @@ namespace Language_en {
   LSTR MSG_MOVE_Z_TO_TOP            = u8"Raise Z to Top";
   LSTR MSG_MAX_SPEED_NO_UNITS       = u8"Max Speed";
 
+  //LSTR MSG_FTDI_HEATER_TIMEOUT    = u8"Idle timeout, temperature decreased. Press Okay to reheat and again to resume.";
+
   #if ENABLED(TOUCH_UI_LULZBOT_BIO)
     LSTR MSG_MOVE_TO_HOME           = u8"Move to Home";
     LSTR MSG_RAISE_PLUNGER          = u8"Raise Plunger";

--- a/Marlin/src/lcd/language/language_an.h
+++ b/Marlin/src/lcd/language/language_an.h
@@ -31,7 +31,7 @@
 #define DISPLAY_CHARSET_ISO10646_1
 #define NOT_EXTENDED_ISO10646_1_5X7
 
-namespace Language_an {
+namespace LanguageNarrow_an {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -55,23 +55,23 @@ namespace Language_an {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Nivelacion feita!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Achustar desfases");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Desfase aplicau");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Precalentar ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Precalentar ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Boquilla");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Boquilla ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Tot");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Base");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Precalentar $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Precalentar $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Precal. $ Boquilla");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Precal. $ Boquilla ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Precalentar $ Tot");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Precalentar $ Base");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Precalentar $ Conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Precalentar ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Precalentar ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Boquilla");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Boquilla ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Tot");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Base");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Precalentar ") PREHEAT_1_LABEL _UxGT(" Conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Precalentar $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Precalentar $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Precal. $ Boquilla");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Precal. $ Boquilla ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Precalentar $ Tot");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Precalentar $ Base");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Precalentar $ Conf");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Enfriar");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Enchegar Fuent");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Amortar Fuent");
@@ -192,19 +192,11 @@ namespace Language_an {
   LSTR MSG_INFO_PROTOCOL                  = _UxGT("Protocolo");
   LSTR MSG_CASE_LIGHT                     = _UxGT("Luz");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Conteo de impresion");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tiempo total d'imp.");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresion mas larga");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total d'extrusion");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impresions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Mas larga");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrusion");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impresions");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completadas");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Mas larga");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extrusion");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temperatura menima");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temperatura maxima");
@@ -214,22 +206,35 @@ namespace Language_an {
   LSTR MSG_DAC_EEPROM_WRITE               = _UxGT("Escri. DAC EEPROM");
   LSTR MSG_FILAMENT_CHANGE_OPTION_RESUME  = _UxGT("Resumir imp.");
 
-  //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
-  //
-
-  #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Aguardand iniciar", "d'o filamento", "cambear"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Meta o filamento", "y prete lo boton", "pa continar..."));
-  #else // LCD_HEIGHT < 4
-    // Up to 2 lines allowed
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Aguardand iniciar", "d'o fil. cambear"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_2_LINE("Meta o filamento", "y prete lo boton"));
-  #endif // LCD_HEIGHT < 4
+  // Up to 2 lines allowed
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_2_LINE("Aguardand iniciar", "d'o fil. cambear"));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_2_LINE("Meta o filamento", "y prete lo boton"));
 
   LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_2_LINE("Aguardando a", "expulsar filament"));
   LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Aguardando a", "cargar filamento"));
   LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_2_LINE("Aguardando impre.", "pa continar"));
+}
+
+namespace LanguageWide_an {
+  using namespace LanguageNarrow_an;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Conteo de impresion");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tiempo total d'imp.");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresion mas larga");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total d'extrusion");
+  #endif
+}
+
+namespace LanguageTall_an {
+  using namespace LanguageWide_an;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Aguardand iniciar", "d'o filamento", "cambear"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Meta o filamento", "y prete lo boton", "pa continar..."));
+  #endif
+}
+
+namespace Language_an {
+  using namespace LanguageTall_an;
 }

--- a/Marlin/src/lcd/language/language_bg.h
+++ b/Marlin/src/lcd/language/language_bg.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_5
 
-namespace Language_bg {
+namespace LanguageNarrow_bg {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -44,23 +44,23 @@ namespace Language_bg {
   LSTR MSG_DISABLE_STEPPERS               = _UxGT("Изкл. двигатели");
   LSTR MSG_AUTO_HOME                      = _UxGT("Паркиране");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Задай Начало");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Подгряване ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Подгряване ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Подгряване ") PREHEAT_1_LABEL _UxGT(" Дюза");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Подгряване ") PREHEAT_1_LABEL _UxGT(" Дюза ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Подгр. ") PREHEAT_1_LABEL _UxGT(" Всички");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Подгр. ") PREHEAT_1_LABEL _UxGT(" Легло");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Настройки ") PREHEAT_1_LABEL;
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Подгряване $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Подгряване $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Подгряване $ Дюза");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Подгряване $ Дюза ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Подгр. $ Всички");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Подгр. $ Легло");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Настройки $");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Подгряване ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Подгряване ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Подгряване ") PREHEAT_1_LABEL _UxGT(" Дюза");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Подгряване ") PREHEAT_1_LABEL _UxGT(" Дюза ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Подгр. ") PREHEAT_1_LABEL _UxGT(" Всички");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Подгр. ") PREHEAT_1_LABEL _UxGT(" Легло");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Настройки ") PREHEAT_1_LABEL;
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Подгряване $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Подгряване $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Подгряване $ Дюза");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Подгряване $ Дюза ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Подгр. $ Всички");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Подгр. $ Легло");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Настройки $");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Охлаждане");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Вкл. захранване");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Изкл. захранване");
@@ -156,4 +156,21 @@ namespace Language_bg {
   LSTR MSG_DELTA_CALIBRATE_Z              = _UxGT("Калибровка Z");
   LSTR MSG_DELTA_CALIBRATE_CENTER         = _UxGT("Калибровка Център");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Неправилен принтер");
+}
+
+namespace LanguageWide_bg {
+  using namespace LanguageNarrow_bg;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_bg {
+  using namespace LanguageWide_bg;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_bg {
+  using namespace LanguageTall_bg;
 }

--- a/Marlin/src/lcd/language/language_ca.h
+++ b/Marlin/src/lcd/language/language_ca.h
@@ -27,7 +27,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_ca {
+namespace LanguageNarrow_ca {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -53,23 +53,23 @@ namespace Language_ca {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Anivellament fet!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Ajusta decalatge");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Decalatge aplicat");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Preescalfa ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Preescalfa ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" End");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" End ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Tot");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Llit");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Conf.");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Preescalfa $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Preescalfa $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Preescalfa $ End");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Preescalfa $ End ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Preescalfa $ Tot");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Preescalfa $ Llit");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Preescalfa $ Conf.");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Preescalfa ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Preescalfa ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" End");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" End ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Tot");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Llit");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Preescalfa ") PREHEAT_1_LABEL _UxGT(" Conf.");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Preescalfa $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Preescalfa $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Preescalfa $ End");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Preescalfa $ End ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Preescalfa $ Tot");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Preescalfa $ Llit");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Preescalfa $ Conf.");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Refreda");
 
   LSTR MSG_EXTRUDE                        = _UxGT("Extrudeix");
@@ -183,19 +183,11 @@ namespace Language_ca {
   LSTR MSG_INFO_PROTOCOL                  = _UxGT("Protocol");
   LSTR MSG_CASE_LIGHT                     = _UxGT("Llum");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Acabades");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Temps imprimint");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Treball mes llarg");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total extrudit");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Acabades");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Mes llarg");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrudit");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impressions");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Acabades");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Mes llarg");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extrudit");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp. mínima");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp. màxima");
@@ -208,10 +200,31 @@ namespace Language_ca {
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Impressora incorrecta");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Espereu..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Expulsant..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Insereix i prem"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Escalfant..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Carregant..."));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Reprenent..."));
+}
+
+namespace LanguageWide_ca {
+  using namespace LanguageNarrow_ca;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total impressions");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Acabades");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Temps imprimint");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Treball mes llarg");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total extrudit");
+  #endif
+}
+
+namespace LanguageTall_ca {
+  using namespace LanguageWide_ca;
   #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Esperant per", "iniciar el canvi", "de filament"));
     LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Esperant per", "treure filament"));
     LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Poseu filament", "i premeu el boto", "per continuar..."));
@@ -219,12 +232,9 @@ namespace Language_ca {
     LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Escalfant nozzle", "Espereu..."));
     LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Esperant carrega", "de filament"));
     LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Esperant per", "reprendre"));
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Espereu..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Expulsant..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Insereix i prem"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Escalfant..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Carregant..."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Reprenent..."));
-  #endif // LCD_HEIGHT < 4
+  #endif
+}
+
+namespace Language_ca {
+  using namespace LanguageTall_ca;
 }

--- a/Marlin/src/lcd/language/language_cz.h
+++ b/Marlin/src/lcd/language/language_cz.h
@@ -35,7 +35,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_CZ
 
-namespace Language_cz {
+namespace LanguageNarrow_cz {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -60,11 +60,7 @@ namespace Language_cz {
   LSTR MSG_RUN_AUTO_FILES                 = _UxGT("Autostart");
   LSTR MSG_DISABLE_STEPPERS               = _UxGT("Uvolnit motory");
   LSTR MSG_DEBUG_MENU                     = _UxGT("Nabídka ladění");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_PROGRESS_BAR_TEST            = _UxGT("Test ukaz. průběhu");
-  #else
-    LSTR MSG_PROGRESS_BAR_TEST            = _UxGT("Test uk. průběhu");
-  #endif
+  LSTR MSG_PROGRESS_BAR_TEST              = _UxGT("Test uk. průběhu");
   LSTR MSG_AUTO_HOME                      = _UxGT("Domovská pozice");
   LSTR MSG_AUTO_HOME_X                    = _UxGT("Domů osa X");
   LSTR MSG_AUTO_HOME_Y                    = _UxGT("Domů osa Y");
@@ -77,23 +73,23 @@ namespace Language_cz {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Výška srovnávání");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Nastavit ofsety");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Ofsety nastaveny");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Zahřát ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Zahřát ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" end");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" end ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" vše");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" podlož");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" nast");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Zahřát $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Zahřát $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Zahřát $ end");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Zahřát $ end ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Zahřát $ vše");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Zahřát $ podlož");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Zahřát $ nast");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Zahřát ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Zahřát ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" end");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" end ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" vše");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" podlož");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Zahřát ") PREHEAT_1_LABEL _UxGT(" nast");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Zahřát $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Zahřát $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Zahřát $ end");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Zahřát $ end ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Zahřát $ vše");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Zahřát $ podlož");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Zahřát $ nast");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Zahřát vlastní");
   LSTR MSG_COOLDOWN                       = _UxGT("Zchladit");
   LSTR MSG_LASER_MENU                     = _UxGT("Ovládání laseru");
@@ -152,10 +148,8 @@ namespace Language_cz {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Konec úprav sítě");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Vlastní síť");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Vytvořit síť");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Síť bodů $");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Kontrola sítě $");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Síť bodů $");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Kontrola sítě $");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Studená síť bodů");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Upravit výšku sítě");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Výška");
@@ -414,16 +408,8 @@ namespace Language_cz {
   LSTR MSG_PLEASE_RESET                   = _UxGT("Proveďte reset");
   LSTR MSG_HEATING                        = _UxGT("Zahřívání...");
   LSTR MSG_COOLING                        = _UxGT("Chlazení...");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_BED_HEATING                  = _UxGT("Zahřívání podložky");
-  #else
-    LSTR MSG_BED_HEATING                  = _UxGT("Zahřívání podl.");
-  #endif
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_BED_COOLING                  = _UxGT("Chlazení podložky");
-  #else
-    LSTR MSG_BED_COOLING                  = _UxGT("Chlazení podl.");
-  #endif
+  LSTR MSG_BED_HEATING                    = _UxGT("Zahřívání podl.");
+  LSTR MSG_BED_COOLING                    = _UxGT("Chlazení podl.");
   LSTR MSG_CHAMBER_HEATING                = _UxGT("Zahřívání komory...");
   LSTR MSG_CHAMBER_COOLING                = _UxGT("Chlazení komory...");
   LSTR MSG_DELTA_CALIBRATE                = _UxGT("Delta Kalibrace");
@@ -456,19 +442,11 @@ namespace Language_cz {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Jas světla");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("NESPRÁVNÁ TISKÁRNA");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Počet tisků");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Dokončeno");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Celkový čas");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Nejdelší tisk");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Celkem vytlačeno");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Tisky");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Hotovo");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Čas");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Nejdelší");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Vytlačeno");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Tisky");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Hotovo");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Čas");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Nejdelší");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Vytlačeno");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Teplota min");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Teplota max");
@@ -520,23 +498,13 @@ namespace Language_cz {
   LSTR MSG_CYCLE_MIX                      = _UxGT("Střídat mix");
   LSTR MSG_GRADIENT_MIX                   = _UxGT("Přechod mix");
   LSTR MSG_REVERSE_GRADIENT               = _UxGT("Opačný přechod");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_ACTIVE_VTOOL                 = _UxGT("Aktivní V-nástroj");
-    LSTR MSG_START_VTOOL                  = _UxGT("Spustit V-nástroj");
-    LSTR MSG_END_VTOOL                    = _UxGT("Ukončit V-nástroj");
-    LSTR MSG_GRADIENT_ALIAS               = _UxGT("Alias V-nástroje");
-    LSTR MSG_RESET_VTOOLS                 = _UxGT("Resetovat V-nástroj");
-    LSTR MSG_COMMIT_VTOOL                 = _UxGT("Uložit V-nástroj mix");
-    LSTR MSG_VTOOLS_RESET                 = _UxGT("V-nástroj resetovat");
-  #else
-    LSTR MSG_ACTIVE_VTOOL                 = _UxGT("Aktivní V-nástr.");
-    LSTR MSG_START_VTOOL                  = _UxGT("Spustit V-nástr.");
-    LSTR MSG_END_VTOOL                    = _UxGT("Ukončit V-nástr.");
-    LSTR MSG_GRADIENT_ALIAS               = _UxGT("Alias V-nástr.");
-    LSTR MSG_RESET_VTOOLS                 = _UxGT("Reset. V-nástr.");
-    LSTR MSG_COMMIT_VTOOL                 = _UxGT("Uložit V-nás. mix");
-    LSTR MSG_VTOOLS_RESET                 = _UxGT("V-nástr. reset.");
-  #endif
+  LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Aktivní V-nástr.");
+  LSTR MSG_START_VTOOL                    = _UxGT("Spustit V-nástr.");
+  LSTR MSG_END_VTOOL                      = _UxGT("Ukončit V-nástr.");
+  LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Alias V-nástr.");
+  LSTR MSG_RESET_VTOOLS                   = _UxGT("Reset. V-nástr.");
+  LSTR MSG_COMMIT_VTOOL                   = _UxGT("Uložit V-nás. mix");
+  LSTR MSG_VTOOLS_RESET                   = _UxGT("V-nástr. reset.");
   LSTR MSG_START_Z                        = _UxGT("Počáteční Z:");
   LSTR MSG_END_Z                          = _UxGT("  Koncové Z:");
 
@@ -546,33 +514,18 @@ namespace Language_cz {
   LSTR MSG_SNAKE                          = _UxGT("Sn4k3");
   LSTR MSG_MAZE                           = _UxGT("Bludiště");
 
-  #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Stikněte tlačítko", "pro obnovení tisku"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkování..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Čekejte prosím", "na zahájení", "výměny filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Vložte filament", "a stiskněte", "tlačítko..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Klikněte pro", "nahřátí trysky"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Čekejte prosím", "na nahřátí tr."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Čekejte prosím", "na vysunuti", "filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Čekejte prosím", "na zavedení", "filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Vyčkejte na", "vytlačení"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Klikněte pro", "ukončení", "vytlačování"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Čekejte prosím", "na pokračování", "tisku"));
-  #else // LCD_HEIGHT < 4
-    // Up to 2 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Stikněte tlač.", "pro obnovení"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkování..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Čekejte..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Vložte, klikněte"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Klikněte pro", "nahřátí"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Nahřívání..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Vysouvání..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Zavádění..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Vytlačování..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Klikněte pro", "ukončení"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Pokračování..."));
-  #endif // LCD_HEIGHT < 4
+  // Up to 2 lines allowed
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_2_LINE("Stikněte tlač.", "pro obnovení"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parkování..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Čekejte..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Vložte, klikněte"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_2_LINE("Klikněte pro", "nahřátí"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Nahřívání..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Vysouvání..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Zavádění..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Vytlačování..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_2_LINE("Klikněte pro", "ukončení"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Pokračování..."));
 
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC budiče");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Proud budičů");
@@ -585,4 +538,47 @@ namespace Language_cz {
   LSTR MSG_BACKLASH                       = _UxGT("Vůle");
   LSTR MSG_BACKLASH_CORRECTION            = _UxGT("Korekce");
   LSTR MSG_BACKLASH_SMOOTHING             = _UxGT("Vyhlazení");
+}
+
+namespace LanguageWide_cz {
+  using namespace LanguageNarrow_cz;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_PROGRESS_BAR_TEST            = _UxGT("Test ukaz. průběhu");
+    LSTR MSG_BED_HEATING                  = _UxGT("Zahřívání podložky");
+    LSTR MSG_BED_COOLING                  = _UxGT("Chlazení podložky");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Počet tisků");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Dokončeno");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Celkový čas");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Nejdelší tisk");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Celkem vytlačeno");
+    LSTR MSG_ACTIVE_VTOOL                 = _UxGT("Aktivní V-nástroj");
+    LSTR MSG_START_VTOOL                  = _UxGT("Spustit V-nástroj");
+    LSTR MSG_END_VTOOL                    = _UxGT("Ukončit V-nástroj");
+    LSTR MSG_GRADIENT_ALIAS               = _UxGT("Alias V-nástroje");
+    LSTR MSG_RESET_VTOOLS                 = _UxGT("Resetovat V-nástroj");
+    LSTR MSG_COMMIT_VTOOL                 = _UxGT("Uložit V-nástroj mix");
+    LSTR MSG_VTOOLS_RESET                 = _UxGT("V-nástroj resetovat");
+  #endif
+}
+
+namespace LanguageTall_cz {
+  using namespace LanguageWide_cz;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Stikněte tlačítko", "pro obnovení tisku"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkování..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Čekejte prosím", "na zahájení", "výměny filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Vložte filament", "a stiskněte", "tlačítko..."));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Klikněte pro", "nahřátí trysky"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Čekejte prosím", "na nahřátí tr."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Čekejte prosím", "na vysunuti", "filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Čekejte prosím", "na zavedení", "filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Vyčkejte na", "vytlačení"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Klikněte pro", "ukončení", "vytlačování"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Čekejte prosím", "na pokračování", "tisku"));
+  #endif
+}
+
+namespace Language_cz {
+  using namespace LanguageTall_cz;
 }

--- a/Marlin/src/lcd/language/language_da.h
+++ b/Marlin/src/lcd/language/language_da.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_da {
+namespace LanguageNarrow_da {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -47,23 +47,23 @@ namespace Language_da {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Bed level er færdig!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Sæt forsk. af home");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Forsk. er nu aktiv");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Forvarm ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Forvarm ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Alle");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Bed");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Forvarm $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Forvarm $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Forvarm $ end");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Forvarm $ end ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Forvarm $ Alle");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Forvarm $ Bed");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Forvarm $ conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Forvarm ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Forvarm ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Alle");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Bed");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Forvarm $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Forvarm $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Forvarm $ end");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Forvarm $ end ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Forvarm $ Alle");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Forvarm $ Bed");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Forvarm $ conf");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Afkøl");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Slå strøm til");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Slå strøm fra");
@@ -158,19 +158,11 @@ namespace Language_da {
   LSTR MSG_INFO_BOARD_MENU                = _UxGT("Kort Info");
   LSTR MSG_INFO_THERMISTOR_MENU           = _UxGT("Thermistors");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Ant. Prints");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Færdige");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total print tid");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Længste print");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruderet");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Prints");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Færdige");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Længste");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruderet");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Prints");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Færdige");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Længste");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruderet");
 
   LSTR MSG_INFO_PSU                       = _UxGT("Strømfors.");
 
@@ -183,17 +175,36 @@ namespace Language_da {
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Forkert printer");
 
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Vent venligst..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Udskyder..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Indsæt og klik"));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Indtager..."));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Fortsætter..."));
+}
+
+namespace LanguageWide_da {
+  using namespace LanguageNarrow_da;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Ant. Prints");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Færdige");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total print tid");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Længste print");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruderet");
+  #endif
+}
+
+namespace LanguageTall_da {
+  using namespace LanguageWide_da;
   #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Vent på start", "af filament", "skift"));
     LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Vent på", "filament udskyd."));
     LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Indsæt filament", "og tryk på knap", "for at fortsætte..."));
     LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Vent på", "filament indtag"));
     LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Vent på at print", "fortsætter"));
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Vent venligst..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Udskyder..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Indsæt og klik"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Indtager..."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Fortsætter..."));
-  #endif // LCD_HEIGHT < 4
+  #endif
+}
+
+namespace Language_da {
+  using namespace LanguageTall_da;
 }

--- a/Marlin/src/lcd/language/language_de.h
+++ b/Marlin/src/lcd/language/language_de.h
@@ -28,7 +28,7 @@
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
 
-namespace Language_de {
+namespace LanguageNarrow_de {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -92,30 +92,23 @@ namespace Language_de {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Tramming Assistent");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Wählen Sie Ursprung");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Letzter Wert ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = PREHEAT_1_LABEL _UxGT(" Vorwärmen");
-    LSTR MSG_PREHEAT_1_H                  = PREHEAT_1_LABEL _UxGT(" Vorwärmen ~");
-    LSTR MSG_PREHEAT_1_END                = PREHEAT_1_LABEL _UxGT(" Extr. Vorwärmen");
-    LSTR MSG_PREHEAT_1_END_E              = PREHEAT_1_LABEL _UxGT(" Extr. Vorwärm. ~");
-    LSTR MSG_PREHEAT_1_ALL                = PREHEAT_1_LABEL _UxGT(" Alles Vorwärmen");
-    LSTR MSG_PREHEAT_1_BEDONLY            = PREHEAT_1_LABEL _UxGT(" Bett Vorwärmen");
-    LSTR MSG_PREHEAT_1_SETTINGS           = PREHEAT_1_LABEL _UxGT(" Einstellungen");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                  = PREHEAT_2_LABEL _UxGT(" Vorwärmen");
-      LSTR MSG_PREHEAT_2_SETTINGS         = PREHEAT_2_LABEL _UxGT(" Vorwärmen Konf");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                  = PREHEAT_3_LABEL _UxGT(" Vorwärmen");
-      LSTR MSG_PREHEAT_3_SETTINGS         = PREHEAT_3_LABEL _UxGT(" Vorwärmen Konf");
-    #endif
-    LSTR MSG_PREHEAT_M                    = _UxGT("$ Vorwärmen");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("$ Vorwärmen") " ~";
-    LSTR MSG_PREHEAT_M_END                = _UxGT("$ Extr. Vorwärmen");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("$ Extr. Vorwärm. ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("$ Alles Vorwärmen");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("$ Bett Vorwärmen");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("$ Einstellungen");
-  #endif
+
+  LSTR MSG_PREHEAT_1                      = PREHEAT_1_LABEL _UxGT(" Vorwärmen");
+  LSTR MSG_PREHEAT_1_H                    = PREHEAT_1_LABEL _UxGT(" Vorwärmen ~");
+  LSTR MSG_PREHEAT_1_END                  = PREHEAT_1_LABEL _UxGT(" Extr. Vorwärmen");
+  LSTR MSG_PREHEAT_1_END_E                = PREHEAT_1_LABEL _UxGT(" Extr. Vorwärm. ~");
+  LSTR MSG_PREHEAT_1_ALL                  = PREHEAT_1_LABEL _UxGT(" Alles Vorwärmen");
+  LSTR MSG_PREHEAT_1_BEDONLY              = PREHEAT_1_LABEL _UxGT(" Bett Vorwärmen");
+  LSTR MSG_PREHEAT_1_SETTINGS             = PREHEAT_1_LABEL _UxGT(" Einstellungen");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("$ Vorwärmen");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("$ Vorwärmen") " ~";
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("$ Extr. Vorwärmen");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("$ Extr. Vorwärm. ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("$ Alles Vorwärmen");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("$ Bett Vorwärmen");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("$ Einstellungen");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("benutzerdef. Heizen");
   LSTR MSG_COOLDOWN                       = _UxGT("Abkühlen");
 
@@ -622,25 +615,13 @@ namespace Language_de {
   LSTR MSG_LOCKSCREEN_LOCKED              = _UxGT("Drucker ist gesperrt,");
   LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("Scrollen zum Entsper.");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Kein Medium eingelegt.");
-    LSTR MSG_PLEASE_WAIT_REBOOT           = _UxGT("Bitte auf Neustart warten.");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Bitte das Hotend vorheizen.");
-    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Druckzähler zurücksetzen");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Gesamte Drucke");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Komplette Drucke");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Gesamte Druckzeit");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längste Druckzeit");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Gesamt Extrudiert");
-  #else
-    LSTR MSG_PLEASE_WAIT_REBOOT           = _UxGT("Auf Neustart warten");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Bitte vorheizen");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Drucke");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Komplette");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Gesamte");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längste");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrud.");
-  #endif
+  LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Auf Neustart warten");
+  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Bitte vorheizen");
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Drucke");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Komplette");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Gesamte");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Längste");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extrud.");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min Temp");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Max Temp");
@@ -729,34 +710,19 @@ namespace Language_de {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Passwort gelöscht");
 
   //
-  // Die Filament-Change-Bildschirme können bis zu 3 Zeilen auf einem 4-Zeilen-Display anzeigen
-  //                                       ...oder 2 Zeilen auf einem 3-Zeilen-Display.
-
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Knopf drücken um", "Druck fortzusetzen"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_2_LINE("Druck ist", "pausiert..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Warte auf den", "Start des", "Filamentwechsels..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Filament einlegen", "und Knopf drücken", "um fortzusetzen"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Knopf drücken um", "Düse aufzuheizen"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Düse heizt auf", "bitte warten..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Warte auf", "Entnahme", "des Filaments..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Warte auf", "Laden des", "Filaments..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Warte auf", "Spülung", "der Düse..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Klicke um", "die Düsenspülung", "zu beenden"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Warte auf", "Fortsetzen des", "Drucks..."));
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Klick zum Fortsetzen"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Pausiert..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Bitte warten..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Laden und Klick"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Klick zum Heizen"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Heizen..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Entnehmen..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Laden..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Spülen..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Klick zum beenden", "der Düsenspülung"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Fortsetzen..."));
-  #endif // LCD_HEIGHT < 4
+  // Die Filament-Change-Bildschirme können bis zu 2 Zeilen auf einem 3-Zeilen-Display.
+  //
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Klick zum Fortsetzen"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Pausiert..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Bitte warten..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Laden und Klick"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Klick zum Heizen"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Heizen..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Entnehmen..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Laden..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Spülen..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_2_LINE("Klick zum beenden", "der Düsenspülung"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Fortsetzen..."));
 
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC Treiber"); // Max length 18 characters
   LSTR MSG_TMC_CURRENT                    = _UxGT("Treiber Strom");
@@ -772,11 +738,8 @@ namespace Language_de {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("X Achse leveln");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Auto. Kalibiren");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Idle Timeout, Temperatur gefallen. Drücke Okay, um erneut aufzuheizen und fortzufahren.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Heizungs Timeout");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Idle Timeout, Temperatur gefallen. Drücke Okay, um erneut aufzuheizen und fortzufahren.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Heizungs Timeout");
   LSTR MSG_REHEAT                         = _UxGT("Erneut aufheizen");
   LSTR MSG_REHEATING                      = _UxGT("Erneut aufhei. ...");
   LSTR MSG_REHEATDONE                     = _UxGT("Aufwärmen fertig");
@@ -808,4 +771,41 @@ namespace Language_de {
   LSTR MSG_SHORT_DAY                      = _UxGT("t"); // One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("h"); // One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("m"); // One character only
+}
+
+namespace LanguageWide_de {
+  using namespace LanguageNarrow_de;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Kein Medium eingelegt.");
+    LSTR MSG_PLEASE_WAIT_REBOOT           = _UxGT("Bitte auf Neustart warten.");
+    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Bitte das Hotend vorheizen.");
+    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Druckzähler zurücksetzen");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Gesamte Drucke");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Komplette Drucke");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Gesamte Druckzeit");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längste Druckzeit");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Gesamt Extrudiert");
+  #endif
+}
+
+namespace LanguageTall_de {
+  using namespace LanguageWide_de;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Knopf drücken um", "Druck fortzusetzen"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_2_LINE("Druck ist", "pausiert..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Warte auf den", "Start des", "Filamentwechsels..."));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Filament einlegen", "und Knopf drücken", "um fortzusetzen"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Knopf drücken um", "Düse aufzuheizen"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Düse heizt auf", "bitte warten..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Warte auf", "Entnahme", "des Filaments..."));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Warte auf", "Laden des", "Filaments..."));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Warte auf", "Spülung", "der Düse..."));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Klicke um", "die Düsenspülung", "zu beenden"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Warte auf", "Fortsetzen des", "Drucks..."));
+  #endif
+}
+
+namespace Language_de {
+  using namespace LanguageTall_de;
 }

--- a/Marlin/src/lcd/language/language_el.h
+++ b/Marlin/src/lcd/language/language_el.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_GREEK
 
-namespace Language_el {
+namespace LanguageNarrow_el {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -64,23 +64,23 @@ namespace Language_el {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Τέλος επιπεδοποίησης!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Ορισμός μετατοπίσεων");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Εφαρμογή μετατοπίσεων");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" όλα");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" bed"); // SHORTEN
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" επιβεβαίωση"); // SHORTEN
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Προθέρμανση $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Προθέρμανση $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Προθέρμανση $ End");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Προθέρμανση $ End ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Προθέρμανση $ όλα");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Προθέρμανση $ bed"); // SHORTEN
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Προθέρμανση $ επιβεβαίωση"); // SHORTEN
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" όλα");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" bed"); // SHORTEN
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" επιβεβαίωση"); // SHORTEN
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Προθέρμανση $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Προθέρμανση $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Προθέρμανση $ End");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Προθέρμανση $ End ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Προθέρμανση $ όλα");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Προθέρμανση $ bed"); // SHORTEN
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Προθέρμανση $ επιβεβαίωση"); // SHORTEN
+
   LSTR MSG_COOLDOWN                       = _UxGT("Αποθέρμανση");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Ενεργοποίηση");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Απενεργοποίηση");
@@ -208,4 +208,21 @@ namespace Language_el {
   LSTR MSG_DELTA_CALIBRATE_CENTER         = _UxGT("Βαθμονόμηση κέντρου");
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Εσφαλμένος εκτυπωτής");
+}
+
+namespace LanguageWide_el {
+  using namespace LanguageNarrow_el;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_el {
+  using namespace LanguageWide_el;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_el {
+  using namespace LanguageTall_el;
 }

--- a/Marlin/src/lcd/language/language_el_gr.h
+++ b/Marlin/src/lcd/language/language_el_gr.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_GREEK
 
-namespace Language_el_gr {
+namespace LanguageNarrow_el_gr {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -53,23 +53,23 @@ namespace Language_el_gr {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Ολοκλήρωση επιπεδοποίησης!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Ορισμός βασικών μετατοπίσεων");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Εφαρμόστηκαν οι μετατοπίσεις");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" όλα");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" κλίνη");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" επιβεβαίωση");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Προθέρμανση $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Προθέρμανση $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Προθέρμανση $ End");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Προθέρμανση $ End ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Προθέρμανση $ όλα");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Προθέρμανση $ κλίνη");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Προθέρμανση $ επιβεβαίωση");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" End ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" όλα");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" κλίνη");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Προθέρμανση ") PREHEAT_1_LABEL _UxGT(" επιβεβαίωση");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Προθέρμανση $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Προθέρμανση $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Προθέρμανση $ End");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Προθέρμανση $ End ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Προθέρμανση $ όλα");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Προθέρμανση $ κλίνη");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Προθέρμανση $ επιβεβαίωση");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Μειωση θερμοκρασιας");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Ενεργοποίηση");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Απενεργοποίηση");
@@ -196,4 +196,21 @@ namespace Language_el_gr {
   LSTR MSG_DELTA_CALIBRATE_CENTER         = _UxGT("Βαθμονόμηση κέντρου");
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Εσφαλμένος εκτυπωτής");
+}
+
+namespace LanguageWide_el_gr {
+  using namespace LanguageNarrow_el_gr;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_el_gr {
+  using namespace LanguageWide_el_gr;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_el_gr {
+  using namespace LanguageTall_el_gr;
 }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -44,7 +44,11 @@
 
 #define MEDIA_TYPE_EN "Media"
 
-namespace Language_en {
+#ifndef PREHEAT_1_LABEL
+  #define PREHEAT_1_LABEL ""
+#endif
+
+namespace LanguageNarrow_en {
   constexpr uint8_t CHARSIZE              = 2;
   LSTR LANGUAGE                           = _UxGT("English");
 
@@ -113,30 +117,23 @@ namespace Language_en {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Tramming Wizard");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Select Origin");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Last value ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Preheat ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Preheat ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" End");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" End ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" All");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" Bed");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" Conf");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                  = _UxGT("Preheat ") PREHEAT_2_LABEL;
-      LSTR MSG_PREHEAT_2_SETTINGS         = _UxGT("Preheat ") PREHEAT_2_LABEL _UxGT(" Conf");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                  = _UxGT("Preheat ") PREHEAT_3_LABEL;
-      LSTR MSG_PREHEAT_3_SETTINGS         = _UxGT("Preheat ") PREHEAT_3_LABEL _UxGT(" Conf");
-    #endif
-    LSTR MSG_PREHEAT_M                    = _UxGT("Preheat $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Preheat $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Preheat $ End");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Preheat $ End ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Preheat $ All");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Preheat $ Bed");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Preheat $ Conf");
-  #endif
+
+  LSTR MSG_PREHEAT_1                      = _UxGT("Preheat ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Preheat ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" End");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" End ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" All");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" Bed");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Preheat ") PREHEAT_1_LABEL _UxGT(" Conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Preheat $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Preheat $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Preheat $ End");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Preheat $ End ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Preheat $ All");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Preheat $ Bed");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Preheat $ Conf");
+
   LSTR MSG_PREHEAT_HOTEND                 = _UxGT("Preheat Hotend");
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Preheat Custom");
   LSTR MSG_COOLDOWN                       = _UxGT("Cooldown");
@@ -511,25 +508,14 @@ namespace Language_en {
   LSTR MSG_RESUME_PRINT                   = _UxGT("Resume Print");
   LSTR MSG_STOP_PRINT                     = _UxGT("Stop Print");
   LSTR MSG_OUTAGE_RECOVERY                = _UxGT("Power Outage");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Start Host Print");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Printing Object");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Cancel Object");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Cancel Object {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Continue Print Job");
-    LSTR MSG_MEDIA_MENU                   = _UxGT("Select from ") MEDIA_TYPE_EN;
-    LSTR MSG_TURN_OFF                     = _UxGT("Turn off the printer");
-    LSTR MSG_END_LOOPS                    = _UxGT("End Repeat Loops");
-  #else
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Host Start");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Print Obj");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Cancel Obj");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Cancel Obj {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Continue Job");
-    LSTR MSG_MEDIA_MENU                   = MEDIA_TYPE_EN _UxGT(" Print");
-    LSTR MSG_TURN_OFF                     = _UxGT("Turn off now");
-    LSTR MSG_END_LOOPS                    = _UxGT("End Loops");
-  #endif
+  LSTR MSG_HOST_START_PRINT               = _UxGT("Host Start");
+  LSTR MSG_PRINTING_OBJECT                = _UxGT("Print Obj");
+  LSTR MSG_CANCEL_OBJECT                  = _UxGT("Cancel Obj");
+  LSTR MSG_CANCEL_OBJECT_N                = _UxGT("Cancel Obj {");
+  LSTR MSG_CONTINUE_PRINT_JOB             = _UxGT("Continue Job");
+  LSTR MSG_MEDIA_MENU                     = MEDIA_TYPE_EN _UxGT(" Print");
+  LSTR MSG_TURN_OFF                       = _UxGT("Turn off now");
+  LSTR MSG_END_LOOPS                      = _UxGT("End Loops");
   LSTR MSG_NO_MEDIA                       = _UxGT("No ") MEDIA_TYPE_EN;
   LSTR MSG_DWELL                          = _UxGT("Sleep...");
   LSTR MSG_USERWAIT                       = _UxGT("Click to Resume...");
@@ -579,12 +565,9 @@ namespace Language_en {
   LSTR MSG_FILAMENTUNLOAD                 = _UxGT("Unload Filament");
   LSTR MSG_FILAMENTUNLOAD_E               = _UxGT("Unload * Filament");
   LSTR MSG_FILAMENTUNLOAD_ALL             = _UxGT("Unload All");
-  #if ENABLED(MULTI_VOLUME)
-    LSTR MSG_ATTACH_MEDIA                 = _UxGT("Attach SD Card");
-    LSTR MSG_ATTACH_USB_MEDIA             = _UxGT("Attach USB Drive");
-  #else
-    LSTR MSG_ATTACH_MEDIA                 = _UxGT("Attach ") MEDIA_TYPE_EN;
-  #endif
+  LSTR MSG_ATTACH_MEDIA                   = _UxGT("Attach ") MEDIA_TYPE_EN;
+  LSTR MSG_ATTACH_SD_MEDIA                = _UxGT("Attach SD Card");
+  LSTR MSG_ATTACH_USB_MEDIA               = _UxGT("Attach USB Drive");
   LSTR MSG_CHANGE_MEDIA                   = _UxGT("Change ") MEDIA_TYPE_EN;
   LSTR MSG_RELEASE_MEDIA                  = _UxGT("Release ") MEDIA_TYPE_EN;
   LSTR MSG_ZPROBE_OUT                     = _UxGT("Z Probe Past Bed");
@@ -703,22 +686,12 @@ namespace Language_en {
   LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("Scroll to unlock.");
   LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Please wait until reboot.");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No media inserted.");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Please preheat the hot end.");
-    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Reset Print Count");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Print Count");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Print Time");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest Job Time");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruded Total");
-  #else
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No Media");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Please Preheat");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Prints");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruded");
-  #endif
+  LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("No Media");
+  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Please Preheat");
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Prints");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Longest");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruded");
 
   LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completed");
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min Temp");
@@ -808,35 +781,18 @@ namespace Language_en {
   LSTR MSG_REMINDER_SAVE_SETTINGS         = _UxGT("Remember to Save!");
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Password Removed");
 
-  //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
-  //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Press Button", "to resume print"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Wait for", "filament change", "to start"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Insert filament", "and press button", "to continue"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Press button", "to heat nozzle"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nozzle heating", "Please wait..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Wait for", "filament unload"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Wait for", "filament load"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Wait for", "filament purge"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Click to finish", "filament purge"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Wait for print", "to resume..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Click to continue"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Please wait..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Insert and Click"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Click to heat"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Heating..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Ejecting..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Loading..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purging..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Click to finish"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Resuming..."));
-  #endif
+  // Filament Change screens show up to 2 lines on a 3-line display
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Click to continue"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parking..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Please wait..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Insert and Click"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Click to heat"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Heating..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Ejecting..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Loading..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purging..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Click to finish"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Resuming..."));
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC Drivers");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Driver Current");
   LSTR MSG_TMC_ACURRENT                   = STR_A _UxGT("Driver Current");
@@ -871,11 +827,8 @@ namespace Language_en {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Level X Axis");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Auto Calibrate");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Idle timeout, temperature decreased. Press Okay to reheat and again to resume.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Heater Timeout");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Idle timeout, temperature decreased. Press Okay to reheat and again to resume.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Heater Timeout");
   LSTR MSG_REHEAT                         = _UxGT("Reheat");
   LSTR MSG_REHEATING                      = _UxGT("Reheating...");
   LSTR MSG_REHEATDONE                     = _UxGT("Reheat Done");
@@ -944,5 +897,47 @@ namespace Language_en {
   LSTR DGUS_MSG_WRITE_EEPROM_FAILED       = _UxGT("EEPROM write failed");
   LSTR DGUS_MSG_READ_EEPROM_FAILED        = _UxGT("EEPROM read failed");
   LSTR DGUS_MSG_FILAMENT_RUNOUT           = _UxGT("Filament runout E%d");
+}
 
+namespace LanguageWide_en {
+  using namespace LanguageNarrow_en;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_HOST_START_PRINT             = _UxGT("Start Host Print");
+    LSTR MSG_PRINTING_OBJECT              = _UxGT("Printing Object");
+    LSTR MSG_CANCEL_OBJECT                = _UxGT("Cancel Object");
+    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Cancel Object {");
+    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Continue Print Job");
+    LSTR MSG_MEDIA_MENU                   = _UxGT("Select from ") MEDIA_TYPE_EN;
+    LSTR MSG_TURN_OFF                     = _UxGT("Turn off the printer");
+    LSTR MSG_END_LOOPS                    = _UxGT("End Repeat Loops");
+    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No media inserted.");
+    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Please preheat the hot end.");
+    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Reset Print Count");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Print Count");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Print Time");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest Job Time");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruded Total");
+  #endif
+}
+
+namespace LanguageTall_en {
+  using namespace LanguageWide_en;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Press Button", "to resume print"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Wait for", "filament change", "to start"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Insert filament", "and press button", "to continue"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Press button", "to heat nozzle"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nozzle heating", "Please wait..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Wait for", "filament unload"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Wait for", "filament load"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Wait for", "filament purge"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Click to finish", "filament purge"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Wait for print", "to resume..."));
+  #endif
+}
+
+namespace Language_en {
+  using namespace LanguageTall_en;
 }

--- a/Marlin/src/lcd/language/language_es.h
+++ b/Marlin/src/lcd/language/language_es.h
@@ -28,7 +28,7 @@
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
 
-namespace Language_es {
+namespace LanguageNarrow_es {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -72,23 +72,23 @@ namespace Language_es {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Compen. Altura");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Ajustar desfases");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Desfase aplicada");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Precal. ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Precal. ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Fusor");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Fusor ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Todo");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Cama");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Ajuste");
 
-    LSTR MSG_PREHEAT_M                   = _UxGT("Precal. $");
-    LSTR MSG_PREHEAT_M_H                 = _UxGT("Precal. $ ~");
-    LSTR MSG_PREHEAT_M_END               = _UxGT("Precal. $ Fusor");
-    LSTR MSG_PREHEAT_M_END_E             = _UxGT("Precal. $ Fusor ~");
-    LSTR MSG_PREHEAT_M_ALL               = _UxGT("Precal. $ Todo");
-    LSTR MSG_PREHEAT_M_BEDONLY           = _UxGT("Precal. $ Cama");
-    LSTR MSG_PREHEAT_M_SETTINGS          = _UxGT("Precal. $ Ajuste");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Precal. ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Precal. ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Fusor");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Fusor ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Todo");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Cama");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Precal. ") PREHEAT_1_LABEL _UxGT(" Ajuste");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Precal. $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Precal. $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Precal. $ Fusor");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Precal. $ Fusor ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Precal. $ Todo");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Precal. $ Cama");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Precal. $ Ajuste");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Precal. manual");
   LSTR MSG_COOLDOWN                       = _UxGT("Enfriar");
   LSTR MSG_CUTTER_FREQUENCY               = _UxGT("Frecuencia");
@@ -146,10 +146,8 @@ namespace Language_es {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Term. edici. Mallado");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Crear Mallado Pers.");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Crear Mallado");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Crear Mallado ($)");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Valid. Mall. ($)");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Crear Mallado ($)");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Valid. Mall. ($)");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Crear Mallado Frío");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Ajustar alt. Mallado");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Cantidad de altura");
@@ -454,19 +452,11 @@ namespace Language_es {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Brillo cabina");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Impresora incorrecta");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Cont. de impresión");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tiempo total de imp.");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresión más larga");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruido");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impresiones");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Más larga");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruido");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impresiones");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completadas");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Más larga");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruido");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp. Mínima");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp. Máxima");
@@ -534,31 +524,18 @@ namespace Language_es {
   LSTR MSG_SNAKE                          = _UxGT("Sn4k3");
   LSTR MSG_MAZE                           = _UxGT("Maze");
 
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Pulsar el botón para", "reanudar impresión"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Aparcando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Esperando para", "iniciar el cambio", "de filamento"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserte el filamento", "y pulse el botón", "para continuar..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Pulse el botón para", "calentar la boquilla"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Calentando boquilla", "Espere por favor..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Espere para", "liberar el filamento"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Espere para", "cargar el filamento"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Espere para", "purgar el filamento"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Pulse para finalizar", "la purga de filamen."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Esperando impresora", "para reanudar..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Pulse para continuar"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Aparcando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Por Favor espere..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Inserte y Pulse"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Pulse para Calentar"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Calentando..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Liberando..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Cargando..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purgando..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Pulse para finalizar"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Reanudando..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Pulse para continuar"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Aparcando..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Por Favor espere..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Inserte y Pulse"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Pulse para Calentar"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Calentando..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Liberando..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Cargando..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purgando..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Pulse para finalizar"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Reanudando..."));
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("Controladores TMC");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Amperaje Controlador");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Límite Hibrido");
@@ -576,4 +553,37 @@ namespace Language_es {
   LSTR MSG_HEATER_TIMEOUT                 = _UxGT("T. de esp. Calent.");
   LSTR MSG_REHEAT                         = _UxGT("Recalentar");
   LSTR MSG_REHEATING                      = _UxGT("Recalentando...");
+}
+
+namespace LanguageWide_es {
+  using namespace LanguageNarrow_es;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Cont. de impresión");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tiempo total de imp.");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresión más larga");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruido");
+  #endif
+}
+
+namespace LanguageTall_es {
+  using namespace LanguageWide_es;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Pulsar el botón para", "reanudar impresión"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Aparcando..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Esperando para", "iniciar el cambio", "de filamento"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserte el filamento", "y pulse el botón", "para continuar..."));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Pulse el botón para", "calentar la boquilla"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Calentando boquilla", "Espere por favor..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Espere para", "liberar el filamento"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Espere para", "cargar el filamento"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Espere para", "purgar el filamento"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Pulse para finalizar", "la purga de filamen."));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Esperando impresora", "para reanudar..."));
+  #endif
+}
+
+namespace Language_es {
+  using namespace LanguageTall_es;
 }

--- a/Marlin/src/lcd/language/language_eu.h
+++ b/Marlin/src/lcd/language/language_eu.h
@@ -31,7 +31,7 @@
 #define DISPLAY_CHARSET_ISO10646_1
 #define NOT_EXTENDED_ISO10646_1_5X7
 
-namespace Language_eu {
+namespace LanguageNarrow_eu {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -56,23 +56,23 @@ namespace Language_eu {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Berdintzea eginda");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Etxe. offset eza.");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Offsetak ezarrita");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Berotu ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Berotu ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Amaia");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Amaia ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Guztia");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Ohea");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Ezarp.");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Berotu $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Berotu $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Berotu $ Amaia");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Berotu $ Amaia ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Berotu $ Guztia");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Berotu $ Ohea");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Berotu $ Ezarp.");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Berotu ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Berotu ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Amaia");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Amaia ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Guztia");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Ohea");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Berotu ") PREHEAT_1_LABEL _UxGT(" Ezarp.");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Berotu $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Berotu $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Berotu $ Amaia");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Berotu $ Amaia ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Berotu $ Guztia");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Berotu $ Ohea");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Berotu $ Ezarp.");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Hoztu");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Energia piztu");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Energia itzali");
@@ -99,10 +99,8 @@ namespace Language_eu {
   LSTR MSG_UBL_MESH_EDIT                  = _UxGT("Sarea editatu");
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Sarea editatzea eginda");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Sarea sortu");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("$ sarea sortu");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("$ sarea balioetsi");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("$ sarea sortu");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("$ sarea balioetsi");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Sare hotza sortu");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Sarearen altuera doitu");
   LSTR MSG_UBL_VALIDATE_MESH_MENU         = _UxGT("Sarea balioetsi");
@@ -276,19 +274,13 @@ namespace Language_eu {
   LSTR MSG_INFO_PROTOCOL                  = _UxGT("Protokoloa");
   LSTR MSG_CASE_LIGHT                     = _UxGT("Kabina Argia");
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Argiaren Distira");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Inprim. Zenbaketa");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Burututa");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Inprim. denbora");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Imprimatze luzeena");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Estruituta guztira");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Inprimatze");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Burututa");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Guztira");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Luzeena");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Estrusio");
-  #endif
+
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Inprimatze");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Burututa");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Guztira");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Luzeena");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Estrusio");
+
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Tenp. Minimoa");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Tenp. Maximoa");
   LSTR MSG_INFO_PSU                       = _UxGT("Elikadura-iturria");
@@ -315,4 +307,26 @@ namespace Language_eu {
   LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Sartu eta click egin"));
   LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Berotzen..."));
   LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Kargatzen..."));
+}
+
+namespace LanguageWide_eu {
+  using namespace LanguageNarrow_eu;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Inprim. Zenbaketa");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Burututa");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Inprim. denbora");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Imprimatze luzeena");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Estruituta guztira");
+  #endif
+}
+
+namespace LanguageTall_eu {
+  using namespace LanguageWide_eu;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_eu {
+  using namespace LanguageTall_eu;
 }

--- a/Marlin/src/lcd/language/language_fi.h
+++ b/Marlin/src/lcd/language/language_fi.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_fi {
+namespace LanguageNarrow_fi {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -43,23 +43,23 @@ namespace Language_fi {
   LSTR MSG_RUN_AUTO_FILES                 = _UxGT("Automaatti");
   LSTR MSG_DISABLE_STEPPERS               = _UxGT("Vapauta moottorit");
   LSTR MSG_AUTO_HOME                      = _UxGT("Aja referenssiin");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Esilämmitä ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Esilämmitä ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT("Suutin");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT("Suutin ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT(" Kaikki");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT(" Alusta");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Esilämm. ") PREHEAT_1_LABEL _UxGT(" konf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Esilämmitä $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Esilämmitä $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Esilä. $Suutin");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Esilä. $Suutin ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Esilä. $ Kaikki");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Esilä. $ Alusta");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Esilämm. $ konf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Esilämmitä ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Esilämmitä ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT("Suutin");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT("Suutin ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT(" Kaikki");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Esilä. ") PREHEAT_1_LABEL _UxGT(" Alusta");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Esilämm. ") PREHEAT_1_LABEL _UxGT(" konf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Esilämmitä $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Esilämmitä $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Esilä. $Suutin");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Esilä. $Suutin ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Esilä. $ Kaikki");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Esilä. $ Alusta");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Esilämm. $ konf");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Jäähdytä");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Virta päälle");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Virta pois");
@@ -129,4 +129,21 @@ namespace Language_fi {
   LSTR MSG_DELTA_CALIBRATE_CENTER         = _UxGT("Kalibroi Center");
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Väärä tulostin");
+}
+
+namespace LanguageWide_fi {
+  using namespace LanguageNarrow_fi;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_fi {
+  using namespace LanguageWide_fi;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_fi {
+  using namespace LanguageTall_fi;
 }

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_fr {
+namespace LanguageNarrow_fr {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -76,23 +76,23 @@ namespace Language_fr {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Assistant Molettes");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Molette du lit"); // Not a selection of the origin
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Ecart origine ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Préchauffage ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Préchauffage ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" buse");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" buse ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" Tout");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" lit");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Régler préch. ") PREHEAT_1_LABEL;
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Préchauffage $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Préchauffage $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Préch. $ buse");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Préch. $ buse ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Préch. $ Tout");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Préch. $ lit");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Régler préch. $");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Préchauffage ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Préchauffage ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" buse");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" buse ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" Tout");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Préch. ") PREHEAT_1_LABEL _UxGT(" lit");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Régler préch. ") PREHEAT_1_LABEL;
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Préchauffage $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Préchauffage $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Préch. $ buse");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Préch. $ buse ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Préch. $ Tout");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Préch. $ lit");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Régler préch. $");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Préchauf. perso");
   LSTR MSG_COOLDOWN                       = _UxGT("Refroidir");
   LSTR MSG_LASER_MENU                     = _UxGT("Contrôle Laser");
@@ -156,10 +156,8 @@ namespace Language_fr {
   LSTR MSG_UBL_FINE_TUNE_MESH             = _UxGT("Réglage fin");
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Terminer");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Créer la grille");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Créer grille $");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Impr. grille $");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Créer grille $");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Impr. grille $");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Créer grille ...");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Mesure à froid");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Ajuster haut. couche");
@@ -485,19 +483,11 @@ namespace Language_fr {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Luminosité");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Imprimante incorrecte");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nbre impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminées");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tps impr. total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impr. la + longue");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total filament");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminées");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("+ long");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Filament");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impressions");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Terminées");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("+ long");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Filament");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp Min");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp Max");
@@ -566,32 +556,17 @@ namespace Language_fr {
   LSTR MSG_BAD_PAGE                       = _UxGT("Erreur index page");
   LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Erreur vitesse page");
 
-  #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Presser bouton", "pour reprendre"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Attente filament", "pour démarrer"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Insérer filament", "et app. bouton", "pour continuer..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Presser le bouton", "pour chauffer..."));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Buse en chauffe", "Patienter SVP..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Attente", "retrait du filament"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Attente", "chargement filament"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Attente", "Purge filament"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Presser pour finir", "la purge du filament"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Attente reprise", "impression"));
-  #else // LCD_HEIGHT < 4
-    // Up to 2 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Clic pour continuer"));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Patience..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Insérer fil."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Chauffer ?"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Chauffage..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Retrait fil..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Chargement..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purge..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Terminer ?"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Reprise..."));
-  #endif // LCD_HEIGHT < 4
+  // Up to 2 lines allowed
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Clic pour continuer"));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Patience..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Insérer fil."));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Chauffer ?"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Chauffage..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Retrait fil..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Chargement..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purge..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Terminer ?"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Reprise..."));
 
   LSTR MSG_TMC_CURRENT                    = _UxGT("Courant driver");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Seuil hybride");
@@ -605,11 +580,8 @@ namespace Language_fr {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Niveau axe X");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Etalon. auto.");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("En protection, temp. réduite. Ok pour rechauffer et continuer.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("En protection");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("En protection, temp. réduite. Ok pour rechauffer et continuer.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("En protection");
   LSTR MSG_REHEAT                         = _UxGT("Chauffer");
   LSTR MSG_REHEATING                      = _UxGT("Réchauffe...");
 
@@ -655,4 +627,37 @@ namespace Language_fr {
   LSTR MSG_SHORT_DAY                      = _UxGT("j"); // One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("h"); // One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("m"); // One character only
+}
+
+namespace LanguageWide_fr {
+  using namespace LanguageNarrow_fr;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nbre impressions");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminées");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tps impr. total");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impr. la + longue");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total filament");
+  #endif
+}
+
+namespace LanguageTall_fr {
+  using namespace LanguageWide_fr;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Presser bouton", "pour reprendre"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Attente filament", "pour démarrer"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Insérer filament", "et app. bouton", "pour continuer..."));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Presser le bouton", "pour chauffer..."));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Buse en chauffe", "Patienter SVP..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Attente", "retrait du filament"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Attente", "chargement filament"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Attente", "Purge filament"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Presser pour finir", "la purge du filament"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Attente reprise", "impression"));
+  #endif
+}
+
+namespace Language_fr {
+  using namespace LanguageTall_fr;
 }

--- a/Marlin/src/lcd/language/language_fr_na.h
+++ b/Marlin/src/lcd/language/language_fr_na.h
@@ -31,7 +31,7 @@
 #define DISPLAY_CHARSET_ISO10646_1
 #define NOT_EXTENDED_ISO10646_1_5X7
 
-namespace Language_fr_na {
+namespace LanguageNarrow_fr_na {
   using namespace Language_en; // Inherit undefined strings from English
 
   LSTR LANGUAGE                           = _UxGT("Francais");
@@ -76,23 +76,23 @@ namespace Language_fr_na {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Assistant Molettes");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Molette du lit"); // Not a selection of the origin
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Ecart origine ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Prechauffage ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Prechauffage ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" buse");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" buse ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" Tout");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" lit");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Regler prech. ") PREHEAT_1_LABEL;
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Prechauffage $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Prechauffage $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Prech. $ buse");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Prech. $ buse ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Prech. $ Tout");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Prech. $ lit");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Regler prech. $");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Prechauffage ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Prechauffage ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" buse");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" buse ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" Tout");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Prech. ") PREHEAT_1_LABEL _UxGT(" lit");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Regler prech. ") PREHEAT_1_LABEL;
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Prechauffage $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Prechauffage $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Prech. $ buse");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Prech. $ buse ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Prech. $ Tout");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Prech. $ lit");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Regler prech. $");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Prechauf. perso");
   LSTR MSG_COOLDOWN                       = _UxGT("Refroidir");
   LSTR MSG_LASER_MENU                     = _UxGT("Controle Laser");
@@ -156,10 +156,8 @@ namespace Language_fr_na {
   LSTR MSG_UBL_FINE_TUNE_MESH             = _UxGT("Reglage fin");
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Terminer");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Creer la grille");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Creer grille $");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Impr. grille $");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Creer grille $");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Impr. grille $");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Creer grille ...");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Mesure a froid");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Ajuster haut. couche");
@@ -488,19 +486,11 @@ namespace Language_fr_na {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Luminosite");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Imprimante incorrecte");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nbre impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminees");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tps impr. total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impr. la + longue");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total filament");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impressions");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminees");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("+ long");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Filament");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impressions");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Terminees");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("+ long");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Filament");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp Min");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp Max");
@@ -569,32 +559,17 @@ namespace Language_fr_na {
   LSTR MSG_BAD_PAGE                       = _UxGT("Erreur index page");
   LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Erreur vitesse page");
 
-  #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Presser bouton", "pour reprendre"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Attente filament", "pour demarrer"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserer filament", "et app. bouton", "pour continuer..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Presser le bouton", "pour chauffer..."));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Buse en chauffe", "Patienter SVP..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Attente", "retrait du filament"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Attente", "chargement filament"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Attente", "Purge filament"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Presser pour finir", "la purge du filament"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Attente reprise", "impression"));
-  #else // LCD_HEIGHT < 4
-    // Up to 2 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Clic pour continuer"));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Patience..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Inserer fil."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Chauffer ?"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Chauffage..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Retrait fil..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Chargement..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purge..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Terminer ?"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Reprise..."));
-  #endif // LCD_HEIGHT < 4
+  // Up to 2 lines allowed
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Clic pour continuer"));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Patience..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Inserer fil."));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Chauffer ?"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Chauffage..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Retrait fil..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Chargement..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purge..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Terminer ?"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Reprise..."));
 
   LSTR MSG_TMC_CURRENT                    = _UxGT("Courant driver");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Seuil hybride");
@@ -608,11 +583,8 @@ namespace Language_fr_na {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Niveau axe X");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Etalon. auto.");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("En protection, temp. reduite. Ok pour rechauffer et continuer.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("En protection");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("En protection, temp. reduite. Ok pour rechauffer et continuer.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("En protection");
   LSTR MSG_REHEAT                         = _UxGT("Chauffer");
   LSTR MSG_REHEATING                      = _UxGT("Rechauffe...");
 
@@ -655,4 +627,37 @@ namespace Language_fr_na {
   LSTR DGUS_MSG_READ_EEPROM_FAILED        = _UxGT("Echec lecture de l'EEPROM");
   LSTR DGUS_MSG_FILAMENT_RUNOUT           = _UxGT("Sortie de filament E%d");
 
+}
+
+namespace LanguageWide_fr_na {
+  using namespace LanguageNarrow_fr_na;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nbre impressions");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Terminees");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tps impr. total");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impr. la + longue");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total filament");
+  #endif
+}
+
+namespace LanguageTall_fr_na {
+  using namespace LanguageWide_fr_na;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Presser bouton", "pour reprendre"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parking..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Attente filament", "pour demarrer"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserer filament", "et app. bouton", "pour continuer..."));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Presser le bouton", "pour chauffer..."));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Buse en chauffe", "Patienter SVP..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Attente", "retrait du filament"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Attente", "chargement filament"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Attente", "Purge filament"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Presser pour finir", "la purge du filament"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Attente reprise", "impression"));
+  #endif
+}
+
+namespace Language_fr_na {
+  using namespace LanguageTall_fr_na;
 }

--- a/Marlin/src/lcd/language/language_gl.h
+++ b/Marlin/src/lcd/language/language_gl.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_gl {
+namespace LanguageNarrow_gl {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -69,23 +69,23 @@ namespace Language_gl {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Compensación Altura");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Axustar Desfases");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Desfases aplicados");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Prequentar ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Prequentar ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Bico");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Bico ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Todo");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Cama");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Prequentar $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Prequentar $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Preque. $ Bico");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Preque. $ Bico ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Preque. $ Todo");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Preque. $ Cama");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Preque. $ conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Prequentar ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Prequentar ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Bico");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Bico ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Todo");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" Cama");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Preque. ") PREHEAT_1_LABEL _UxGT(" conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Prequentar $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Prequentar $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Preque. $ Bico");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Preque. $ Bico ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Preque. $ Todo");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Preque. $ Cama");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Preque. $ conf");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Preque. Personali.");
   LSTR MSG_COOLDOWN                       = _UxGT("Arrefriar");
   LSTR MSG_CUTTER_FREQUENCY               = _UxGT("Frecuencia");
@@ -143,10 +143,8 @@ namespace Language_gl {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Fin Edición da Malla");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Crear Malla Person.");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Crear Malla");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Crear Malla ($)");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Validar Malla ($)");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Crear Malla ($)");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Validar Malla ($)");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Crear Malla Fría");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Axustar Altura Malla");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Altura");
@@ -469,19 +467,11 @@ namespace Language_gl {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Brillo Luces");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("IMPRESORA INCORRECTA");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total Impresións");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo Total Imp.");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresión máis longa");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruído");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Impresións");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Máis Longa");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruido");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Impresións");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completadas");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Máis Longa");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruido");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp Mín");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp Máx");
@@ -549,31 +539,17 @@ namespace Language_gl {
   LSTR MSG_SNAKE                          = _UxGT("Sn4k3");
   LSTR MSG_MAZE                           = _UxGT("Labirinto");
 
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Preme o botón para", "continuar impresión"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Estacionando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Agarde para", "comezar cambio", "de filamento"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Introduza o", "filamento e", "faga click"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Prema o botón para", "quentar o bico"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Quentando bico", "Agarde, por favor..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Agarde pola", "descarga do", "filamento"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Agarde pola", "carga do", "filamento"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Agarde para", "purgar o filamento"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Prema para finalizar", "a purga do filamen."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Agarde a que", "se retome", "a impresión"));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Premer para continuar"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Estacionando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Agarde..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Introduza e click"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Prema para quentar"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Quentando..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Descargando..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Cargando..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purgando..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Prema para finalizar"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Retomando..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Premer para continuar"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Estacionando..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Agarde..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Introduza e click"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Prema para quentar"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Quentando..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Descargando..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Cargando..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purgando..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Prema para finalizar"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Retomando..."));
 
   LSTR MSG_TMC_DRIVERS                    = _UxGT("Controladores TMC");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Controlador Actual");
@@ -592,4 +568,36 @@ namespace Language_gl {
   LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Tempo exc. Quent.");
   LSTR MSG_REHEAT                         = _UxGT("Requentar");
   LSTR MSG_REHEATING                      = _UxGT("Requentando...");
+}
+
+namespace LanguageWide_gl {
+  using namespace LanguageNarrow_gl;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total Impresións");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completadas");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo Total Imp.");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Impresión máis longa");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extruído");
+  #endif
+}
+
+namespace LanguageTall_gl {
+  using namespace LanguageWide_gl;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Preme o botón para", "continuar impresión"));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Agarde para", "comezar cambio", "de filamento"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Introduza o", "filamento e", "faga click"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Prema o botón para", "quentar o bico"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Quentando bico", "Agarde, por favor..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Agarde pola", "descarga do", "filamento"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Agarde pola", "carga do", "filamento"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Agarde para", "purgar o filamento"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Prema para finalizar", "a purga do filamen."));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Agarde a que", "se retome", "a impresión"));
+  #endif
+}
+
+namespace Language_gl {
+  using namespace LanguageTall_gl;
 }

--- a/Marlin/src/lcd/language/language_hr.h
+++ b/Marlin/src/lcd/language/language_hr.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.
 
-namespace Language_hr {
+namespace LanguageNarrow_hr {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -53,23 +53,23 @@ namespace Language_hr {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Niveliranje gotovo!");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Postavi home offsete");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Offsets postavljeni");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Predgrij ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Predgrij ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Dizna");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Dizna ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Sve");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Bed");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Predgrij $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Predgrij $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Predgrij $ Dizna");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Predgrij $ Dizna ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Predgrij $ Sve");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Predgrij $ Bed");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Predgrij $ conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Predgrij ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Predgrij ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Dizna");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Dizna ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Sve");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" Bed");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Predgrij ") PREHEAT_1_LABEL _UxGT(" conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Predgrij $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Predgrij $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Predgrij $ Dizna");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Predgrij $ Dizna ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Predgrij $ Sve");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Predgrij $ Bed");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Predgrij $ conf");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Hlađenje");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Uključi napajanje");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Isključi napajanje");
@@ -140,19 +140,11 @@ namespace Language_hr {
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Neispravan pisač");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Broj printova");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Završeni");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Ukupno printanja");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najduži print");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrudirano ukupno");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Printovi");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Završeni");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Ukupno");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najduži");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrudirano");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Printovi");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Završeni");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Ukupno");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Najduži");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extrudirano");
 
   LSTR MSG_INFO_PSU                       = _UxGT("Napajanje");
 
@@ -162,12 +154,30 @@ namespace Language_hr {
   LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Pričekaj", "filament load"));
   LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Nastavljam..."));
 
+  // Up to 2 lines allowed
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT("Pričekaj...");
+}
+
+namespace LanguageWide_hr {
+  using namespace LanguageNarrow_hr;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Broj printova");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Završeni");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Ukupno printanja");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najduži print");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrudirano ukupno");
+  #endif
+}
+
+namespace LanguageTall_hr {
+  using namespace LanguageWide_hr;
   #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Čekaj početak", "filamenta", "promijeni"));
     LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Umetni filament", "i pritisni tipku", "za nastavak..."));
-  #else
-    // Up to 2 lines allowed
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT("Pričekaj...");
   #endif
+}
+
+namespace Language_hr {
+  using namespace LanguageTall_hr;
 }

--- a/Marlin/src/lcd/language/language_hu.h
+++ b/Marlin/src/lcd/language/language_hu.h
@@ -33,7 +33,7 @@
  * A Fordítás utolsó frissítése: 2021.08.30. - 22:20
  */
 
-namespace Language_hu {
+namespace LanguageNarrow_hu {
   using namespace Language_en; // A fordítás az örökölt Amerikai Angol (English) karakterláncokat használja.
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -83,23 +83,23 @@ namespace Language_hu {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Elektromos varázsló");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Eredeti választása");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Utolsó érték ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Fütés ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Fütés ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Fej");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Fej ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Mind");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Ágy");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Beáll");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Fütés $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Fütés $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Fütés $ Fej");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Fütés $ Fej ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Fütés $ Mind");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Fütés $ Ágy");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Fütés $ Beáll");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Fütés ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Fütés ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Fej");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Fej ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Mind");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Ágy");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Fütés ") PREHEAT_1_LABEL _UxGT(" Beáll");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Fütés $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Fütés $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Fütés $ Fej");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Fütés $ Fej ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Fütés $ Mind");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Fütés $ Ágy");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Fütés $ Beáll");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Egyedi elömelegítés");
   LSTR MSG_COOLDOWN                       = _UxGT("Visszahütés");
 
@@ -531,19 +531,11 @@ namespace Language_hu {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Fényerösség");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("HELYTELEN NYOMTATÓ");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nyomtatás számláló");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Befejezett");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Összes nyomtatási idö");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Leghosszabb munkaidö");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Összes anyag");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nyomtatások");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Befejezett");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Összes");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Leghosszabb");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Kiadott");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Nyomtatások");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Befejezett");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Összes");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Leghosszabb");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Kiadott");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min höfok");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Max höfok");
@@ -626,34 +618,20 @@ namespace Language_hu {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Jelszó törölve");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Nyomj gombot", "nyomtatás folytatáshoz"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkolás..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Várj míg", "szálcsere", "indítás"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Szál behelyezés", "majd nyomj gombot", "a folytatáshoz"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Nyomj gombot", "a fej fütéséhez"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Fej fütése", "Kérlek várj..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Várj a", "szál kiadására"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Várj a", "szál betöltésére"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Várj a", "szál tisztításra"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Kattints a készre", "szál tiszta"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Várj a nyomtatóra", "majd folytat..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Katt a folytatáshoz"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkolás..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Kérlek várj..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Behelyez majd katt"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Katt a fütéshez"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Fütés..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Kiadás..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Betöltés..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Tisztítás..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Katt ha kész"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Folytatás..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Katt a folytatáshoz"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parkolás..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Kérlek várj..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Behelyez majd katt"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Katt a fütéshez"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Fütés..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Kiadás..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Betöltés..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Tisztítás..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Katt ha kész"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Folytatás..."));
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC meghajtók");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Meghajtó áram");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Hibrid küszöbérték");
@@ -668,11 +646,8 @@ namespace Language_hu {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("X tengely szint");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Önkalibrálás");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Tétlenségi idökorlát, a hömérséklet csökkent. Nyomd meg az OK gombot az ismételt felfütéshez, és újra a folytatáshoz.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Fütés idökorlátja");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Tétlenségi idökorlát, a hömérséklet csökkent. Nyomd meg az OK gombot az ismételt felfütéshez, és újra a folytatáshoz.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Fütés idökorlátja");
   LSTR MSG_REHEAT                         = _UxGT("Újrafüt");
   LSTR MSG_REHEATING                      = _UxGT("Újrafütés...");
 
@@ -697,4 +672,36 @@ namespace Language_hu {
   LSTR MSG_SHORT_DAY                      = _UxGT("n"); // Csak egy karakter
   LSTR MSG_SHORT_HOUR                     = _UxGT("ó"); // Csak egy karakter
   LSTR MSG_SHORT_MINUTE                   = _UxGT("p"); // Csak egy karakter
+}
+
+namespace LanguageWide_hu {
+  using namespace LanguageNarrow_hu;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Nyomtatás számláló");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Befejezett");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Összes nyomtatási idö");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Leghosszabb munkaidö");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Összes anyag");
+  #endif
+}
+
+namespace LanguageTall_hu {
+  using namespace LanguageWide_hu;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Nyomj gombot", "nyomtatás folytatáshoz"));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Várj míg", "szálcsere", "indítás"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Szál behelyezés", "majd nyomj gombot", "a folytatáshoz"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Nyomj gombot", "a fej fütéséhez"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Fej fütése", "Kérlek várj..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Várj a", "szál kiadására"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Várj a", "szál betöltésére"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Várj a", "szál tisztításra"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Kattints a készre", "szál tiszta"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Várj a nyomtatóra", "majd folytat..."));
+  #endif
+}
+
+namespace Language_hu {
+  using namespace LanguageTall_hu;
 }

--- a/Marlin/src/lcd/language/language_it.h
+++ b/Marlin/src/lcd/language/language_it.h
@@ -38,7 +38,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_it {
+namespace LanguageNarrow_it {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -106,30 +106,23 @@ namespace Language_it {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Wizard Tramming");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Selez. origine");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Ultimo valore ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Preriscalda ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Preriscalda ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Ugello");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Ugello ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Tutto");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Piatto");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" conf");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                  = _UxGT("Preris.") PREHEAT_2_LABEL;
-      LSTR MSG_PREHEAT_2_SETTINGS         = _UxGT("Preris.") PREHEAT_2_LABEL _UxGT(" conf");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                  = _UxGT("Preris.") PREHEAT_3_LABEL;
-      LSTR MSG_PREHEAT_3_SETTINGS         = _UxGT("Preris.") PREHEAT_3_LABEL _UxGT(" conf");
-    #endif
-    LSTR MSG_PREHEAT_M                    = _UxGT("Preriscalda $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Preriscalda $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Preris.$ Ugello");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Preris.$ Ugello ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Preris.$ Tutto");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Preris.$ Piatto");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Preris.$ conf");
-  #endif
+
+  LSTR MSG_PREHEAT_1                      = _UxGT("Preriscalda ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Preriscalda ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Ugello");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Ugello ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Tutto");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" Piatto");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Preris.") PREHEAT_1_LABEL _UxGT(" conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Preriscalda $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Preriscalda $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Preris.$ Ugello");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Preris.$ Ugello ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Preris.$ Tutto");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Preris.$ Piatto");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Preris.$ conf");
+
   LSTR MSG_PREHEAT_HOTEND                 = _UxGT("Prerisc.Hotend");
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Prerisc.personal.");
   LSTR MSG_COOLDOWN                       = _UxGT("Raffredda");
@@ -221,10 +214,8 @@ namespace Language_it {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Modif.Mesh fatta");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Crea Mesh personal.");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Crea Mesh");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Crea Mesh ($)");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Valida Mesh ($)");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Crea Mesh ($)");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Valida Mesh ($)");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Crea Mesh a freddo");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Aggiusta Alt. Mesh");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Altezza");
@@ -672,22 +663,12 @@ namespace Language_it {
   LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("Scroll x sbloccare.");
   LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Attendere fino al riavvio.");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Nessun supporto inserito.");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Si prega di preriscaldare l'hot end.");
-    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Azzera contatori stampa");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Contatori stampa");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo totale");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Lavoro più lungo");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Totale estruso");
-  #else
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No Supporto");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Prerisc. hot end.");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Stampe");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Durata");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Più lungo");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Estruso");
-  #endif
+  LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("No Supporto");
+  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Prerisc. hot end.");
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Stampe");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Durata");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Più lungo");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Estruso");
 
   LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completate");
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp min");
@@ -778,33 +759,18 @@ namespace Language_it {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Password eliminata");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_3_LINE("Premi per", "riprendere", "la stampa"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Sto parcheggiando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Attendere avvio", "del cambio", "di filamento"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserisci il", "filamento e premi", "per continuare"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Premi per", "riscaldare ugello"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Riscaldam. ugello", "Attendere prego..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Attendere", "l'espulsione", "del filamento"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Attendere", "il caricamento", "del filamento"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Attendere", "lo spurgo", "del filamento"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Premi x terminare", "lo spurgo", "del filamento"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Attendere", "la ripresa", "della stampa..."));
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Premi x continuare"));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Attendere..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Inserisci e premi"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Riscalda ugello"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Riscaldamento..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Espulsione..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Caricamento..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Spurgo filamento"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Premi x terminare"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Ripresa..."));
-  #endif // LCD_HEIGHT < 4
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Premi x continuare"));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Attendere..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Inserisci e premi"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Riscalda ugello"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Riscaldamento..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Espulsione..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Caricamento..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Spurgo filamento"));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Premi x terminare"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Ripresa..."));
 
   LSTR MSG_TMC_DRIVERS                    = _UxGT("Driver TMC");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Correnti driver");
@@ -838,11 +804,8 @@ namespace Language_it {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Livello asse X");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Auto Calibra");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Timeout inattività, temperatura diminuita. Premere OK per riscaldare e riprendere di nuovo.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Timeout riscaldatore");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Timeout inattività, temperatura diminuita. Premere OK per riscaldare e riprendere di nuovo.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Timeout riscaldatore");
   LSTR MSG_REHEAT                         = _UxGT("Riscalda");
   LSTR MSG_REHEATING                      = _UxGT("Riscaldando...");
   LSTR MSG_REHEATDONE                     = _UxGT("Riscaldato");
@@ -894,4 +857,39 @@ namespace Language_it {
   LSTR DGUS_MSG_READ_EEPROM_FAILED        = _UxGT("Lettura EEPROM fallita");
   LSTR DGUS_MSG_FILAMENT_RUNOUT           = _UxGT("Filament runout E%d");
 
+}
+
+namespace LanguageWide_it {
+  using namespace LanguageNarrow_it;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Nessun supporto inserito.");
+    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Si prega di preriscaldare l'hot end.");
+    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Azzera contatori stampa");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Contatori stampa");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo totale");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Lavoro più lungo");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Totale estruso");
+  #endif
+}
+
+namespace LanguageTall_it {
+  using namespace LanguageWide_it;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_3_LINE("Premi per", "riprendere", "la stampa"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Sto parcheggiando..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Attendere avvio", "del cambio", "di filamento"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Inserisci il", "filamento e premi", "per continuare"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Premi per", "riscaldare ugello"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Riscaldam. ugello", "Attendere prego..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Attendere", "l'espulsione", "del filamento"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Attendere", "il caricamento", "del filamento"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Attendere", "lo spurgo", "del filamento"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Premi x terminare", "lo spurgo", "del filamento"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Attendere", "la ripresa", "della stampa..."));
+  #endif
+}
+
+namespace Language_it {
+  using namespace LanguageTall_it;
 }

--- a/Marlin/src/lcd/language/language_jp_kana.h
+++ b/Marlin/src/lcd/language/language_jp_kana.h
@@ -31,7 +31,7 @@
 
 //#define DISPLAY_CHARSET_ISO10646_KANA
 
-namespace Language_jp_kana {
+namespace LanguageNarrow_jp_kana {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 3;
@@ -61,23 +61,23 @@ namespace Language_jp_kana {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("レベリングカンリョウ"); // "Leveling Done!"
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("キジュンオフセットセッテイ"); // "Set home offsets"
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("オフセットガテキヨウサレマシタ"); // "Offsets applied"
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = PREHEAT_1_LABEL _UxGT(" ヨネツ"); // "Preheat " PREHEAT_1_LABEL
-    LSTR MSG_PREHEAT_1_H                  = PREHEAT_1_LABEL _UxGT(" ヨネツ ~"); // "Preheat " PREHEAT_1_LABEL
-    LSTR MSG_PREHEAT_1_END                = PREHEAT_1_LABEL _UxGT(" ヨネツノズル"); // " Nozzle"
-    LSTR MSG_PREHEAT_1_END_E              = PREHEAT_1_LABEL _UxGT(" ヨネツノズル ~"); // " Nozzle"
-    LSTR MSG_PREHEAT_1_ALL                = PREHEAT_1_LABEL _UxGT(" スベテヨネツ"); // " All"
-    LSTR MSG_PREHEAT_1_BEDONLY            = PREHEAT_1_LABEL _UxGT(" ベッドヨネツ"); // " Bed"
-    LSTR MSG_PREHEAT_1_SETTINGS           = PREHEAT_1_LABEL _UxGT(" ヨネツセッテイ"); // " conf"
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("$ ヨネツ"); // "Preheat " PREHEAT_1_LABEL
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("$ ヨネツ ~"); // "Preheat " PREHEAT_1_LABEL
-    LSTR MSG_PREHEAT_M_END                = _UxGT("$ ヨネツノズル"); // " Nozzle"
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("$ ヨネツノズル ~"); // " Nozzle"
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("$ スベテヨネツ"); // " All"
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("$ ベッドヨネツ"); // " Bed"
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("$ ヨネツセッテイ"); // " conf"
-  #endif
+  LSTR MSG_PREHEAT_1                      = PREHEAT_1_LABEL _UxGT(" ヨネツ"); // "Preheat " PREHEAT_1_LABEL
+  LSTR MSG_PREHEAT_1_H                    = PREHEAT_1_LABEL _UxGT(" ヨネツ ~"); // "Preheat " PREHEAT_1_LABEL
+  LSTR MSG_PREHEAT_1_END                  = PREHEAT_1_LABEL _UxGT(" ヨネツノズル"); // " Nozzle"
+  LSTR MSG_PREHEAT_1_END_E                = PREHEAT_1_LABEL _UxGT(" ヨネツノズル ~"); // " Nozzle"
+  LSTR MSG_PREHEAT_1_ALL                  = PREHEAT_1_LABEL _UxGT(" スベテヨネツ"); // " All"
+  LSTR MSG_PREHEAT_1_BEDONLY              = PREHEAT_1_LABEL _UxGT(" ベッドヨネツ"); // " Bed"
+  LSTR MSG_PREHEAT_1_SETTINGS             = PREHEAT_1_LABEL _UxGT(" ヨネツセッテイ"); // " conf"
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("$ ヨネツ"); // "Preheat " PREHEAT_1_LABEL
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("$ ヨネツ ~"); // "Preheat " PREHEAT_1_LABEL
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("$ ヨネツノズル"); // " Nozzle"
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("$ ヨネツノズル ~"); // " Nozzle"
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("$ スベテヨネツ"); // " All"
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("$ ベッドヨネツ"); // " Bed"
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("$ ヨネツセッテイ"); // " conf"
+
   LSTR MSG_COOLDOWN                       = _UxGT("カネツテイシ"); // "Cooldown"
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("デンゲン オン"); // "Switch power on"
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("デンゲン オフ"); // "Switch power off"
@@ -246,4 +246,21 @@ namespace Language_jp_kana {
   LSTR MSG_CUSTOM_COMMANDS                = _UxGT("ユーザーコマンド");
   LSTR MSG_PRINT_PAUSED                   = _UxGT("プリントガイチジテイシサレマシタ");
   LSTR MSG_PRINTING                       = _UxGT("プリントチュウ...");
+}
+
+namespace LanguageWide_jp_kana {
+  using namespace LanguageNarrow_jp_kana;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_jp_kana {
+  using namespace LanguageWide_jp_kana;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_jp_kana {
+  using namespace LanguageTall_jp_kana;
 }

--- a/Marlin/src/lcd/language/language_ko_KR.h
+++ b/Marlin/src/lcd/language/language_ko_KR.h
@@ -27,7 +27,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_ko_KR {
+namespace LanguageNarrow_ko_KR {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -54,17 +54,17 @@ namespace Language_ko_KR {
   LSTR MSG_LEVEL_BED_WAITING              = _UxGT("누르면 시작합니다");
   LSTR MSG_LEVEL_BED_NEXT_POINT           = _UxGT("다음 Point");
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("레벨링 완료!");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("예열하기 - ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("예열하기 - ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("예열하기 - ") PREHEAT_1_LABEL _UxGT(" 노즐");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("예열하기 - ") PREHEAT_1_LABEL _UxGT(" 노즐 ~");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("예열하기 - $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("예열하기 - $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("예열하기 - $ 노즐");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("예열하기 - $ 노즐 ~");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("예열하기 - ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("예열하기 - ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("예열하기 - ") PREHEAT_1_LABEL _UxGT(" 노즐");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("예열하기 - ") PREHEAT_1_LABEL _UxGT(" 노즐 ~");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("예열하기 - $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("예열하기 - $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("예열하기 - $ 노즐");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("예열하기 - $ 노즐 ~");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Custom 예열");
   LSTR MSG_COOLDOWN                       = _UxGT("식히기");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("스위치 전원 켜기");
@@ -103,4 +103,21 @@ namespace Language_ko_KR {
   LSTR MSG_KILLED                         = _UxGT("죽음. ");
   LSTR MSG_STOPPED                        = _UxGT("멈춤. ");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("잘못된 프린터");
+}
+
+namespace LanguageWide_ko_KR {
+  using namespace LanguageNarrow_ko_KR;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_ko_KR {
+  using namespace LanguageWide_ko_KR;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_ko_KR {
+  using namespace LanguageTall_ko_KR;
 }

--- a/Marlin/src/lcd/language/language_nl.h
+++ b/Marlin/src/lcd/language/language_nl.h
@@ -31,7 +31,7 @@
 #define DISPLAY_CHARSET_ISO10646_1
 #define NOT_EXTENDED_ISO10646_1_5X7
 
-namespace Language_nl {
+namespace LanguageNarrow_nl {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 1;
@@ -53,23 +53,23 @@ namespace Language_nl {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Bed level kompl.");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Zet home offsets");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("H offset toegep.");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = PREHEAT_1_LABEL _UxGT(" voorverwarmen");
-    LSTR MSG_PREHEAT_1_H                  = PREHEAT_1_LABEL _UxGT(" voorverw. ~");
-    LSTR MSG_PREHEAT_1_END                = PREHEAT_1_LABEL _UxGT(" voorverw. Einde");
-    LSTR MSG_PREHEAT_1_END_E              = PREHEAT_1_LABEL _UxGT(" voorverw. Einde ~");
-    LSTR MSG_PREHEAT_1_ALL                = PREHEAT_1_LABEL _UxGT(" voorverw. aan");
-    LSTR MSG_PREHEAT_1_BEDONLY            = PREHEAT_1_LABEL _UxGT(" voorverw. Bed");
-    LSTR MSG_PREHEAT_1_SETTINGS           = PREHEAT_1_LABEL _UxGT(" verw. conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("$ voorverwarmen");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("$ voorverw. ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("$ voorverw. Einde");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("$ voorverw. Einde ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("$ voorverw. aan");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("$ voorverw. Bed");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("$ verw. conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = PREHEAT_1_LABEL _UxGT(" voorverwarmen");
+  LSTR MSG_PREHEAT_1_H                    = PREHEAT_1_LABEL _UxGT(" voorverw. ~");
+  LSTR MSG_PREHEAT_1_END                  = PREHEAT_1_LABEL _UxGT(" voorverw. Einde");
+  LSTR MSG_PREHEAT_1_END_E                = PREHEAT_1_LABEL _UxGT(" voorverw. Einde ~");
+  LSTR MSG_PREHEAT_1_ALL                  = PREHEAT_1_LABEL _UxGT(" voorverw. aan");
+  LSTR MSG_PREHEAT_1_BEDONLY              = PREHEAT_1_LABEL _UxGT(" voorverw. Bed");
+  LSTR MSG_PREHEAT_1_SETTINGS             = PREHEAT_1_LABEL _UxGT(" verw. conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("$ voorverwarmen");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("$ voorverw. ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("$ voorverw. Einde");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("$ voorverw. Einde ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("$ voorverw. aan");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("$ voorverw. Bed");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("$ verw. conf");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Afkoelen");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Stroom aan");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Stroom uit");
@@ -180,19 +180,11 @@ namespace Language_nl {
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Onjuiste printer");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Printed Aantal");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Totaal Voltooid");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Totale Printtijd");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Langste Printtijd");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Totaal Extrudeert");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Aantal");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Voltooid");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Printtijd ");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Langste");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extrud.");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Aantal");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Voltooid");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Printtijd ");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Langste");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extrud.");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min Temp");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Max Temp");
@@ -204,11 +196,32 @@ namespace Language_nl {
   LSTR MSG_FILAMENT_CHANGE_OPTION_RESUME  = _UxGT("Hervat print");
   LSTR MSG_FILAMENT_CHANGE_NOZZLE         = _UxGT(" Nozzle: "); // accepted English term
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_2_LINE("Wacht voor", "start..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_2_LINE("Wacht voor", "uitladen..."));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_2_LINE("Klik knop om...", "verw. nozzle.")); //nozzle accepted English term
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Verwarmen..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_2_LINE("Laad filament", "en druk knop"));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Wacht voor", "inladen..."));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_2_LINE("Wacht voor", "printing..."));
+}
+
+namespace LanguageWide_nl {
+  using namespace LanguageNarrow_nl;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Printed Aantal");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Totaal Voltooid");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Totale Printtijd");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Langste Printtijd");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Totaal Extrudeert");
+  #endif
+}
+
+namespace LanguageTall_nl {
+  using namespace LanguageWide_nl;
   #if LCD_HEIGHT >= 4
-    // Up to 3 lines
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Wacht voor start", "filament te", "verwisselen"));
     LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Wacht voor", "filament uit", "te laden"));
     LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Klik knop om...", "verw. nozzle.")); //nozzle accepted English term
@@ -216,14 +229,9 @@ namespace Language_nl {
     LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Laad filament", "en druk knop", "om verder..."));
     LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Wacht voor", "filament te", "laden"));
     LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Wacht voor print", "om verder", "te gaan"));
-  #else
-    // Up to 2 lines
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Wacht voor", "start..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Wacht voor", "uitladen..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Klik knop om...", "verw. nozzle.")); //nozzle accepted English term
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Verwarmen..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_2_LINE("Laad filament", "en druk knop"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Wacht voor", "inladen..."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Wacht voor", "printing..."));
   #endif
+}
+
+namespace Language_nl {
+  using namespace LanguageTall_nl;
 }

--- a/Marlin/src/lcd/language/language_pl.h
+++ b/Marlin/src/lcd/language/language_pl.h
@@ -38,7 +38,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_PL
 
-namespace Language_pl {
+namespace LanguageNarrow_pl {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -81,23 +81,23 @@ namespace Language_pl {
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Poz. zerowa ust.");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Wybierz punkt zero");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Poprzednia wartość ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Rozgrzej ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Rozgrzej ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" Dysza");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" Dysza ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" wsz.");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" stół");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" ustaw.");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Rozgrzej $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Rozgrzej $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Rozgrzej $ Dysza");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Rozgrzej $ Dysza ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Rozgrzej $ wsz.");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Rozgrzej $ stół");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Rozgrzej $ ustaw.");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Rozgrzej ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Rozgrzej ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" Dysza");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" Dysza ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" wsz.");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" stół");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Rozgrzej ") PREHEAT_1_LABEL _UxGT(" ustaw.");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Rozgrzej $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Rozgrzej $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Rozgrzej $ Dysza");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Rozgrzej $ Dysza ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Rozgrzej $ wsz.");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Rozgrzej $ stół");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Rozgrzej $ ustaw.");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Rozgrzej własne ust.");
   LSTR MSG_COOLDOWN                       = _UxGT("Chłodzenie");
 
@@ -422,19 +422,11 @@ namespace Language_pl {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Jasność oświetlenia");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Niepoprawna drukarka");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Wydrukowano");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Ukończono");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Czas druku");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdł. druk");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Użyty fil.");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Wydrukowano");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Ukończono");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Razem");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdł. druk");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Użyty fil.");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Wydrukowano");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Ukończono");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Razem");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Najdł. druk");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Użyty fil.");
 
   LSTR MSG_INFO_PSU                       = _UxGT("Zasilacz");
   LSTR MSG_DRIVE_STRENGTH                 = _UxGT("Siła silnika");
@@ -495,34 +487,20 @@ namespace Language_pl {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Hasło usunięte");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Nacisnik przycisk", "by wznowić drukowanie"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkowanie..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Czekam na", "zmianę filamentu", "by wystartować"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Włóż filament", "i naciśnij przycisk", "by kontynuować"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Naciśnij przycisk", "by nagrzać dyszę"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nagrzewanie dyszy", "Proszę czekać..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Czekam na", "wyjęcie filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Czekam na", "włożenie filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Czekam na", "oczyszczenie filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Kliknij by zakończyć", "oczyszczanie filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Czekam na", "wznowienie wydruku..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Kliknij by kontynuować"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkowanie..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Proszę czekać..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Włóż i kliknij"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Kliknij by nagrzać"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Nagrzewanie..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Wysuwanie..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Wsuwanie..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Oczyszczanie..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Kliknij by zakończyć"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Wznawianie..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Kliknij by kontynuować"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parkowanie..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Proszę czekać..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Włóż i kliknij"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Kliknij by nagrzać"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Nagrzewanie..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Wysuwanie..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Wsuwanie..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Oczyszczanie..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Kliknij by zakończyć"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Wznawianie..."));
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("Sterowniki TMC");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Prąd sterownika");
   LSTR MSG_TMC_HOMING_THRS                = _UxGT("Zerowanie bezczujnikowe");
@@ -537,4 +515,36 @@ namespace Language_pl {
   LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Kalibracja zakończona");
   LSTR MSG_CALIBRATION_FAILED             = _UxGT("Kalibracja nie powiodła się");
 
+}
+
+namespace LanguageWide_pl {
+  using namespace LanguageNarrow_pl;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Wydrukowano");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Ukończono");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Czas druku");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdł. druk");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Użyty fil.");
+  #endif
+}
+
+namespace LanguageTall_pl {
+  using namespace LanguageWide_pl;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Nacisnik przycisk", "by wznowić drukowanie"));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Czekam na", "zmianę filamentu", "by wystartować"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Włóż filament", "i naciśnij przycisk", "by kontynuować"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Naciśnij przycisk", "by nagrzać dyszę"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nagrzewanie dyszy", "Proszę czekać..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Czekam na", "wyjęcie filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Czekam na", "włożenie filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Czekam na", "oczyszczenie filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Kliknij by zakończyć", "oczyszczanie filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Czekam na", "wznowienie wydruku..."));
+  #endif
+}
+
+namespace Language_pl {
+  using namespace LanguageTall_pl;
 }

--- a/Marlin/src/lcd/language/language_pt.h
+++ b/Marlin/src/lcd/language/language_pt.h
@@ -31,7 +31,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_pt {
+namespace LanguageNarrow_pt {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -52,23 +52,23 @@ namespace Language_pt {
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Pronto !");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Definir desvio");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Offsets aplicados");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL _UxGT(" Bico");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL _UxGT(" Bico ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Pre-aq. ") PREHEAT_1_LABEL _UxGT(" Tudo");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Pre-aq. ") PREHEAT_1_LABEL _UxGT(" ") LCD_STR_THERMOMETER _UxGT("Base");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Definições ") PREHEAT_1_LABEL;
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Pre-aquecer $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Pre-aquecer $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Pre-aquecer $ Bico");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Pre-aquecer $ Bico ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Pre-aq. $ Tudo");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Pre-aq. $ ") LCD_STR_THERMOMETER _UxGT("Base");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Definições $");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL _UxGT(" Bico");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL _UxGT(" Bico ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Pre-aq. ") PREHEAT_1_LABEL _UxGT(" Tudo");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Pre-aq. ") PREHEAT_1_LABEL _UxGT(" ") LCD_STR_THERMOMETER _UxGT("Base");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Definições ") PREHEAT_1_LABEL;
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Pre-aquecer $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Pre-aquecer $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Pre-aquecer $ Bico");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Pre-aquecer $ Bico ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Pre-aq. $ Tudo");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Pre-aq. $ ") LCD_STR_THERMOMETER _UxGT("Base");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Definições $");
+
   LSTR MSG_COOLDOWN                       = _UxGT("Arrefecer");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Ligar");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Desligar");
@@ -169,4 +169,21 @@ namespace Language_pt {
   LSTR MSG_BOTTOM_RIGHT                   = _UxGT("Inferior Direto");
   LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Calibração Completa");
   LSTR MSG_CALIBRATION_FAILED             = _UxGT("Calibração Falhou");
+}
+
+namespace LanguageWide_pt {
+  using namespace LanguageNarrow_pt;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_pt {
+  using namespace LanguageWide_pt;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_pt {
+  using namespace LanguageTall_pt;
 }

--- a/Marlin/src/lcd/language/language_pt_br.h
+++ b/Marlin/src/lcd/language/language_pt_br.h
@@ -28,7 +28,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_pt_br {
+namespace LanguageNarrow_pt_br {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -67,23 +67,23 @@ namespace Language_pt_br {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Suavizar altura");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Compensar origem");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Alteração aplicada");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Extrusora ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Extrusora ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Pre-aq.Todo ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Pre-aq.Mesa ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Ajustar ") PREHEAT_1_LABEL;
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Pre-aquecer $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Pre-aquecer $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Extrusora $");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Extrusora $ ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Pre-aq.Todo $");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Pre-aq.Mesa $");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Ajustar $");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Pre-aquecer ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Extrusora ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Extrusora ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Pre-aq.Todo ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Pre-aq.Mesa ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Ajustar ") PREHEAT_1_LABEL;
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Pre-aquecer $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Pre-aquecer $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Extrusora $");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Extrusora $ ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Pre-aq.Todo $");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Pre-aq.Mesa $");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Ajustar $");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Customizar Pre-aq.");
   LSTR MSG_COOLDOWN                       = _UxGT("Esfriar");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Ligar");
@@ -132,10 +132,8 @@ namespace Language_pt_br {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Fim da Edição");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Montar Malha Custom");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Montar ");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Montar $");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Checar $");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Montar $");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Checar $");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Montar Malha fria");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Ajustar Altura");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Quant. de Altura");
@@ -394,19 +392,11 @@ namespace Language_pt_br {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Intensidade Brilho");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("Impressora Incorreta");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total de Impressões");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Realizadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo de Impressão");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Trabalho Mais longo");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total de Extrusão");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Qtd de Impressões");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Realizadas");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo de Impressão");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Maior trabalho");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("T. Extrusão");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Qtd de Impressões");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Realizadas");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Tempo de Impressão");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Maior trabalho");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("T. Extrusão");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temp Mín");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temp Máx");
@@ -450,9 +440,42 @@ namespace Language_pt_br {
   LSTR MSG_SNAKE                          = _UxGT("Sn4k3");
   LSTR MSG_MAZE                           = _UxGT("Labirinto");
 
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Clique p. continuar"));
+  LSTR MSG_PAUSE_PRINT_INIT               = _UxGT(MSG_1_LINE("Estacionando..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Aguarde..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Insira e Clique"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Clique para Aquecer"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Aquecendo..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Ejetando..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Carregando..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Purgando..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Clique p. finalizar"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Continuando..."));
+
+  LSTR MSG_TOP_LEFT                       = _UxGT("Superior Esquerdo");
+  LSTR MSG_BOTTOM_LEFT                    = _UxGT("Inferior Esquerdo");
+  LSTR MSG_TOP_RIGHT                      = _UxGT("Superior Direto");
+  LSTR MSG_BOTTOM_RIGHT                   = _UxGT("Inferior Direto");
+  LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Calibração Completa");
+  LSTR MSG_CALIBRATION_FAILED             = _UxGT("Calibração Falhou");
+}
+
+namespace LanguageWide_pt_br {
+  using namespace LanguageNarrow_pt_br;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total de Impressões");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Realizadas");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Tempo de Impressão");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Trabalho Mais longo");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total de Extrusão");
+  #endif
+}
+
+namespace LanguageTall_pt_br {
+  using namespace LanguageWide_pt_br;
   #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Aperte o botão para", "continuar impressão"));
-    LSTR MSG_PAUSE_PRINT_INIT             = _UxGT(MSG_1_LINE("Estacionando..."));
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Esperando o", "inicio da", "troca de filamento"));
     LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Coloque filamento", "pressione o botão", "para continuar..."));
     LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Pressione o botão", "p/ aquecer o bocal"));
@@ -462,24 +485,9 @@ namespace Language_pt_br {
     LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Espere pela", "purga de filamento"));
     LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Clique para finaliz.", "purga de filamento"));
     LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Esperando impressão", "continuar"));
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Clique p. continuar"));
-    LSTR MSG_PAUSE_PRINT_INIT             = _UxGT(MSG_1_LINE("Estacionando..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Aguarde..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Insira e Clique"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Clique para Aquecer"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Aquecendo..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Ejetando..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Carregando..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Purgando..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Clique p. finalizar"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Continuando..."));
   #endif
+}
 
-  LSTR MSG_TOP_LEFT                       = _UxGT("Superior Esquerdo");
-  LSTR MSG_BOTTOM_LEFT                    = _UxGT("Inferior Esquerdo");
-  LSTR MSG_TOP_RIGHT                      = _UxGT("Superior Direto");
-  LSTR MSG_BOTTOM_RIGHT                   = _UxGT("Inferior Direto");
-  LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Calibração Completa");
-  LSTR MSG_CALIBRATION_FAILED             = _UxGT("Calibração Falhou");
+namespace Language_pt_br {
+  using namespace LanguageTall_pt_br;
 }

--- a/Marlin/src/lcd/language/language_ro.h
+++ b/Marlin/src/lcd/language/language_ro.h
@@ -29,7 +29,7 @@
   *
   * Translation by cristyanul
   */
-namespace Language_ro {
+namespace LanguageNarrow_ro {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -68,23 +68,23 @@ namespace Language_ro {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Fade Inaltime");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Seteaza Offseturile Acasa");
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Offseturi Aplicate");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Preincalzeste ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Preincalzeste ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Capatul");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Capatul ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Tot");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Patul");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Conf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Preincalzeste $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Preincalzeste $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Preincalzeste $ Capatul");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Preincalzeste $ Capatul ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Preincalzeste $ Tot");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Preincalzeste $ Patul");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Preincalzeste $ Conf");
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Preincalzeste ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Preincalzeste ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Capatul");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Capatul ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Tot");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Patul");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Preincalzeste ") PREHEAT_1_LABEL _UxGT(" Conf");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Preincalzeste $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Preincalzeste $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Preincalzeste $ Capatul");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Preincalzeste $ Capatul ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Preincalzeste $ Tot");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Preincalzeste $ Patul");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Preincalzeste $ Conf");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Preincalzeste Personalizat");
   LSTR MSG_COOLDOWN                       = _UxGT("Racire");
   LSTR MSG_CUTTER_FREQUENCY               = _UxGT("Frecventa");
@@ -142,10 +142,8 @@ namespace Language_ro {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Done Editing Mesh");
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Build Custom Mesh");
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Build Mesh");
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Build Mesh ($)");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Validate Mesh ($)");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Build Mesh ($)");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Validate Mesh ($)");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Build Cold Mesh");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Adjust Mesh Height");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Height Amount");
@@ -476,19 +474,11 @@ namespace Language_ro {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Light Brightness");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("INCORRECT PRINTER");
 
-#if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Total Printuri");
-  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completat");
-  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Timp Imprimare Total");
-  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Longest Job Time");
-  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Total Extrudat");
-#else
   LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Prints");
   LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Completed");
   LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
   LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Longest");
   LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruded");
-#endif
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Temperatura Minima");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Temperatura Maxima");
@@ -560,22 +550,8 @@ namespace Language_ro {
   LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Bad page speed");
 
   //
-  // Filament Inlocuire screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Inlocuire screens show up to 2 lines on a 3-line display
   //
-#if LCD_HEIGHT >= 4
-  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_2_LINE("Apasa Butonul", "pentru a reveni la print"));
-  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parcare..."));
-  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_3_LINE("Astept ca", "inlocuirea filamentului", "sa inceapa"));
-  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_3_LINE("Insert filament", "and press button", "to continue"));
-  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_2_LINE("Press button", "to heat nozzle"));
-  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_2_LINE("Nozzle heating", "Please wait..."));
-  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_2_LINE("Wait for", "filament unload"));
-  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Wait for", "filament load"));
-  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_2_LINE("Wait for", "filament purge"));
-  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_2_LINE("Click to finish", "filament purge"));
-  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_2_LINE("Wait for print", "to resume..."));
-#else
   LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Click to continue"));
   LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parcare..."));
   LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Va rog asteptati..."));
@@ -587,7 +563,7 @@ namespace Language_ro {
   LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Curatare..."));
   LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Click pentru a termina"));
   LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Se Reia..."));
-#endif
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC Drivers");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Driver Current");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Hybrid Threshold");
@@ -605,4 +581,36 @@ namespace Language_ro {
   LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Timeout Incalzitor");
   LSTR MSG_REHEAT                         = _UxGT("Reincalzire");
   LSTR MSG_REHEATING                      = _UxGT("Reincalzire...");
+}
+
+namespace LanguageWide_ro {
+  using namespace LanguageNarrow_ro;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Total Printuri");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Completat");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Timp Imprimare Total");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest Job Time");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Total Extrudat");
+  #endif
+}
+
+namespace LanguageTall_ro {
+  using namespace LanguageWide_ro;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Apasa Butonul", "pentru a reveni la print"));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Astept ca", "inlocuirea filamentului", "sa inceapa"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Insert filament", "and press button", "to continue"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Press button", "to heat nozzle"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nozzle heating", "Please wait..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Wait for", "filament unload"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Wait for", "filament load"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Wait for", "filament purge"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Click to finish", "filament purge"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Wait for print", "to resume..."));
+  #endif
+}
+
+namespace Language_ro {
+  using namespace LanguageTall_ro;
 }

--- a/Marlin/src/lcd/language/language_ru.h
+++ b/Marlin/src/lcd/language/language_ru.h
@@ -29,7 +29,7 @@
  */
 #define DISPLAY_CHARSET_ISO10646_5
 
-namespace Language_ru {
+namespace LanguageNarrow_ru {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE                = 2;
@@ -43,15 +43,9 @@ namespace Language_ru {
   LSTR MSG_MEDIA_INSERTED                   = _UxGT("SD карта вставлена");
   LSTR MSG_MEDIA_REMOVED                    = _UxGT("SD карта извлечена");
   LSTR MSG_MEDIA_WAITING                    = _UxGT("Вставьте SD карту");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Сбой инициализации SD");
-    LSTR MSG_ADVANCED_SETTINGS              = _UxGT("Расширенные настройки");
-    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переполнение вызова");
-  #else
-    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Сбой инициализ. SD");
-    LSTR MSG_ADVANCED_SETTINGS              = _UxGT("Расшир. настройки");
-    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переполн. вызова");
-  #endif
+  LSTR MSG_MEDIA_INIT_FAIL                  = _UxGT("Сбой инициализ. SD");
+  LSTR MSG_ADVANCED_SETTINGS                = _UxGT("Расшир. настройки");
+  LSTR MSG_KILL_SUBCALL_OVERFLOW            = _UxGT("Переполн. вызова");
   LSTR MSG_MEDIA_READ_ERROR                 = _UxGT("Ошибка чтения");
   LSTR MSG_MEDIA_USB_REMOVED                = _UxGT("USB диск удалён");
   LSTR MSG_MEDIA_USB_FAILED                 = _UxGT("Ошибка USB диска");
@@ -77,71 +71,46 @@ namespace Language_ru {
   LSTR MSG_LEVEL_BED_NEXT_POINT             = _UxGT("Следующая точка");
   LSTR MSG_LEVEL_BED_DONE                   = _UxGT("Выравнивание готово!");
   LSTR MSG_Z_FADE_HEIGHT                    = _UxGT("Лимит выранивания");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Установ. смещения дома");
-    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Смещение дома X");
-    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Смещение дома Y");
-    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Смещение дома Z");
-  #else
-    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Установ.смещ.дома");
-    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Смещ. дома X");
-    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Смещ. дома Y");
-    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Смещ. дома Z");
-  #endif
+
+  LSTR MSG_SET_HOME_OFFSETS                 = _UxGT("Установ.смещ.дома");
+  LSTR MSG_HOME_OFFSET_X                    = _UxGT("Смещ. дома X");
+  LSTR MSG_HOME_OFFSET_Y                    = _UxGT("Смещ. дома Y");
+  LSTR MSG_HOME_OFFSET_Z                    = _UxGT("Смещ. дома Z");
+
   LSTR MSG_HOME_OFFSETS_APPLIED             = _UxGT("Смещения применены");
   LSTR MSG_SELECT_ORIGIN                    = _UxGT("Выберите ноль");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Последнее значение ");
-  #else
-    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Послед. знач. ");
-  #endif
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                      = _UxGT("Нагрев ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                    = _UxGT("Нагреть ~ ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                  = _UxGT("Нагреть сопло ") PREHEAT_1_LABEL _UxGT(" сопло");
-    LSTR MSG_PREHEAT_1_END_E                = _UxGT("Нагреть сопло ~") PREHEAT_1_LABEL _UxGT(" сопло ~");;
-    LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Нагреть всё ") PREHEAT_1_LABEL _UxGT(" всё");
-    LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Нагреть стол ") PREHEAT_1_LABEL _UxGT(" стол");
-    LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Правка предн. ") PREHEAT_1_LABEL _UxGT(" наст.");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                    = _UxGT("Нагрев ") PREHEAT_2_LABEL;
-      LSTR MSG_PREHEAT_2_SETTINGS           = _UxGT("Нагрев ") PREHEAT_2_LABEL _UxGT(" настр.");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                    = _UxGT("Нагрев ") PREHEAT_3_LABEL;
-      LSTR MSG_PREHEAT_3_SETTINGS           = _UxGT("Нагрев ") PREHEAT_3_LABEL _UxGT(" настр.");
-    #endif
-    LSTR MSG_PREHEAT_M                      = _UxGT("Нагрев $");
-    LSTR MSG_PREHEAT_M_H                    = _UxGT("Нагреть ~ $");
-    LSTR MSG_PREHEAT_M_END                  = _UxGT("Нагреть сопло $");
-    LSTR MSG_PREHEAT_M_END_E                = _UxGT("Нагреть сопло ~ $");
-    LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Нагреть всё $");
-    LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Нагреть стол $");
-    LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Настр.нагрева $");
-  #endif
+  LSTR MSG_LAST_VALUE_SP                    = _UxGT("Послед. знач. ");
+
+  LSTR MSG_PREHEAT_1                        = _UxGT("Нагрев ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                      = _UxGT("Нагреть ~ ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                    = _UxGT("Нагреть сопло ") PREHEAT_1_LABEL _UxGT(" сопло");
+  LSTR MSG_PREHEAT_1_END_E                  = _UxGT("Нагреть сопло ~") PREHEAT_1_LABEL _UxGT(" сопло ~");;
+  LSTR MSG_PREHEAT_1_ALL                    = _UxGT("Нагреть всё ") PREHEAT_1_LABEL _UxGT(" всё");
+  LSTR MSG_PREHEAT_1_BEDONLY                = _UxGT("Нагреть стол ") PREHEAT_1_LABEL _UxGT(" стол");
+  LSTR MSG_PREHEAT_1_SETTINGS               = _UxGT("Правка предн. ") PREHEAT_1_LABEL _UxGT(" наст.");
+
+  LSTR MSG_PREHEAT_M                        = _UxGT("Нагрев $");
+  LSTR MSG_PREHEAT_M_H                      = _UxGT("Нагреть ~ $");
+  LSTR MSG_PREHEAT_M_END                    = _UxGT("Нагреть сопло $");
+  LSTR MSG_PREHEAT_M_END_E                  = _UxGT("Нагреть сопло ~ $");
+  LSTR MSG_PREHEAT_M_ALL                    = _UxGT("Нагреть всё $");
+  LSTR MSG_PREHEAT_M_BEDONLY                = _UxGT("Нагреть стол $");
+  LSTR MSG_PREHEAT_M_SETTINGS               = _UxGT("Настр.нагрева $");
+
   LSTR MSG_PREHEAT_CUSTOM                   = _UxGT("Нагрев Свой");
   LSTR MSG_COOLDOWN                         = _UxGT("Охлаждение");
   LSTR MSG_CUTTER_FREQUENCY                 = _UxGT("Частота");
   LSTR MSG_LASER_MENU                       = _UxGT("Управление лазером");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SPINDLE_MENU                   = _UxGT("Управлен.шпинделем");
-    LSTR MSG_LASER_TOGGLE                   = _UxGT("Переключить лазер");
-    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Переключ. шпиндель");
-    LSTR MSG_SPINDLE_POWER                  = _UxGT("Мощность шпинделя");
-    LSTR MSG_LASER_POWER                    = _UxGT("Мощность лазера");
-    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тестовый импульс мс");
-    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Переключить обдув");
-    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Переключить вакуум");
-  #else
-    LSTR MSG_SPINDLE_MENU                   = _UxGT("Управл. шпинд.");
-    LSTR MSG_LASER_TOGGLE                   = _UxGT("Переключ.лазер");
-    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Переключ.шпинд");
-    LSTR MSG_SPINDLE_POWER                  = _UxGT("Мощн.шпинделя");
-    LSTR MSG_LASER_POWER                    = _UxGT("Мощн. лазера");
-    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тест. имп. мс");
-    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Переключ. обдув");
-    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Переключ. вакуум");
-  #endif
+
+  LSTR MSG_SPINDLE_MENU                     = _UxGT("Управл. шпинд.");
+  LSTR MSG_LASER_TOGGLE                     = _UxGT("Переключ.лазер");
+  LSTR MSG_SPINDLE_TOGGLE                   = _UxGT("Переключ.шпинд");
+  LSTR MSG_SPINDLE_POWER                    = _UxGT("Мощн.шпинделя");
+  LSTR MSG_LASER_POWER                      = _UxGT("Мощн. лазера");
+  LSTR MSG_LASER_PULSE_MS                   = _UxGT("Тест. имп. мс");
+  LSTR MSG_LASER_EVAC_TOGGLE                = _UxGT("Переключ. обдув");
+  LSTR MSG_SPINDLE_EVAC_TOGGLE              = _UxGT("Переключ. вакуум");
+
   LSTR MSG_LASER_ASSIST_TOGGLE              = _UxGT("Управление обдувом");
   LSTR MSG_FLOWMETER_FAULT                  = _UxGT("Ошибка обдува");
   LSTR MSG_LASER_FIRE_PULSE                 = _UxGT("Импульс лазера");
@@ -157,22 +126,12 @@ namespace Language_ru {
   LSTR MSG_LEVEL_BED                        = _UxGT("Выровнять стол");
   LSTR MSG_BED_TRAMMING                     = _UxGT("Выровнять углы");
   LSTR MSG_NEXT_CORNER                      = _UxGT("Следующий угол");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вверх до срабатыв. зонда");
-    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Углы в норме. Вырав.стола");
-  #else
-    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вверх до сраб. зонда");
-    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Углы в норме. Вырав.");
-  #endif
+  LSTR MSG_BED_TRAMMING_RAISE               = _UxGT("Вверх до сраб. зонда");
+  LSTR MSG_BED_TRAMMING_IN_RANGE            = _UxGT("Углы в норме. Вырав.");
   LSTR MSG_BED_TRAMMING_GOOD_POINTS         = _UxGT("Хорошие точки: ");
   LSTR MSG_BED_TRAMMING_LAST_Z              = _UxGT("Последняя Z: ");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MESH_EDITOR                    = _UxGT("Смещение по Z");
-    LSTR MSG_EDITING_STOPPED                = _UxGT("Правка сетки окончена");
-  #else
-    LSTR MSG_MESH_EDITOR                    = _UxGT("Смещение Z");
-    LSTR MSG_EDITING_STOPPED                = _UxGT("Правка окончена");
-  #endif
+  LSTR MSG_MESH_EDITOR                      = _UxGT("Смещение Z");
+  LSTR MSG_EDITING_STOPPED                  = _UxGT("Правка окончена");
   LSTR MSG_EDIT_MESH                        = _UxGT("Редактировать сетку");
   LSTR MSG_PROBING_POINT                    = _UxGT("Точка сетки");
   LSTR MSG_MESH_X                           = _UxGT("Индекс X");
@@ -201,13 +160,8 @@ namespace Language_ru {
   LSTR MSG_UBL_LEVEL_BED                    = _UxGT("Настройка UBL");
   LSTR MSG_LCD_TILTING_MESH                 = _UxGT("Точка разворота");
   LSTR MSG_UBL_MANUAL_MESH                  = _UxGT("Ручной ввод сетки");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Разместить шайбу,измерить");
-    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Убрать и замерить стол");
-  #else
-    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Разм.шайбу, измерить");
-    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Убрать, измер. стол");
-  #endif
+  LSTR MSG_UBL_BC_INSERT                    = _UxGT("Разм.шайбу, измерить");
+  LSTR MSG_UBL_BC_REMOVE                    = _UxGT("Убрать, измер. стол");
   LSTR MSG_UBL_MESH_WIZARD                  = _UxGT("Мастер сеток UBL");
   LSTR MSG_UBL_BC_INSERT2                   = _UxGT("Измерение");
   LSTR MSG_UBL_MOVING_TO_NEXT               = _UxGT("Двигаемся дальше");
@@ -215,39 +169,21 @@ namespace Language_ru {
   LSTR MSG_UBL_DEACTIVATE_MESH              = _UxGT("Деактивировать UBL");
   LSTR MSG_UBL_MESH_EDIT                    = _UxGT("Редактор сеток");
   LSTR MSG_UBL_EDIT_CUSTOM_MESH             = _UxGT("Править свою сетку");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_SET_TEMP_BED               = _UxGT("Температура стола");
-    LSTR MSG_UBL_BED_TEMP_CUSTOM            = _UxGT("Температура стола");
-    LSTR MSG_UBL_SET_TEMP_HOTEND            = _UxGT("Температура сопла");
-    LSTR MSG_UBL_HOTEND_TEMP_CUSTOM         = _UxGT("Температура сопла");
-    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Построить свою сетку");
-    LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Правка сетки завершена");
-  #else
-    LSTR MSG_UBL_SET_TEMP_BED               = LCD_STR_THERMOMETER _UxGT(" стола, ") LCD_STR_DEGREE _UxGT("C");
-    LSTR MSG_UBL_BED_TEMP_CUSTOM            = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" стола,") LCD_STR_DEGREE _UxGT("C");
-    LSTR MSG_UBL_SET_TEMP_HOTEND            = LCD_STR_THERMOMETER _UxGT(" сопла, ") LCD_STR_DEGREE _UxGT("C");
-    LSTR MSG_UBL_HOTEND_TEMP_CUSTOM         = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" сопла,") LCD_STR_DEGREE _UxGT("C");
-    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Построить свою");
-    LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Правка завершена");
-  #endif
+  LSTR MSG_UBL_SET_TEMP_BED                 = LCD_STR_THERMOMETER _UxGT(" стола, ") LCD_STR_DEGREE _UxGT("C");
+  LSTR MSG_UBL_BED_TEMP_CUSTOM              = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" стола,") LCD_STR_DEGREE _UxGT("C");
+  LSTR MSG_UBL_SET_TEMP_HOTEND              = LCD_STR_THERMOMETER _UxGT(" сопла, ") LCD_STR_DEGREE _UxGT("C");
+  LSTR MSG_UBL_HOTEND_TEMP_CUSTOM           = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" сопла,") LCD_STR_DEGREE _UxGT("C");
+  LSTR MSG_UBL_BUILD_CUSTOM_MESH            = _UxGT("Построить свою");
+  LSTR MSG_UBL_DONE_EDITING_MESH            = _UxGT("Правка завершена");
   LSTR MSG_UBL_FINE_TUNE_MESH               = _UxGT("Точная правка сетки");
   LSTR MSG_UBL_BUILD_MESH_MENU              = _UxGT("Построить сетку");
   LSTR MSG_UBL_BUILD_MESH_M                 = _UxGT("Построить сетку $");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Построить холодную сетку");
-  #else
-    LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Строить холод.сетку");
-  #endif
+  LSTR MSG_UBL_BUILD_COLD_MESH              = _UxGT("Строить холод.сетку");
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST           = _UxGT("Правка высоты сетки");
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT           = _UxGT("Высота");
   LSTR MSG_UBL_VALIDATE_MESH_MENU           = _UxGT("Проверить сетку");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Проверить сетку $");
-    LSTR MSG_UBL_VALIDATE_CUSTOM_MESH       = _UxGT("Проверить свою сетку");
-  #else
-    LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Провер. сетку $");
-    LSTR MSG_UBL_VALIDATE_CUSTOM_MESH       = _UxGT("Провер. свою сетку");
-  #endif
+  LSTR MSG_UBL_VALIDATE_MESH_M              = _UxGT("Провер. сетку $");
+  LSTR MSG_UBL_VALIDATE_CUSTOM_MESH         = _UxGT("Провер. свою сетку");
   LSTR MSG_G26_HEATING_BED                  = _UxGT("G26 нагрев стола");
   LSTR MSG_G26_HEATING_NOZZLE               = _UxGT("G26 нагрев сопла");
   LSTR MSG_G26_MANUAL_PRIME                 = _UxGT("Ручная прочистка");
@@ -257,11 +193,7 @@ namespace Language_ru {
   LSTR MSG_G26_LEAVING                      = _UxGT("Выйти из G26");
   LSTR MSG_UBL_CONTINUE_MESH                = _UxGT("Продолжить сетку");
   LSTR MSG_UBL_MESH_LEVELING                = _UxGT("Выравнивание сетки");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_3POINT_MESH_LEVELING       = _UxGT("3-х точечное выравнивание");
-  #else
-    LSTR MSG_UBL_3POINT_MESH_LEVELING       = _UxGT("3-точечное выравн.");
-  #endif
+  LSTR MSG_UBL_3POINT_MESH_LEVELING         = _UxGT("3-точечное выравн.");
   LSTR MSG_UBL_GRID_MESH_LEVELING           = _UxGT("Выравнивание сеткой");
   LSTR MSG_UBL_MESH_LEVEL                   = _UxGT("Выровнять сетку");
   LSTR MSG_UBL_SIDE_POINTS                  = _UxGT("Крайние точки");
@@ -269,15 +201,9 @@ namespace Language_ru {
   LSTR MSG_UBL_OUTPUT_MAP                   = _UxGT("Вывести карту сетки");
   LSTR MSG_UBL_OUTPUT_MAP_HOST              = _UxGT("Вывести на хост");
   LSTR MSG_UBL_OUTPUT_MAP_CSV               = _UxGT("Вывести в CSV");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_OUTPUT_MAP_BACKUP          = _UxGT("Сохранить сетку снаружи");
-    LSTR MSG_UBL_INFO_UBL                   = _UxGT("Вывод информации UBL");
-    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Кол-во заполнителя");
-  #else
-    LSTR MSG_UBL_OUTPUT_MAP_BACKUP          = _UxGT("Сохранить снаружи");
-    LSTR MSG_UBL_INFO_UBL                   = _UxGT("Информация UBL");
-    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Кол-во заполн.");
-  #endif
+  LSTR MSG_UBL_OUTPUT_MAP_BACKUP            = _UxGT("Сохранить снаружи");
+  LSTR MSG_UBL_INFO_UBL                     = _UxGT("Информация UBL");
+  LSTR MSG_UBL_FILLIN_AMOUNT                = _UxGT("Кол-во заполн.");
   LSTR MSG_UBL_MANUAL_FILLIN                = _UxGT("Ручное заполнение");
   LSTR MSG_UBL_SMART_FILLIN                 = _UxGT("Умное заполнение");
   LSTR MSG_UBL_FILLIN_MESH                  = _UxGT("Заполнить сетку");
@@ -319,11 +245,7 @@ namespace Language_ru {
   LSTR MSG_SET_LEDS_DEFAULT                 = _UxGT("Свет по умолчанию");
   LSTR MSG_LED_CHANNEL_N                    = _UxGT("Канал {");
   LSTR MSG_LEDS2                            = _UxGT("Свет #2");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_NEO2_PRESETS                   = _UxGT("Свет #2 предустановки");
-  #else
-    LSTR MSG_NEO2_PRESETS                   = _UxGT("Свет #2 предустан.");
-  #endif
+  LSTR MSG_NEO2_PRESETS                     = _UxGT("Свет #2 предустан.");
   LSTR MSG_NEO2_BRIGHTNESS                  = _UxGT("Яркость");
   LSTR MSG_CUSTOM_LEDS                      = _UxGT("Свой цвет подсветки");
   LSTR MSG_INTENSITY_R                      = _UxGT("Уровень красного");
@@ -359,15 +281,9 @@ namespace Language_ru {
   LSTR MSG_NOZZLE_STANDBY                   = _UxGT("Сопло ожидает");
   LSTR MSG_BED                              = _UxGT("Стол,  ") LCD_STR_DEGREE _UxGT("C");
   LSTR MSG_CHAMBER                          = _UxGT("Камера,") LCD_STR_DEGREE _UxGT("C");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_COOLER                         = _UxGT("Охлаждение лазера");
-    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Переключ. охлажд.");
-    LSTR MSG_FLOWMETER_SAFETY               = _UxGT("Безопасн. потока");
-  #else
-    LSTR MSG_COOLER                         = _UxGT("Охлажд. лазера");
-    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Переключ. охл.");
-    LSTR MSG_FLOWMETER_SAFETY               = _UxGT("Безопас.потока");
-  #endif
+  LSTR MSG_COOLER                           = _UxGT("Охлажд. лазера");
+  LSTR MSG_COOLER_TOGGLE                    = _UxGT("Переключ. охл.");
+  LSTR MSG_FLOWMETER_SAFETY                 = _UxGT("Безопас.потока");
   LSTR MSG_LASER                            = _UxGT("Лазер");
   LSTR MSG_FAN_SPEED                        = _UxGT("Кулер");
   LSTR MSG_FAN_SPEED_N                      = _UxGT("Кулер ~");
@@ -404,11 +320,7 @@ namespace Language_ru {
   LSTR MSG_VC_JERK                          = _UxGT("V") STR_C _UxGT("-рывок");
   LSTR MSG_VN_JERK                          = _UxGT("V@-рывок");
   LSTR MSG_VE_JERK                          = _UxGT("Ve-рывок");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Отклонение угла");
-  #else
-    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Отклон.угла");
-  #endif
+  LSTR MSG_JUNCTION_DEVIATION               = _UxGT("Отклон.угла");
   LSTR MSG_MAX_SPEED                        = _UxGT("Скорость, мм/с");
   LSTR MSG_VMAX_A                           = _UxGT("Скор.макс ") STR_A;
   LSTR MSG_VMAX_B                           = _UxGT("Скор.макс ") STR_B;
@@ -442,13 +354,8 @@ namespace Language_ru {
   LSTR MSG_VOLUMETRIC_ENABLED               = _UxGT("E в мм") SUPERSCRIPT_THREE;
   LSTR MSG_VOLUMETRIC_LIMIT                 = _UxGT("E огран.,мм") SUPERSCRIPT_THREE;
   LSTR MSG_VOLUMETRIC_LIMIT_E               = _UxGT("E огран. *");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_FILAMENT_DIAM                  = _UxGT("Диам. филамента");
-    LSTR MSG_FILAMENT_DIAM_E                = _UxGT("Диам. филамента *");
-  #else
-    LSTR MSG_FILAMENT_DIAM                  = _UxGT("Диам. филам.");
-    LSTR MSG_FILAMENT_DIAM_E                = _UxGT("Диам. филам. *");
-  #endif
+  LSTR MSG_FILAMENT_DIAM                    = _UxGT("Диам. филам.");
+  LSTR MSG_FILAMENT_DIAM_E                  = _UxGT("Диам. филам. *");
   LSTR MSG_FILAMENT_UNLOAD                  = _UxGT("Загрузка, мм");
   LSTR MSG_FILAMENT_LOAD                    = _UxGT("Выгрузка, мм");
   LSTR MSG_ADVANCE_K                        = _UxGT("К-фактор LA");
@@ -456,13 +363,8 @@ namespace Language_ru {
   LSTR MSG_CONTRAST                         = _UxGT("Контраст экрана");
   LSTR MSG_STORE_EEPROM                     = _UxGT("Сохранить настройки");
   LSTR MSG_LOAD_EEPROM                      = _UxGT("Загрузить настройки");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_RESTORE_DEFAULTS               = _UxGT("На базовые параметры");
-    LSTR MSG_INIT_EEPROM                    = _UxGT("Инициализация EEPROM");
-  #else
-    LSTR MSG_RESTORE_DEFAULTS               = _UxGT("На базовые парам.");
-    LSTR MSG_INIT_EEPROM                    = _UxGT("Инициализ. EEPROM");
-  #endif
+  LSTR MSG_RESTORE_DEFAULTS                 = _UxGT("На базовые парам.");
+  LSTR MSG_INIT_EEPROM                      = _UxGT("Инициализ. EEPROM");
   LSTR MSG_ERR_EEPROM_CRC                   = _UxGT("Сбой EEPROM: CRC");
   LSTR MSG_ERR_EEPROM_SIZE                  = _UxGT("Сбой EEPROM: размер");
   LSTR MSG_ERR_EEPROM_VERSION               = _UxGT("Сбой EEPROM: версия");
@@ -511,41 +413,24 @@ namespace Language_ru {
   LSTR MSG_NO_MOVE                          = _UxGT("Нет движения.");
   LSTR MSG_KILLED                           = _UxGT("УБИТО. ");
   LSTR MSG_STOPPED                          = _UxGT("ОСТАНОВЛЕНО. ");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_CONTROL_RETRACT                = _UxGT("Откат, мм");
-    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Откат при смене, мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Возврат при смене, мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAPF  = _UxGT("Возврат при смене, V");
-    LSTR MSG_AUTORETRACT                    = _UxGT("Автооткат");
-  #else
-    LSTR MSG_CONTROL_RETRACT                = _UxGT("Откат, мм");
-    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Откат смены,мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Возвр.смены,мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAPF  = _UxGT("Возвр.смены V");
-    LSTR MSG_AUTORETRACT                    = _UxGT("Автооткат");
-  #endif
+  LSTR MSG_CONTROL_RETRACT                  = _UxGT("Откат, мм");
+  LSTR MSG_CONTROL_RETRACT_SWAP             = _UxGT("Откат смены,мм");
+  LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP     = _UxGT("Возвр.смены,мм");
+  LSTR MSG_CONTROL_RETRACT_RECOVER_SWAPF    = _UxGT("Возвр.смены V");
+  LSTR MSG_AUTORETRACT                      = _UxGT("Автооткат");
   LSTR MSG_CONTROL_RETRACT_ZHOP             = _UxGT("Подскок Z, мм");
   LSTR MSG_CONTROL_RETRACTF                 = _UxGT("Втягивание V");
   LSTR MSG_CONTROL_RETRACT_RECOVER          = _UxGT("Возврат, мм");
   LSTR MSG_CONTROL_RETRACT_RECOVERF         = _UxGT("Возврат V");
 
   LSTR MSG_FILAMENT_SWAP_LENGTH             = _UxGT("Длина замены");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_FILAMENT_SWAP_EXTRA            = _UxGT("Дополнительная длина");
-  #else
-    LSTR MSG_FILAMENT_SWAP_EXTRA            = _UxGT("Доп. длина");
-  #endif
+  LSTR MSG_FILAMENT_SWAP_EXTRA              = _UxGT("Доп. длина");
   LSTR MSG_FILAMENT_PURGE_LENGTH            = _UxGT("Длина прочистки");
 
   LSTR MSG_TOOL_CHANGE                      = _UxGT("Смена сопел");
   LSTR MSG_TOOL_CHANGE_ZLIFT                = _UxGT("Поднятие по Z");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Начальная скор.");
-    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Скорость отката");
-  #else
-    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Началь.скор.");
-    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Скор.отката");
-  #endif
+  LSTR MSG_SINGLENOZZLE_PRIME_SPEED         = _UxGT("Началь.скор.");
+  LSTR MSG_SINGLENOZZLE_RETRACT_SPEED       = _UxGT("Скор.отката");
   LSTR MSG_FILAMENT_PARK_ENABLED            = _UxGT("Парковать голову");
   LSTR MSG_SINGLENOZZLE_UNRETRACT_SPEED     = _UxGT("Скорость возврата");
   LSTR MSG_SINGLENOZZLE_FAN_SPEED           = _UxGT("Скорость кулера");
@@ -559,13 +444,8 @@ namespace Language_ru {
   LSTR MSG_FILAMENTCHANGE                   = _UxGT("Смена филамента");
   LSTR MSG_FILAMENTCHANGE_E                 = _UxGT("Смена филамента *");
   LSTR MSG_FILAMENTLOAD                     = _UxGT("Загрузить филамент");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_FILAMENTLOAD_E                 = _UxGT("Загрузить филамент *");
-    LSTR MSG_FILAMENTUNLOAD_E               = _UxGT("Выгрузить филамент *");
-  #else
-    LSTR MSG_FILAMENTLOAD_E                 = _UxGT("Подать филамент *");
-    LSTR MSG_FILAMENTUNLOAD_E               = _UxGT("Убрать филамент *");
-  #endif
+  LSTR MSG_FILAMENTLOAD_E                   = _UxGT("Подать филамент *");
+  LSTR MSG_FILAMENTUNLOAD_E                 = _UxGT("Убрать филамент *");
   LSTR MSG_FILAMENTUNLOAD_ALL               = _UxGT("Выгрузить всё");
   LSTR MSG_ATTACH_MEDIA                     = _UxGT("Установить SD карту");
   LSTR MSG_CHANGE_MEDIA                     = _UxGT("Сменить SD карту");
@@ -597,11 +477,7 @@ namespace Language_ru {
   LSTR MSG_ZPROBE_XOFFSET                   = _UxGT("Смещение X");
   LSTR MSG_ZPROBE_YOFFSET                   = _UxGT("Смещение Y");
   LSTR MSG_ZPROBE_ZOFFSET                   = _UxGT("Смещение Z");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MOVE_NOZZLE_TO_BED             = _UxGT("Двигать сопло к столу");
-  #else
-    LSTR MSG_MOVE_NOZZLE_TO_BED             = _UxGT("Двиг. сопло к столу");
-  #endif
+  LSTR MSG_MOVE_NOZZLE_TO_BED               = _UxGT("Двиг. сопло к столу");
   LSTR MSG_BABYSTEP_X                       = _UxGT("Микрошаг X");
   LSTR MSG_BABYSTEP_Y                       = _UxGT("Микрошаг Y");
   LSTR MSG_BABYSTEP_Z                       = _UxGT("Микрошаг Z");
@@ -640,22 +516,12 @@ namespace Language_ru {
   LSTR MSG_DELTA_RADIUS                     = _UxGT("Радиус");
   LSTR MSG_INFO_MENU                        = _UxGT("О принтере");
   LSTR MSG_INFO_PRINTER_MENU                = _UxGT("Данные принтера");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точечное выравнивание");
-    LSTR MSG_LINEAR_LEVELING                = _UxGT("Линейное выравнивание");
-    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Билинейное выравнивание");
-  #else
-    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точ. выравнив.");
-    LSTR MSG_LINEAR_LEVELING                = _UxGT("Линейное выравн.");
-    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Билин. выравнив.");
-  #endif
+  LSTR MSG_3POINT_LEVELING                  = _UxGT("3-точ. выравнив.");
+  LSTR MSG_LINEAR_LEVELING                  = _UxGT("Линейное выравн.");
+  LSTR MSG_BILINEAR_LEVELING                = _UxGT("Билин. выравнив.");
   LSTR MSG_UBL_LEVELING                     = _UxGT("Выравнивание UBL");
   LSTR MSG_MESH_LEVELING                    = _UxGT("Выравнивание сеткой");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MESH_DONE                      = _UxGT("Зондирование выполнено");
-  #else
-    LSTR MSG_MESH_DONE                      = _UxGT("Зондиров. выполнено");
-  #endif
+  LSTR MSG_MESH_DONE                        = _UxGT("Зондиров. выполнено");
 
   LSTR MSG_INFO_STATS_MENU                  = _UxGT("Статистика принтера");
   LSTR MSG_INFO_BOARD_MENU                  = _UxGT("Данные платы");
@@ -663,30 +529,17 @@ namespace Language_ru {
   LSTR MSG_INFO_EXTRUDERS                   = _UxGT("Экструдеры");
   LSTR MSG_INFO_BAUDRATE                    = _UxGT("Скорость,БОД");
   LSTR MSG_INFO_PROTOCOL                    = _UxGT("Протокол");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контроль утечки Т: Выкл");
-    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контроль утечки Т: Вкл");
-    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Время простоя хотенда");
-  #else
-    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контр.утечки Т:Выкл");
-    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контр.утечки Т:Вкл");
-    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Время прост.хот-а");
-  #endif
+  LSTR MSG_INFO_RUNAWAY_OFF                 = _UxGT("Контр.утечки Т:Выкл");
+  LSTR MSG_INFO_RUNAWAY_ON                  = _UxGT("Контр.утечки Т:Вкл");
+  LSTR MSG_HOTEND_IDLE_TIMEOUT              = _UxGT("Время прост.хот-а");
   LSTR MSG_CASE_LIGHT                       = _UxGT("Подсветка корпуса");
   LSTR MSG_CASE_LIGHT_BRIGHTNESS            = _UxGT("Яркость подсветки");
   LSTR MSG_KILL_EXPECTED_PRINTER            = _UxGT("НЕВЕРНЫЙ ПРИНТЕР");
 
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Счётчик печати");
-    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Общее время печати");
-    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Наидольшее задание");
-    LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Длина филамента");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Напечатано");
-    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Общее время");
-    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Наидольшее");
-    LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Выдавлено");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT                 = _UxGT("Напечатано");
+  LSTR MSG_INFO_PRINT_TIME                  = _UxGT("Общее время");
+  LSTR MSG_INFO_PRINT_LONGEST               = _UxGT("Наидольшее");
+  LSTR MSG_INFO_PRINT_FILAMENT              = _UxGT("Выдавлено");
   LSTR MSG_INFO_COMPLETED_PRINTS            = _UxGT("Завершено");
 
   LSTR MSG_INFO_MIN_TEMP                    = _UxGT("Мин.  ") LCD_STR_THERMOMETER;
@@ -704,22 +557,14 @@ namespace Language_ru {
   LSTR MSG_FILAMENT_CHANGE_OPTION_PURGE     = _UxGT("Выдавить ещё");
   LSTR MSG_FILAMENT_CHANGE_OPTION_RESUME    = _UxGT("Возобновить печать");
   LSTR MSG_FILAMENT_CHANGE_NOZZLE           = _UxGT("  Сопла: ");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик оконч. филамента");
-  #else
-    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик оконч.филам.");
-  #endif
+  LSTR MSG_RUNOUT_SENSOR                    = _UxGT("Датчик оконч.филам.");
   LSTR MSG_RUNOUT_DISTANCE_MM               = _UxGT("До конца, мм");
   LSTR MSG_KILL_HOMING_FAILED               = _UxGT("Ошибка парковки");
   LSTR MSG_LCD_PROBING_FAILED               = _UxGT("Ошибка зондирования");
 
   LSTR MSG_MMU2_CHOOSE_FILAMENT_HEADER      = _UxGT("ВЫБИРЕТЕ ФИЛАМЕНТ");
   LSTR MSG_MMU2_MENU                        = _UxGT("Настройки MMU");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_KILL_MMU2_FIRMWARE             = _UxGT("Обновить прошивку MMU!");
-  #else
-    LSTR MSG_KILL_MMU2_FIRMWARE             = _UxGT("Обнови прошивку MMU");
-  #endif
+  LSTR MSG_KILL_MMU2_FIRMWARE               = _UxGT("Обнови прошивку MMU");
   LSTR MSG_MMU2_NOT_RESPONDING              = _UxGT("MMU требует внимания");
   LSTR MSG_MMU2_RESUME                      = _UxGT("Продолжить печать");
   LSTR MSG_MMU2_RESUMING                    = _UxGT("Продолжение...");
@@ -730,11 +575,7 @@ namespace Language_ru {
   LSTR MSG_MMU2_EJECT_FILAMENT_N            = _UxGT("Извлечь филамент ~");
   LSTR MSG_MMU2_UNLOAD_FILAMENT             = _UxGT("Выгрузить филамент");
   LSTR MSG_MMU2_LOADING_FILAMENT            = _UxGT("Загрузка %i...");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MMU2_EJECTING_FILAMENT         = _UxGT("Извлечение филамента...");
-  #else
-    LSTR MSG_MMU2_EJECTING_FILAMENT         = _UxGT("Извлеч.филамента...");
-  #endif
+  LSTR MSG_MMU2_EJECTING_FILAMENT           = _UxGT("Извлеч.филамента...");
   LSTR MSG_MMU2_UNLOADING_FILAMENT          = _UxGT("Выгрузка....");
   LSTR MSG_MMU2_ALL                         = _UxGT("Всё");
   LSTR MSG_MMU2_FILAMENT_N                  = _UxGT("Филамент ~");
@@ -742,11 +583,7 @@ namespace Language_ru {
   LSTR MSG_MMU2_RESETTING                   = _UxGT("Перезапуск MMU...");
   LSTR MSG_MMU2_EJECT_RECOVER               = _UxGT("Удалите и нажмите");
 
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MIX                            = _UxGT("Смешивание");
-  #else
-    LSTR MSG_MIX                            = _UxGT("Смешив.");
-  #endif
+  LSTR MSG_MIX                              = _UxGT("Смешив.");
   LSTR MSG_MIX_COMPONENT_N                  = _UxGT("Компонент {");
   LSTR MSG_MIXER                            = _UxGT("Смеситель");
   LSTR MSG_GRADIENT                         = _UxGT("Градиент");
@@ -754,25 +591,15 @@ namespace Language_ru {
   LSTR MSG_CYCLE_MIX                        = _UxGT("Цикличное смешивание");
   LSTR MSG_GRADIENT_MIX                     = _UxGT("Градиент смешивания");
   LSTR MSG_REVERSE_GRADIENT                 = _UxGT("Сменить градиент");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_TOGGLE_MIX                     = _UxGT("Переключить смешивание");
-    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Активация В-инструм.");
-    LSTR MSG_START_VTOOL                    = _UxGT("Начало В-инструмента");
-    LSTR MSG_END_VTOOL                      = _UxGT("Конец В-инструмента");
-    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдоним В-инструмента");
-    LSTR MSG_RESET_VTOOLS                   = _UxGT("Сброс В-инструментов");
-    LSTR MSG_COMMIT_VTOOL                   = _UxGT("Смешать В-инструменты");
-    LSTR MSG_VTOOLS_RESET                   = _UxGT("В-инструменты сброшены");
-  #else
-    LSTR MSG_TOGGLE_MIX                     = _UxGT("Перекл. смешивание");
-    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Актив.В-инструм.");
-    LSTR MSG_START_VTOOL                    = _UxGT("В-инструм.нач.");
-    LSTR MSG_END_VTOOL                      = _UxGT("В-инструм.кон.");
-    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдоним В-инстр.");
-    LSTR MSG_RESET_VTOOLS                   = _UxGT("Сброс В-инструм.");
-    LSTR MSG_COMMIT_VTOOL                   = _UxGT("Смешать В-инструм.");
-    LSTR MSG_VTOOLS_RESET                   = _UxGT("В-инструм. сброшены");
-  #endif
+  LSTR MSG_TOGGLE_MIX                       = _UxGT("Перекл. смешивание");
+  LSTR MSG_ACTIVE_VTOOL                     = _UxGT("Актив.В-инструм.");
+  LSTR MSG_START_VTOOL                      = _UxGT("В-инструм.нач.");
+  LSTR MSG_END_VTOOL                        = _UxGT("В-инструм.кон.");
+  LSTR MSG_GRADIENT_ALIAS                   = _UxGT("Псевдоним В-инстр.");
+  LSTR MSG_RESET_VTOOLS                     = _UxGT("Сброс В-инструм.");
+  LSTR MSG_COMMIT_VTOOL                     = _UxGT("Смешать В-инструм.");
+  LSTR MSG_VTOOLS_RESET                     = _UxGT("В-инструм. сброшены");
+
   LSTR MSG_START_Z                          = _UxGT("Начало Z");
   LSTR MSG_END_Z                            = _UxGT(" Конец Z");
 
@@ -782,269 +609,341 @@ namespace Language_ru {
   LSTR MSG_SNAKE                            = _UxGT("Sn4k3");
   LSTR MSG_MAZE                             = _UxGT("Maze");
 
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_BAD_PAGE                       = _UxGT("Плохой индекс страницы");
-    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Плохая скорость страницы");
-  #else
-    LSTR MSG_BAD_PAGE                       = _UxGT("Плохая страница");
-    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Плохая скор.стран.");
-  #endif
+  LSTR MSG_BAD_PAGE                         = _UxGT("Плохая страница");
+  LSTR MSG_BAD_PAGE_SPEED                   = _UxGT("Плохая скор.стран.");
 
-  LSTR MSG_EDIT_PASSWORD                  = _UxGT("Редактировать пароль");
-  LSTR MSG_LOGIN_REQUIRED                 = _UxGT("Нужен логин");
-  LSTR MSG_PASSWORD_SETTINGS              = _UxGT("Настройки пароля");
-  LSTR MSG_ENTER_DIGIT                    = _UxGT("Введите цифру");
-  LSTR MSG_CHANGE_PASSWORD                = _UxGT("Смените пароль");
-  LSTR MSG_REMOVE_PASSWORD                = _UxGT("Удалить пароль");
-  LSTR MSG_PASSWORD_SET                   = _UxGT("Пароль это ");
-  LSTR MSG_START_OVER                     = _UxGT("Старт через");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_REMINDER_SAVE_SETTINGS       = _UxGT("Не забудь сохранить!");
-  #else
-    LSTR MSG_REMINDER_SAVE_SETTINGS       = _UxGT("Не забудь сохранить");
-  #endif
-  LSTR MSG_PASSWORD_REMOVED               = _UxGT("Пароль удалён");
+  LSTR MSG_EDIT_PASSWORD                    = _UxGT("Редактировать пароль");
+  LSTR MSG_LOGIN_REQUIRED                   = _UxGT("Нужен логин");
+  LSTR MSG_PASSWORD_SETTINGS                = _UxGT("Настройки пароля");
+  LSTR MSG_ENTER_DIGIT                      = _UxGT("Введите цифру");
+  LSTR MSG_CHANGE_PASSWORD                  = _UxGT("Смените пароль");
+  LSTR MSG_REMOVE_PASSWORD                  = _UxGT("Удалить пароль");
+  LSTR MSG_PASSWORD_SET                     = _UxGT("Пароль это ");
+  LSTR MSG_START_OVER                       = _UxGT("Старт через");
+  LSTR MSG_REMINDER_SAVE_SETTINGS           = _UxGT("Не забудь сохранить");
+  LSTR MSG_PASSWORD_REMOVED                 = _UxGT("Пароль удалён");
 
   //
   // Filament Change screens show up to 3 lines on a 4-line display
   //                        ...or up to 2 lines on a 3-line display
   //
-  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Парковка..."));
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_3_LINE("Нажмите кнопку", "для продолжения", "печати"));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_2_LINE("Ожидайте начала", "смены филамента"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Вставьте филамент", "и нажмите кнопку", "для продолжения"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_3_LINE("Нажмите кнопку", "для нагрева", "сопла..."));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Нагрев сопла", "Ждите..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Ожидайте", "выгрузки", "филамента"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Ожидайте", "загрузки", "филамента"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Ожидайте", "экструзии", "филамента"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Нажмите кнопку", "для завершения", "прочистки филамента"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_3_LINE("Ожидайте", "возобновления", "печати"));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Продолжить печать"));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Ожидайте..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Вставь и нажми"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Нагреть сопло"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Нагрев..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Выгрузка..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Загрузка..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Прочистка..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Завершить прочистку"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Возобновление..."));
-  #endif
+  LSTR MSG_PAUSE_PRINT_PARKING              = _UxGT(MSG_1_LINE("Парковка..."));
+  LSTR MSG_ADVANCED_PAUSE_WAITING           = _UxGT(MSG_1_LINE("Продолжить печать"));
+  LSTR MSG_FILAMENT_CHANGE_INIT             = _UxGT(MSG_1_LINE("Ожидайте..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT           = _UxGT(MSG_1_LINE("Вставь и нажми"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT             = _UxGT(MSG_1_LINE("Нагреть сопло"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING          = _UxGT(MSG_1_LINE("Нагрев..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD           = _UxGT(MSG_1_LINE("Выгрузка..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD             = _UxGT(MSG_1_LINE("Загрузка..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE            = _UxGT(MSG_1_LINE("Прочистка..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE       = _UxGT(MSG_1_LINE("Завершить прочистку"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME           = _UxGT(MSG_1_LINE("Возобновление..."));
 
-  LSTR MSG_TMC_DRIVERS                    = _UxGT("Драйвера TMC");
-  LSTR MSG_TMC_CURRENT                    = _UxGT("Ток двигателей");
-  LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Гибридный режим");
-  LSTR MSG_TMC_HOMING_THRS                = _UxGT("Чувствительность");
-  LSTR MSG_TMC_STEPPING_MODE              = _UxGT("Режим драйвера");
-  LSTR MSG_TMC_STEALTH_ENABLED            = _UxGT("Тихий режим вкл");
+  LSTR MSG_TMC_DRIVERS                      = _UxGT("Драйвера TMC");
+  LSTR MSG_TMC_CURRENT                      = _UxGT("Ток двигателей");
+  LSTR MSG_TMC_HYBRID_THRS                  = _UxGT("Гибридный режим");
+  LSTR MSG_TMC_HOMING_THRS                  = _UxGT("Чувствительность");
+  LSTR MSG_TMC_STEPPING_MODE                = _UxGT("Режим драйвера");
+  LSTR MSG_TMC_STEALTH_ENABLED              = _UxGT("Тихий режим вкл");
 
-  LSTR MSG_SERVICE_RESET                  = _UxGT("Сброс");
-  LSTR MSG_SERVICE_IN                     = _UxGT(" в:");
-  LSTR MSG_BACKLASH                       = _UxGT("Люфт");
-  LSTR MSG_BACKLASH_CORRECTION            = _UxGT("Исправление");
-  LSTR MSG_BACKLASH_SMOOTHING             = _UxGT("Сглаживание");
+  LSTR MSG_SERVICE_RESET                    = _UxGT("Сброс");
+  LSTR MSG_SERVICE_IN                       = _UxGT(" в:");
+  LSTR MSG_BACKLASH                         = _UxGT("Люфт");
+  LSTR MSG_BACKLASH_CORRECTION              = _UxGT("Исправление");
+  LSTR MSG_BACKLASH_SMOOTHING               = _UxGT("Сглаживание");
 
-  LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Выровнять ось X");
-  LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Автокалибровка");
-  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Таймаут нагрева");
-  LSTR MSG_REHEAT                         = _UxGT("Возобновить нагрев");
-  LSTR MSG_REHEATING                      = _UxGT("Нагрев...");
+  LSTR MSG_LEVEL_X_AXIS                     = _UxGT("Выровнять ось X");
+  LSTR MSG_AUTO_CALIBRATE                   = _UxGT("Автокалибровка");
+  LSTR MSG_HEATER_TIMEOUT                   = _UxGT("Таймаут нагрева");
+  LSTR MSG_REHEAT                           = _UxGT("Возобновить нагрев");
+  LSTR MSG_REHEATING                        = _UxGT("Нагрев...");
 
-  LSTR MSG_PROBE_WIZARD                   = _UxGT("Мастер Z-зонда");
-  #if LCD_WIDTH > 20 || HAS_DWIN_E3V2
-    LSTR MSG_PROBE_WIZARD_PROBING         = _UxGT("Зондиров. контр. точки Z");
-    LSTR MSG_PROBE_WIZARD_MOVING          = _UxGT("Движение к точке зондиров.");
-  #else
-    LSTR MSG_PROBE_WIZARD_PROBING         = _UxGT("Зондир.контр.точки Z");
-    LSTR MSG_PROBE_WIZARD_MOVING          = _UxGT("Движ.к точке зондир.");
-  #endif
+  LSTR MSG_PROBE_WIZARD                     = _UxGT("Мастер Z-зонда");
+  LSTR MSG_PROBE_WIZARD_PROBING             = _UxGT("Зондир.контр.точки Z");
+  LSTR MSG_PROBE_WIZARD_MOVING              = _UxGT("Движ.к точке зондир.");
 
-  LSTR MSG_SOUND                          = _UxGT("Звук");
+  LSTR MSG_SOUND                            = _UxGT("Звук");
 
-  LSTR MSG_TOP_LEFT                       = _UxGT("Верхний левый");
-  LSTR MSG_BOTTOM_LEFT                    = _UxGT("Нижний левый");
-  LSTR MSG_TOP_RIGHT                      = _UxGT("Верхний правый");
-  LSTR MSG_BOTTOM_RIGHT                   = _UxGT("Нижний правый");
-  LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Калибровка успешна");
-  LSTR MSG_CALIBRATION_FAILED             = _UxGT("Ошибка калибровки");
+  LSTR MSG_TOP_LEFT                         = _UxGT("Верхний левый");
+  LSTR MSG_BOTTOM_LEFT                      = _UxGT("Нижний левый");
+  LSTR MSG_TOP_RIGHT                        = _UxGT("Верхний правый");
+  LSTR MSG_BOTTOM_RIGHT                     = _UxGT("Нижний правый");
+  LSTR MSG_CALIBRATION_COMPLETED            = _UxGT("Калибровка успешна");
+  LSTR MSG_CALIBRATION_FAILED               = _UxGT("Ошибка калибровки");
 
-  LSTR MSG_DRIVER_BACKWARD                = _UxGT(" драйвер наоборот");
+  LSTR MSG_DRIVER_BACKWARD                  = _UxGT(" драйвер наоборот");
 
-  LSTR MSG_SD_CARD                        = _UxGT("SD Карта");
-  LSTR MSG_USB_DISK                       = _UxGT("USB Диск");
+  LSTR MSG_SD_CARD                          = _UxGT("SD Карта");
+  LSTR MSG_USB_DISK                         = _UxGT("USB Диск");
 
-  LSTR MSG_SHORT_DAY                      = _UxGT("д"); // One character only
-  LSTR MSG_SHORT_HOUR                     = _UxGT("ч"); // One character only
-  LSTR MSG_SHORT_MINUTE                   = _UxGT("м"); // One character only
+  LSTR MSG_SHORT_DAY                        = _UxGT("д"); // One character only
+  LSTR MSG_SHORT_HOUR                       = _UxGT("ч"); // One character only
+  LSTR MSG_SHORT_MINUTE                     = _UxGT("м"); // One character only
 
-  LSTR MSG_HIGH                           = _UxGT("ВЫСОКИЙ");
-  LSTR MSG_LOW                            = _UxGT("НИЗКИЙ");
-  LSTR MSG_ERROR                          = _UxGT("Ошибка");
-  LSTR MSG_ENDSTOP_TEST                   = _UxGT("Тест концевиков");
-  LSTR MSG_Z_PROBE                        = _UxGT("Z-зонд");
-  LSTR MSG_HOMING                         = _UxGT("Парковка");
-  LSTR MSG_Z_AFTER_HOME                   = _UxGT("Z после парковки");
-  LSTR MSG_FILAMENT_SET                   = _UxGT("Настройки филамента");
-  #if LCD_WIDTH > 20 || HAS_DWIN_E3V2
-    LSTR MSG_FILAMENT_MAN                 = _UxGT("Управление филаментом");
-  #else
-    LSTR MSG_FILAMENT_MAN                 = _UxGT("Управл.филаментом");
-  #endif
-  LSTR MSG_MANUAL_LEVELING                = _UxGT("Ручное выравнивание");
-  LSTR MSG_TRAM_FL                        = _UxGT("Передний левый");
-  LSTR MSG_TRAM_FR                        = _UxGT("Передний правый");
-  LSTR MSG_TRAM_C                         = _UxGT("Центр");
-  LSTR MSG_TRAM_BL                        = _UxGT("Задний левый");
-  LSTR MSG_TRAM_BR                        = _UxGT("Задний правый");
-  LSTR MSG_MANUAL_MESH                    = _UxGT("Сетка вручную");
-  LSTR MSG_AUTO_MESH                      = _UxGT("Сетка автоматически");
-  LSTR MSG_ERR_M428_TOO_FAR               = _UxGT("Ошибка: слишком далеко!");
-  LSTR MSG_TRAMMING_WIZARD                = _UxGT("Помощник выравнив.");
-  LSTR MSG_PREHEAT_HOTEND                 = _UxGT("Нагреть сопло");
-  LSTR MSG_BED_TRAMMING_MANUAL            = _UxGT("Ручное выравнив.");
-  LSTR MSG_MESH_VIEWER                    = _UxGT("Просмотр сетки");
-  LSTR MSG_MESH_VIEW                      = _UxGT("Смотреть сетку");
-  LSTR MSG_NO_VALID_MESH                  = _UxGT("Нет годной сетки");
-  LSTR MSG_ACTIVATE_MESH                  = _UxGT("Включить сетку");
-  LSTR MSG_MESH_INSET                     = _UxGT("Отступы сетки");
-  LSTR MSG_MESH_MIN_X                     = _UxGT("Сетка X минимум");
-  LSTR MSG_MESH_MAX_X                     = _UxGT("Сетка X максимум");
-  LSTR MSG_MESH_MIN_Y                     = _UxGT("Сетка Y минимум");
-  LSTR MSG_MESH_MAX_Y                     = _UxGT("Сетка Y максимум");
-  LSTR MSG_MESH_AMAX                      = _UxGT("Максимальная зона");
-  LSTR MSG_MESH_CENTER                    = _UxGT("Центрировать зону");
-  LSTR MSG_MESH_CANCEL                    = _UxGT("Сетка отменена");
-  LSTR MSG_UBL_TILT_MESH                  = _UxGT("Наколнить сетку");
-  LSTR MSG_UBL_TILTING_GRID               = _UxGT("Величина наклона");
-  LSTR MSG_UBL_MESH_TILTED                = _UxGT("Сетка наклонена");
-  LSTR MSG_UBL_MESH_FILLED                = _UxGT("Попущенные точки заполнены");
-  LSTR MSG_UBL_MESH_INVALID               = _UxGT("Негодная сетка");
-  LSTR MSG_UBL_INVALID_SLOT               = _UxGT("Сперва выберите слот сетки");
-  LSTR MSG_MESH_ACTIVE                    = _UxGT("Сетка %i активна");
-  LSTR MSG_MOVE_50MM                      = _UxGT("Двигать 50mm");
-  LSTR MSG_LIVE_MOVE                      = _UxGT("Живое перемещение");
-  LSTR MSG_CUTTER                         = _UxGT("Резак");
-  LSTR MSG_PID_CYCLE                      = _UxGT("Циклы PID");
-  LSTR MSG_PID_AUTOTUNE_FAILED            = _UxGT("Автонастройка PID не удалась!");
-  LSTR MSG_BAD_HEATER_ID                  = _UxGT("Неверный экструдер.");
-  LSTR MSG_TEMP_TOO_HIGH                  = _UxGT("Слишком высокая температура.");
-  LSTR MSG_TIMEOUT                        = _UxGT("Таймаут.");
-  LSTR MSG_MPC_MEASURING_AMBIENT          = _UxGT("Тест потери тепла");
-  LSTR MSG_MPC_HEATING_PAST_200           = _UxGT("Нагрев выше >200C");
-  LSTR MSG_MPC_COOLING_TO_AMBIENT         = _UxGT("Охлаждение до окружающей");
-  LSTR MSG_MPC_AUTOTUNE                   = _UxGT("Автонастройка MPC");
-  LSTR MSG_MPC_EDIT                       = _UxGT("Изменить * MPC");
-  LSTR MSG_MPC_POWER                      = _UxGT("Мощность нагревателя");
-  LSTR MSG_MPC_POWER_E                    = _UxGT("Мощность *");
-  LSTR MSG_MPC_BLOCK_HEAT_CAPACITY        = _UxGT("Теплоёмкость");
-  LSTR MSG_MPC_BLOCK_HEAT_CAPACITY_E      = _UxGT("Теплоёмк. *");
-  LSTR MSG_SENSOR_RESPONSIVENESS          = _UxGT("Отклик датчика");
-  LSTR MSG_SENSOR_RESPONSIVENESS_E        = _UxGT("Отклик датч. *");
-  LSTR MSG_MPC_AMBIENT_XFER_COEFF         = _UxGT("Коэфф.окружения");
-  LSTR MSG_MPC_AMBIENT_XFER_COEFF_E       = _UxGT("Коэфф.окруж *");
-  LSTR MSG_MPC_AMBIENT_XFER_COEFF_FAN     = _UxGT("Коэфф.кулера");
-  LSTR MSG_MPC_AMBIENT_XFER_COEFF_FAN_E   = _UxGT("Коэфф.кулер *");
-  LSTR MSG_INPUT_SHAPING                  = _UxGT("Input Shaping");
-  LSTR MSG_SHAPING_ENABLE                 = _UxGT("Включить шейпинг @");
-  LSTR MSG_SHAPING_DISABLE                = _UxGT("Выключить шейпинг @");
-  LSTR MSG_SHAPING_FREQ                   = _UxGT("@ частота");
-  LSTR MSG_SHAPING_ZETA                   = _UxGT("@ подавление");
-  LSTR MSG_FILAMENT_EN                    = _UxGT("Филамент *");
-  LSTR MSG_SEGMENTS_PER_SECOND            = _UxGT("Сегментов/сек");
-  LSTR MSG_DRAW_MIN_X                     = _UxGT("Рисовать мин X");
-  LSTR MSG_DRAW_MAX_X                     = _UxGT("Рисовать макс X");
-  LSTR MSG_DRAW_MIN_Y                     = _UxGT("Рисовать мин Y");
-  LSTR MSG_DRAW_MAX_Y                     = _UxGT("Рисовать макс Y");
-  LSTR MSG_MAX_BELT_LEN                   = _UxGT("Макс.длина ремня");
-  LSTR MSG_LINEAR_ADVANCE                 = _UxGT("Linear Advance");
-  LSTR MSG_BRIGHTNESS                     = _UxGT("Яркость LCD");
-  LSTR MSG_SCREEN_TIMEOUT                 = _UxGT("Таймаут LCD (м)");
-  LSTR MSG_BRIGHTNESS_OFF                 = _UxGT("Выкл.подсветку");
-  LSTR MSG_INFO_MACHINENAME               = _UxGT("Название машины");
-  LSTR MSG_INFO_SIZE                      = _UxGT("Размер");
-  LSTR MSG_INFO_FWVERSION                 = _UxGT("Версия прошивки");
-  LSTR MSG_INFO_BUILD                     = _UxGT("Дата сборки");
-  LSTR MSG_BUTTON_CONFIRM                 = _UxGT("Подтвердить");
-  LSTR MSG_BUTTON_CONTINUE                = _UxGT("Продолжить");
-  LSTR MSG_BUTTON_INFO                    = _UxGT("Инфо");
-  LSTR MSG_BUTTON_LEVEL                   = _UxGT("Выровнять");
-  LSTR MSG_BUTTON_PAUSE                   = _UxGT("Пауза");
-  LSTR MSG_BUTTON_RESUME                  = _UxGT("Продолжить");
-  LSTR MSG_BUTTON_ADVANCED                = _UxGT("Расширанные");
-  LSTR MSG_BUTTON_SAVE                    = _UxGT("Сохранить");
-  LSTR MSG_BUTTON_PURGE                   = _UxGT("Прочистить");
-  LSTR MSG_PAUSING                        = _UxGT("Пауза...");
-  LSTR MSG_ADVANCED_PAUSE                 = _UxGT("Расширенная пауза");
-  LSTR MSG_CONTINUE_PRINT_JOB             = _UxGT("Продолжить печать");
-  LSTR MSG_TURN_OFF                       = _UxGT("Выключить принтер");
-  LSTR MSG_END_LOOPS                      = _UxGT("Завершить петлю");
-  LSTR MSG_STOPPING                       = _UxGT("Остановка...");
-  LSTR MSG_REMAINING_TIME                 = _UxGT("Осталось");
-  LSTR MSG_PRINTER_KILLED                 = _UxGT("Принтер убит!");
-  LSTR MSG_FWRETRACT                      = _UxGT("Откат принтера");
-  LSTR MSG_SINGLENOZZLE_WIPE_RETRACT      = _UxGT("Вытирание при откате");
-  LSTR MSG_PARK_FAILED                    = _UxGT("Не удалось запарковать");
-  LSTR MSG_FILAMENTUNLOAD                 = _UxGT("Выгрузить филамент");
-  LSTR MSG_ATTACH_USB_MEDIA               = _UxGT("Монтировать USB");
-  LSTR MSG_BLTOUCH_SPEED_MODE             = _UxGT("Высокая скорость");
-  LSTR MSG_MANUAL_PENUP                   = _UxGT("Поднять перо");
-  LSTR MSG_MANUAL_PENDOWN                 = _UxGT("Опустить перо");
-  LSTR MSG_ZPROBE_SETTINGS                = _UxGT("Наторойки зонда");
-  LSTR MSG_ZPROBE_MARGIN                  = _UxGT("Отступы зонда");
-  LSTR MSG_Z_FEED_RATE                    = _UxGT("Скорость Z");
-  LSTR MSG_ENABLE_HS_MODE                 = _UxGT("Включить режим ВС");
-  LSTR MSG_TEMP_MALFUNCTION               = _UxGT("СБОЙ ТЕМПЕРАТУРЫ");
-  LSTR MSG_PLEASE_WAIT                    = _UxGT("Ожидайте...");
-  LSTR MSG_PREHEATING                     = _UxGT("Нагреваю...");
-  LSTR MSG_DELTA_CALIBRATION_IN_PROGRESS  = _UxGT("Делаю дельта-калибровку");
-  LSTR MSG_RESET_STATS                    = _UxGT("Сбросить статистику печати?");
-  LSTR MSG_FAN_SPEED_FAULT                = _UxGT("Сбой скорости кулера");
-  LSTR MSG_COLORS_GET                     = _UxGT("Получить цвет");
-  LSTR MSG_COLORS_SELECT                  = _UxGT("Выбрать цвета");
-  LSTR MSG_COLORS_APPLIED                 = _UxGT("Цвета применены");
-  LSTR MSG_COLORS_RED                     = _UxGT("Красный");
-  LSTR MSG_COLORS_GREEN                   = _UxGT("Зелёный");
-  LSTR MSG_COLORS_BLUE                    = _UxGT("Синий");
-  LSTR MSG_COLORS_WHITE                   = _UxGT("Белый");
-  LSTR MSG_UI_LANGUAGE                    = _UxGT("UI Language");
-  LSTR MSG_SOUND_ENABLE                   = _UxGT("Включить звук");
-  LSTR MSG_LOCKSCREEN                     = _UxGT("Блокировать экран");
-  LSTR MSG_LOCKSCREEN_LOCKED              = _UxGT("Принтер заблокирован,");
-  LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("Крутить для разблокировки.");
-  LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Ждите перезагрузки.");
-  LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Нет носителя.");
-  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Нагрейте сопло.");
-  LSTR MSG_INFO_PRINT_COUNT_RESET         = _UxGT("Сбросить счетчик");
-  LSTR MSG_FILAMENT_CHANGE_PURGE_CONTINUE = _UxGT("Прочистить или продолжить?");
-  LSTR MSG_RUNOUT_ENABLE                  = _UxGT("Включить датч.филамента");
-  LSTR MSG_RUNOUT_ACTIVE                  = _UxGT("Датч.филам. активен");
-  LSTR MSG_INVERT_EXTRUDER                = _UxGT("Инвертировать экструдер");
-  LSTR MSG_EXTRUDER_MIN_TEMP              = _UxGT("Миню темп. экструдера.");
-  LSTR MSG_FANCHECK                       = _UxGT("Пров.тахометра кулера");
-  LSTR MSG_MMU2_REMOVE_AND_CLICK          = _UxGT("Уберите и кликните...");
-  LSTR MSG_REHEATDONE                     = _UxGT("Нагрето");
-  LSTR MSG_XATC                           = _UxGT("Помощник перекоса X");
-  LSTR MSG_XATC_DONE                      = _UxGT("Перекос Х настроен!");
-  LSTR MSG_XATC_UPDATE_Z_OFFSET           = _UxGT("Новое смещение Z-зонда ");
-  LSTR MSG_HOST_SHUTDOWN                  = _UxGT("Выключить хост");
+  LSTR MSG_FILAMENT_MAN                     = _UxGT("Управл.филаментом");
+  LSTR MSG_MANUAL_LEVELING                  = _UxGT("Ручное выравнивание");
+  LSTR MSG_TRAM_FL                          = _UxGT("Передний левый");
+  LSTR MSG_TRAM_FR                          = _UxGT("Передний правый");
+  LSTR MSG_TRAM_C                           = _UxGT("Центр");
+  LSTR MSG_TRAM_BL                          = _UxGT("Задний левый");
+  LSTR MSG_TRAM_BR                          = _UxGT("Задний правый");
+  LSTR MSG_MANUAL_MESH                      = _UxGT("Сетка вручную");
+  LSTR MSG_AUTO_MESH                        = _UxGT("Сетка автоматически");
+  LSTR MSG_ERR_M428_TOO_FAR                 = _UxGT("Ошибка: слишком далеко!");
+  LSTR MSG_TRAMMING_WIZARD                  = _UxGT("Помощник выравнив.");
+  LSTR MSG_PREHEAT_HOTEND                   = _UxGT("Нагреть сопло");
+  LSTR MSG_BED_TRAMMING_MANUAL              = _UxGT("Ручное выравнив.");
+  LSTR MSG_MESH_VIEWER                      = _UxGT("Просмотр сетки");
+  LSTR MSG_MESH_VIEW                        = _UxGT("Смотреть сетку");
+  LSTR MSG_NO_VALID_MESH                    = _UxGT("Нет годной сетки");
+  LSTR MSG_ACTIVATE_MESH                    = _UxGT("Включить сетку");
+  LSTR MSG_MESH_INSET                       = _UxGT("Отступы сетки");
+  LSTR MSG_MESH_MIN_X                       = _UxGT("Сетка X минимум");
+  LSTR MSG_MESH_MAX_X                       = _UxGT("Сетка X максимум");
+  LSTR MSG_MESH_MIN_Y                       = _UxGT("Сетка Y минимум");
+  LSTR MSG_MESH_MAX_Y                       = _UxGT("Сетка Y максимум");
+  LSTR MSG_MESH_AMAX                        = _UxGT("Максимальная зона");
+  LSTR MSG_MESH_CENTER                      = _UxGT("Центрировать зону");
+  LSTR MSG_MESH_CANCEL                      = _UxGT("Сетка отменена");
+  LSTR MSG_UBL_TILT_MESH                    = _UxGT("Наколнить сетку");
+  LSTR MSG_UBL_TILTING_GRID                 = _UxGT("Величина наклона");
+  LSTR MSG_UBL_MESH_TILTED                  = _UxGT("Сетка наклонена");
+  LSTR MSG_UBL_MESH_FILLED                  = _UxGT("Попущенные точки заполнены");
+  LSTR MSG_UBL_MESH_INVALID                 = _UxGT("Негодная сетка");
+  LSTR MSG_UBL_INVALID_SLOT                 = _UxGT("Сперва выберите слот сетки");
+  LSTR MSG_MESH_ACTIVE                      = _UxGT("Сетка %i активна");
+  LSTR MSG_MOVE_50MM                        = _UxGT("Двигать 50mm");
+  LSTR MSG_LIVE_MOVE                        = _UxGT("Живое перемещение");
+  LSTR MSG_CUTTER                           = _UxGT("Резак");
+  LSTR MSG_PID_CYCLE                        = _UxGT("Циклы PID");
+  LSTR MSG_PID_AUTOTUNE_FAILED              = _UxGT("Автонастройка PID не удалась!");
+  LSTR MSG_BAD_HEATER_ID                    = _UxGT("Неверный экструдер.");
+  LSTR MSG_TEMP_TOO_HIGH                    = _UxGT("Слишком высокая температура.");
+  LSTR MSG_TIMEOUT                          = _UxGT("Таймаут.");
+  LSTR MSG_MPC_MEASURING_AMBIENT            = _UxGT("Тест потери тепла");
+  LSTR MSG_MPC_HEATING_PAST_200             = _UxGT("Нагрев выше >200C");
+  LSTR MSG_MPC_COOLING_TO_AMBIENT           = _UxGT("Охлаждение до окружающей");
+  LSTR MSG_MPC_AUTOTUNE                     = _UxGT("Автонастройка MPC");
+  LSTR MSG_MPC_EDIT                         = _UxGT("Изменить * MPC");
+  LSTR MSG_MPC_POWER                        = _UxGT("Мощность нагревателя");
+  LSTR MSG_MPC_POWER_E                      = _UxGT("Мощность *");
+  LSTR MSG_MPC_BLOCK_HEAT_CAPACITY          = _UxGT("Теплоёмкость");
+  LSTR MSG_MPC_BLOCK_HEAT_CAPACITY_E        = _UxGT("Теплоёмк. *");
+  LSTR MSG_SENSOR_RESPONSIVENESS            = _UxGT("Отклик датчика");
+  LSTR MSG_SENSOR_RESPONSIVENESS_E          = _UxGT("Отклик датч. *");
+  LSTR MSG_MPC_AMBIENT_XFER_COEFF           = _UxGT("Коэфф.окружения");
+  LSTR MSG_MPC_AMBIENT_XFER_COEFF_E         = _UxGT("Коэфф.окруж *");
+  LSTR MSG_MPC_AMBIENT_XFER_COEFF_FAN       = _UxGT("Коэфф.кулера");
+  LSTR MSG_MPC_AMBIENT_XFER_COEFF_FAN_E     = _UxGT("Коэфф.кулер *");
+  LSTR MSG_INPUT_SHAPING                    = _UxGT("Input Shaping");
+  LSTR MSG_SHAPING_ENABLE                   = _UxGT("Включить шейпинг @");
+  LSTR MSG_SHAPING_DISABLE                  = _UxGT("Выключить шейпинг @");
+  LSTR MSG_SHAPING_FREQ                     = _UxGT("@ частота");
+  LSTR MSG_SHAPING_ZETA                     = _UxGT("@ подавление");
+  LSTR MSG_FILAMENT_EN                      = _UxGT("Филамент *");
+  LSTR MSG_SEGMENTS_PER_SECOND              = _UxGT("Сегментов/сек");
+  LSTR MSG_DRAW_MIN_X                       = _UxGT("Рисовать мин X");
+  LSTR MSG_DRAW_MAX_X                       = _UxGT("Рисовать макс X");
+  LSTR MSG_DRAW_MIN_Y                       = _UxGT("Рисовать мин Y");
+  LSTR MSG_DRAW_MAX_Y                       = _UxGT("Рисовать макс Y");
+  LSTR MSG_MAX_BELT_LEN                     = _UxGT("Макс.длина ремня");
+  LSTR MSG_LINEAR_ADVANCE                   = _UxGT("Linear Advance");
+  LSTR MSG_BRIGHTNESS                       = _UxGT("Яркость LCD");
+  LSTR MSG_SCREEN_TIMEOUT                   = _UxGT("Таймаут LCD (м)");
+  LSTR MSG_BRIGHTNESS_OFF                   = _UxGT("Выкл.подсветку");
+  LSTR MSG_INFO_MACHINENAME                 = _UxGT("Название машины");
+  LSTR MSG_INFO_SIZE                        = _UxGT("Размер");
+  LSTR MSG_INFO_FWVERSION                   = _UxGT("Версия прошивки");
+  LSTR MSG_INFO_BUILD                       = _UxGT("Дата сборки");
+  LSTR MSG_BUTTON_CONFIRM                   = _UxGT("Подтвердить");
+  LSTR MSG_BUTTON_CONTINUE                  = _UxGT("Продолжить");
+  LSTR MSG_BUTTON_INFO                      = _UxGT("Инфо");
+  LSTR MSG_BUTTON_LEVEL                     = _UxGT("Выровнять");
+  LSTR MSG_BUTTON_PAUSE                     = _UxGT("Пауза");
+  LSTR MSG_BUTTON_RESUME                    = _UxGT("Продолжить");
+  LSTR MSG_BUTTON_ADVANCED                  = _UxGT("Расширанные");
+  LSTR MSG_BUTTON_SAVE                      = _UxGT("Сохранить");
+  LSTR MSG_BUTTON_PURGE                     = _UxGT("Прочистить");
+  LSTR MSG_PAUSING                          = _UxGT("Пауза...");
+  LSTR MSG_ADVANCED_PAUSE                   = _UxGT("Расширенная пауза");
+  LSTR MSG_CONTINUE_PRINT_JOB               = _UxGT("Продолжить печать");
+  LSTR MSG_TURN_OFF                         = _UxGT("Выключить принтер");
+  LSTR MSG_END_LOOPS                        = _UxGT("Завершить петлю");
+  LSTR MSG_STOPPING                         = _UxGT("Остановка...");
+  LSTR MSG_REMAINING_TIME                   = _UxGT("Осталось");
+  LSTR MSG_PRINTER_KILLED                   = _UxGT("Принтер убит!");
+  LSTR MSG_FWRETRACT                        = _UxGT("Откат принтера");
+  LSTR MSG_SINGLENOZZLE_WIPE_RETRACT        = _UxGT("Вытирание при откате");
+  LSTR MSG_PARK_FAILED                      = _UxGT("Не удалось запарковать");
+  LSTR MSG_FILAMENTUNLOAD                   = _UxGT("Выгрузить филамент");
+  LSTR MSG_ATTACH_USB_MEDIA                 = _UxGT("Монтировать USB");
+  LSTR MSG_BLTOUCH_SPEED_MODE               = _UxGT("Высокая скорость");
+  LSTR MSG_MANUAL_PENUP                     = _UxGT("Поднять перо");
+  LSTR MSG_MANUAL_PENDOWN                   = _UxGT("Опустить перо");
+  LSTR MSG_ZPROBE_SETTINGS                  = _UxGT("Наторойки зонда");
+  LSTR MSG_ZPROBE_MARGIN                    = _UxGT("Отступы зонда");
+  LSTR MSG_Z_FEED_RATE                      = _UxGT("Скорость Z");
+  LSTR MSG_ENABLE_HS_MODE                   = _UxGT("Включить режим ВС");
+  LSTR MSG_TEMP_MALFUNCTION                 = _UxGT("СБОЙ ТЕМПЕРАТУРЫ");
+  LSTR MSG_PLEASE_WAIT                      = _UxGT("Ожидайте...");
+  LSTR MSG_PREHEATING                       = _UxGT("Нагреваю...");
+  LSTR MSG_DELTA_CALIBRATION_IN_PROGRESS    = _UxGT("Делаю дельта-калибровку");
+  LSTR MSG_RESET_STATS                      = _UxGT("Сбросить статистику печати?");
+  LSTR MSG_FAN_SPEED_FAULT                  = _UxGT("Сбой скорости кулера");
+  LSTR MSG_COLORS_GET                       = _UxGT("Получить цвет");
+  LSTR MSG_COLORS_SELECT                    = _UxGT("Выбрать цвета");
+  LSTR MSG_COLORS_APPLIED                   = _UxGT("Цвета применены");
+  LSTR MSG_COLORS_RED                       = _UxGT("Красный");
+  LSTR MSG_COLORS_GREEN                     = _UxGT("Зелёный");
+  LSTR MSG_COLORS_BLUE                      = _UxGT("Синий");
+  LSTR MSG_COLORS_WHITE                     = _UxGT("Белый");
+  LSTR MSG_UI_LANGUAGE                      = _UxGT("UI Language");
+  LSTR MSG_SOUND_ENABLE                     = _UxGT("Включить звук");
+  LSTR MSG_LOCKSCREEN                       = _UxGT("Блокировать экран");
+  LSTR MSG_LOCKSCREEN_LOCKED                = _UxGT("Принтер заблокирован,");
+  LSTR MSG_LOCKSCREEN_UNLOCK                = _UxGT("Крутить для разблокировки.");
+  LSTR MSG_PLEASE_WAIT_REBOOT               = _UxGT("Ждите перезагрузки.");
+  LSTR MSG_MEDIA_NOT_INSERTED               = _UxGT("Нет носителя.");
+  LSTR MSG_PLEASE_PREHEAT                   = _UxGT("Нагрейте сопло.");
+  LSTR MSG_INFO_PRINT_COUNT_RESET           = _UxGT("Сбросить счетчик");
+  LSTR MSG_FILAMENT_CHANGE_PURGE_CONTINUE   = _UxGT("Прочистить или продолжить?");
+  LSTR MSG_RUNOUT_ENABLE                    = _UxGT("Включить датч.филамента");
+  LSTR MSG_RUNOUT_ACTIVE                    = _UxGT("Датч.филам. активен");
+  LSTR MSG_INVERT_EXTRUDER                  = _UxGT("Инвертировать экструдер");
+  LSTR MSG_EXTRUDER_MIN_TEMP                = _UxGT("Миню темп. экструдера.");
+  LSTR MSG_FANCHECK                         = _UxGT("Пров.тахометра кулера");
+  LSTR MSG_MMU2_REMOVE_AND_CLICK            = _UxGT("Уберите и кликните...");
+  LSTR MSG_REHEATDONE                       = _UxGT("Нагрето");
+  LSTR MSG_XATC                             = _UxGT("Помощник перекоса X");
+  LSTR MSG_XATC_DONE                        = _UxGT("Перекос Х настроен!");
+  LSTR MSG_XATC_UPDATE_Z_OFFSET             = _UxGT("Новое смещение Z-зонда ");
+  LSTR MSG_HOST_SHUTDOWN                    = _UxGT("Выключить хост");
 
   // did not translate as there is no local terms/slang yet
-  LSTR MSG_FIXED_TIME_MOTION              = _UxGT("Fixed-Time Motion");
-  LSTR MSG_FTM_MODE                       = _UxGT("Motion Mode:");
-  LSTR MSG_FTM_ZV                         = _UxGT("ZV");
-  LSTR MSG_FTM_ZVD                        = _UxGT("ZVD");
-  LSTR MSG_FTM_EI                         = _UxGT("EI");
-  LSTR MSG_FTM_2HEI                       = _UxGT("2HEI");
-  LSTR MSG_FTM_3HEI                       = _UxGT("3HEI");
-  LSTR MSG_FTM_MZV                        = _UxGT("MZV");
-  //LSTR MSG_FTM_ULENDO_FBS               = _UxGT("Ulendo ФBС");
-  //LSTR MSG_FTM_DISCTF                   = _UxGT("DISCTF");
-  LSTR MSG_FTM_DYN_MODE                   = _UxGT("DF Mode:");
-  LSTR MSG_FTM_Z_BASED                    = _UxGT("Z-based");
-  LSTR MSG_FTM_MASS_BASED                 = _UxGT("Mass-based");
-  LSTR MSG_FTM_BASE_FREQ_N                = _UxGT("@ Base Freq.");
-  LSTR MSG_FTM_DFREQ_K_N                  = _UxGT("@ Dyn. Freq.");
+  LSTR MSG_FIXED_TIME_MOTION                = _UxGT("Fixed-Time Motion");
+  LSTR MSG_FTM_MODE                         = _UxGT("Motion Mode:");
+  LSTR MSG_FTM_ZV                           = _UxGT("ZV");
+  LSTR MSG_FTM_ZVD                          = _UxGT("ZVD");
+  LSTR MSG_FTM_EI                           = _UxGT("EI");
+  LSTR MSG_FTM_2HEI                         = _UxGT("2HEI");
+  LSTR MSG_FTM_3HEI                         = _UxGT("3HEI");
+  LSTR MSG_FTM_MZV                          = _UxGT("MZV");
+  //LSTR MSG_FTM_ULENDO_FBS                 = _UxGT("Ulendo ФBС");
+  //LSTR MSG_FTM_DISCTF                     = _UxGT("DISCTF");
+  LSTR MSG_FTM_DYN_MODE                     = _UxGT("DF Mode:");
+  LSTR MSG_FTM_Z_BASED                      = _UxGT("Z-based");
+  LSTR MSG_FTM_MASS_BASED                   = _UxGT("Mass-based");
+  LSTR MSG_FTM_BASE_FREQ_N                  = _UxGT("@ Base Freq.");
+  LSTR MSG_FTM_DFREQ_K_N                    = _UxGT("@ Dyn. Freq.");
+}
+
+namespace LanguageWide_ru {
+  using namespace LanguageNarrow_ru;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Сбой инициализации SD");
+    LSTR MSG_ADVANCED_SETTINGS              = _UxGT("Расширенные настройки");
+    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переполнение вызова");
+    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Установ. смещения дома");
+    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Смещение дома X");
+    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Смещение дома Y");
+    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Смещение дома Z");
+    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Последнее значение ");
+    LSTR MSG_SPINDLE_MENU                   = _UxGT("Управлен.шпинделем");
+    LSTR MSG_LASER_TOGGLE                   = _UxGT("Переключить лазер");
+    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Переключ. шпиндель");
+    LSTR MSG_SPINDLE_POWER                  = _UxGT("Мощность шпинделя");
+    LSTR MSG_LASER_POWER                    = _UxGT("Мощность лазера");
+    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тестовый импульс мс");
+    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Переключить обдув");
+    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Переключить вакуум");
+    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вверх до срабатыв. зонда");
+    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Углы в норме. Вырав.стола");
+    LSTR MSG_MESH_EDITOR                    = _UxGT("Смещение по Z");
+    LSTR MSG_EDITING_STOPPED                = _UxGT("Правка сетки окончена");
+    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Разместить шайбу,измерить");
+    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Убрать и замерить стол");
+    LSTR MSG_UBL_SET_TEMP_BED               = _UxGT("Температура стола");
+    LSTR MSG_UBL_BED_TEMP_CUSTOM            = _UxGT("Температура стола");
+    LSTR MSG_UBL_SET_TEMP_HOTEND            = _UxGT("Температура сопла");
+    LSTR MSG_UBL_HOTEND_TEMP_CUSTOM         = _UxGT("Температура сопла");
+    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Построить свою сетку");
+    LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Правка сетки завершена");
+    LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Построить холодную сетку");
+    LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Проверить сетку $");
+    LSTR MSG_UBL_VALIDATE_CUSTOM_MESH       = _UxGT("Проверить свою сетку");
+    LSTR MSG_UBL_3POINT_MESH_LEVELING       = _UxGT("3-х точечное выравнивание");
+    LSTR MSG_UBL_OUTPUT_MAP_BACKUP          = _UxGT("Сохранить сетку снаружи");
+    LSTR MSG_UBL_INFO_UBL                   = _UxGT("Вывод информации UBL");
+    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Кол-во заполнителя");
+    LSTR MSG_NEO2_PRESETS                   = _UxGT("Свет #2 предустановки");
+    LSTR MSG_COOLER                         = _UxGT("Охлаждение лазера");
+    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Переключ. охлажд.");
+    LSTR MSG_FLOWMETER_SAFETY               = _UxGT("Безопасн. потока");
+    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Отклонение угла");
+    LSTR MSG_FILAMENT_DIAM                  = _UxGT("Диам. филамента");
+    LSTR MSG_FILAMENT_DIAM_E                = _UxGT("Диам. филамента *");
+    LSTR MSG_RESTORE_DEFAULTS               = _UxGT("На базовые параметры");
+    LSTR MSG_INIT_EEPROM                    = _UxGT("Инициализация EEPROM");
+    LSTR MSG_CONTROL_RETRACT                = _UxGT("Откат, мм");
+    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Откат при смене, мм");
+    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Возврат при смене, мм");
+    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAPF  = _UxGT("Возврат при смене, V");
+    LSTR MSG_AUTORETRACT                    = _UxGT("Автооткат");
+    LSTR MSG_FILAMENT_SWAP_EXTRA            = _UxGT("Дополнительная длина");
+    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Начальная скор.");
+    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Скорость отката");
+    LSTR MSG_FILAMENTLOAD_E                 = _UxGT("Загрузить филамент *");
+    LSTR MSG_FILAMENTUNLOAD_E               = _UxGT("Выгрузить филамент *");
+    LSTR MSG_MOVE_NOZZLE_TO_BED             = _UxGT("Двигать сопло к столу");
+    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точечное выравнивание");
+    LSTR MSG_LINEAR_LEVELING                = _UxGT("Линейное выравнивание");
+    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Билинейное выравнивание");
+    LSTR MSG_MESH_DONE                      = _UxGT("Зондирование выполнено");
+    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контроль утечки Т: Выкл");
+    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контроль утечки Т: Вкл");
+    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Время простоя хотенда");
+    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Счётчик печати");
+    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Общее время печати");
+    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Наидольшее задание");
+    LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Длина филамента");
+    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик оконч. филамента");
+    LSTR MSG_KILL_MMU2_FIRMWARE             = _UxGT("Обновить прошивку MMU!");
+    LSTR MSG_MMU2_EJECTING_FILAMENT         = _UxGT("Извлечение филамента...");
+    LSTR MSG_MIX                            = _UxGT("Смешивание");
+    LSTR MSG_TOGGLE_MIX                     = _UxGT("Переключить смешивание");
+    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Активация В-инструм.");
+    LSTR MSG_START_VTOOL                    = _UxGT("Начало В-инструмента");
+    LSTR MSG_END_VTOOL                      = _UxGT("Конец В-инструмента");
+    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдоним В-инструмента");
+    LSTR MSG_RESET_VTOOLS                   = _UxGT("Сброс В-инструментов");
+    LSTR MSG_COMMIT_VTOOL                   = _UxGT("Смешать В-инструменты");
+    LSTR MSG_VTOOLS_RESET                   = _UxGT("В-инструменты сброшены");
+    LSTR MSG_BAD_PAGE                       = _UxGT("Плохой индекс страницы");
+    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Плохая скорость страницы");
+    LSTR MSG_REMINDER_SAVE_SETTINGS         = _UxGT("Не забудь сохранить!");
+    LSTR MSG_PROBE_WIZARD_PROBING           = _UxGT("Зондиров. контр. точки Z");
+    LSTR MSG_PROBE_WIZARD_MOVING            = _UxGT("Движение к точке зондиров.");
+    LSTR MSG_FILAMENT_MAN                   = _UxGT("Управление филаментом");
+  #endif
+}
+
+namespace LanguageTall_ru {
+  using namespace LanguageWide_ru;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_3_LINE("Нажмите кнопку", "для продолжения", "печати"));
+    LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_2_LINE("Ожидайте начала", "смены филамента"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_3_LINE("Вставьте филамент", "и нажмите кнопку", "для продолжения"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_3_LINE("Нажмите кнопку", "для нагрева", "сопла..."));
+    LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_2_LINE("Нагрев сопла", "Ждите..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_3_LINE("Ожидайте", "выгрузки", "филамента"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_3_LINE("Ожидайте", "загрузки", "филамента"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_3_LINE("Ожидайте", "экструзии", "филамента"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_3_LINE("Нажмите кнопку", "для завершения", "прочистки филамента"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_3_LINE("Ожидайте", "возобновления", "печати"));
+  #endif
+}
+
+namespace Language_ru {
+  using namespace LanguageTall_ru;
 }

--- a/Marlin/src/lcd/language/language_sk.h
+++ b/Marlin/src/lcd/language/language_sk.h
@@ -41,7 +41,7 @@
  */
 #define DISPLAY_CHARSET_ISO10646_SK
 
-namespace Language_sk {
+namespace LanguageNarrow_sk {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -107,30 +107,23 @@ namespace Language_sk {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Spriev. vyrovn.");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Vyberte začiatok");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Posl. hodnota ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Zahriať ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Zahriať ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" hotend");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" hotend ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" všetko");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" podlož");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" nast.");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                  = _UxGT("Zahriať ") PREHEAT_2_LABEL;
-      LSTR MSG_PREHEAT_2_SETTINGS         = _UxGT("Zahriať ") PREHEAT_2_LABEL _UxGT(" nast.");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                  = _UxGT("Zahriať ") PREHEAT_3_LABEL;
-      LSTR MSG_PREHEAT_3_SETTINGS         = _UxGT("Zahriať ") PREHEAT_3_LABEL _UxGT(" nast.");
-    #endif
-    LSTR MSG_PREHEAT_M                    = _UxGT("Zahriať $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Zahriať $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Zahriať $ hotend");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Zahriať $ hotend ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Zahriať $ všetko");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Zahriať $ podlož");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Zahriať $ nast.");
-  #endif
+
+  LSTR MSG_PREHEAT_1                      = _UxGT("Zahriať ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Zahriať ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" hotend");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" hotend ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" všetko");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" podlož");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Zahriať ") PREHEAT_1_LABEL _UxGT(" nast.");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Zahriať $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Zahriať $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Zahriať $ hotend");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Zahriať $ hotend ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Zahriať $ všetko");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Zahriať $ podlož");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Zahriať $ nast.");
+
   LSTR MSG_PREHEAT_HOTEND                 = _UxGT("Zahriať hotend");
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Vlastná teplota");
   LSTR MSG_COOLDOWN                       = _UxGT("Schladiť");
@@ -494,25 +487,14 @@ namespace Language_sk {
   LSTR MSG_RESUME_PRINT                   = _UxGT("Obnoviť tlač");
   LSTR MSG_STOP_PRINT                     = _UxGT("Zastaviť tlač");
   LSTR MSG_OUTAGE_RECOVERY                = _UxGT("Obnova po výp. nap.");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Spustiť z hosta");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Tlačím objekt");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Zrušiť objekt");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Zrušiť objekt {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Pokračovať v úlohe");
-    LSTR MSG_MEDIA_MENU                   = _UxGT("Vytlačiť z karty");
-    LSTR MSG_TURN_OFF                     = _UxGT("Vypnite tlačiareň");
-    LSTR MSG_END_LOOPS                    = _UxGT("Ukončiť opak. sluč.");
-  #else
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Spustiť z hosta");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Tlačím obj.");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Zrušiť obj.");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Zrušiť obj. {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Pokrač. v úlohe");
-    LSTR MSG_MEDIA_MENU                   = _UxGT("Tlač z karty");
-    LSTR MSG_TURN_OFF                     = _UxGT("Vypnit. teraz");
-    LSTR MSG_END_LOOPS                    = _UxGT("Ukončiť sluč.");
-  #endif
+  LSTR MSG_HOST_START_PRINT               = _UxGT("Spustiť z hosta");
+  LSTR MSG_PRINTING_OBJECT                = _UxGT("Tlačím obj.");
+  LSTR MSG_CANCEL_OBJECT                  = _UxGT("Zrušiť obj.");
+  LSTR MSG_CANCEL_OBJECT_N                = _UxGT("Zrušiť obj. {");
+  LSTR MSG_CONTINUE_PRINT_JOB             = _UxGT("Pokrač. v úlohe");
+  LSTR MSG_MEDIA_MENU                     = _UxGT("Tlač z karty");
+  LSTR MSG_TURN_OFF                       = _UxGT("Vypnit. teraz");
+  LSTR MSG_END_LOOPS                      = _UxGT("Ukončiť sluč.");
   LSTR MSG_NO_MEDIA                       = _UxGT("Žiadna karta");
   LSTR MSG_DWELL                          = _UxGT("Spím...");
   LSTR MSG_USERWAIT                       = _UxGT("Pokrač. kliknutím...");
@@ -562,12 +544,9 @@ namespace Language_sk {
   LSTR MSG_FILAMENTUNLOAD                 = _UxGT("Vysunúť filament");
   LSTR MSG_FILAMENTUNLOAD_E               = _UxGT("Vysunúť filament *");
   LSTR MSG_FILAMENTUNLOAD_ALL             = _UxGT("Vysunúť všetko");
-  #if ENABLED(MULTI_VOLUME)
-    LSTR MSG_ATTACH_MEDIA                 = _UxGT("Načítať SD kartu");
-    LSTR MSG_ATTACH_USB_MEDIA             = _UxGT("Načítať USB disk");
-  #else
-    LSTR MSG_ATTACH_MEDIA                 = _UxGT("Načítať kartu");
-  #endif
+  LSTR MSG_ATTACH_MEDIA                   = _UxGT("Načítať kartu");
+  LSTR MSG_ATTACH_SD_MEDIA                = _UxGT("Načítať SD kartu");
+  LSTR MSG_ATTACH_USB_MEDIA               = _UxGT("Načítať USB disk");
   LSTR MSG_CHANGE_MEDIA                   = _UxGT("Vymeniť kartu");
   LSTR MSG_RELEASE_MEDIA                  = _UxGT("Odpojiť kartu");
   LSTR MSG_ZPROBE_OUT                     = _UxGT("Sonda Z mimo podl.");
@@ -680,22 +659,12 @@ namespace Language_sk {
   LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("potiahnite pre odomknutie.");
   LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Prosím čakajte do reštartu.");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Nie je vložená karta.");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Prosím zahrejte hotend.");
-    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Vynulovať počítadlo");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Počet tlačí");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Celkový čas");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdlhšia tlač");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Celkom vytlačené");
-  #else
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Žiadna karta");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Prosím zahrejte");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Tlače");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Čas");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdlhšia");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Vytlačené");
-  #endif
+  LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Žiadna karta");
+  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Prosím zahrejte");
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Tlače");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Čas");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Najdlhšia");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Vytlačené");
 
   LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Dokončené");
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Teplota min");
@@ -785,34 +754,20 @@ namespace Language_sk {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Heslo odstránené");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Stlačte tlačidlo", "pre obnovu tlače"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkovanie..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Čakajte prosím", "na spustenie", "výmeny filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Vložte filament", "a stlačte tlačidlo", "pre pokračovanie"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Stlačte tlačidlo", "pre ohrev trysky"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Ohrev trysky", "Čakajte prosím..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Čakajte prosím", "na vysunutie", "filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Čakajte prosím", "na zavedenie", "filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Čakajte prosím", "na vytlačenie", "filamentu"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Stlačte tlačidlo", "pre dokončenie", "vytláčania filam."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Čakajte prosím na", "obnovenie tlače..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Kliknite pre pokr."));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkovanie..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Čakajte prosím..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Vložte a kliknite"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Kliknite pre ohrev"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Ohrev..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Vysúvanie..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Zavádzanie..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Vytlačovanie..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Klik. pre dokonč."));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Pokračovanie..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Kliknite pre pokr."));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Parkovanie..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Čakajte prosím..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Vložte a kliknite"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Kliknite pre ohrev"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Ohrev..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Vysúvanie..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Zavádzanie..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Vytlačovanie..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Klik. pre dokonč."));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Pokračovanie..."));
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("Ovládače TMC");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Prúd ovládača");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Hybridný prah");
@@ -827,11 +782,8 @@ namespace Language_sk {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Vyrovnať os X");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Auto-kalibrovať");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Vypršal čas ohrevu, znížená teplota. Stlačte OK pre ohrev a ešte raz pre obnovu.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Vypršal čas ohrevu");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Vypršal čas ohrevu, znížená teplota. Stlačte OK pre ohrev a ešte raz pre obnovu.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Vypršal čas ohrevu");
   LSTR MSG_REHEAT                         = _UxGT("Zohriať");
   LSTR MSG_REHEATING                      = _UxGT("Zohrievanie...");
   LSTR MSG_REHEATDONE                     = _UxGT("Zohrievanie dokonč.");
@@ -859,4 +811,47 @@ namespace Language_sk {
   LSTR MSG_USB_DISK                       = _UxGT("USB disk");
 
   LSTR MSG_HOST_SHUTDOWN                  = _UxGT("Vypnúť hosta");
+}
+
+namespace LanguageWide_sk {
+  using namespace LanguageNarrow_sk;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_HOST_START_PRINT             = _UxGT("Spustiť z hosta");
+    LSTR MSG_PRINTING_OBJECT              = _UxGT("Tlačím objekt");
+    LSTR MSG_CANCEL_OBJECT                = _UxGT("Zrušiť objekt");
+    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Zrušiť objekt {");
+    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Pokračovať v úlohe");
+    LSTR MSG_MEDIA_MENU                   = _UxGT("Vytlačiť z karty");
+    LSTR MSG_TURN_OFF                     = _UxGT("Vypnite tlačiareň");
+    LSTR MSG_END_LOOPS                    = _UxGT("Ukončiť opak. sluč.");
+    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Nie je vložená karta.");
+    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Prosím zahrejte hotend.");
+    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Vynulovať počítadlo");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Počet tlačí");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Celkový čas");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Najdlhšia tlač");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Celkom vytlačené");
+  #endif
+}
+
+namespace LanguageTall_sk {
+  using namespace LanguageWide_sk;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Stlačte tlačidlo", "pre obnovu tlače"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkovanie..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Čakajte prosím", "na spustenie", "výmeny filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Vložte filament", "a stlačte tlačidlo", "pre pokračovanie"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Stlačte tlačidlo", "pre ohrev trysky"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Ohrev trysky", "Čakajte prosím..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_3_LINE("Čakajte prosím", "na vysunutie", "filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_3_LINE("Čakajte prosím", "na zavedenie", "filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_3_LINE("Čakajte prosím", "na vytlačenie", "filamentu"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_3_LINE("Stlačte tlačidlo", "pre dokončenie", "vytláčania filam."));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Čakajte prosím na", "obnovenie tlače..."));
+  #endif
+}
+
+namespace Language_sk {
+  using namespace LanguageTall_sk;
 }

--- a/Marlin/src/lcd/language/language_sv.h
+++ b/Marlin/src/lcd/language/language_sv.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_1
 
-namespace Language_sv {
+namespace LanguageNarrow_sv {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -77,23 +77,21 @@ namespace Language_sv {
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Välj Origo");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Senaste värde ");
 
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Förvärmning ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Förvärmning ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Stoppa");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Stoppa ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Alla");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Bädd");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Konf");
+  LSTR MSG_PREHEAT_1                      = _UxGT("Förvärmning ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Förvärmning ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Stoppa");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Stoppa ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Alla");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Bädd");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Förvärmning ") PREHEAT_1_LABEL _UxGT(" Konf");
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Förvärmning $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Förvärmning $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Förvärmning $ Stoppa");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Förvärmning $ Stoppa ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Förvärmning $ Alla");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Förvärmning $ Bädd");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Förvärmning $ Donf");
-  #endif
+  LSTR MSG_PREHEAT_M                      = _UxGT("Förvärmning $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Förvärmning $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Förvärmning $ Stoppa");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Förvärmning $ Stoppa ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Förvärmning $ Alla");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Förvärmning $ Bädd");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Förvärmning $ Donf");
 
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Förvärmning Anpassad");
   LSTR MSG_COOLDOWN                       = _UxGT("Nedkylning");
@@ -513,19 +511,11 @@ namespace Language_sv {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("Ljus ljusstyrka");
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("INKORREKT SKRIVARE");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Utskriftsantal");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Färdiga");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total Utskriftstid");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längsta Jobbtid");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruderade Totalt");
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Utskrift");
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Färdig");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längsta");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruderad");
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Utskrift");
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Färdig");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Total");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Längsta");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Extruderad");
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min Temp");
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("Max Temp");
@@ -608,34 +598,20 @@ namespace Language_sv {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Lösenord Bort taget");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Tryck på knappen", "för att fortsätta utskrift"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkera..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Vänta på", "trådbyte", "att börja"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Sätt in tråd", "och tryck på knappen", "för att fortsätta"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Tryck på knappen", "för att värma munstycke"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Munstycke värms", "Var snäll och vänta..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Väntar på", "trådlossning"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Väntar på", "trådladdning"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Väntar på", "tråd utrensning"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Klicka för att slutföra", "tråd utrensning"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Väntar på utskrift", "att återstarta..."));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Klick för att fortsätta"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkera..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Vänta..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Sätt in och klicka"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Klicka för att värma"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Värmer..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Lossar..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Laddar..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Rensar..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Klicka för att slutföra"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Återgår..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Klick för att fortsätta"));
+  LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Parkera..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Vänta..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Sätt in och klicka"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Klicka för att värma"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Värmer..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Lossar..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Laddar..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Rensar..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Klicka för att slutföra"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Återgår..."));
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC Drivers");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Driver Ström");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Hybrid Tröskelvärde");
@@ -650,11 +626,8 @@ namespace Language_sv {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Nivå X Axel");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Auto Kalibrera");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Overksam tidsgräns, temperatur minskning. Tryck ok för att återvärma och igen för att fortsätta.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Värmare Tidsgräns");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Overksam tidsgräns, temperatur minskning. Tryck ok för att återvärma och igen för att fortsätta.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Värmare Tidsgräns");
   LSTR MSG_REHEAT                         = _UxGT("Återvärm");
   LSTR MSG_REHEATING                      = _UxGT("Återvärmning...");
 
@@ -670,4 +643,36 @@ namespace Language_sv {
   LSTR MSG_BOTTOM_RIGHT                   = _UxGT("Nere Höger");
   LSTR MSG_CALIBRATION_COMPLETED          = _UxGT("Kalibrering Färdig");
   LSTR MSG_CALIBRATION_FAILED             = _UxGT("Kalibrering Misslyckad");
+}
+
+namespace LanguageWide_sv {
+  using namespace LanguageNarrow_sv;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Utskriftsantal");
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("Färdiga");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total Utskriftstid");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Längsta Jobbtid");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruderade Totalt");
+  #endif
+}
+
+namespace LanguageTall_sv {
+  using namespace LanguageWide_sv;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Tryck på knappen", "för att fortsätta utskrift"));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Vänta på", "trådbyte", "att börja"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Sätt in tråd", "och tryck på knappen", "för att fortsätta"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Tryck på knappen", "för att värma munstycke"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Munstycke värms", "Var snäll och vänta..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Väntar på", "trådlossning"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Väntar på", "trådladdning"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Väntar på", "tråd utrensning"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Klicka för att slutföra", "tråd utrensning"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Väntar på utskrift", "att återstarta..."));
+  #endif
+}
+
+namespace Language_sv {
+  using namespace LanguageTall_sv;
 }

--- a/Marlin/src/lcd/language/language_tr.h
+++ b/Marlin/src/lcd/language/language_tr.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_TR
 
-namespace Language_tr {
+namespace LanguageNarrow_tr {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -95,30 +95,23 @@ namespace Language_tr {
   LSTR MSG_TRAMMING_WIZARD                = _UxGT("Hizalama Sihirbazı");
   LSTR MSG_SELECT_ORIGIN                  = _UxGT("Başlangıç Seç");
   LSTR MSG_LAST_VALUE_SP                  = _UxGT("Son değer ");
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Ön Isınma ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Ön Isınma ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Nozul");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Nozul ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Tüm");
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Tabla");
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Ayarlar");
-    #ifdef PREHEAT_2_LABEL
-      LSTR MSG_PREHEAT_2                  = _UxGT("Ön Isınma ") PREHEAT_2_LABEL;
-      LSTR MSG_PREHEAT_2_SETTINGS         = _UxGT("Ön Isınma ") PREHEAT_2_LABEL _UxGT(" Conf");
-    #endif
-    #ifdef PREHEAT_3_LABEL
-      LSTR MSG_PREHEAT_3                  = _UxGT("Ön Isınma ") PREHEAT_3_LABEL;
-      LSTR MSG_PREHEAT_3_SETTINGS         = _UxGT("Ön Isınma ") PREHEAT_3_LABEL _UxGT(" Conf");
-    #endif
-    LSTR MSG_PREHEAT_M                    = _UxGT("Ön Isınma $");
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Ön Isınma $ ~");
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Ön Isınma $ Nozul");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Ön Isınma $ Nozul ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Ön Isınma $ Tüm");
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Ön Isınma $ Tabla");
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Ön Isınma $ Ayarlar");
-  #endif
+
+  LSTR MSG_PREHEAT_1                      = _UxGT("Ön Isınma ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Ön Isınma ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Nozul");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Nozul ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Tüm");
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Tabla");
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Ön Isınma ") PREHEAT_1_LABEL _UxGT(" Ayarlar");
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Ön Isınma $");
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Ön Isınma $ ~");
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Ön Isınma $ Nozul");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Ön Isınma $ Nozul ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Ön Isınma $ Tüm");
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Ön Isınma $ Tabla");
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Ön Isınma $ Ayarlar");
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Özel Ön Isınma");
   LSTR MSG_COOLDOWN                       = _UxGT("Soğut/(Durdur)");
 
@@ -473,25 +466,16 @@ namespace Language_tr {
   LSTR MSG_RESUME_PRINT                   = _UxGT("Baskıyı Sürdür");
   LSTR MSG_STOP_PRINT                     = _UxGT("Baskıyı Durdur");
   LSTR MSG_OUTAGE_RECOVERY                = _UxGT("Kesinti Kurtarma");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Host Baskıyı başlat");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Yazdırma Nesnesi");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Nesneyi İptal Et");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Nesneyi İptal Et {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Yazdırmaya Devam Et");
-    LSTR MSG_MEDIA_MENU                   = _UxGT("SD Karttan Yazdır");
-    LSTR MSG_TURN_OFF                     = _UxGT("Yazıcıyı kapat");
-    LSTR MSG_END_LOOPS                    = _UxGT("Tekrr Döngüler Bitir");
-  #else
-    LSTR MSG_HOST_START_PRINT             = _UxGT("Host Başlatma");
-    LSTR MSG_PRINTING_OBJECT              = _UxGT("Nesneyi Yazdır");
-    LSTR MSG_CANCEL_OBJECT                = _UxGT("Nesneyi İptal Et");
-    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Nesneyi İptal Et {");
-    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("İşe Devam Et");
-    LSTR MSG_MEDIA_MENU                   = MEDIA_TYPE_EN _UxGT(" Yazdır");
-    LSTR MSG_TURN_OFF                     = _UxGT("Şimdi kapat");
-    LSTR MSG_END_LOOPS                    = _UxGT("Son Döngüler");
-  #endif
+
+  LSTR MSG_HOST_START_PRINT               = _UxGT("Host Başlatma");
+  LSTR MSG_PRINTING_OBJECT                = _UxGT("Nesneyi Yazdır");
+  LSTR MSG_CANCEL_OBJECT                  = _UxGT("Nesneyi İptal Et");
+  LSTR MSG_CANCEL_OBJECT_N                = _UxGT("Nesneyi İptal Et {");
+  LSTR MSG_CONTINUE_PRINT_JOB             = _UxGT("İşe Devam Et");
+  LSTR MSG_MEDIA_MENU                     = MEDIA_TYPE_EN _UxGT(" Yazdır");
+  LSTR MSG_TURN_OFF                       = _UxGT("Şimdi kapat");
+  LSTR MSG_END_LOOPS                      = _UxGT("Son Döngüler");
+
   LSTR MSG_NO_MEDIA                       = _UxGT("SD Kart Yok!");
   LSTR MSG_DWELL                          = _UxGT("Uyku...");
   LSTR MSG_USERWAIT                       = _UxGT("Devam için tıkla...");
@@ -652,22 +636,12 @@ namespace Language_tr {
   LSTR MSG_LOCKSCREEN_UNLOCK              = _UxGT("Açmak için kaydırın.");
   LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Y.Başlatma bekleyin.");
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Ortam yerleştirilmedi.");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Lütfen önce hotend'i ısıtın.");
-    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Baskı Sayısını Sıfırla");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Baskı Sayısı");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Toplam Baskı Süresi");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("En Uzun Baskı Süresi");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Toplam Filaman");
-  #else
-    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Medya Yok");
-    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Ön Isıtma Lütfen");
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Baskı");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Süre");
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("En Uzun");
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Filaman");
-  #endif
+  LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Medya Yok");
+  LSTR MSG_PLEASE_PREHEAT                 = _UxGT("Ön Isıtma Lütfen");
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Baskı");
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("Süre");
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("En Uzun");
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("Filaman");
 
   LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("Tamamlanan");
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("Min Sıc.");
@@ -757,35 +731,20 @@ namespace Language_tr {
   LSTR MSG_PASSWORD_REMOVED               = _UxGT("Şifre Kaldırıldı");
 
   //
-  // Filament Değişim ekranları 4 satırlı ekranda 3 satıra kadar gösterilir
-  //                        ...veya 3 satırlı ekranda 2 satıra kadar
+  // Filament Değişim ekranları 3 satırlı ekranda 2 satıra kadar
   //
-  #if LCD_HEIGHT >= 4
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Sürdürmek İçin Tıkla"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Park Ediliyor..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Lütfen bekleyiniz..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Yükle ve bas"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Isıtmak için Tıkla"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Isınıyor..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Çıkartılıyor..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Yüklüyor..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Temizleniyor..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Bitirmek için Tıkla"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Sürdürülüyor..."));
 
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Baskıya devam etmek", "için Butona bas"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Park Ediliyor..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Filaman değişimi", "için başlama", "bekleniyor"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Filamanı yükle", "ve devam için", "tuşa bas..."));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Nozulü Isıtmak için", "Butona Bas."));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nozul Isınıyor", "Lütfen Bekleyin..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Filamanın çıkması", "bekleniyor"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Filamanın yüklenmesi", "bekleniyor.."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Filaman Temizlemesi", "için bekle"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Filaman Temizlemesi", "bitirmek için tıkla"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Baskının devam ", "etmesi için bekle"));
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("Sürdürmek İçin Tıkla"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Park Ediliyor..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("Lütfen bekleyiniz..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("Yükle ve bas"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("Isıtmak için Tıkla"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("Isınıyor..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("Çıkartılıyor..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("Yüklüyor..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("Temizleniyor..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("Bitirmek için Tıkla"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("Sürdürülüyor..."));
-  #endif
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC Sürücüleri");
   LSTR MSG_TMC_CURRENT                    = _UxGT("Sürücü Akımı");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("Hibrit Eşiği");
@@ -800,11 +759,8 @@ namespace Language_tr {
 
   LSTR MSG_LEVEL_X_AXIS                   = _UxGT("Seviye X Ekseni");
   LSTR MSG_AUTO_CALIBRATE                 = _UxGT("Otomatik Kalibre Et");
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Boşta kalma zaman aşımı, sıcaklık düştü. Yeniden ısıtmak ve tekrar devam etmek için için Tamam'a basın.");
-  #else
-    LSTR MSG_HEATER_TIMEOUT               = _UxGT("Isıtıcı Zaman Aşımı");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT            = _UxGT("Boşta kalma zaman aşımı, sıcaklık düştü. Yeniden ısıtmak ve tekrar devam etmek için için Tamam'a basın.");
+  LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Isıtıcı Zaman Aşımı");
   LSTR MSG_REHEAT                         = _UxGT("Yeniden ısıt");
   LSTR MSG_REHEATING                      = _UxGT("Yeniden ısıtılıyor...");
   LSTR MSG_REHEATDONE                     = _UxGT("Y. Isıtma Tamam");
@@ -836,4 +792,47 @@ namespace Language_tr {
   LSTR MSG_SHORT_DAY                      = _UxGT("g"); // One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("s"); // One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("d"); // One character only
+}
+
+namespace LanguageWide_tr {
+  using namespace LanguageNarrow_tr;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_HOST_START_PRINT             = _UxGT("Host Baskıyı başlat");
+    LSTR MSG_PRINTING_OBJECT              = _UxGT("Yazdırma Nesnesi");
+    LSTR MSG_CANCEL_OBJECT                = _UxGT("Nesneyi İptal Et");
+    LSTR MSG_CANCEL_OBJECT_N              = _UxGT("Nesneyi İptal Et {");
+    LSTR MSG_CONTINUE_PRINT_JOB           = _UxGT("Yazdırmaya Devam Et");
+    LSTR MSG_MEDIA_MENU                   = _UxGT("SD Karttan Yazdır");
+    LSTR MSG_TURN_OFF                     = _UxGT("Yazıcıyı kapat");
+    LSTR MSG_END_LOOPS                    = _UxGT("Tekrr Döngüler Bitir");
+    LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("Ortam yerleştirilmedi.");
+    LSTR MSG_PLEASE_PREHEAT               = _UxGT("Lütfen önce hotend'i ısıtın.");
+    LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Baskı Sayısını Sıfırla");
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Baskı Sayısı");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Toplam Baskı Süresi");
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("En Uzun Baskı Süresi");
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Toplam Filaman");
+  #endif
+}
+
+namespace LanguageTall_tr {
+  using namespace LanguageWide_tr;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("Baskıya devam etmek", "için Butona bas"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("Park Ediliyor..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("Filaman değişimi", "için başlama", "bekleniyor"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("Filamanı yükle", "ve devam için", "tuşa bas..."));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("Nozulü Isıtmak için", "Butona Bas."));
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("Nozul Isınıyor", "Lütfen Bekleyin..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("Filamanın çıkması", "bekleniyor"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("Filamanın yüklenmesi", "bekleniyor.."));
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("Filaman Temizlemesi", "için bekle"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("Filaman Temizlemesi", "bitirmek için tıkla"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("Baskının devam ", "etmesi için bekle"));
+  #endif
+}
+
+namespace Language_tr {
+  using namespace LanguageTall_tr;
 }

--- a/Marlin/src/lcd/language/language_uk.h
+++ b/Marlin/src/lcd/language/language_uk.h
@@ -30,7 +30,7 @@
 
 #define DISPLAY_CHARSET_ISO10646_5
 
-namespace Language_uk {
+namespace LanguageNarrow_uk {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE                = 2;
@@ -44,21 +44,12 @@ namespace Language_uk {
   LSTR MSG_MEDIA_INSERTED                   = _UxGT("SD-картка вставлена");
   LSTR MSG_MEDIA_REMOVED                    = _UxGT("SD-картка видалена");
   LSTR MSG_MEDIA_WAITING                    = _UxGT("Вставте SD-картку");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Збій ініціалізації SD");
-  #else
-    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Збій ініціаліз. SD");
-  #endif
+  LSTR MSG_MEDIA_INIT_FAIL                  = _UxGT("Збій ініціаліз. SD");
   LSTR MSG_MEDIA_READ_ERROR                 = _UxGT("Помилка зчитування");
   LSTR MSG_MEDIA_USB_REMOVED                = _UxGT("USB диск видалений");
   LSTR MSG_MEDIA_USB_FAILED                 = _UxGT("Помилка USB диску");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переповнення виклику");
-    LSTR MSG_LCD_SOFT_ENDSTOPS              = _UxGT("Програмні кінцевики");
-  #else
-    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переповн. виклику");
-    LSTR MSG_LCD_SOFT_ENDSTOPS              = _UxGT("Прогр.кінцевики");
-  #endif
+  LSTR MSG_KILL_SUBCALL_OVERFLOW            = _UxGT("Переповн. виклику");
+  LSTR MSG_LCD_SOFT_ENDSTOPS                = _UxGT("Прогр.кінцевики");
   LSTR MSG_LCD_ENDSTOPS                     = _UxGT("Кінцевик"); // Max length 8 characters
   LSTR MSG_MAIN_MENU                        = _UxGT("Основне меню");
   LSTR MSG_ADVANCED_SETTINGS                = _UxGT("Інші налаштування");
@@ -81,64 +72,43 @@ namespace Language_uk {
   LSTR MSG_LEVEL_BED_NEXT_POINT             = _UxGT("Наступна точка");
   LSTR MSG_LEVEL_BED_DONE                   = _UxGT("Завершено!");
   LSTR MSG_Z_FADE_HEIGHT                    = _UxGT("Висота спаду");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Встанов. зміщення дому");
-    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Зміщення дому X");
-    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Зміщення дому Y");
-    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Зміщення дому Z");
-  #else
-    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Встан. зміщ. дому");
-    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Зміщ. дому X");
-    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Зміщ. дому Y");
-    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Зміщ. дому Z");
-  #endif
+  LSTR MSG_SET_HOME_OFFSETS                 = _UxGT("Встан. зміщ. дому");
+  LSTR MSG_HOME_OFFSET_X                    = _UxGT("Зміщ. дому X");
+  LSTR MSG_HOME_OFFSET_Y                    = _UxGT("Зміщ. дому Y");
+  LSTR MSG_HOME_OFFSET_Z                    = _UxGT("Зміщ. дому Z");
   LSTR MSG_HOME_OFFSETS_APPLIED             = _UxGT("Зміщення прийняті");
   LSTR MSG_SELECT_ORIGIN                    = _UxGT("Оберіть нуль");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Останнє значення ");
-  #else
-    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Останнє знач. ");
-  #endif
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                      = _UxGT("Нагрів ") PREHEAT_1_LABEL;
-    LSTR MSG_PREHEAT_1_H                    = _UxGT("Нагрів ") PREHEAT_1_LABEL " ~";
-    LSTR MSG_PREHEAT_1_END                  = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" сопло");
-    LSTR MSG_PREHEAT_1_END_E                = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" сопло ~");
-    LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" все");
-    LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" стіл");
-    LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" налашт");
+  LSTR MSG_LAST_VALUE_SP                    = _UxGT("Останнє знач. ");
 
-    LSTR MSG_PREHEAT_M                      = _UxGT("Нагрів $");
-    LSTR MSG_PREHEAT_M_H                    = _UxGT("Нагрів $ ~");
-    LSTR MSG_PREHEAT_M_END                  = _UxGT("Нагрів $ сопло");
-    LSTR MSG_PREHEAT_M_END_E                = _UxGT("Нагрів $ сопло ~");
-    LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Нагрів $ все");
-    LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Нагрів $ стіл");
-    LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Нагрів $ налашт");
-  #endif
+  LSTR MSG_PREHEAT_1                        = _UxGT("Нагрів ") PREHEAT_1_LABEL;
+  LSTR MSG_PREHEAT_1_H                      = _UxGT("Нагрів ") PREHEAT_1_LABEL " ~";
+  LSTR MSG_PREHEAT_1_END                    = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" сопло");
+  LSTR MSG_PREHEAT_1_END_E                  = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" сопло ~");
+  LSTR MSG_PREHEAT_1_ALL                    = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" все");
+  LSTR MSG_PREHEAT_1_BEDONLY                = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" стіл");
+  LSTR MSG_PREHEAT_1_SETTINGS               = _UxGT("Нагрів ") PREHEAT_1_LABEL _UxGT(" налашт");
+
+  LSTR MSG_PREHEAT_M                        = _UxGT("Нагрів $");
+  LSTR MSG_PREHEAT_M_H                      = _UxGT("Нагрів $ ~");
+  LSTR MSG_PREHEAT_M_END                    = _UxGT("Нагрів $ сопло");
+  LSTR MSG_PREHEAT_M_END_E                  = _UxGT("Нагрів $ сопло ~");
+  LSTR MSG_PREHEAT_M_ALL                    = _UxGT("Нагрів $ все");
+  LSTR MSG_PREHEAT_M_BEDONLY                = _UxGT("Нагрів $ стіл");
+  LSTR MSG_PREHEAT_M_SETTINGS               = _UxGT("Нагрів $ налашт");
+
   LSTR MSG_PREHEAT_CUSTOM                   = _UxGT("Нагрів свого");
   LSTR MSG_COOLDOWN                         = _UxGT("Вимкнути нагрів");
 
   LSTR MSG_CUTTER_FREQUENCY                 = _UxGT("Частота");
   LSTR MSG_LASER_MENU                       = _UxGT("Керування лазером");
   LSTR MSG_SPINDLE_MENU                     = _UxGT("Керування шпінделем");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_LASER_POWER                    = _UxGT("Потужність лазера");
-    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Перемкн. шпіндель");
-    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Перемкнути вакуум");
-    LSTR MSG_LASER_TOGGLE                   = _UxGT("Перемкнути лазер");
-    LSTR MSG_SPINDLE_POWER                  = _UxGT("Потужн. шпінделя");
-    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тестовий імпульс мс");
-    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Перемкнути обдув");
-  #else
-    LSTR MSG_LASER_POWER                    = _UxGT("Потужн. лазера");
-    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Перемк. шпінд.");
-    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Перемк. вакуум");
-    LSTR MSG_LASER_TOGGLE                   = _UxGT("Перемкн. лазер");
-    LSTR MSG_SPINDLE_POWER                  = _UxGT("Потужн. шпінд.");
-    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тест. імп., мс");
-    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Перемкн. обдув");
-  #endif
+  LSTR MSG_LASER_POWER                      = _UxGT("Потужн. лазера");
+  LSTR MSG_SPINDLE_TOGGLE                   = _UxGT("Перемк. шпінд.");
+  LSTR MSG_SPINDLE_EVAC_TOGGLE              = _UxGT("Перемк. вакуум");
+  LSTR MSG_LASER_TOGGLE                     = _UxGT("Перемкн. лазер");
+  LSTR MSG_SPINDLE_POWER                    = _UxGT("Потужн. шпінд.");
+  LSTR MSG_LASER_PULSE_MS                   = _UxGT("Тест. імп., мс");
+  LSTR MSG_LASER_EVAC_TOGGLE                = _UxGT("Перемкн. обдув");
   LSTR MSG_LASER_ASSIST_TOGGLE              = _UxGT("Керування обдувом");
   LSTR MSG_FLOWMETER_FAULT                  = _UxGT("Помилка обдуву");
   LSTR MSG_LASER_FIRE_PULSE                 = _UxGT("Імпульс лазеру");
@@ -153,21 +123,12 @@ namespace Language_uk {
   LSTR MSG_BED_LEVELING                     = _UxGT("Вирівнювання столу");
   LSTR MSG_LEVEL_BED                        = _UxGT("Вирівняти стіл");
   LSTR MSG_BED_TRAMMING                     = _UxGT("Вирівняти кути");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вгору до спрацюв. зонду");
-    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Кути в межах. Вирів.столу");
-  #else
-    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вгору до спрац.зонду");
-    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Кути в межах. Вирівн");
-  #endif
+  LSTR MSG_BED_TRAMMING_RAISE               = _UxGT("Вгору до спрац.зонду");
+  LSTR MSG_BED_TRAMMING_IN_RANGE            = _UxGT("Кути в межах. Вирівн");
   LSTR MSG_BED_TRAMMING_GOOD_POINTS         = _UxGT("Хороші точки: ");
   LSTR MSG_BED_TRAMMING_LAST_Z              = _UxGT("Остання Z: ");
   LSTR MSG_NEXT_CORNER                      = _UxGT("Наступний кут");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MESH_EDITOR                    = _UxGT("Зміщення по Z");
-  #else
-    LSTR MSG_MESH_EDITOR                    = _UxGT("Зміщення Z");
-  #endif
+  LSTR MSG_MESH_EDITOR                      = _UxGT("Зміщення Z");
   LSTR MSG_EDIT_MESH                        = _UxGT("Редагувати сітку");
   LSTR MSG_EDITING_STOPPED                  = _UxGT("Редагув. зупинено");
   LSTR MSG_PROBING_POINT                    = _UxGT("Точка сітки");
@@ -196,20 +157,11 @@ namespace Language_uk {
   LSTR MSG_UBL_TOOLS                        = _UxGT("Інструменти UBL");
   LSTR MSG_UBL_LEVEL_BED                    = _UxGT("Налаштування UBL");
   LSTR MSG_LCD_TILTING_MESH                 = _UxGT("Точка нахилу");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_MANUAL_MESH                = _UxGT("Ручне введення сітки");
-    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Розмістити шайбу і вимір.");
-  #else
-    LSTR MSG_UBL_MANUAL_MESH                = _UxGT("Ручне введ. сітки");
-    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Розм. шайбу і вимір.");
-  #endif
+  LSTR MSG_UBL_MANUAL_MESH                  = _UxGT("Ручне введ. сітки");
+  LSTR MSG_UBL_BC_INSERT                    = _UxGT("Розм. шайбу і вимір.");
   LSTR MSG_UBL_MESH_WIZARD                  = _UxGT("Майстер сіток UBL");
   LSTR MSG_UBL_BC_INSERT2                   = _UxGT("Вимірювання");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Видалити і виміряти стіл");
-  #else
-    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Видали і вимір. стіл");
-  #endif
+  LSTR MSG_UBL_BC_REMOVE                    = _UxGT("Видали і вимір. стіл");
   LSTR MSG_UBL_MOVING_TO_NEXT               = _UxGT("Рух до наступної");
   LSTR MSG_UBL_ACTIVATE_MESH                = _UxGT("Активувати UBL");
   LSTR MSG_UBL_DEACTIVATE_MESH              = _UxGT("Деактивувати UBL");
@@ -217,15 +169,9 @@ namespace Language_uk {
   LSTR MSG_UBL_BED_TEMP_CUSTOM              = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" столу,") LCD_STR_DEGREE _UxGT("C");
   LSTR MSG_UBL_SET_TEMP_HOTEND              = LCD_STR_THERMOMETER _UxGT(" сопла, ") LCD_STR_DEGREE _UxGT("C");
   LSTR MSG_UBL_HOTEND_TEMP_CUSTOM           = _UxGT("Своя ") LCD_STR_THERMOMETER _UxGT(" сопла,") LCD_STR_DEGREE _UxGT("C");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_EDIT_CUSTOM_MESH           = _UxGT("Редагувати свою сітку");
-    LSTR MSG_UBL_FINE_TUNE_MESH             = _UxGT("Точне редагування сітки");
-    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Будувати свою сітку");
-  #else
-    LSTR MSG_UBL_EDIT_CUSTOM_MESH           = _UxGT("Редагувати свою");
-    LSTR MSG_UBL_FINE_TUNE_MESH             = _UxGT("Точне редаг. сітки");
-    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Будувати свою");
-  #endif
+  LSTR MSG_UBL_EDIT_CUSTOM_MESH             = _UxGT("Редагувати свою");
+  LSTR MSG_UBL_FINE_TUNE_MESH               = _UxGT("Точне редаг. сітки");
+  LSTR MSG_UBL_BUILD_CUSTOM_MESH            = _UxGT("Будувати свою");
   LSTR MSG_UBL_MESH_EDIT                    = _UxGT("Редагування сітки");
   LSTR MSG_UBL_DONE_EDITING_MESH            = _UxGT("Сітка побудована");
   LSTR MSG_UBL_BUILD_MESH_MENU              = _UxGT("Будувати сітку");
@@ -247,11 +193,7 @@ namespace Language_uk {
   LSTR MSG_UBL_CONTINUE_MESH                = _UxGT("Продовжити сітку");
   LSTR MSG_UBL_MESH_LEVELING                = _UxGT("Вирівнювання сітки");
   LSTR MSG_UBL_3POINT_MESH_LEVELING         = _UxGT("3-точкове вирівн.");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_GRID_MESH_LEVELING         = _UxGT("Вирівнювання растру");
-  #else
-    LSTR MSG_UBL_GRID_MESH_LEVELING         = _UxGT("Вирівнюв. растру");
-  #endif
+  LSTR MSG_UBL_GRID_MESH_LEVELING           = _UxGT("Вирівнюв. растру");
   LSTR MSG_UBL_MESH_LEVEL                   = _UxGT("Вирівняти сітку");
   LSTR MSG_UBL_SIDE_POINTS                  = _UxGT("Крайні точки");
   LSTR MSG_UBL_MAP_TYPE                     = _UxGT("Тип мапи сітки");
@@ -260,23 +202,14 @@ namespace Language_uk {
   LSTR MSG_UBL_OUTPUT_MAP_CSV               = _UxGT("Вивести в CSV");
   LSTR MSG_UBL_OUTPUT_MAP_BACKUP            = _UxGT("Зберегти зовні");
   LSTR MSG_UBL_INFO_UBL                     = _UxGT("Інформація по UBL");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Обсяг заповнюв.");
-  #else
-    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Обсяг заповн.");
-  #endif
+  LSTR MSG_UBL_FILLIN_AMOUNT                = _UxGT("Обсяг заповн.");
   LSTR MSG_UBL_MANUAL_FILLIN                = _UxGT("Ручне заповнення");
   LSTR MSG_UBL_SMART_FILLIN                 = _UxGT("Розумне заповнення");
   LSTR MSG_UBL_FILLIN_MESH                  = _UxGT("Заповнити сітку");
   LSTR MSG_UBL_INVALIDATE_ALL               = _UxGT("Анулювати все");
   LSTR MSG_UBL_INVALIDATE_CLOSEST           = _UxGT("Анулювати найближчу");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_UBL_FINE_TUNE_ALL              = _UxGT("Точно налаштувати все");
-    LSTR MSG_UBL_FINE_TUNE_CLOSEST          = _UxGT("Точно налашт.найближчу");
-  #else
-    LSTR MSG_UBL_FINE_TUNE_ALL              = _UxGT("Точно налашт. все");
-    LSTR MSG_UBL_FINE_TUNE_CLOSEST          = _UxGT("Точно найближчу");
-  #endif
+  LSTR MSG_UBL_FINE_TUNE_ALL                = _UxGT("Точно налашт. все");
+  LSTR MSG_UBL_FINE_TUNE_CLOSEST            = _UxGT("Точно найближчу");
   LSTR MSG_UBL_STORAGE_MESH_MENU            = _UxGT("Збереження сітки");
   LSTR MSG_UBL_STORAGE_SLOT                 = _UxGT("Слот пам'яті");
   LSTR MSG_UBL_LOAD_MESH                    = _UxGT("Завантажити сітку");
@@ -299,11 +232,7 @@ namespace Language_uk {
 
   LSTR MSG_LED_CONTROL                      = _UxGT("Керування світлом");
   LSTR MSG_LEDS                             = _UxGT("Підсвітка");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_LED_PRESETS                    = _UxGT("Передустановки світла");
-  #else
-    LSTR MSG_LED_PRESETS                    = _UxGT("Передустан. світла");
-  #endif
+  LSTR MSG_LED_PRESETS                      = _UxGT("Передустан. світла");
   LSTR MSG_SET_LEDS_RED                     = _UxGT("Червоний");
   LSTR MSG_SET_LEDS_ORANGE                  = _UxGT("Помаранчевий");
   LSTR MSG_SET_LEDS_YELLOW                  = _UxGT("Жовтий");
@@ -315,11 +244,7 @@ namespace Language_uk {
   LSTR MSG_SET_LEDS_DEFAULT                 = _UxGT("За умовчанням");
   LSTR MSG_LED_CHANNEL_N                    = _UxGT("Канал {");
   LSTR MSG_LEDS2                            = _UxGT("Світло #2");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_NEO2_PRESETS                   = _UxGT("Передустановка світла #2");
-  #else
-    LSTR MSG_NEO2_PRESETS                   = _UxGT("Передуст. світла #2");
-  #endif
+  LSTR MSG_NEO2_PRESETS                     = _UxGT("Передуст. світла #2");
   LSTR MSG_NEO2_BRIGHTNESS                  = _UxGT("Яскравість");
   LSTR MSG_CUSTOM_LEDS                      = _UxGT("Своє світло");
   LSTR MSG_INTENSITY_R                      = _UxGT("Рівень червоного");
@@ -350,24 +275,14 @@ namespace Language_uk {
   LSTR MSG_NOZZLE_STANDBY                   = _UxGT("Сопло очікує");
   LSTR MSG_BED                              = _UxGT("Стіл,  ") LCD_STR_DEGREE _UxGT("C");
   LSTR MSG_CHAMBER                          = _UxGT("Камера,") LCD_STR_DEGREE _UxGT("C");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_COOLER                         = _UxGT("Охолодження лазеру");
-    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Перемк. охолодж.");
-  #else
-    LSTR MSG_COOLER                         = _UxGT("Охолодж. лазеру");
-    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Перемк.охолод");
-  #endif
+  LSTR MSG_COOLER                           = _UxGT("Охолодж. лазеру");
+  LSTR MSG_COOLER_TOGGLE                    = _UxGT("Перемк.охолод");
   LSTR MSG_FLOWMETER_SAFETY                 = _UxGT("Безпека потоку");
   LSTR MSG_LASER                            = _UxGT("Лазер");
   LSTR MSG_FAN_SPEED                        = _UxGT("Швидк. вент.");
   LSTR MSG_FAN_SPEED_N                      = _UxGT("Швидк. вент. ~");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_STORED_FAN_N                   = _UxGT("Збереж.швидк.вент. ~");
-    LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Дод. швидк. вент. ~");
-  #else
-    LSTR MSG_STORED_FAN_N                   = _UxGT("Збереж. вент. ~");
-    LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Додат.вент. ~");
-  #endif
+  LSTR MSG_STORED_FAN_N                     = _UxGT("Збереж. вент. ~");
+  LSTR MSG_EXTRA_FAN_SPEED_N                = _UxGT("Додат.вент. ~");
   LSTR MSG_EXTRA_FAN_SPEED                  = _UxGT("Дод. швидк. вент.");
   LSTR MSG_CONTROLLER_FAN                   = _UxGT("Вент. контролера");
   LSTR MSG_CONTROLLER_FAN_IDLE_SPEED        = _UxGT("Холості оберти");
@@ -399,11 +314,7 @@ namespace Language_uk {
   LSTR MSG_VC_JERK                          = _UxGT("V") STR_C _UxGT("-ривок");
   LSTR MSG_VN_JERK                          = _UxGT("V@-ривок");
   LSTR MSG_VE_JERK                          = _UxGT("Ve-ривок");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Відхилення вузла");
-  #else
-    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Відхил.вузла");
-  #endif
+  LSTR MSG_JUNCTION_DEVIATION               = _UxGT("Відхил.вузла");
   LSTR MSG_MAX_SPEED                        = _UxGT("Швидкість, мм/с");
   LSTR MSG_VMAX_A                           = _UxGT("Швидк.макс ") STR_A;
   LSTR MSG_VMAX_B                           = _UxGT("Швидк.макс ") STR_B;
@@ -412,11 +323,7 @@ namespace Language_uk {
   LSTR MSG_VMAX_E                           = _UxGT("Швидк.макс E");
   LSTR MSG_VMAX_EN                          = _UxGT("Швидк.макс *");
   LSTR MSG_VMIN                             = _UxGT("Швидк. мін");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_VTRAV_MIN                      = _UxGT("Переміщення мін");
-  #else
-    LSTR MSG_VTRAV_MIN                      = _UxGT("Переміщ. мін");
-  #endif
+  LSTR MSG_VTRAV_MIN                        = _UxGT("Переміщ. мін");
   LSTR MSG_ACCELERATION                     = _UxGT("Прискорення, мм/с2");
   LSTR MSG_AMAX_A                           = _UxGT("Приск.макс ") STR_A;
   LSTR MSG_AMAX_B                           = _UxGT("Приск.макс ") STR_B;
@@ -447,23 +354,14 @@ namespace Language_uk {
   LSTR MSG_FILAMENT_LOAD                    = _UxGT("Завантаж., мм");
   LSTR MSG_ADVANCE_K                        = _UxGT("Kоеф. просув.");
   LSTR MSG_ADVANCE_K_E                      = _UxGT("Kоеф. просув. *");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_CONTRAST                       = _UxGT("Контраст екрану");
-    LSTR MSG_BRIGHTNESS                     = _UxGT("Яскравість LCD");
-  #else
-    LSTR MSG_CONTRAST                       = _UxGT("Контраст");
-    LSTR MSG_BRIGHTNESS                     = _UxGT("Яскравість");
-  #endif
+  LSTR MSG_CONTRAST                         = _UxGT("Контраст");
+  LSTR MSG_BRIGHTNESS                       = _UxGT("Яскравість");
   LSTR MSG_SCREEN_TIMEOUT                   = _UxGT("LCD Таймаут, x");
   LSTR MSG_BRIGHTNESS_OFF                   = _UxGT("Підсвітка вимк.");
   LSTR MSG_STORE_EEPROM                     = _UxGT("Зберегти в EEPROM");
   LSTR MSG_LOAD_EEPROM                      = _UxGT("Зчитати з EEPROM");
   LSTR MSG_RESTORE_DEFAULTS                 = _UxGT("На базові параметри");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_INIT_EEPROM                    = _UxGT("Ініціалізація EEPROM");
-  #else
-    LSTR MSG_INIT_EEPROM                    = _UxGT("Ініціаліз. EEPROM");
-  #endif
+  LSTR MSG_INIT_EEPROM                      = _UxGT("Ініціаліз. EEPROM");
   LSTR MSG_ERR_EEPROM_CRC                   = _UxGT("Збій EEPROM: CRC");
   LSTR MSG_ERR_EEPROM_SIZE                  = _UxGT("Збій EEPROM: розмір");
   LSTR MSG_ERR_EEPROM_VERSION               = _UxGT("Збій EEPROM: версія");
@@ -522,19 +420,11 @@ namespace Language_uk {
   LSTR MSG_NO_MOVE                          = _UxGT("Немає руху.");
   LSTR MSG_KILLED                           = _UxGT("ПЕРЕРВАНО. ");
   LSTR MSG_STOPPED                          = _UxGT("ЗУПИНЕНО. ");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_CONTROL_RETRACT                = _UxGT("Втягування, мм");
-    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Зміна втягув.,мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER        = _UxGT("Повернення, мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Поверн.зміни, мм");
-    LSTR MSG_AUTORETRACT                    = _UxGT("Автовтягування");
-  #else
-    LSTR MSG_CONTROL_RETRACT                = _UxGT("Втягув., мм");
-    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Зміна втяг.мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER        = _UxGT("Поверн., мм");
-    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Повер.зміни,мм");
-    LSTR MSG_AUTORETRACT                    = _UxGT("Автовтягув.");
-  #endif
+  LSTR MSG_CONTROL_RETRACT                  = _UxGT("Втягув., мм");
+  LSTR MSG_CONTROL_RETRACT_SWAP             = _UxGT("Зміна втяг.мм");
+  LSTR MSG_CONTROL_RETRACT_RECOVER          = _UxGT("Поверн., мм");
+  LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP     = _UxGT("Повер.зміни,мм");
+  LSTR MSG_AUTORETRACT                      = _UxGT("Автовтягув.");
   LSTR MSG_CONTROL_RETRACTF                 = _UxGT("Втягування V");
   LSTR MSG_CONTROL_RETRACT_ZHOP             = _UxGT("Підскок, мм");
   LSTR MSG_CONTROL_RETRACT_RECOVERF         = _UxGT("Повернення V");
@@ -544,22 +434,12 @@ namespace Language_uk {
   LSTR MSG_FILAMENT_PURGE_LENGTH            = _UxGT("Очистити довжину");
   LSTR MSG_TOOL_CHANGE                      = _UxGT("Зміна сопла");
   LSTR MSG_TOOL_CHANGE_ZLIFT                = _UxGT("Підняти по Z");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Початк.швидкість");
-    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Швидкість втягув.");
-  #else
-    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Початк.швидк.");
-    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Швидк.втягув.");
-  #endif
+  LSTR MSG_SINGLENOZZLE_PRIME_SPEED         = _UxGT("Початк.швидк.");
+  LSTR MSG_SINGLENOZZLE_RETRACT_SPEED       = _UxGT("Швидк.втягув.");
   LSTR MSG_FILAMENT_PARK_ENABLED            = _UxGT("Паркувати голову");
   LSTR MSG_SINGLENOZZLE_UNRETRACT_SPEED     = _UxGT("Відновити швидкість");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_SINGLENOZZLE_FAN_SPEED         = _UxGT("Оберти вентилятора");
-    LSTR MSG_SINGLENOZZLE_FAN_TIME          = _UxGT("Час вентилятора");
-  #else
-    LSTR MSG_SINGLENOZZLE_FAN_SPEED         = _UxGT("Оберти вент.");
-    LSTR MSG_SINGLENOZZLE_FAN_TIME          = _UxGT("Час вент.");
-  #endif
+  LSTR MSG_SINGLENOZZLE_FAN_SPEED           = _UxGT("Оберти вент.");
+  LSTR MSG_SINGLENOZZLE_FAN_TIME            = _UxGT("Час вент.");
   LSTR MSG_TOOL_MIGRATION_ON                = _UxGT("Авто Увімк.");
   LSTR MSG_TOOL_MIGRATION_OFF               = _UxGT("Авто Вимкн.");
   LSTR MSG_TOOL_MIGRATION                   = _UxGT("Заміна інструменту");
@@ -616,11 +496,7 @@ namespace Language_uk {
   LSTR MSG_THERMAL_RUNAWAY_BED              = _UxGT("ВИТІК ТЕПЛА СТОЛУ");
   LSTR MSG_THERMAL_RUNAWAY_CHAMBER          = _UxGT("ВИТІК ТЕПЛА КАМЕРИ");
   LSTR MSG_THERMAL_RUNAWAY_COOLER           = _UxGT("ВИТІК ОХОЛОДЖЕННЯ");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_COOLING_FAILED                 = _UxGT("ОХОЛОДЖЕННЯ НЕ ВДАЛОСЬ");
-  #else
-    LSTR MSG_COOLING_FAILED                 = _UxGT("ОХОЛОДЖ. НЕ ВДАЛОСЬ");
-  #endif
+  LSTR MSG_COOLING_FAILED                   = _UxGT("ОХОЛОДЖ. НЕ ВДАЛОСЬ");
   LSTR MSG_ERR_MAXTEMP                      = _UxGT("МАКСИМАЛЬНА Т") LCD_STR_DEGREE;
   LSTR MSG_ERR_MINTEMP                      = _UxGT("МІНІМАЛЬНА Т") LCD_STR_DEGREE;
   LSTR MSG_HALTED                           = _UxGT("ПРИНТЕР ЗУПИНЕНО");
@@ -630,17 +506,10 @@ namespace Language_uk {
   LSTR MSG_BED_HEATING                      = _UxGT("Нагрів столу...");
   LSTR MSG_PROBE_HEATING                    = _UxGT("Нагрів зонду...");
   LSTR MSG_CHAMBER_HEATING                  = _UxGT("Нагрів камери...");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_BED_COOLING                    = _UxGT("Охолодження столу...");
-    LSTR MSG_PROBE_COOLING                  = _UxGT("Охолодження зонду...");
-    LSTR MSG_CHAMBER_COOLING                = _UxGT("Охолодження камери...");
-    LSTR MSG_LASER_COOLING                  = _UxGT("Охолодження лазеру...");
-  #else
-    LSTR MSG_BED_COOLING                    = _UxGT("Охолодж. столу...");
-    LSTR MSG_PROBE_COOLING                  = _UxGT("Охолодж. зонду...");
-    LSTR MSG_CHAMBER_COOLING                = _UxGT("Охолодж. камери...");
-    LSTR MSG_LASER_COOLING                  = _UxGT("Охолодж. лазеру...");
-  #endif
+  LSTR MSG_BED_COOLING                      = _UxGT("Охолодж. столу...");
+  LSTR MSG_PROBE_COOLING                    = _UxGT("Охолодж. зонду...");
+  LSTR MSG_CHAMBER_COOLING                  = _UxGT("Охолодж. камери...");
+  LSTR MSG_LASER_COOLING                    = _UxGT("Охолодж. лазеру...");
   LSTR MSG_DELTA_CALIBRATE                  = _UxGT("Калібрування Delta");
   LSTR MSG_DELTA_CALIBRATE_X                = _UxGT("Калібрувати X");
   LSTR MSG_DELTA_CALIBRATE_Y                = _UxGT("Калібрувати Y");
@@ -655,22 +524,12 @@ namespace Language_uk {
   LSTR MSG_INFO_MENU                        = _UxGT("Про принтер");
   LSTR MSG_INFO_PRINTER_MENU                = _UxGT("Дані принтера");
 
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точкове вирівнювання");
-    LSTR MSG_LINEAR_LEVELING                = _UxGT("Лінійне вирівнювання");
-    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Білінійне вирівнювання");
-  #else
-    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точкове вирівн.");
-    LSTR MSG_LINEAR_LEVELING                = _UxGT("Лінійне вирівн.");
-    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Білінійне вирівн.");
-  #endif
+  LSTR MSG_3POINT_LEVELING                  = _UxGT("3-точкове вирівн.");
+  LSTR MSG_LINEAR_LEVELING                  = _UxGT("Лінійне вирівн.");
+  LSTR MSG_BILINEAR_LEVELING                = _UxGT("Білінійне вирівн.");
   LSTR MSG_UBL_LEVELING                     = _UxGT("UBL");
   LSTR MSG_MESH_LEVELING                    = _UxGT("Вирівнювання сітки");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MESH_DONE                      = _UxGT("Зондування сітки виконано");
-  #else
-    LSTR MSG_MESH_DONE                      = _UxGT("Зондування виконано");
-  #endif
+  LSTR MSG_MESH_DONE                        = _UxGT("Зондування виконано");
 
   LSTR MSG_INFO_STATS_MENU                  = _UxGT("Статистика принтера");
   LSTR MSG_INFO_BOARD_MENU                  = _UxGT("Про плату");
@@ -678,15 +537,9 @@ namespace Language_uk {
   LSTR MSG_INFO_EXTRUDERS                   = _UxGT("Екструдери");
   LSTR MSG_INFO_BAUDRATE                    = _UxGT("Бод");
   LSTR MSG_INFO_PROTOCOL                    = _UxGT("Протокол");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контроль витіку ") LCD_STR_THERMOMETER _UxGT(" Вимк");
-    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контроль витіку ") LCD_STR_THERMOMETER _UxGT(" Увімк");
-    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Час простою хотенду");
-  #else
-    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контр.витіку ") LCD_STR_THERMOMETER _UxGT(" Вимк");
-    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контр.витіку ") LCD_STR_THERMOMETER _UxGT(" Увімк");
-    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Час прост. хот-у");
-  #endif
+  LSTR MSG_INFO_RUNAWAY_OFF                 = _UxGT("Контр.витіку ") LCD_STR_THERMOMETER _UxGT(" Вимк");
+  LSTR MSG_INFO_RUNAWAY_ON                  = _UxGT("Контр.витіку ") LCD_STR_THERMOMETER _UxGT(" Увімк");
+  LSTR MSG_HOTEND_IDLE_TIMEOUT              = _UxGT("Час прост. хот-у");
 
   LSTR MSG_CASE_LIGHT                       = _UxGT("Підсвітка");
   LSTR MSG_CASE_LIGHT_BRIGHTNESS            = _UxGT("Яскравість світла");
@@ -696,23 +549,13 @@ namespace Language_uk {
   LSTR MSG_INFO_PRINT_FILAMENT              = _UxGT("Екструдовано");
   LSTR MSG_PLEASE_PREHEAT                   = _UxGT("Нагрійте хотенд");
   LSTR MSG_COLORS_GET                       = _UxGT("Отримати колір");
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Носій не вставлений");
-    LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Перезавантаження...");
-    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Кількість друків");
-    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Час друку");
-    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Найдовший час");
-    LSTR MSG_COLORS_SELECT                  = _UxGT("Обрати кольори");
-    LSTR MSG_COLORS_APPLIED                 = _UxGT("Кольори застосовані");
-  #else
-    LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Немає носія");
-    LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Перезавантаж...");
-    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Друків");
-    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Загалом");
-    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Найдовше");
-    LSTR MSG_COLORS_SELECT                  = _UxGT("Кольори");
-    LSTR MSG_COLORS_APPLIED                 = _UxGT("Кольори застос.");
-  #endif
+  LSTR MSG_MEDIA_NOT_INSERTED               = _UxGT("Немає носія");
+  LSTR MSG_PLEASE_WAIT_REBOOT               = _UxGT("Перезавантаж...");
+  LSTR MSG_INFO_PRINT_COUNT                 = _UxGT("Друків");
+  LSTR MSG_INFO_PRINT_TIME                  = _UxGT("Загалом");
+  LSTR MSG_INFO_PRINT_LONGEST               = _UxGT("Найдовше");
+  LSTR MSG_COLORS_SELECT                    = _UxGT("Кольори");
+  LSTR MSG_COLORS_APPLIED                   = _UxGT("Кольори застос.");
   LSTR MSG_COLORS_RED                       = _UxGT("Червоний");
   LSTR MSG_COLORS_GREEN                     = _UxGT("Зелений");
   LSTR MSG_COLORS_BLUE                      = _UxGT("Синій");
@@ -732,21 +575,12 @@ namespace Language_uk {
   LSTR MSG_FILAMENT_CHANGE_HEADER_PAUSE     = _UxGT("ЗУПИНКА ДРУКУ");
   LSTR MSG_FILAMENT_CHANGE_HEADER_LOAD      = _UxGT("ЗАВАНТАЖИТИ ПРУТОК");
   LSTR MSG_FILAMENT_CHANGE_HEADER_UNLOAD    = _UxGT("ВИВАНТАЖИТИ ПРУТОК");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_FILAMENT_CHANGE_OPTION_HEADER  = _UxGT("ПАРАМЕТРИ ПРОДОВЖЕННЯ:");
-  #else
-    LSTR MSG_FILAMENT_CHANGE_OPTION_HEADER  = _UxGT("ПАРАМ.ПРОДОВЖЕННЯ:");
-  #endif
+  LSTR MSG_FILAMENT_CHANGE_OPTION_HEADER    = _UxGT("ПАРАМ.ПРОДОВЖЕННЯ:");
   LSTR MSG_FILAMENT_CHANGE_OPTION_PURGE     = _UxGT("Видавити ще");
   LSTR MSG_FILAMENT_CHANGE_OPTION_RESUME    = _UxGT("Відновити друк");
   LSTR MSG_FILAMENT_CHANGE_NOZZLE           = _UxGT("  Сопло: ");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик закінчення прутка");
-    LSTR MSG_RUNOUT_DISTANCE_MM             = _UxGT("Відстань закінч.,мм");
-  #else
-    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик закінч.прутка");
-    LSTR MSG_RUNOUT_DISTANCE_MM             = _UxGT("До закінч.,мм");
-  #endif
+  LSTR MSG_RUNOUT_SENSOR                    = _UxGT("Датчик закінч.прутка");
+  LSTR MSG_RUNOUT_DISTANCE_MM               = _UxGT("До закінч.,мм");
   LSTR MSG_KILL_HOMING_FAILED               = _UxGT("Помилка паркування");
   LSTR MSG_LCD_PROBING_FAILED               = _UxGT("Помилка зондування");
 
@@ -758,11 +592,7 @@ namespace Language_uk {
   LSTR MSG_MMU2_RESUMING                    = _UxGT("MMU Продовження...");
   LSTR MSG_MMU2_LOAD_FILAMENT               = _UxGT("MMU Завантажити");
   LSTR MSG_MMU2_LOAD_ALL                    = _UxGT("MMU Завантажити все");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MMU2_LOAD_TO_NOZZLE            = _UxGT("MMU Завантажити в сопло");
-  #else
-    LSTR MSG_MMU2_LOAD_TO_NOZZLE            = _UxGT("MMU Завант. в сопло");
-  #endif
+  LSTR MSG_MMU2_LOAD_TO_NOZZLE              = _UxGT("MMU Завант. в сопло");
   LSTR MSG_MMU2_EJECT_FILAMENT              = _UxGT("MMU Звільнити");
   LSTR MSG_MMU2_EJECT_FILAMENT_N            = _UxGT("MMU Звільнити ~");
   LSTR MSG_MMU2_UNLOAD_FILAMENT             = _UxGT("MMU Вивантажити");
@@ -775,33 +605,18 @@ namespace Language_uk {
   LSTR MSG_MMU2_RESETTING                   = _UxGT("MMU Перезапуск...");
   LSTR MSG_MMU2_EJECT_RECOVER               = _UxGT("Видаліть, натисніть");
 
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_MIX                            = _UxGT("Змішування");
-  #else
-    LSTR MSG_MIX                            = _UxGT("Змішув.");
-  #endif
+  LSTR MSG_MIX                              = _UxGT("Змішув.");
   LSTR MSG_MIX_COMPONENT_N                  = _UxGT("Компонент {");
   LSTR MSG_MIXER                            = _UxGT("Змішувач");
   LSTR MSG_GRADIENT                         = _UxGT("Градієнт");
   LSTR MSG_FULL_GRADIENT                    = _UxGT("Повний градієнт");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_TOGGLE_MIX                     = _UxGT("Переключити змішування");
-  #else
-    LSTR MSG_TOGGLE_MIX                     = _UxGT("Переключ.змішування");
-  #endif
+  LSTR MSG_TOGGLE_MIX                       = _UxGT("Переключ.змішування");
   LSTR MSG_CYCLE_MIX                        = _UxGT("Циклічне змішування");
   LSTR MSG_GRADIENT_MIX                     = _UxGT("Градієнт змішування");
   LSTR MSG_REVERSE_GRADIENT                 = _UxGT("Змінити градієнт");
-
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Активація В-інструменту");
-    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдонім В-інструменту");
-    LSTR MSG_RESET_VTOOLS                   = _UxGT("Зкидання В-інструментів");
-  #else
-    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Актив. В-інструм.");
-    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдонім В-інструм");
-    LSTR MSG_RESET_VTOOLS                   = _UxGT("Зкидання В-інструм.");
-  #endif
+  LSTR MSG_ACTIVE_VTOOL                     = _UxGT("Актив. В-інструм.");
+  LSTR MSG_GRADIENT_ALIAS                   = _UxGT("Псевдонім В-інструм");
+  LSTR MSG_RESET_VTOOLS                     = _UxGT("Зкидання В-інструм.");
   LSTR MSG_START_VTOOL                      = _UxGT("Початок В-інструменту");
   LSTR MSG_END_VTOOL                        = _UxGT("Кінець В-інструменту");
   LSTR MSG_COMMIT_VTOOL                     = _UxGT("Змішати В-інструменти");
@@ -816,11 +631,7 @@ namespace Language_uk {
   LSTR MSG_MAZE                             = _UxGT("Лабіринт");
 
   LSTR MSG_BAD_PAGE                         = _UxGT("Погана сторінка");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Погана швидкість стор.");
-  #else
-    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Погана швидк. стор.");
-  #endif
+  LSTR MSG_BAD_PAGE_SPEED                   = _UxGT("Погана швидк. стор.");
 
   LSTR MSG_EDIT_PASSWORD                    = _UxGT("Редагувати пароль");
   LSTR MSG_LOGIN_REQUIRED                   = _UxGT("Потрібен логін");
@@ -835,35 +646,19 @@ namespace Language_uk {
 
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
   LSTR MSG_PAUSE_PRINT_PARKING              = _UxGT(MSG_1_LINE("Паркування..."));
-  #if LCD_HEIGHT >= 4
-    // Up to 3 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_3_LINE("Натисніть кнопку", "для продовження", "друку"));
-    LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_3_LINE("Зачекайте", "на початок", "заміни прутка"));
-    LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_3_LINE("Вставте пруток", "та натисніть", "для продовження"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_2_LINE("Натисніть кнопку", "для нагріву сопла"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_2_LINE("Сопло нагрівається", "зачекайте..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_2_LINE("Зачекайте", "на вивід прутка"));
-    LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Зачекайте", "на ввід прутка"));
-    LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_2_LINE("Дочекайтесь", "очищення прутка"));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_3_LINE("Натисніть кнопку", "для завершення", "очищення прутка"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_3_LINE("Зачекайте", "на відновлення", "друку"));
-  #else
-    // Up to 2 lines allowed
-    LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Продовжити друк"));
-    LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Зачекайте..."));
-    LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Вставте і натисніть"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Нагріти сопло"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("Нагрів сопла..."));
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("Вивід прутка..."));
-    LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("Ввід прутка..."));
-    LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("Очищення прутка..."));
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("Завершити очищення"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("Поновлення друку..."));
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING           = _UxGT(MSG_1_LINE("Продовжити друк"));
+  LSTR MSG_FILAMENT_CHANGE_INIT             = _UxGT(MSG_1_LINE("Зачекайте..."));
+  LSTR MSG_FILAMENT_CHANGE_INSERT           = _UxGT(MSG_1_LINE("Вставте і натисніть"));
+  LSTR MSG_FILAMENT_CHANGE_HEAT             = _UxGT(MSG_1_LINE("Нагріти сопло"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING          = _UxGT(MSG_1_LINE("Нагрів сопла..."));
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD           = _UxGT(MSG_1_LINE("Вивід прутка..."));
+  LSTR MSG_FILAMENT_CHANGE_LOAD             = _UxGT(MSG_1_LINE("Ввід прутка..."));
+  LSTR MSG_FILAMENT_CHANGE_PURGE            = _UxGT(MSG_1_LINE("Очищення прутка..."));
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE       = _UxGT(MSG_1_LINE("Завершити очищення"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME           = _UxGT(MSG_1_LINE("Поновлення друку..."));
 
   LSTR MSG_TMC_DRIVERS                      = _UxGT("Драйвери TMC");
   LSTR MSG_TMC_CURRENT                      = _UxGT("Струм драйвера");
@@ -880,22 +675,14 @@ namespace Language_uk {
   LSTR MSG_LEVEL_X_AXIS                     = _UxGT("Рівень вісі X");
   LSTR MSG_AUTO_CALIBRATE                   = _UxGT("Авто калібрування");
 
-  #if ENABLED(TOUCH_UI_FTDI_EVE)
-    LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Час простою збіг, температура впала. Натисніть ОК, щоби знову нагріти та продовжити");
-  #else
-    LSTR MSG_HEATER_TIMEOUT                 = _UxGT("Час нагрівача збіг");
-  #endif
+  LSTR MSG_FTDI_HEATER_TIMEOUT              = _UxGT("Час простою збіг, температура впала. Натисніть ОК, щоби знову нагріти та продовжити");
+  LSTR MSG_HEATER_TIMEOUT                   = _UxGT("Час нагрівача збіг");
   LSTR MSG_REHEAT                           = _UxGT("Поновити нагрів");
   LSTR MSG_REHEATING                        = _UxGT("Нагрівання...");
 
   LSTR MSG_PROBE_WIZARD                     = _UxGT("Майстер Z-зонда");
-  #if LCD_WIDTH > 21 || HAS_DWIN_E3V2
-    LSTR MSG_PROBE_WIZARD_PROBING           = _UxGT("Зондув. контрольної точки Z");
-    LSTR MSG_PROBE_WIZARD_MOVING            = _UxGT("Рух до точки зондування");
-  #else
-    LSTR MSG_PROBE_WIZARD_PROBING           = _UxGT("Зондув.контр.точки Z");
-    LSTR MSG_PROBE_WIZARD_MOVING            = _UxGT("Рух до точки зондув.");
-  #endif
+  LSTR MSG_PROBE_WIZARD_PROBING             = _UxGT("Зондув.контр.точки Z");
+  LSTR MSG_PROBE_WIZARD_MOVING              = _UxGT("Рух до точки зондув.");
 
   LSTR MSG_SOUND                            = _UxGT("Звук");
 
@@ -914,4 +701,110 @@ namespace Language_uk {
   LSTR MSG_SHORT_DAY                        = _UxGT("д"); // One character only
   LSTR MSG_SHORT_HOUR                       = _UxGT("г"); // One character only
   LSTR MSG_SHORT_MINUTE                     = _UxGT("х"); // One character only
+}
+
+namespace LanguageWide_uk {
+  using namespace LanguageNarrow_uk;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Збій ініціалізації SD");
+    LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Переповнення виклику");
+    LSTR MSG_LCD_SOFT_ENDSTOPS              = _UxGT("Програмні кінцевики");
+    LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Встанов. зміщення дому");
+    LSTR MSG_HOME_OFFSET_X                  = _UxGT("Зміщення дому X");
+    LSTR MSG_HOME_OFFSET_Y                  = _UxGT("Зміщення дому Y");
+    LSTR MSG_HOME_OFFSET_Z                  = _UxGT("Зміщення дому Z");
+    LSTR MSG_LAST_VALUE_SP                  = _UxGT("Останнє значення ");
+    LSTR MSG_LASER_POWER                    = _UxGT("Потужність лазера");
+    LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Перемкн. шпіндель");
+    LSTR MSG_SPINDLE_EVAC_TOGGLE            = _UxGT("Перемкнути вакуум");
+    LSTR MSG_LASER_TOGGLE                   = _UxGT("Перемкнути лазер");
+    LSTR MSG_SPINDLE_POWER                  = _UxGT("Потужн. шпінделя");
+    LSTR MSG_LASER_PULSE_MS                 = _UxGT("Тестовий імпульс мс");
+    LSTR MSG_LASER_EVAC_TOGGLE              = _UxGT("Перемкнути обдув");
+    LSTR MSG_BED_TRAMMING_RAISE             = _UxGT("Вгору до спрацюв. зонду");
+    LSTR MSG_BED_TRAMMING_IN_RANGE          = _UxGT("Кути в межах. Вирів.столу");
+    LSTR MSG_MESH_EDITOR                    = _UxGT("Зміщення по Z");
+    LSTR MSG_UBL_MANUAL_MESH                = _UxGT("Ручне введення сітки");
+    LSTR MSG_UBL_BC_INSERT                  = _UxGT("Розмістити шайбу і вимір.");
+    LSTR MSG_UBL_BC_REMOVE                  = _UxGT("Видалити і виміряти стіл");
+    LSTR MSG_UBL_EDIT_CUSTOM_MESH           = _UxGT("Редагувати свою сітку");
+    LSTR MSG_UBL_FINE_TUNE_MESH             = _UxGT("Точне редагування сітки");
+    LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Будувати свою сітку");
+    LSTR MSG_UBL_GRID_MESH_LEVELING         = _UxGT("Вирівнювання растру");
+    LSTR MSG_UBL_FILLIN_AMOUNT              = _UxGT("Обсяг заповнюв.");
+    LSTR MSG_UBL_FINE_TUNE_ALL              = _UxGT("Точно налаштувати все");
+    LSTR MSG_UBL_FINE_TUNE_CLOSEST          = _UxGT("Точно налашт.найближчу");
+    LSTR MSG_LED_PRESETS                    = _UxGT("Передустановки світла");
+    LSTR MSG_NEO2_PRESETS                   = _UxGT("Передустановка світла #2");
+    LSTR MSG_COOLER                         = _UxGT("Охолодження лазеру");
+    LSTR MSG_COOLER_TOGGLE                  = _UxGT("Перемк. охолодж.");
+    LSTR MSG_STORED_FAN_N                   = _UxGT("Збереж.швидк.вент. ~");
+    LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Дод. швидк. вент. ~");
+    LSTR MSG_JUNCTION_DEVIATION             = _UxGT("Відхилення вузла");
+    LSTR MSG_VTRAV_MIN                      = _UxGT("Переміщення мін");
+    LSTR MSG_CONTRAST                       = _UxGT("Контраст екрану");
+    LSTR MSG_BRIGHTNESS                     = _UxGT("Яскравість LCD");
+    LSTR MSG_INIT_EEPROM                    = _UxGT("Ініціалізація EEPROM");
+    LSTR MSG_CONTROL_RETRACT                = _UxGT("Втягування, мм");
+    LSTR MSG_CONTROL_RETRACT_SWAP           = _UxGT("Зміна втягув.,мм");
+    LSTR MSG_CONTROL_RETRACT_RECOVER        = _UxGT("Повернення, мм");
+    LSTR MSG_CONTROL_RETRACT_RECOVER_SWAP   = _UxGT("Поверн.зміни, мм");
+    LSTR MSG_AUTORETRACT                    = _UxGT("Автовтягування");
+    LSTR MSG_SINGLENOZZLE_PRIME_SPEED       = _UxGT("Початк.швидкість");
+    LSTR MSG_SINGLENOZZLE_RETRACT_SPEED     = _UxGT("Швидкість втягув.");
+    LSTR MSG_SINGLENOZZLE_FAN_SPEED         = _UxGT("Оберти вентилятора");
+    LSTR MSG_SINGLENOZZLE_FAN_TIME          = _UxGT("Час вентилятора");
+    LSTR MSG_COOLING_FAILED                 = _UxGT("ОХОЛОДЖЕННЯ НЕ ВДАЛОСЬ");
+    LSTR MSG_BED_COOLING                    = _UxGT("Охолодження столу...");
+    LSTR MSG_PROBE_COOLING                  = _UxGT("Охолодження зонду...");
+    LSTR MSG_CHAMBER_COOLING                = _UxGT("Охолодження камери...");
+    LSTR MSG_LASER_COOLING                  = _UxGT("Охолодження лазеру...");
+    LSTR MSG_3POINT_LEVELING                = _UxGT("3-точкове вирівнювання");
+    LSTR MSG_LINEAR_LEVELING                = _UxGT("Лінійне вирівнювання");
+    LSTR MSG_BILINEAR_LEVELING              = _UxGT("Білінійне вирівнювання");
+    LSTR MSG_MESH_DONE                      = _UxGT("Зондування сітки виконано");
+    LSTR MSG_INFO_RUNAWAY_OFF               = _UxGT("Контроль витіку ") LCD_STR_THERMOMETER _UxGT(" Вимк");
+    LSTR MSG_INFO_RUNAWAY_ON                = _UxGT("Контроль витіку ") LCD_STR_THERMOMETER _UxGT(" Увімк");
+    LSTR MSG_HOTEND_IDLE_TIMEOUT            = _UxGT("Час простою хотенду");
+    LSTR MSG_MEDIA_NOT_INSERTED             = _UxGT("Носій не вставлений");
+    LSTR MSG_PLEASE_WAIT_REBOOT             = _UxGT("Перезавантаження...");
+    LSTR MSG_INFO_PRINT_COUNT               = _UxGT("Кількість друків");
+    LSTR MSG_INFO_PRINT_TIME                = _UxGT("Час друку");
+    LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("Найдовший час");
+    LSTR MSG_COLORS_SELECT                  = _UxGT("Обрати кольори");
+    LSTR MSG_COLORS_APPLIED                 = _UxGT("Кольори застосовані");
+    LSTR MSG_FILAMENT_CHANGE_OPTION_HEADER  = _UxGT("ПАРАМЕТРИ ПРОДОВЖЕННЯ:");
+    LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Датчик закінчення прутка");
+    LSTR MSG_RUNOUT_DISTANCE_MM             = _UxGT("Відстань закінч.,мм");
+    LSTR MSG_MMU2_LOAD_TO_NOZZLE            = _UxGT("MMU Завантажити в сопло");
+    LSTR MSG_MIX                            = _UxGT("Змішування");
+    LSTR MSG_TOGGLE_MIX                     = _UxGT("Переключити змішування");
+    LSTR MSG_ACTIVE_VTOOL                   = _UxGT("Активація В-інструменту");
+    LSTR MSG_GRADIENT_ALIAS                 = _UxGT("Псевдонім В-інструменту");
+    LSTR MSG_RESET_VTOOLS                   = _UxGT("Зкидання В-інструментів");
+    LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("Погана швидкість стор.");
+    LSTR MSG_PROBE_WIZARD_PROBING           = _UxGT("Зондув. контрольної точки Z");
+    LSTR MSG_PROBE_WIZARD_MOVING            = _UxGT("Рух до точки зондування");
+  #endif
+}
+
+namespace LanguageTall_uk {
+  using namespace LanguageWide_uk;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_3_LINE("Натисніть кнопку", "для продовження", "друку"));
+    LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_3_LINE("Зачекайте", "на початок", "заміни прутка"));
+    LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_3_LINE("Вставте пруток", "та натисніть", "для продовження"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_2_LINE("Натисніть кнопку", "для нагріву сопла"));
+    LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_2_LINE("Сопло нагрівається", "зачекайте..."));
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_2_LINE("Зачекайте", "на вивід прутка"));
+    LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_2_LINE("Зачекайте", "на ввід прутка"));
+    LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_2_LINE("Дочекайтесь", "очищення прутка"));
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_3_LINE("Натисніть кнопку", "для завершення", "очищення прутка"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_3_LINE("Зачекайте", "на відновлення", "друку"));
+  #endif
+}
+
+namespace Language_uk {
+  using namespace LanguageTall_uk;
 }

--- a/Marlin/src/lcd/language/language_vi.h
+++ b/Marlin/src/lcd/language/language_vi.h
@@ -27,7 +27,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_vi {
+namespace LanguageNarrow_vi {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 2;
@@ -63,23 +63,23 @@ namespace Language_vi {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Chiều cao mờ dần");                     // Fade Height
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Đặt bù đắp nhà");                       // Set home offsets
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("Bù đắp được áp dụng");                  // Offsets applied
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" trước");      // Preheat
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" trước ~");    // Preheat
-    LSTR MSG_PREHEAT_1_END                = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Đầu");
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Đầu ~");
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Tất cả");     // All
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Bàn");        // Bed -- using vietnamese term for 'table' instead
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Cấu hình");   // Conf
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("Làm nóng $ trước");                     // Preheat
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("Làm nóng $ trước ~");                   // Preheat
-    LSTR MSG_PREHEAT_M_END                = _UxGT("Làm nóng $ Đầu");
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("Làm nóng $ Đầu ~");
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("Làm nóng $ Tất cả");                    // All
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("Làm nóng $ Bàn");                       // Bed -- using vietnamese term for 'table' instead
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("Làm nóng $ Cấu hình");                  // Conf
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" trước");      // Preheat
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" trước ~");    // Preheat
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Đầu");
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Đầu ~");
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Tất cả");     // All
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Bàn");        // Bed -- using vietnamese term for 'table' instead
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("Làm nóng ") PREHEAT_1_LABEL _UxGT(" Cấu hình");   // Conf
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("Làm nóng $ trước");                     // Preheat
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("Làm nóng $ trước ~");                   // Preheat
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("Làm nóng $ Đầu");
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("Làm nóng $ Đầu ~");
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("Làm nóng $ Tất cả");                    // All
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("Làm nóng $ Bàn");                       // Bed -- using vietnamese term for 'table' instead
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("Làm nóng $ Cấu hình");                  // Conf
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("Sự nóng trước tự chọn");                // Preheat Custom
   LSTR MSG_COOLDOWN                       = _UxGT("Nguội xuống");                          // Cooldown
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Bật nguồn");                            // Switch power on
@@ -125,10 +125,8 @@ namespace Language_vi {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("Chỉnh sửa xong lưới");                  // Done Editing Mesh
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("Xây dựng lưới tự chọn");                // Build Custom Mesh
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("Xây dựng lưới");                        // Build Mesh
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("Xây dựng lưới ($)");
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("Thẩm tra lưới ($)");
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("Xây dựng lưới ($)");
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("Thẩm tra lưới ($)");
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("Xây dựng lưới lạnh");                   // Build cold mesh
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("Điều chỉnh chiều cao lưới");            // Adjust Mesh Height
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("Số lượng chiều cao");                   // Height Amount
@@ -438,4 +436,21 @@ namespace Language_vi {
   LSTR MSG_SHORT_DAY                      = _UxGT("n");                                   // d - ngày - One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("g");                                   // h - giờ  - One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("p");                                   // m - phút - One character only
+}
+
+namespace LanguageWide_vi {
+  using namespace LanguageNarrow_vi;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+  #endif
+}
+
+namespace LanguageTall_vi {
+  using namespace LanguageWide_vi;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+  #endif
+}
+
+namespace Language_vi {
+  using namespace LanguageTall_vi;
 }

--- a/Marlin/src/lcd/language/language_zh_CN.h
+++ b/Marlin/src/lcd/language/language_zh_CN.h
@@ -27,7 +27,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_zh_CN {
+namespace LanguageNarrow_zh_CN {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 3;
@@ -68,23 +68,23 @@ namespace Language_zh_CN {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("淡出高度"); // "Fade Height"
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("设置原点偏移"); // "Set home offsets"
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("偏移已启用"); // "Offsets applied"
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("预热 ") PREHEAT_1_LABEL; // "Preheat PREHEAT_2_LABEL"
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("预热 ") PREHEAT_1_LABEL " ~"; // "Preheat PREHEAT_2_LABEL"
-    LSTR MSG_PREHEAT_1_END                = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 喷嘴"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 喷嘴 ~"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 全部"); //MSG_PREHEAT_1 " All"
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 热床"); //MSG_PREHEAT_1 " Bed"
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 设置"); //MSG_PREHEAT_1 " conf"
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("预热 $"); // "Preheat PREHEAT_2_LABEL"
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("预热 $ ~"); // "Preheat PREHEAT_2_LABEL"
-    LSTR MSG_PREHEAT_M_END                = _UxGT("预热 $ 喷嘴"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("预热 $ 喷嘴 ~"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("预热 $ 全部"); //MSG_PREHEAT_1 " All"
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("预热 $ 热床"); //MSG_PREHEAT_1 " Bed"
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("预热 $ 设置"); //MSG_PREHEAT_1 " conf"
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("预热 ") PREHEAT_1_LABEL; // "Preheat PREHEAT_2_LABEL"
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("预热 ") PREHEAT_1_LABEL " ~"; // "Preheat PREHEAT_2_LABEL"
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 喷嘴"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 喷嘴 ~"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 全部"); //MSG_PREHEAT_1 " All"
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 热床"); //MSG_PREHEAT_1 " Bed"
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("预热 ") PREHEAT_1_LABEL _UxGT(" 设置"); //MSG_PREHEAT_1 " conf"
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("预热 $"); // "Preheat PREHEAT_2_LABEL"
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("预热 $ ~"); // "Preheat PREHEAT_2_LABEL"
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("预热 $ 喷嘴"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("预热 $ 喷嘴 ~"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("预热 $ 全部"); //MSG_PREHEAT_1 " All"
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("预热 $ 热床"); //MSG_PREHEAT_1 " Bed"
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("预热 $ 设置"); //MSG_PREHEAT_1 " conf"
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("预热自定义");
   LSTR MSG_COOLDOWN                       = _UxGT("降温"); // "Cooldown"
   LSTR MSG_CUTTER_FREQUENCY               = _UxGT("切割频率");
@@ -142,10 +142,8 @@ namespace Language_zh_CN {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("完成编辑网格"); // "Done Editing Mesh"
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("创设客户网格"); // "Build Custom Mesh"
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("创设网格"); // "Build Mesh"
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("创设 $ 网格"); // "Build PREHEAT_1_LABEL Mesh"
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("批准 $ 网格"); // "Validate PREHEAT_1_LABEL Mesh"
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("创设 $ 网格"); // "Build PREHEAT_1_LABEL Mesh"
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("批准 $ 网格"); // "Validate PREHEAT_1_LABEL Mesh"
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("创设冷网格"); // "Build Cold Mesh"
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("调整网格高度"); // "Adjust Mesh Height"
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("高度合计"); // "Height Amount"
@@ -476,19 +474,11 @@ namespace Language_zh_CN {
 
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("打印机不正确"); // "The printer is incorrect"
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("打印计数"); // "Print Count"
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("完成了"); // "Completed"
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("总打印时间"); // "Total print time"
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最长工作时间"); // "Longest job time"
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("总计挤出"); // "Extruded total"
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("打印数"); // "Prints"
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("完成"); // "Completed"
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("总共"); // "Total"
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最长"); // "Longest"
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("已挤出"); // "Extruded"
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("打印数"); // "Prints"
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("完成"); // "Completed"
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("总共"); // "Total"
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("最长"); // "Longest"
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("已挤出"); // "Extruded"
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("最低温度"); // "Min Temp"
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("最高温度"); // "Max Temp"
@@ -560,34 +550,20 @@ namespace Language_zh_CN {
   LSTR MSG_BAD_PAGE_SPEED                 = _UxGT("错误页面速度");
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
-  #if LCD_HEIGHT >= 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("按下按钮", "恢复打印"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("停靠中..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("等待开始", "丝料", "变更")); // "Wait for start of the filament change"
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("插入料", "并按下", "以继续"));
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("按下按钮来", "加热喷嘴.")); // "Press button to heat nozzle."
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("加热喷嘴", "请等待 ...")); // "Heating nozzle Please wait..."
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("等待", "卸下丝料")); // "Wait for filament unload"
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("等待", "进料")); // "Wait for filament load"
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("等待", "丝料清除")); // "Wait for filament purge"
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("按下已完成", "料的清洗"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("等待打印", "恢复")); // "Wait for print to resume"
-  #else
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("按下继续"));
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("停靠中..."));
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("请等待 ...")); // "Please wait..."
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("插入并单击")); // "Insert and Click"
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("按下加热"));
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("加热中 ...")); // "Heating..."
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("退出中 ...")); // "Ejecting..."
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("装载中 ...")); // "Loading..."
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("清除中 ...")); // "Purging..."
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("按下完成"));
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("恢复中 ...")); // "Resuming..."
-  #endif
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("按下继续"));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("停靠中..."));
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("请等待 ...")); // "Please wait..."
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("插入并单击")); // "Insert and Click"
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("按下加热"));
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("加热中 ...")); // "Heating..."
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("退出中 ...")); // "Ejecting..."
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("装载中 ...")); // "Loading..."
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("清除中 ...")); // "Purging..."
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("按下完成"));
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("恢复中 ...")); // "Resuming..."
+
   LSTR MSG_TMC_DRIVERS                    = _UxGT("TMC驱动器");
   LSTR MSG_TMC_CURRENT                    = _UxGT("驱动电流");
   LSTR MSG_TMC_HYBRID_THRS                = _UxGT("混合阈值");
@@ -609,4 +585,37 @@ namespace Language_zh_CN {
   LSTR MSG_SHORT_DAY                      = _UxGT("天"); // "d" // One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("时"); // "h" // One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("分"); // "m" // One character only
+}
+
+namespace LanguageWide_zh_CN {
+  using namespace LanguageNarrow_zh_CN;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("打印计数"); // "Print Count"
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("完成了"); // "Completed"
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("总打印时间"); // "Total print time"
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最长工作时间"); // "Longest job time"
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("总计挤出"); // "Extruded total"
+  #endif
+}
+
+namespace LanguageTall_zh_CN {
+  using namespace LanguageWide_zh_CN;
+  #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
+    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("按下按钮", "恢复打印"));
+    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("停靠中..."));
+    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("等待开始", "丝料", "变更")); // "Wait for start of the filament change"
+    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_3_LINE("插入料", "并按下", "以继续"));
+    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_2_LINE("按下按钮来", "加热喷嘴.")); // "Press button to heat nozzle."
+    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_2_LINE("加热喷嘴", "请等待 ...")); // "Heating nozzle Please wait..."
+    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_2_LINE("等待", "卸下丝料")); // "Wait for filament unload"
+    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_2_LINE("等待", "进料")); // "Wait for filament load"
+    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("等待", "丝料清除")); // "Wait for filament purge"
+    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("按下已完成", "料的清洗"));
+    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("等待打印", "恢复")); // "Wait for print to resume"
+  #endif
+}
+
+namespace Language_zh_CN {
+  using namespace LanguageTall_zh_CN;
 }

--- a/Marlin/src/lcd/language/language_zh_TW.h
+++ b/Marlin/src/lcd/language/language_zh_TW.h
@@ -27,7 +27,7 @@
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  */
-namespace Language_zh_TW {
+namespace LanguageNarrow_zh_TW {
   using namespace Language_en; // Inherit undefined strings from English
 
   constexpr uint8_t CHARSIZE              = 3;
@@ -65,23 +65,23 @@ namespace Language_zh_TW {
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("淡出高度"); // "Fade Height"
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("設置原點偏移"); // "Set home offsets"
   LSTR MSG_HOME_OFFSETS_APPLIED           = _UxGT("偏移已啟用"); // "Offsets applied"
-  #if HAS_PREHEAT
-    LSTR MSG_PREHEAT_1                    = _UxGT("預熱 ") PREHEAT_1_LABEL; // "Preheat PREHEAT_1_LABEL"
-    LSTR MSG_PREHEAT_1_H                  = _UxGT("預熱 ") PREHEAT_1_LABEL " ~"; // "Preheat PREHEAT_1_LABEL"
-    LSTR MSG_PREHEAT_1_END                = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 噴嘴"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_1_END_E              = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 噴嘴 ~"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_1_ALL                = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 全部"); //MSG_PREHEAT_1 " All"
-    LSTR MSG_PREHEAT_1_BEDONLY            = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 熱床"); //MSG_PREHEAT_1 " Bed"
-    LSTR MSG_PREHEAT_1_SETTINGS           = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 設置"); //MSG_PREHEAT_1 " conf"
 
-    LSTR MSG_PREHEAT_M                    = _UxGT("預熱 $"); // "Preheat PREHEAT_1_LABEL"
-    LSTR MSG_PREHEAT_M_H                  = _UxGT("預熱 $ ~"); // "Preheat PREHEAT_1_LABEL"
-    LSTR MSG_PREHEAT_M_END                = _UxGT("預熱 $ 噴嘴"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_M_END_E              = _UxGT("預熱 $ 噴嘴 ~"); //MSG_PREHEAT_1 " "
-    LSTR MSG_PREHEAT_M_ALL                = _UxGT("預熱 $ 全部"); //MSG_PREHEAT_1 " All"
-    LSTR MSG_PREHEAT_M_BEDONLY            = _UxGT("預熱 $ 熱床"); //MSG_PREHEAT_1 " Bed"
-    LSTR MSG_PREHEAT_M_SETTINGS           = _UxGT("預熱 $ 設置"); //MSG_PREHEAT_1 " conf"
-  #endif
+  LSTR MSG_PREHEAT_1                      = _UxGT("預熱 ") PREHEAT_1_LABEL; // "Preheat PREHEAT_1_LABEL"
+  LSTR MSG_PREHEAT_1_H                    = _UxGT("預熱 ") PREHEAT_1_LABEL " ~"; // "Preheat PREHEAT_1_LABEL"
+  LSTR MSG_PREHEAT_1_END                  = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 噴嘴"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_1_END_E                = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 噴嘴 ~"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_1_ALL                  = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 全部"); //MSG_PREHEAT_1 " All"
+  LSTR MSG_PREHEAT_1_BEDONLY              = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 熱床"); //MSG_PREHEAT_1 " Bed"
+  LSTR MSG_PREHEAT_1_SETTINGS             = _UxGT("預熱 ") PREHEAT_1_LABEL _UxGT(" 設置"); //MSG_PREHEAT_1 " conf"
+
+  LSTR MSG_PREHEAT_M                      = _UxGT("預熱 $"); // "Preheat PREHEAT_1_LABEL"
+  LSTR MSG_PREHEAT_M_H                    = _UxGT("預熱 $ ~"); // "Preheat PREHEAT_1_LABEL"
+  LSTR MSG_PREHEAT_M_END                  = _UxGT("預熱 $ 噴嘴"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_M_END_E                = _UxGT("預熱 $ 噴嘴 ~"); //MSG_PREHEAT_1 " "
+  LSTR MSG_PREHEAT_M_ALL                  = _UxGT("預熱 $ 全部"); //MSG_PREHEAT_1 " All"
+  LSTR MSG_PREHEAT_M_BEDONLY              = _UxGT("預熱 $ 熱床"); //MSG_PREHEAT_1 " Bed"
+  LSTR MSG_PREHEAT_M_SETTINGS             = _UxGT("預熱 $ 設置"); //MSG_PREHEAT_1 " conf"
+
   LSTR MSG_PREHEAT_CUSTOM                 = _UxGT("自定預熱"); // "Preheat Custom"
   LSTR MSG_COOLDOWN                       = _UxGT("降溫"); // "Cooldown"
   LSTR MSG_LASER_MENU                     = _UxGT("激光控制"); // "Laser Control"
@@ -138,10 +138,8 @@ namespace Language_zh_TW {
   LSTR MSG_UBL_DONE_EDITING_MESH          = _UxGT("完成編輯網格"); // "Done Editing Mesh"
   LSTR MSG_UBL_BUILD_CUSTOM_MESH          = _UxGT("創設客戶網格"); // "Build Custom Mesh"
   LSTR MSG_UBL_BUILD_MESH_MENU            = _UxGT("創設網格"); // "Build Mesh"
-  #if HAS_PREHEAT
-    LSTR MSG_UBL_BUILD_MESH_M             = _UxGT("創設 $ 網格"); // "Build PREHEAT_1_LABEL Mesh"
-    LSTR MSG_UBL_VALIDATE_MESH_M          = _UxGT("批准 $ 網格"); // "Validate PREHEAT_1_LABEL Mesh"
-  #endif
+  LSTR MSG_UBL_BUILD_MESH_M               = _UxGT("創設 $ 網格"); // "Build PREHEAT_1_LABEL Mesh"
+  LSTR MSG_UBL_VALIDATE_MESH_M            = _UxGT("批准 $ 網格"); // "Validate PREHEAT_1_LABEL Mesh"
   LSTR MSG_UBL_BUILD_COLD_MESH            = _UxGT("創設冷網格"); // "Build Cold Mesh"
   LSTR MSG_UBL_MESH_HEIGHT_ADJUST         = _UxGT("調整網格高度"); // "Adjust Mesh Height"
   LSTR MSG_UBL_MESH_HEIGHT_AMOUNT         = _UxGT("高度合計"); // "Height Amount"
@@ -424,19 +422,11 @@ namespace Language_zh_TW {
   LSTR MSG_CASE_LIGHT_BRIGHTNESS          = _UxGT("燈亮度"); // "Light BRIGHTNESS"
   LSTR MSG_KILL_EXPECTED_PRINTER          = _UxGT("打印機不正確"); // "The printer is incorrect"
 
-  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("列印計數"); // "Print Count"
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("已完成"); // "Completed"
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("總列印時間"); // "Total print time"
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最長工作時間"); // "Longest job time"
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("總計擠出"); // "Extruded total"
-  #else
-    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("列印數"); // "Prints"
-    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("完成"); // "Completed"
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("總共"); // "Total"
-    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最長"); // "Longest"
-    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("已擠出"); // "Extruded"
-  #endif
+  LSTR MSG_INFO_PRINT_COUNT               = _UxGT("列印數"); // "Prints"
+  LSTR MSG_INFO_COMPLETED_PRINTS          = _UxGT("完成"); // "Completed"
+  LSTR MSG_INFO_PRINT_TIME                = _UxGT("總共"); // "Total"
+  LSTR MSG_INFO_PRINT_LONGEST             = _UxGT("最長"); // "Longest"
+  LSTR MSG_INFO_PRINT_FILAMENT            = _UxGT("已擠出"); // "Extruded"
 
   LSTR MSG_INFO_MIN_TEMP                  = _UxGT("最低溫度"); // "Min Temp"
   LSTR MSG_INFO_MAX_TEMP                  = _UxGT("最高溫度"); // "Max Temp"
@@ -459,10 +449,40 @@ namespace Language_zh_TW {
   LSTR MSG_LCD_PROBING_FAILED             = _UxGT("探針探測失敗"); // "Probing failed"
 
   //
-  // Filament Change screens show up to 3 lines on a 4-line display
-  //                        ...or up to 2 lines on a 3-line display
+  // Filament Change screens show up to 2 lines on a 3-line display
   //
+  LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("按下繼續..")); // "Click to continue"
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("停車中 ...")); // "Parking..."
+  LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("請等待 ...")); // "Please wait..."
+  LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("插入並點擊")); // "Insert and Click"
+  LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("按下加熱..")); // "Click to heat"
+  LSTR MSG_FILAMENT_CHANGE_HEATING        = _UxGT(MSG_1_LINE("加熱中 ...")); // "Heating..."
+  LSTR MSG_FILAMENT_CHANGE_UNLOAD         = _UxGT(MSG_1_LINE("退出中 ...")); // "Ejecting..."
+  LSTR MSG_FILAMENT_CHANGE_LOAD           = _UxGT(MSG_1_LINE("載入中 ...")); // "Loading..."
+  LSTR MSG_FILAMENT_CHANGE_PURGE          = _UxGT(MSG_1_LINE("清除中 ...")); // "Purging..."
+  LSTR MSG_FILAMENT_CHANGE_CONT_PURGE     = _UxGT(MSG_1_LINE("按下完成..")); // "Click to finish"
+  LSTR MSG_FILAMENT_CHANGE_RESUME         = _UxGT(MSG_1_LINE("恢復中 ...")); // "Resuming..."
+
+  LSTR MSG_SHORT_DAY                      = _UxGT("天"); // "d" // One character only
+  LSTR MSG_SHORT_HOUR                     = _UxGT("時"); // "h" // One character only
+  LSTR MSG_SHORT_MINUTE                   = _UxGT("分"); // "m" // One character only
+}
+
+namespace LanguageWide_zh_TW {
+  using namespace LanguageNarrow_zh_TW;
+  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
+    LSTR MSG_INFO_PRINT_COUNT             = _UxGT("列印計數"); // "Print Count"
+    LSTR MSG_INFO_COMPLETED_PRINTS        = _UxGT("已完成"); // "Completed"
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("總列印時間"); // "Total print time"
+    LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("最長工作時間"); // "Longest job time"
+    LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("總計擠出"); // "Extruded total"
+  #endif
+}
+
+namespace LanguageTall_zh_TW {
+  using namespace LanguageWide_zh_TW;
   #if LCD_HEIGHT >= 4
+    // Filament Change screens show up to 3 lines on a 4-line display
     LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_2_LINE("按下按鈕", "恢復列印")); //"Press Button to resume print"
     LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("停車中 ...")); // "Parking..."
     LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_3_LINE("等待開始", "絲料", "變更")); // "Wait for start of the filament change"
@@ -474,21 +494,9 @@ namespace Language_zh_TW {
     LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_2_LINE("等待", "絲料清除")); // "Wait for filament purge"
     LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_2_LINE("按下完成","絲料清除")); //"Press button to filament purge"
     LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_2_LINE("等待列印", "恢復")); // "Wait for print to resume"
-  #else // LCD_HEIGHT < 4
-    LSTR MSG_ADVANCED_PAUSE_WAITING       = _UxGT(MSG_1_LINE("按下繼續..")); // "Click to continue"
-    LSTR MSG_PAUSE_PRINT_PARKING          = _UxGT(MSG_1_LINE("停車中 ...")); // "Parking..."
-    LSTR MSG_FILAMENT_CHANGE_INIT         = _UxGT(MSG_1_LINE("請等待 ...")); // "Please wait..."
-    LSTR MSG_FILAMENT_CHANGE_INSERT       = _UxGT(MSG_1_LINE("插入並點擊")); // "Insert and Click"
-    LSTR MSG_FILAMENT_CHANGE_HEAT         = _UxGT(MSG_1_LINE("按下加熱..")); // "Click to heat"
-    LSTR MSG_FILAMENT_CHANGE_HEATING      = _UxGT(MSG_1_LINE("加熱中 ...")); // "Heating..."
-    LSTR MSG_FILAMENT_CHANGE_UNLOAD       = _UxGT(MSG_1_LINE("退出中 ...")); // "Ejecting..."
-    LSTR MSG_FILAMENT_CHANGE_LOAD         = _UxGT(MSG_1_LINE("載入中 ...")); // "Loading..."
-    LSTR MSG_FILAMENT_CHANGE_PURGE        = _UxGT(MSG_1_LINE("清除中 ...")); // "Purging..."
-    LSTR MSG_FILAMENT_CHANGE_CONT_PURGE   = _UxGT(MSG_1_LINE("按下完成..")); // "Click to finish"
-    LSTR MSG_FILAMENT_CHANGE_RESUME       = _UxGT(MSG_1_LINE("恢復中 ...")); // "Resuming..."
-  #endif // LCD_HEIGHT < 4
+  #endif
+}
 
-  LSTR MSG_SHORT_DAY                      = _UxGT("天"); // "d" // One character only
-  LSTR MSG_SHORT_HOUR                     = _UxGT("時"); // "h" // One character only
-  LSTR MSG_SHORT_MINUTE                   = _UxGT("分"); // "m" // One character only
+namespace Language_zh_TW {
+  using namespace LanguageTall_zh_TW;
 }

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -307,9 +307,11 @@ void menu_main() {
         #if HAS_SD_DETECT
           ACTION_ITEM(MSG_NO_MEDIA, nullptr);               // "No Media"
         #else
-          GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21" TERN_(MULTI_VOLUME, "S"))); // M21 Attach Media
           #if ENABLED(MULTI_VOLUME)
-            GCODES_ITEM(MSG_ATTACH_USB_MEDIA, F("M21U"));   // M21 Attach USB Media
+            GCODES_ITEM(MSG_ATTACH_SD_MEDIA, F("M21S"));    // M21S Attach SD Card
+            GCODES_ITEM(MSG_ATTACH_USB_MEDIA, F("M21U"));   // M21U Attach USB Media
+          #else
+            GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21"));        // M21 Attach Media
           #endif
         #endif
       }
@@ -422,10 +424,12 @@ void menu_main() {
       #if HAS_SD_DETECT
         ACTION_ITEM(MSG_NO_MEDIA, nullptr);               // "No Media"
       #else
-        GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21" TERN_(MULTI_VOLUME, "S"))); // M21 Attach Media
-        #if ENABLED(MULTI_VOLUME)
-          GCODES_ITEM(MSG_ATTACH_USB_MEDIA, F("M21U"));   // M21 Attach USB Media
-        #endif
+          #if ENABLED(MULTI_VOLUME)
+            GCODES_ITEM(MSG_ATTACH_SD_MEDIA, F("M21S"));    // M21S Attach SD Card
+            GCODES_ITEM(MSG_ATTACH_USB_MEDIA, F("M21U"));   // M21U Attach USB Media
+          #else
+            GCODES_ITEM(MSG_ATTACH_MEDIA, F("M21"));        // M21 Attach Media
+          #endif
       #endif
     }
     // END MEDIA MENU

--- a/buildroot/share/scripts/languageImport.py
+++ b/buildroot/share/scripts/languageImport.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+languageImport.py
+
+Import LCD language strings from a CSV file or Google Sheets
+and write Marlin LCD language files based on the data.
+
+Use languageExport.py to export CSV from the language files.
+
+Google Sheets Link:
+https://docs.google.com/spreadsheets/d/12yiy-kS84ajKFm7oQIrC4CF8ZWeu9pAR4zrgxH4ruk4/edit#gid=84528699
+
+TODO: Use the defines and comments above the namespace from existing language files.
+      Get the 'constexpr uint8_t CHARSIZE' from existing language files.
+      Get the correct 'using namespace' for languages that don't inherit from English.
+
+"""
+
+import sys, re, requests, csv, datetime
+from languageUtil import namebyid
+
+LANGHOME = "Marlin/src/lcd/language"
+OUTDIR = 'out-language'
+
+# Get the file path from the command line
+FILEPATH = sys.argv[1] if len(sys.argv) > 1 else None
+
+download = FILEPATH == 'download'
+
+if not FILEPATH or download:
+    SHEETID = "12yiy-kS84ajKFm7oQIrC4CF8ZWeu9pAR4zrgxH4ruk4"
+    FILEPATH = 'https://docs.google.com/spreadsheet/ccc?key=%s&output=csv' % SHEETID
+
+if FILEPATH.startswith('http'):
+    response = requests.get(FILEPATH)
+    assert response.status_code == 200, 'GET failed for %s' % FILEPATH
+    csvdata = response.content.decode('utf-8')
+else:
+    if not FILEPATH.endswith('.csv'): FILEPATH += '.csv'
+    with open(FILEPATH, 'r', encoding='utf-8') as f: csvdata = f.read()
+
+if not csvdata:
+    print("Error: couldn't read CSV data from %s" % FILEPATH)
+    exit(1)
+
+if download:
+    DLNAME = sys.argv[2] if len(sys.argv) > 2 else 'languages.csv'
+    if not DLNAME.endswith('.csv'): DLNAME += '.csv'
+    with open(DLNAME, 'w', encoding='utf-8') as f: f.write(csvdata)
+    print("Downloaded %s from %s" % (DLNAME, FILEPATH))
+    exit(0)
+
+lines = csvdata.splitlines()
+print(lines)
+reader = csv.reader(lines, delimiter=',')
+gothead = False
+columns = ['']
+numcols = 0
+strings_per_lang = {}
+for row in reader:
+    if not gothead:
+        gothead = True
+        numcols = len(row)
+        if row[0] != 'name':
+            print('Error: first column should be "name"')
+            exit(1)
+        # The rest of the columns are language codes and names
+        for i in range(1, numcols):
+            elms = row[i].split(' ')
+            lang = elms[0]
+            style = ('Wide' if elms[-1] == '(wide)' else 'Tall' if elms[-1] == '(tall)' else 'Narrow')
+            columns.append({ 'lang': lang, 'style': style })
+            if not lang in strings_per_lang: strings_per_lang[lang] = {}
+            if not style in strings_per_lang[lang]: strings_per_lang[lang][style] = {}
+        continue
+    # Add the named string for all the included languages
+    name = row[0]
+    for i in range(1, numcols):
+        str = row[i]
+        if str:
+            col = columns[i]
+            strings_per_lang[col['lang']][col['style']][name] = str
+
+# Create a folder for the imported language outfiles
+from pathlib import Path
+Path.mkdir(Path(OUTDIR), exist_ok=True)
+
+FILEHEADER = '''
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * %s
+ *
+ * LCD Menu Messages
+ * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
+ */
+
+'''
+
+# Iterate over the languages which correspond to the columns
+# The columns are assumed to be grouped by language in the order Narrow, Wide, Tall
+# TODO: Go through lang only, then impose the order Narrow, Wide, Tall.
+#       So if something is missing or out of order everything still gets built correctly.
+
+f = None
+gotlang = {}
+for i in range(1, numcols):
+    #if i > 6: break # Testing
+    col = columns[i]
+    lang, style = col['lang'], col['style']
+
+    # If we haven't already opened a file for this language, do so now
+    if not lang in gotlang:
+        gotlang[lang] = {}
+        if f: f.close()
+        fn = "%s/language_%s.h" % (OUTDIR, lang)
+        f = open(fn, 'w', encoding='utf-8')
+        if not f:
+            print("Failed to open %s." % fn)
+            exit(1)
+
+        # Write the opening header for the new language file
+        #f.write(FILEHEADER % namebyid(lang))
+        f.write('/**\n * Imported from %s on %s at %s\n */\n' % (FILEPATH, datetime.date.today(), datetime.datetime.now().strftime("%H:%M:%S")))
+
+    # Start a namespace for the language and style
+    f.write('\nnamespace Language%s_%s {\n' % (style, lang))
+
+    # Wide and tall namespaces inherit from the others
+    if style == 'Wide':
+        f.write('  using namespace LanguageNarrow_%s;\n' % lang)
+        f.write('  #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2\n')
+    elif style == 'Tall':
+        f.write('  using namespace LanguageWide_%s;\n' % lang)
+        f.write('  #if LCD_HEIGHT >= 4\n')
+    elif lang != 'en':
+        f.write('  using namespace Language_en; // Inherit undefined strings from English\n')
+
+    # Formatting for the lines
+    indent = '  ' if style == 'Narrow' else '    '
+    width = 34 if style == 'Narrow' else 32
+    lstr_fmt = '%sLSTR %%-%ds = %%s;%%s\n' % (indent, width)
+
+    # Emit all the strings for this language and style
+    for name in strings_per_lang[lang][style].keys():
+        # Get the raw string value
+        val = strings_per_lang[lang][style][name]
+        # Count the number of bars
+        if val.startswith('|'):
+            bars = val.count('|')
+            val = val[1:]
+        else:
+            bars = 0
+        # Escape backslashes, substitute quotes, and wrap in _UxGT("...")
+        val = '_UxGT("%s")' % val.replace('\\', '\\\\').replace('"', '$$$')
+        # Move named references outside of the macro
+        val = re.sub(r'\(([A-Z0-9]+_[A-Z0-9_]+)\)', r'") \1 _UxGT("', val)
+        # Remove all empty _UxGT("") that result from the above
+        val = re.sub(r'\s*_UxGT\(""\)\s*', '', val)
+        # No wrapper needed for just spaces
+        val = re.sub(r'_UxGT\((" +")\)', r'\1', val)
+        # Multi-line strings start with a bar...
+        if bars:
+            # Wrap the string in MSG_#_LINE(...) and split on bars
+            val = re.sub(r'^_UxGT\((.+)\)', r'_UxGT(MSG_%s_LINE(\1))' % bars, val)
+            val = val.replace('|', '", "')
+        # Restore quotes inside the string
+        val = val.replace('$$$', '\\"')
+        # Add a comment with the English string for reference
+        comm = ''
+        if lang != 'en' and 'en' in strings_per_lang:
+            en = strings_per_lang['en']
+            if name in en[style]: str = en[style][name]
+            elif name in en['Narrow']: str = en['Narrow'][name]
+            if str:
+                cfmt = '%%%ss// %%s' % (50 - len(val) if len(val) < 50 else 1)
+                comm = cfmt % (' ', str)
+
+        # Write out the string definition
+        f.write(lstr_fmt % (name, val, comm))
+
+    if style == 'Wide' or style == 'Tall': f.write('  #endif\n')
+
+    f.write('}\n') # End namespace
+
+    # Assume the 'Tall' namespace comes last
+    if style == 'Tall': f.write('\nnamespace Language_%s {\n  using namespace LanguageTall_%s;\n}\n' % (lang, lang))
+
+# Close the last-opened output file
+if f: f.close()

--- a/buildroot/share/scripts/languageUtil.py
+++ b/buildroot/share/scripts/languageUtil.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# marlang.py
+#
+
+# A dictionary to contain language names
+LANGNAME = {
+    'an': "Aragonese",
+    'bg': "Bulgarian",
+    'ca': "Catalan",
+    'cz': "Czech",
+    'da': "Danish",
+    'de': "German",
+    'el': "Greek", 'el_CY': "Greek (Cyprus)", 'el_gr': "Greek (Greece)",
+    'en': "English",
+    'es': "Spanish",
+    'eu': "Basque-Euskera",
+    'fi': "Finnish",
+    'fr': "French", 'fr_na': "French (no accent)",
+    'gl': "Galician",
+    'hr': "Croatian (Hrvatski)",
+    'hu': "Hungarian / Magyar",
+    'it': "Italian",
+    'jp_kana': "Japanese (Kana)",
+    'ko_KR': "Korean",
+    'nl': "Dutch",
+    'pl': "Polish",
+    'pt': "Portuguese", 'pt_br': "Portuguese (Brazil)",
+    'ro': "Romanian",
+    'ru': "Russian",
+    'sk': "Slovak",
+    'sv': "Swedish",
+    'tr': "Turkish",
+    'uk': "Ukrainian",
+    'vi': "Vietnamese",
+    'zh_CN': "Simplified Chinese", 'zh_TW': "Traditional Chinese"
+}
+
+def namebyid(id):
+    if id in LANGNAME: return LANGNAME[id]
+    return '<unknown>'


### PR DESCRIPTION
Work on a language translation workflow that uses CSV files and an editable [Google Sheet](https://docs.google.com/spreadsheets/d/12yiy-kS84ajKFm7oQIrC4CF8ZWeu9pAR4zrgxH4ruk4/edit#gid=84528699).

- Add a script to create language files from a local CSV file or the public "[Marlin LCD Strings](https://docs.google.com/spreadsheets/d/12yiy-kS84ajKFm7oQIrC4CF8ZWeu9pAR4zrgxH4ruk4/edit#gid=84528699)" Google Sheet.
- Move some common code to `languageUtil.py`.
- Aim to replace `MSG_PREHEAT_#` with `MSG_PREHEAT_M` strings in ProUI and elsewhere.
- Use `namespace` overrides for "Wide" and "Tall" strings selected by the available LCD width/height.