### PR TITLE
Added clarification to wrong environment error

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -72,7 +72,7 @@ if pioutil.is_pio_build():
         result = check_envs("env:"+build_env, board_envs, config)
 
         if not result:
-            err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
+            err = "Error: Build environment '%s' is incompatible with %s. Use one of these environments: %s" % \
                   ( build_env, motherboard, ", ".join([ e[4:] for e in board_envs if e.startswith("env:") ]) )
             raise SystemExit(err)
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

After seeing the following error
`Error: Build environment 'simulator_linux_release' is incompatible with BOARD_RAMPS_14_EFB. Use one of these: mega2560, mega1280` 
and not being clear as to if it meant to set the Motherboard or Environment values, the string has been amended to make the error clearer to understand at first glance.

The error string now reads the following
``Error: Build environment 'simulator_linux_release' is incompatible with BOARD_RAMPS_14_EFB. Use one of these environments: mega2560, mega1280``

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->
Ease of resolving an error for people less familiar with the system, this helps clarify the exact issues by removing some ambiguity

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
