### PR TITLE
🧑‍💻 ExtUI::onLevelingStart/Done for all leveling

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
@@ -104,10 +104,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
@@ -91,11 +91,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
-
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }

--- a/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
@@ -108,10 +108,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);

--- a/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
@@ -112,10 +112,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -118,8 +118,7 @@ void DGUSScreenHandler::Loop() {
   }
 
   if (current_screen == DGUS_Screen::WAIT
-      && ((wait_continue && !wait_for_user)
-          || (!wait_continue && IsPrinterIdle()))
+      && ((wait_continue && !wait_for_user) || (!wait_continue && IsPrinterIdle()))
   ) {
     MoveToScreen(wait_return_screen, true);
     return;
@@ -128,7 +127,7 @@ void DGUSScreenHandler::Loop() {
   if (current_screen == DGUS_Screen::LEVELING_PROBING && IsPrinterIdle()) {
     dgus_display.PlaySound(3);
 
-    SetStatusMessage(ExtUI::getMeshValid() ? GET_TEXT_F(DGUS_MSG_PROBING_SUCCESS) : GET_TEXT_F(DGUS_MSG_PROBING_FAILED));
+    SetStatusMessage(ExtUI::getLevelingIsValid() ? GET_TEXT_F(DGUS_MSG_PROBING_SUCCESS) : GET_TEXT_F(DGUS_MSG_PROBING_FAILED));
 
     MoveToScreen(DGUS_Screen::LEVELING_AUTOMATIC);
     return;
@@ -190,7 +189,7 @@ void DGUSScreenHandler::StoreSettings(char *buff) {
   data.initialized = true;
   data.volume = dgus_display.GetVolume();
   data.brightness = dgus_display.GetBrightness();
-  data.abl_okay = (ExtUI::getLevelingActive() && ExtUI::getMeshValid());
+  data.abl_okay = (ExtUI::getLevelingActive() && ExtUI::getLevelingIsValid());
 
   memcpy(buff, &data, sizeof(data));
 }
@@ -206,7 +205,7 @@ void DGUSScreenHandler::LoadSettings(const char *buff) {
   dgus_display.SetBrightness(data.initialized ? data.brightness : DGUS_DEFAULT_BRIGHTNESS);
 
   if (data.initialized) {
-    leveling_active = (data.abl_okay && ExtUI::getMeshValid());
+    leveling_active = (data.abl_okay && ExtUI::getLevelingIsValid());
     ExtUI::setLevelingActive(leveling_active);
   }
 }
@@ -247,7 +246,7 @@ void DGUSScreenHandler::MeshUpdate(const int8_t xpos, const int8_t ypos) {
   uint8_t point = ypos * GRID_MAX_POINTS_X + xpos;
   probing_icons[point < 16 ? 0 : 1] |= (1U << (point % 16));
 
-  if (xpos >= GRID_MAX_POINTS_X - 1 && ypos >= GRID_MAX_POINTS_Y - 1 && !ExtUI::getMeshValid())
+  if (xpos >= GRID_MAX_POINTS_X - 1 && ypos >= GRID_MAX_POINTS_Y - 1 && !ExtUI::getLevelingIsValid())
     probing_icons[0] = probing_icons[1] = 0;
 
   TriggerFullUpdate();

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSSetupHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSSetupHandler.cpp
@@ -136,7 +136,7 @@ bool DGUSSetupHandler::LevelingOffset() {
 }
 
 bool DGUSSetupHandler::LevelingAutomatic() {
-  if (ExtUI::getMeshValid()) {
+  if (ExtUI::getLevelingIsValid()) {
     dgus_screen_handler.leveling_active = true;
 
     ExtUI::setLevelingActive(true);

--- a/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
@@ -108,10 +108,12 @@ namespace ExtUI {
     dgus_screen_handler.ConfigurationStoreRead(success);
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       dgus_screen_handler.MeshUpdate(xpos, ypos);
     }

--- a/Marlin/src/lcd/extui/example/example.cpp
+++ b/Marlin/src/lcd/extui/example/example.cpp
@@ -98,10 +98,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
@@ -117,9 +117,12 @@ namespace ExtUI {
       ConfirmUserRequestAlertBox::hide();
   }
 
-  #if HAS_LEVELING && HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
+
+  #if HAS_MESH
     void onMeshUpdate(const int8_t x, const int8_t y, const_float_t val) { BedMeshViewScreen::onMeshUpdate(x, y, val); }
     void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) { BedMeshViewScreen::onMeshUpdate(x, y, state); }
   #endif

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_edit_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_edit_screen.cpp
@@ -95,7 +95,7 @@ void BedMeshEditScreen::setHighlightedValue(float value) {
 }
 
 void BedMeshEditScreen::moveToHighlightedValue() {
-  if (ExtUI::getMeshValid()) {
+  if (ExtUI::getLevelingIsValid()) {
     ExtUI::setLevelingActive(true);
     ExtUI::setSoftEndstopState(false);
     ExtUI::moveToMeshPoint(mydata.highlight, gaugeThickness + mydata.zAdjustment);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_view_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_view_screen.cpp
@@ -125,7 +125,7 @@ void BedMeshViewScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI
       mydata.count = 0;
       break;
     case ExtUI::G29_FINISH:
-      if (mydata.count == GRID_MAX_POINTS && ExtUI::getMeshValid())
+      if (mydata.count == GRID_MAX_POINTS && ExtUI::getLevelingIsValid())
         mydata.message = GET_TEXT_F(MSG_BED_MAPPING_DONE);
       else
         mydata.message = GET_TEXT_F(MSG_BED_MAPPING_INCOMPLETE);

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
@@ -311,7 +311,7 @@ void onSettingsStored(const bool success) {
 
 void onSettingsLoaded(const bool success) {
   #if HAS_MESH
-    if (ExtUI::getMeshValid()) {
+    if (ExtUI::getLevelingIsValid()) {
       uint8_t abl_probe_index = 0;
       for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
         for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
@@ -371,7 +371,7 @@ void onLevelingStart() {}
 
 void onLevelingDone() {
   #if HAS_MESH
-    if (ExtUI::getMeshValid()) {
+    if (ExtUI::getLevelingIsValid()) {
       uint8_t abl_probe_index = 0;
       for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
         for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
@@ -1043,7 +1043,7 @@ void RTS::handleData() {
         #if HAS_MESH
           sendData(getLevelingActive() ? 3 : 2, AutoLevelIcon);
 
-          if (ExtUI::getMeshValid()) {
+          if (ExtUI::getLevelingIsValid()) {
             uint8_t abl_probe_index = 0;
             for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
               for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {

--- a/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
@@ -150,11 +150,14 @@ namespace ExtUI {
   void onSettingsStored(const bool) {}
   void onSettingsLoaded(const bool) {}
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {}
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {}
+  #endif
+
+  #if HAS_MESH
+    void onMeshUpdate(const int8_t, const int8_t, const_float_t) {}
+    void onMeshUpdate(const int8_t, const int8_t, const ExtUI::probe_state_t) {}
   #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)

--- a/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
@@ -89,10 +89,12 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  #if HAS_MESH
+  #if HAS_LEVELING
     void onLevelingStart() {}
     void onLevelingDone() {}
+  #endif
 
+  #if HAS_MESH
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
       // Called when any mesh points are updated
     }

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -919,7 +919,7 @@ namespace ExtUI {
 
     bool getLevelingActive() { return planner.leveling_active; }
     void setLevelingActive(const bool state) { set_bed_leveling_enabled(state); }
-    bool getMeshValid() { return leveling_is_valid(); }
+    bool getLevelingIsValid() { return leveling_is_valid(); }
 
     #if HAS_MESH
 

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -172,14 +172,14 @@ namespace ExtUI {
   #if HAS_LEVELING
     bool getLevelingActive();
     void setLevelingActive(const bool);
-    bool getMeshValid();
+    bool getLevelingIsValid();
+    void onLevelingStart();
+    void onLevelingDone();
     #if HAS_MESH
       bed_mesh_t& getMeshArray();
       float getMeshPoint(const xy_uint8_t &pos);
       void setMeshPoint(const xy_uint8_t &pos, const_float_t zval);
       void moveToMeshPoint(const xy_uint8_t &pos, const_float_t z);
-      void onLevelingStart();
-      void onLevelingDone();
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval);
       inline void onMeshUpdate(const xy_int8_t &pos, const_float_t zval) { onMeshUpdate(pos.x, pos.y, zval); }
 


### PR DESCRIPTION
Make `ExtUI::onLevelingStart` and `onLevelingDone` accessible for all leveling procedures, not just mesh leveling.