### PR TITLE
🔨 Install 'heatshrink' if needed

### DIFF
--- a/buildroot/share/scripts/upload.py
+++ b/buildroot/share/scripts/upload.py
@@ -7,17 +7,6 @@ import serial
 
 Import("env")
 
-# Needed (only) for compression, but there are problems with pip install heatshrink
-#try:
-#    import heatshrink
-#except ImportError:
-#    # Install heatshrink
-#    print("Installing 'heatshrink' python module...")
-#    env.Execute(env.subst("$PYTHONEXE -m pip install heatshrink"))
-#
-# Not tested: If it's safe to install python libraries in PIO python try:
-#    env.Execute(env.subst("$PYTHONEXE -m pip install https://github.com/p3p/pyheatshrink/releases/download/0.3.3/pyheatshrink-pip.zip"))
-
 import MarlinBinaryProtocol
 
 #-----------------#
@@ -190,6 +179,21 @@ def Upload(source, target, env):
                                                     'BOARD_CREALITY_V24S1']
     # "upload_random_name": generate a random 8.3 firmware filename to upload
     upload_random_filename = upload_delete_old_bins and not marlin_long_filename_host_support
+
+    # Heatshrink module is needed (only) for compression
+    if upload_compression:
+        if sys.version_info[0] > 2:
+            try:
+               import heatshrink2
+            except ImportError:
+               print("Installing 'heatshrink2' python module...")
+               env.Execute(env.subst("$PYTHONEXE -m pip install heatshrink2"))
+        else:
+            try:
+               import heatshrink
+            except ImportError:
+               print("Installing 'heatshrink' python module...")
+               env.Execute(env.subst("$PYTHONEXE -m pip install heatshrink"))
 
     try:
 


### PR DESCRIPTION
Make it easier to resolve a missing 'heatshrink' module by downloading as needed.

Followup to #14817