### PR TITLE
🧑‍💻 Remove LOOP macros

### DIFF
--- a/Marlin/src/HAL/AVR/HAL_SPI.cpp
+++ b/Marlin/src/HAL/AVR/HAL_SPI.cpp
@@ -198,7 +198,7 @@ void spiBegin() {
     // output pin high - like sending 0xFF
     WRITE(SD_MOSI_PIN, HIGH);
 
-    LOOP_L_N(i, 8) {
+    for (uint8_t i = 0; i < 8; ++i) {
       WRITE(SD_SCK_PIN, HIGH);
 
       nop; // adjust so SCK is nice
@@ -225,7 +225,7 @@ void spiBegin() {
   void spiSend(uint8_t data) {
     // no interrupts during byte send - about 8µs
     cli();
-    LOOP_L_N(i, 8) {
+    for (uint8_t i = 0; i < 8; ++i) {
       WRITE(SD_SCK_PIN, LOW);
       WRITE(SD_MOSI_PIN, data & 0x80);
       data <<= 1;

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -132,7 +132,7 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
 
     DEBUG_ECHOLNPGM("f=", f);
     DEBUG_ECHOLNPGM("(prescaler loop)");
-    LOOP_L_N(i, COUNT(prescaler)) {                           // Loop through all prescaler values
+    for (uint8_t i = 0; i < COUNT(prescaler); ++i) {          // Loop through all prescaler values
       const uint32_t p = prescaler[i];                        // Extend to 32 bits for calculations
       DEBUG_ECHOLNPGM("prescaler[", i, "]=", p);
       uint16_t res_fast_temp, res_pc_temp;
@@ -232,7 +232,7 @@ void MarlinHAL::init_pwm_timers() {
     #endif
   };
 
-  LOOP_L_N(i, COUNT(pwm_pin))
+  for (uint8_t i = 0; i < COUNT(pwm_pin); ++i)
     set_pwm_frequency(pwm_pin[i], 1000);
 }
 

--- a/Marlin/src/HAL/AVR/pinsDebug.h
+++ b/Marlin/src/HAL/AVR/pinsDebug.h
@@ -77,12 +77,12 @@
 
 void PRINT_ARRAY_NAME(uint8_t x) {
   PGM_P const name_mem_pointer = (PGM_P)pgm_read_ptr(&pin_array[x].name);
-  LOOP_L_N(y, MAX_NAME_LENGTH) {
+  for (uint8_t y = 0; y < MAX_NAME_LENGTH; ++y) {
     char temp_char = pgm_read_byte(name_mem_pointer + y);
     if (temp_char != 0)
       SERIAL_CHAR(temp_char);
     else {
-      LOOP_L_N(i, MAX_NAME_LENGTH - y) SERIAL_CHAR(' ');
+      for (uint8_t i = 0; i < MAX_NAME_LENGTH - y; ++i) SERIAL_CHAR(' ');
       break;
     }
   }

--- a/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
+++ b/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
@@ -88,7 +88,7 @@ void u8g_spiSend_sw_AVR_mode_0(uint8_t val) {
   volatile uint8_t *outData = u8g_outData,
                    *outClock = u8g_outClock;
   U8G_ATOMIC_START();
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     if (val & 0x80)
       *outData |= bitData;
     else
@@ -108,7 +108,7 @@ void u8g_spiSend_sw_AVR_mode_3(uint8_t val) {
   volatile uint8_t *outData = u8g_outData,
                    *outClock = u8g_outClock;
   U8G_ATOMIC_START();
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     *outClock &= bitNotClock;
     if (val & 0x80)
       *outData |= bitData;

--- a/Marlin/src/HAL/DUE/dogm/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/DUE/dogm/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -81,7 +81,7 @@ Pio *SCK_pPio, *MOSI_pPio;
 uint32_t SCK_dwMask, MOSI_dwMask;
 
 void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     if (val & 0x80)
       MOSI_pPio->PIO_SODR = MOSI_dwMask;
     else
@@ -95,7 +95,7 @@ void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
 }
 
 void u8g_spiSend_sw_DUE_mode_3(uint8_t val) { // 3.5MHz
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     SCK_pPio->PIO_CODR = SCK_dwMask;
     DELAY_NS(50);
     if (val & 0x80)

--- a/Marlin/src/HAL/DUE/fastio/G2_PWM.h
+++ b/Marlin/src/HAL/DUE/fastio/G2_PWM.h
@@ -63,7 +63,7 @@ extern PWM_map ISR_table[NUM_PWMS];
 extern uint32_t motor_current_setting[3];
 
 #define IR_BIT(p) (WITHIN(p, 0, 3) ? (p) : (p) + 4)
-#define COPY_ACTIVE_TABLE() do{ LOOP_L_N(i, 6) work_table[i] = active_table[i]; }while(0)
+#define COPY_ACTIVE_TABLE() do{ for (uint8_t i = 0; i < 6; ++i) work_table[i] = active_table[i]; }while(0)
 
 #define PWM_MR0 19999         // base repetition rate minus one count - 20mS
 #define PWM_PR 24             // prescaler value - prescaler divide by 24 + 1  -  1 MHz output

--- a/Marlin/src/HAL/ESP32/i2s.cpp
+++ b/Marlin/src/HAL/ESP32/i2s.cpp
@@ -356,7 +356,7 @@ void i2s_push_sample() {
   // Every 4µs (when space in DMA buffer) toggle each expander PWM output using
   // the current duty cycle/frequency so they sync with any steps (once
   // through the DMA/FIFO buffers).  PWM signal inversion handled by other functions
-  LOOP_L_N(p, MAX_EXPANDER_BITS) {
+  for (uint8_t p = 0; p < MAX_EXPANDER_BITS; ++p) {
     if (hal.pwm_pin_data[p].pwm_duty_ticks > 0) { // pin has active pwm?
       if (hal.pwm_pin_data[p].pwm_tick_count == 0) {
         if (TEST32(i2s_port_data, p)) {  // hi->lo

--- a/Marlin/src/HAL/LPC1768/main.cpp
+++ b/Marlin/src/HAL/LPC1768/main.cpp
@@ -68,7 +68,7 @@ void MarlinHAL::init() {
     #endif
 
     // Flash status LED 3 times to indicate Marlin has started booting
-    LOOP_L_N(i, 6) {
+    for (uint8_t i = 0; i < 6; ++i) {
       TOGGLE(LED_PIN);
       delay(100);
     }

--- a/Marlin/src/HAL/LPC1768/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/LPC1768/tft/tft_spi.cpp
@@ -74,7 +74,7 @@ uint32_t TFT_SPI::ReadID(uint16_t Reg) {
     WRITE(TFT_CS_PIN, LOW);
     WriteReg(Reg);
 
-    LOOP_L_N(i, 4) {
+    for (uint8_t i = 0; i < 4; ++i) {
       SPIx.read((uint8_t*)&d, 1);
       data = (data << 8) | d;
     }

--- a/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -75,7 +75,7 @@
 
 uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       LPC176x::gpio_set(mosi_pin, !!(b & 0x80));
       LPC176x::gpio_set(sck_pin, HIGH);
@@ -85,16 +85,16 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(mosi_pin, state);
 
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         LPC176x::gpio_set(sck_pin, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && LPC176x::gpio_get(miso_pin)) b |= 1;
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(sck_pin, LOW);
     }
   }
@@ -104,7 +104,7 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
 
 uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       LPC176x::gpio_set(sck_pin, LOW);
@@ -113,13 +113,13 @@ uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck
       LPC176x::gpio_set(sck_pin, HIGH);
     }
     else {
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         LPC176x::gpio_set(sck_pin, LOW);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(mosi_pin, state);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         LPC176x::gpio_set(sck_pin, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
@@ -70,7 +70,7 @@
 #endif
 
 uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       WRITE_PIN(mosi_pin, !!(b & 0x80));
       WRITE_PIN(sck_pin, HIGH);
@@ -80,16 +80,16 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(mosi_pin, state);
 
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE_PIN(sck_pin, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(sck_pin, LOW);
     }
   }
@@ -99,7 +99,7 @@ uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck
 
 uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
 
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       WRITE_PIN(sck_pin, LOW);
@@ -108,13 +108,13 @@ uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck
       WRITE_PIN(sck_pin, HIGH);
     }
     else {
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE_PIN(sck_pin, LOW);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(mosi_pin, state);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE_PIN(sck_pin, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -650,10 +650,10 @@ void MarlinHAL::adc_init() {
   #if ADC_IS_REQUIRED
     memset(adc_results, 0xFF, sizeof(adc_results));                         // Fill result with invalid values
 
-    LOOP_L_N(pi, COUNT(adc_pins))
+    for (uint8_t pi = 0; pi < COUNT(adc_pins); ++pi)
       pinPeripheral(adc_pins[pi], PIO_ANALOG);
 
-    LOOP_S_LE_N(ai, FIRST_ADC, LAST_ADC) {
+    for (uint8_t ai = FIRST_ADC; ai <= LAST_ADC; ++ai) {
       Adc* adc = ((Adc*[])ADC_INSTS)[ai];
 
       // ADC clock setup
@@ -685,7 +685,7 @@ void MarlinHAL::adc_init() {
 
 void MarlinHAL::adc_start(const pin_t pin) {
   #if ADC_IS_REQUIRED
-    LOOP_L_N(pi, COUNT(adc_pins))
+    for (uint8_t pi = 0; pi < COUNT(adc_pins); ++pi)
       if (pin == adc_pins[pi]) { adc_result = adc_results[pi]; return; }
   #endif
 

--- a/Marlin/src/HAL/STM32/fastio.cpp
+++ b/Marlin/src/HAL/STM32/fastio.cpp
@@ -29,7 +29,7 @@
 GPIO_TypeDef* FastIOPortMap[LastPort + 1] = { 0 };
 
 void FastIO_init() {
-  LOOP_L_N(i, NUM_DIGITAL_PINS)
+  for (uint8_t i = 0; i < NUM_DIGITAL_PINS; ++i)
     FastIOPortMap[STM_PORT(digitalPin[i])] = get_GPIO_Port(STM_PORT(digitalPin[i]));
 }
 

--- a/Marlin/src/HAL/STM32/tft/gt911.cpp
+++ b/Marlin/src/HAL/STM32/tft/gt911.cpp
@@ -90,7 +90,7 @@ bool SW_IIC::read_ack() {
 }
 
 void SW_IIC::send_byte(uint8_t txd) {
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     write_sda(txd & 0x80); // write data bit
     txd <<= 1;
     iic_delay(1);
@@ -107,7 +107,7 @@ uint8_t SW_IIC::read_byte(bool ack) {
   uint8_t data = 0;
 
   set_sda_in();
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     write_scl(HIGH); // SCL = 1
     iic_delay(1);
     data <<= 1;
@@ -128,12 +128,12 @@ SW_IIC GT911::sw_iic = SW_IIC(GT911_SW_I2C_SDA_PIN, GT911_SW_I2C_SCL_PIN);
 void GT911::write_reg(uint16_t reg, uint8_t reg_len, uint8_t* w_data, uint8_t w_len) {
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address);  // Set IIC Slave address
-  LOOP_L_N(i, reg_len) {  // Set reg address
+  for (uint8_t i = 0; i < reg_len; ++i) {  // Set reg address
     uint8_t r = (reg >> (8 * (reg_len - 1 - i))) & 0xFF;
     sw_iic.send_byte(r);
   }
 
-  LOOP_L_N(i, w_len) {  // Write data to reg
+  for (uint8_t i = 0; i < w_len; ++i) {  // Write data to reg
     sw_iic.send_byte(w_data[i]);
   }
   sw_iic.stop();
@@ -142,7 +142,7 @@ void GT911::write_reg(uint16_t reg, uint8_t reg_len, uint8_t* w_data, uint8_t w_
 void GT911::read_reg(uint16_t reg, uint8_t reg_len, uint8_t* r_data, uint8_t r_len) {
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address);  // Set IIC Slave address
-  LOOP_L_N(i, reg_len) {  // Set reg address
+  for (uint8_t i = 0; i < reg_len; ++i) {  // Set reg address
     uint8_t r = (reg >> (8 * (reg_len - 1 - i))) & 0xFF;
     sw_iic.send_byte(r);
   }
@@ -150,7 +150,7 @@ void GT911::read_reg(uint16_t reg, uint8_t reg_len, uint8_t* r_data, uint8_t r_l
   sw_iic.start();
   sw_iic.send_byte(gt911_slave_address + 1);  // Set read mode
 
-  LOOP_L_N(i, r_len)
+  for (uint8_t i = 0; i < r_len; ++i)
     r_data[i] = sw_iic.read_byte(1);  // Read data from reg
 
   sw_iic.stop();

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -316,8 +316,8 @@ static constexpr struct { TimerPurpose p; int t; } timers_in_use[] = {
 };
 
 static constexpr bool verify_no_timer_conflicts() {
-  LOOP_L_N(i, COUNT(timers_in_use))
-    LOOP_S_L_N(j, i + 1, COUNT(timers_in_use))
+  for (uint8_t i = 0; i < COUNT(timers_in_use); ++i)
+    for (uint8_t j = i + 1; j < COUNT(timers_in_use); ++j)
       if (timers_in_use[i].t == timers_in_use[j].t) return false;
   return true;
 }

--- a/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
@@ -37,7 +37,7 @@
 static uint8_t SPI_speed = LCD_SPI_SPEED;
 
 static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin=-1) {
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     if (spi_speed == 0) {
       WRITE(DOGLCD_MOSI, !!(b & 0x80));
       WRITE(DOGLCD_SCK, HIGH);
@@ -47,16 +47,16 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
     }
     else {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_MOSI, state);
 
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE(DOGLCD_SCK, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && READ(miso_pin)) b |= 1;
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_SCK, LOW);
     }
   }
@@ -64,7 +64,7 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
 }
 
 static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin=-1) {
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0) {
       WRITE(DOGLCD_SCK, LOW);
@@ -73,13 +73,13 @@ static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, c
       WRITE(DOGLCD_SCK, HIGH);
     }
     else {
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for (uint8_t j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); ++j)
         WRITE(DOGLCD_SCK, LOW);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_MOSI, state);
 
-      LOOP_L_N(j, spi_speed)
+      for (uint8_t j = 0; j < spi_speed; ++j)
         WRITE(DOGLCD_SCK, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
@@ -101,7 +101,7 @@ uint32_t TFT_SPI::ReadID(uint16_t Reg) {
     DataTransferBegin(DATASIZE_8BIT);
     WriteReg(Reg);
 
-    LOOP_L_N(i, 4) {
+    for (uint8_t i = 0; i < 4; ++i) {
       uint8_t d;
       SPIx.read(&d, 1);
       data = (data << 8) | d;

--- a/Marlin/src/HAL/shared/servo.cpp
+++ b/Marlin/src/HAL/shared/servo.cpp
@@ -67,7 +67,7 @@ uint8_t ServoCount = 0;                         // the total number of attached 
 
 static bool anyTimerChannelActive(const timer16_Sequence_t timer) {
   // returns true if any servo is active on this timer
-  LOOP_L_N(channel, SERVOS_PER_TIMER) {
+  for (uint8_t channel = 0; channel < SERVOS_PER_TIMER; ++channel) {
     if (SERVO(timer, channel).Pin.isActive)
       return true;
   }

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -321,7 +321,7 @@ bool pin_is_protected(const pin_t pin) {
     static constexpr size_t pincount = OnlyPins<SENSITIVE_PINS>::size;
     static const pin_t (&sensitive_pins)[pincount] PROGMEM = OnlyPins<SENSITIVE_PINS>::table;
   #endif
-  LOOP_L_N(i, pincount) {
+  for (uint8_t i = 0; i < pincount; ++i) {
     const pin_t * const pptr = &sensitive_pins[i];
     if (pin == (sizeof(pin_t) == 2 ? (pin_t)pgm_read_word(pptr) : (pin_t)pgm_read_byte(pptr))) return true;
   }
@@ -800,7 +800,7 @@ void idle(const bool no_stepper_sleep/*=false*/) {
   // Run StallGuard endstop checks
   #if ENABLED(SPI_ENDSTOPS)
     if (endstops.tmc_spi_homing.any && TERN1(IMPROVE_HOMING_RELIABILITY, ELAPSED(millis(), sg_guard_period)))
-      LOOP_L_N(i, 4) if (endstops.tmc_spi_homing_check()) break; // Read SGT 4 times per idle loop
+      for (uint8_t i = 0; i < 4; ++i) if (endstops.tmc_spi_homing_check()) break; // Read SGT 4 times per idle loop
   #endif
 
   // Handle SD Card insert / remove

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -330,11 +330,6 @@
 #define _JOIN_1(O)         (O)
 #define JOIN_N(N,C,V...)   (DO(JOIN,C,LIST_N(N,V)))
 
-#define LOOP_S_LE_N(VAR, S, N) for (uint8_t VAR=(S); VAR<=(N); VAR++)
-#define LOOP_S_L_N(VAR, S, N) for (uint8_t VAR=(S); VAR<(N); VAR++)
-#define LOOP_LE_N(VAR, N) LOOP_S_LE_N(VAR, 0, N)
-#define LOOP_L_N(VAR, N) LOOP_S_L_N(VAR, 0, N)
-
 #define NOOP (void(0))
 
 #define CEILING(x,y) (((x) + (y) - 1) / (y))

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -234,7 +234,7 @@ struct SerialBase {
 
     // Round correctly so that print(1.999, 2) prints as "2.00"
     double rounding = 0.5;
-    LOOP_L_N(i, digits) rounding *= 0.1;
+    for (uint8_t i = 0; i < digits; ++i) rounding *= 0.1;
     number += rounding;
 
     // Extract the integer part of the number and print it

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -246,11 +246,11 @@ enum AxisEnum : uint8_t {
 //
 // Loop over axes
 //
-#define LOOP_ABC(VAR) LOOP_S_LE_N(VAR, A_AXIS, C_AXIS)
-#define LOOP_NUM_AXES(VAR) LOOP_S_L_N(VAR, 0, NUM_AXES)
-#define LOOP_LOGICAL_AXES(VAR) LOOP_S_L_N(VAR, 0, LOGICAL_AXES)
-#define LOOP_DISTINCT_AXES(VAR) LOOP_S_L_N(VAR, 0, DISTINCT_AXES)
-#define LOOP_DISTINCT_E(VAR) LOOP_L_N(VAR, DISTINCT_E)
+#define LOOP_ABC(VAR) for (uint8_t VAR = A_AXIS; VAR <= C_AXIS; ++VAR)
+#define LOOP_NUM_AXES(VAR) for (uint8_t VAR = 0; VAR < NUM_AXES; ++VAR)
+#define LOOP_LOGICAL_AXES(VAR) for (uint8_t VAR = 0; VAR < LOGICAL_AXES; ++VAR)
+#define LOOP_DISTINCT_AXES(VAR) for (uint8_t VAR = 0; VAR < DISTINCT_AXES; ++VAR)
+#define LOOP_DISTINCT_E(VAR) for (uint8_t VAR = 0; VAR < DISTINCT_E; ++VAR)
 
 //
 // feedRate_t is just a humble float

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -95,7 +95,7 @@ public:
   // apply accumulated babysteps to the axes.
   //
   static void task() {
-    LOOP_LE_N(i, BS_AXIS_IND(Z_AXIS)) step_axis(BS_AXIS(i));
+    for (uint8_t i = 0; i <= BS_AXIS_IND(Z_AXIS); ++i) step_axis(BS_AXIS(i));
   }
 
 private:

--- a/Marlin/src/feature/bedlevel/abl/bbl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/bbl.cpp
@@ -133,8 +133,8 @@ void LevelingBilinear::extrapolate_unprobed_bed_level() {
                       yend = ctry1;
   #endif
 
-  LOOP_LE_N(xo, xend)
-    LOOP_LE_N(yo, yend) {
+  for (uint8_t xo = 0; xo <= xend; ++xo)
+    for (uint8_t yo = 0; yo <= yend; ++yo) {
       uint8_t x2 = ctrx2 + xo, y2 = ctry2 + yo;
       #ifndef HALF_IN_X
         const uint8_t x1 = ctrx1 - xo;
@@ -231,8 +231,8 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
 
   float LevelingBilinear::virt_2cmr(const uint8_t x, const uint8_t y, const_float_t tx, const_float_t ty) {
     float row[4], column[4];
-    LOOP_L_N(i, 4) {
-      LOOP_L_N(j, 4) {
+    for (uint8_t i = 0; i < 4; ++i) {
+      for (uint8_t j = 0; j < 4; ++j) {
         column[j] = virt_coord(i + x - 1, j + y - 1);
       }
       row[i] = virt_cmr(column, 1, ty);
@@ -243,10 +243,10 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
   void LevelingBilinear::subdivide_mesh() {
     grid_spacing_virt = grid_spacing / (BILINEAR_SUBDIVISIONS);
     grid_factor_virt = grid_spacing_virt.reciprocal();
-    LOOP_L_N(y, GRID_MAX_POINTS_Y)
-      LOOP_L_N(x, GRID_MAX_POINTS_X)
-        LOOP_L_N(ty, BILINEAR_SUBDIVISIONS)
-          LOOP_L_N(tx, BILINEAR_SUBDIVISIONS) {
+    for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; ++y)
+      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; ++x)
+        for (uint8_t ty = 0; ty < BILINEAR_SUBDIVISIONS; ++ty)
+          for (uint8_t tx = 0; tx < BILINEAR_SUBDIVISIONS; ++tx) {
             if ((ty && y == (GRID_MAX_POINTS_Y) - 1) || (tx && x == (GRID_MAX_POINTS_X) - 1))
               continue;
             z_values_virt[x * (BILINEAR_SUBDIVISIONS) + tx][y * (BILINEAR_SUBDIVISIONS) + ty] =

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -137,7 +137,7 @@ void reset_bed_level() {
    */
   void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, const float *values) {
     #ifndef SCAD_MESH_OUTPUT
-      LOOP_L_N(x, sx) {
+      for (uint8_t x = 0; x < sx; ++x) {
         serial_spaces(precision + (x < 10 ? 3 : 2));
         SERIAL_ECHO(x);
       }
@@ -146,14 +146,14 @@ void reset_bed_level() {
     #ifdef SCAD_MESH_OUTPUT
       SERIAL_ECHOLNPGM("measured_z = ["); // open 2D array
     #endif
-    LOOP_L_N(y, sy) {
+    for (uint8_t y = 0; y < sy; ++y) {
       #ifdef SCAD_MESH_OUTPUT
         SERIAL_ECHOPGM(" [");             // open sub-array
       #else
         if (y < 10) SERIAL_CHAR(' ');
         SERIAL_ECHO(y);
       #endif
-      LOOP_L_N(x, sx) {
+      for (uint8_t x = 0; x < sx; ++x) {
         SERIAL_CHAR(' ');
         const float offset = values[x * sy + y];
         if (!isnan(offset)) {
@@ -166,7 +166,7 @@ void reset_bed_level() {
               SERIAL_CHAR(' ');
             SERIAL_ECHOPGM("NAN");
           #else
-            LOOP_L_N(i, precision + 3)
+            for (uint8_t i = 0; i < precision + 3; ++i)
               SERIAL_CHAR(i ? '=' : ' ');
           #endif
         }

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -40,9 +40,9 @@
         mesh_bed_leveling::index_to_ypos[GRID_MAX_POINTS_Y];
 
   mesh_bed_leveling::mesh_bed_leveling() {
-    LOOP_L_N(i, GRID_MAX_POINTS_X)
+    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i)
       index_to_xpos[i] = MESH_MIN_X + i * (MESH_X_DIST);
-    LOOP_L_N(i, GRID_MAX_POINTS_Y)
+    for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; ++i)
       index_to_ypos[i] = MESH_MIN_Y + i * (MESH_Y_DIST);
     reset();
   }

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -149,7 +149,7 @@ static void serial_echo_xy(const uint8_t sp, const int16_t x, const int16_t y) {
 
 static void serial_echo_column_labels(const uint8_t sp) {
   SERIAL_ECHO_SP(7);
-  LOOP_L_N(i, GRID_MAX_POINTS_X) {
+  for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
     if (i < 10) SERIAL_CHAR(' ');
     SERIAL_ECHO(i);
     SERIAL_ECHO_SP(sp);
@@ -199,7 +199,7 @@ void unified_bed_leveling::display_map(const uint8_t map_type) {
     }
 
     // Row Values (I indexes)
-    LOOP_L_N(i, GRID_MAX_POINTS_X) {
+    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
 
       // Opening Brace or Space
       const bool is_current = i == curr.x && j == curr.y;

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -396,7 +396,7 @@ void unified_bed_leveling::G29() {
         break;
 
       case 1:
-        LOOP_L_N(x, GRID_MAX_POINTS_X) {                     // Create a diagonal line several Mesh cells thick that is raised
+        for (uint8_t x = 0; x < GRID_MAX_POINTS_X; ++x) {                     // Create a diagonal line several Mesh cells thick that is raised
           const uint8_t x2 = x + (x < (GRID_MAX_POINTS_Y) - 1 ? 1 : -1);
           z_values[x][x] += 9.999f;
           z_values[x][x2] += 9.999f; // We want the altered line several mesh points thick
@@ -1445,7 +1445,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     info3 PROGMEM = { (GRID_MAX_POINTS_X) - 1, 0, 0, GRID_MAX_POINTS_Y,       true  };  // Right side of the mesh looking left
   static const smart_fill_info * const info[] PROGMEM = { &info0, &info1, &info2, &info3 };
 
-  LOOP_L_N(i, COUNT(info)) {
+  for (uint8_t i = 0; i < COUNT(info); ++i) {
     const smart_fill_info *f = (smart_fill_info*)pgm_read_ptr(&info[i]);
     const int8_t sx = pgm_read_byte(&f->sx), sy = pgm_read_byte(&f->sy),
                  ex = pgm_read_byte(&f->ex), ey = pgm_read_byte(&f->ey);
@@ -1484,7 +1484,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 
       #if ENABLED(UBL_TILT_ON_MESH_POINTS_3POINT)
         mesh_index_pair cpos[3];
-        LOOP_L_N(ix, 3) { // Convert points to coordinates of mesh points
+        for (uint8_t ix = 0; ix < 3; ++ix) { // Convert points to coordinates of mesh points
           cpos[ix] = find_closest_mesh_point_of_type(REAL, points[ix], true);
           points[ix] = cpos[ix].meshpos();
         }
@@ -1494,7 +1494,7 @@ void unified_bed_leveling::smart_fill_mesh() {
         float gotz[3];  // Used for algorithm validation below
       #endif
 
-      LOOP_L_N(i, 3) {
+      for (uint8_t i = 0; i < 3; ++i) {
         SERIAL_ECHOLNPGM("Tilting mesh (", i + 1, "/3)");
         TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), GET_TEXT(MSG_LCD_TILTING_MESH), i + 1));
 
@@ -1534,10 +1534,10 @@ void unified_bed_leveling::smart_fill_mesh() {
       const uint16_t total_points = sq(param.J_grid_size);
       uint16_t point_num = 1;
 
-      LOOP_L_N(ix, param.J_grid_size) {
+      for (uint8_t ix = 0; ix < param.J_grid_size; ++ix) {
         xy_pos_t rpos;
         rpos.x = x_min + ix * dx;
-        LOOP_L_N(iy, param.J_grid_size) {
+        for (uint8_t iy = 0; iy < param.J_grid_size; ++iy) {
           rpos.y = y_min + dy * (zig_zag ? param.J_grid_size - 1 - iy : iy);
 
           #if ENABLED(UBL_TILT_ON_MESH_POINTS)
@@ -1714,17 +1714,17 @@ void unified_bed_leveling::smart_fill_mesh() {
     GRID_LOOP(jx, jy) if (!isnan(z_values[jx][jy])) SBI(bitmap[jx], jy);
 
     xy_pos_t ppos;
-    LOOP_L_N(ix, GRID_MAX_POINTS_X) {
+    for (uint8_t ix = 0; ix < GRID_MAX_POINTS_X; ++ix) {
       ppos.x = get_mesh_x(ix);
-      LOOP_L_N(iy, GRID_MAX_POINTS_Y) {
+      for (uint8_t iy = 0; iy < GRID_MAX_POINTS_Y; ++iy) {
         ppos.y = get_mesh_y(iy);
         if (isnan(z_values[ix][iy])) {
           // undefined mesh point at (ppos.x,ppos.y), compute weighted LSF from original valid mesh points.
           incremental_LSF_reset(&lsf_results);
           xy_pos_t rpos;
-          LOOP_L_N(jx, GRID_MAX_POINTS_X) {
+          for (uint8_t jx = 0; jx < GRID_MAX_POINTS_X; ++jx) {
             rpos.x = get_mesh_x(jx);
-            LOOP_L_N(jy, GRID_MAX_POINTS_Y) {
+            for (uint8_t jy = 0; jy < GRID_MAX_POINTS_Y; ++jy) {
               if (TEST(bitmap[jx], jy)) {
                 rpos.y = get_mesh_y(jy);
                 const float rz = z_values[jx][jy],
@@ -1784,7 +1784,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     SERIAL_ECHOLNPGM("MESH_Y_DIST  ", MESH_Y_DIST);                         serial_delay(50);
 
     SERIAL_ECHOPGM("X-Axis Mesh Points at: ");
-    LOOP_L_N(i, GRID_MAX_POINTS_X) {
+    for (uint8_t i = 0; i < GRID_MAX_POINTS_X; ++i) {
       SERIAL_ECHO_F(LOGICAL_X_POSITION(get_mesh_x(i)), 3);
       SERIAL_ECHOPGM("  ");
       serial_delay(25);
@@ -1792,7 +1792,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     SERIAL_EOL();
 
     SERIAL_ECHOPGM("Y-Axis Mesh Points at: ");
-    LOOP_L_N(i, GRID_MAX_POINTS_Y) {
+    for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; ++i) {
       SERIAL_ECHO_F(LOGICAL_Y_POSITION(get_mesh_y(i)), 3);
       SERIAL_ECHOPGM("  ");
       serial_delay(25);

--- a/Marlin/src/feature/digipot/digipot_mcp4018.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4018.cpp
@@ -89,7 +89,7 @@ void DigipotI2C::set_current(const uint8_t channel, const float current) {
 }
 
 void DigipotI2C::init() {
-  LOOP_L_N(i, DIGIPOT_I2C_NUM_CHANNELS) pots[i].i2c_init();
+  for (uint8_t i = 0; i < DIGIPOT_I2C_NUM_CHANNELS; ++i) pots[i].i2c_init();
 
   // Init currents according to Configuration_adv.h
   static const float digipot_motor_current[] PROGMEM =
@@ -99,7 +99,7 @@ void DigipotI2C::init() {
       DIGIPOT_I2C_MOTOR_CURRENTS
     #endif
   ;
-  LOOP_L_N(i, COUNT(digipot_motor_current))
+  for (uint8_t i = 0; i < COUNT(digipot_motor_current); ++i)
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 

--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -94,7 +94,7 @@ void DigipotI2C::init() {
       DIGIPOT_I2C_MOTOR_CURRENTS
     #endif
   ;
-  LOOP_L_N(i, COUNT(digipot_motor_current))
+  for (uint8_t i = 0; i < COUNT(digipot_motor_current); ++i)
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 

--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -138,7 +138,7 @@ void I2CPositionEncoder::update() {
       errIdx = (errIdx >= I2CPE_ERR_ARRAY_SIZE - 1) ? 0 : errIdx + 1;
       err[errIdx] = get_axis_error_steps(false);
 
-      LOOP_L_N(i, I2CPE_ERR_ARRAY_SIZE) {
+      for (uint8_t i = 0; i < I2CPE_ERR_ARRAY_SIZE; ++i) {
         sum += err[i];
         if (i) diffSum += ABS(err[i-1] - err[i]);
       }
@@ -170,7 +170,7 @@ void I2CPositionEncoder::update() {
           errPrst[errPrstIdx++] = error; // Error must persist for I2CPE_ERR_PRST_ARRAY_SIZE error cycles. This also serves to improve the average accuracy
           if (errPrstIdx >= I2CPE_ERR_PRST_ARRAY_SIZE) {
             float sumP = 0;
-            LOOP_L_N(i, I2CPE_ERR_PRST_ARRAY_SIZE) sumP += errPrst[i];
+            for (uint8_t i = 0; i < I2CPE_ERR_PRST_ARRAY_SIZE; ++i) sumP += errPrst[i];
             const int32_t errorP = int32_t(sumP * RECIPROCAL(I2CPE_ERR_PRST_ARRAY_SIZE));
             SERIAL_CHAR(AXIS_CHAR(encoderAxis));
             SERIAL_ECHOLNPGM(" : CORRECT ERR ", errorP * planner.mm_per_step[encoderAxis], "mm");
@@ -404,7 +404,7 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
   planner.synchronize();
 
-  LOOP_L_N(i, iter) {
+  for (uint8_t i = 0; i < iter; ++i) {
     TERN_(HAS_EXTRUDERS, startCoord.e = planner.get_axis_position_mm(E_AXIS));
     planner.buffer_line(startCoord, fr_mm_s, 0);
     planner.synchronize();

--- a/Marlin/src/feature/encoder_i2c.h
+++ b/Marlin/src/feature/encoder_i2c.h
@@ -90,7 +90,7 @@
 #define I2CPE_PARSE_ERR               1
 #define I2CPE_PARSE_OK                0
 
-#define LOOP_PE(VAR) LOOP_L_N(VAR, I2CPE_ENCODER_CNT)
+#define LOOP_PE(VAR) for (uint8_t VAR = 0; VAR < I2CPE_ENCODER_CNT; ++VAR)
 #define CHECK_IDX() do{ if (!WITHIN(idx, 0, I2CPE_ENCODER_CNT - 1)) return; }while(0)
 
 typedef union {

--- a/Marlin/src/feature/fancheck.cpp
+++ b/Marlin/src/feature/fancheck.cpp
@@ -72,7 +72,7 @@ void FanCheck::update_tachometers() {
   bool status;
 
   #define _TACHO_CASE(N) case N: status = READ(E##N##_FAN_TACHO_PIN); break;
-  LOOP_L_N(f, TACHO_COUNT) {
+  for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
     switch (f) {
       #if HAS_E0_FAN_TACHO
         _TACHO_CASE(0)
@@ -113,7 +113,7 @@ void FanCheck::compute_speed(uint16_t elapsedTime) {
   static uint8_t fan_reported_errors_msk = 0;
 
   uint8_t fan_error_msk = 0;
-  LOOP_L_N(f, TACHO_COUNT) {
+  for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
     switch (f) {
       TERN_(HAS_E0_FAN_TACHO, case 0:)
       TERN_(HAS_E1_FAN_TACHO, case 1:)
@@ -150,7 +150,7 @@ void FanCheck::compute_speed(uint16_t elapsedTime) {
 
   if (fan_error_msk & ~fan_reported_errors_msk) {
     // Handle new faults only
-    LOOP_L_N(f, TACHO_COUNT) if (TEST(fan_error_msk, f)) report_speed_error(f);
+    for (uint8_t f = 0; f < TACHO_COUNT; ++f) if (TEST(fan_error_msk, f)) report_speed_error(f);
   }
   fan_reported_errors_msk = fan_error_msk;
 }
@@ -176,8 +176,8 @@ void FanCheck::report_speed_error(uint8_t fan) {
 }
 
 void FanCheck::print_fan_states() {
-  LOOP_L_N(s, 2) {
-    LOOP_L_N(f, TACHO_COUNT) {
+  for (uint8_t s = 0; s < 2; ++s) {
+    for (uint8_t f = 0; f < TACHO_COUNT; ++f) {
       switch (f) {
         TERN_(HAS_E0_FAN_TACHO, case 0:)
         TERN_(HAS_E1_FAN_TACHO, case 1:)

--- a/Marlin/src/feature/filwidth.cpp
+++ b/Marlin/src/feature/filwidth.cpp
@@ -42,7 +42,7 @@ int8_t FilamentWidthSensor::ratios[MAX_MEASUREMENT_DELAY + 1],          // Ring 
 
 void FilamentWidthSensor::init() {
   const int8_t ratio = sample_to_size_ratio();
-  LOOP_L_N(i, COUNT(ratios)) ratios[i] = ratio;
+  for (uint8_t i = 0; i < COUNT(ratios); ++i) ratios[i] = ratio;
   index_r = index_w = 0;
 }
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -76,8 +76,8 @@ void LEDLights::setup() {
         #endif
         delay(200);
 
-        LOOP_L_N(i, led_pin_count) {
-          LOOP_LE_N(b, 200) {
+        for (uint8_t i = 0; i < led_pin_count; ++i) {
+          for (uint8_t b = 0; b <= 200; ++b) {
             const uint16_t led_pwm = b <= 100 ? b : 200 - b;
             if (i == 0 && PWM_PIN(RGB_LED_R_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_R_PIN), led_pwm); else WRITE(RGB_LED_R_PIN, b < 100 ? HIGH : LOW);
             if (i == 1 && PWM_PIN(RGB_LED_G_PIN)) hal.set_pwm_duty(pin_t(RGB_LED_G_PIN), led_pwm); else WRITE(RGB_LED_G_PIN, b < 100 ? HIGH : LOW);
@@ -118,7 +118,7 @@ void LEDLights::setup() {
     while (led_pin_counters[0] != 99 || !canEnd) {
       if (led_pin_counters[0] == 99)        // End loop next time pin0 counter is 99
         canEnd = true;
-      LOOP_L_N(i, led_pin_count) {
+      for (uint8_t i = 0; i < led_pin_count; ++i) {
         if (led_pin_counters[i] > 0) {
           if (++led_pin_counters[i] == 400) // turn off current pin counter in led_pin_counters
             led_pin_counters[i] = 0;
@@ -140,7 +140,7 @@ void LEDLights::setup() {
     }
 
     // Fade to white
-    LOOP_LE_N(led_pwm, 100) {
+    for (uint8_t led_pwm = 0; led_pwm <= 100; ++led_pwm) {
       NOLESS(curColor.r, led_pwm);
       NOLESS(curColor.g, led_pwm);
       NOLESS(curColor.b, led_pwm);

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -156,7 +156,7 @@ void Max7219::error(FSTR_P const func, const int32_t v1, const int32_t v2/*=-1*/
  */
 inline uint32_t flipped(const uint32_t bits, const uint8_t n_bytes) {
   uint32_t mask = 1, outbits = 0;
-  LOOP_L_N(b, n_bytes * 8) {
+  for (uint8_t b = 0; b < n_bytes * 8; ++b) {
     outbits <<= 1;
     if (bits & mask) outbits |= 1;
     mask <<= 1;
@@ -339,13 +339,13 @@ void Max7219::fill() {
 
 void Max7219::clear_row(const uint8_t row) {
   if (row >= MAX7219_Y_LEDS) return error(F("clear_row"), row);
-  LOOP_L_N(x, MAX7219_X_LEDS) CLR_7219(x, row);
+  for (uint8_t x = 0; x < MAX7219_X_LEDS; ++x) CLR_7219(x, row);
   send_row(row);
 }
 
 void Max7219::clear_column(const uint8_t col) {
   if (col >= MAX7219_X_LEDS) return error(F("set_column"), col);
-  LOOP_L_N(y, MAX7219_Y_LEDS) CLR_7219(col, y);
+  for (uint8_t y = 0; y < MAX7219_Y_LEDS; ++y) CLR_7219(col, y);
   send_column(col);
 }
 
@@ -357,7 +357,7 @@ void Max7219::clear_column(const uint8_t col) {
 void Max7219::set_row(const uint8_t row, const uint32_t val) {
   if (row >= MAX7219_Y_LEDS) return error(F("set_row"), row);
   uint32_t mask = _BV32(MAX7219_X_LEDS - 1);
-  LOOP_L_N(x, MAX7219_X_LEDS) {
+  for (uint8_t x = 0; x < MAX7219_X_LEDS; ++x) {
     if (val & mask) SET_7219(x, row); else CLR_7219(x, row);
     mask >>= 1;
   }
@@ -372,7 +372,7 @@ void Max7219::set_row(const uint8_t row, const uint32_t val) {
 void Max7219::set_column(const uint8_t col, const uint32_t val) {
   if (col >= MAX7219_X_LEDS) return error(F("set_column"), col);
   uint32_t mask = _BV32(MAX7219_Y_LEDS - 1);
-  LOOP_L_N(y, MAX7219_Y_LEDS) {
+  for (uint8_t y = 0; y < MAX7219_Y_LEDS; ++y) {
     if (val & mask) SET_7219(col, y); else CLR_7219(col, y);
     mask >>= 1;
   }
@@ -437,23 +437,23 @@ void Max7219::set_columns_32bits(const uint8_t x, uint32_t val) {
 
 // Initialize the Max7219
 void Max7219::register_setup() {
-  LOOP_L_N(i, MAX7219_NUMBER_UNITS)
+  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_scanLimit, 0x07);
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  LOOP_L_N(i, MAX7219_NUMBER_UNITS)
+  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_decodeMode, 0x00);       // Using an led matrix (not digits)
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  LOOP_L_N(i, MAX7219_NUMBER_UNITS)
+  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_shutdown, 0x01);         // Not in shutdown mode
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  LOOP_L_N(i, MAX7219_NUMBER_UNITS)
+  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_displayTest, 0x00);      // No display test
   pulse_load();                               // Tell the chips to load the clocked out data
 
-  LOOP_L_N(i, MAX7219_NUMBER_UNITS)
+  for (uint8_t i = 0; i < MAX7219_NUMBER_UNITS; ++i)
     send(max7219_reg_intensity, 0x01 & 0x0F); // The first 0x0F is the value you can set
                                               // Range: 0x00 to 0x0F
   pulse_load();                               // Tell the chips to load the clocked out data
@@ -740,7 +740,7 @@ void Max7219::idle_tasks() {
   // batch line updates
   suspended--;
   if (!suspended)
-    LOOP_L_N(i, 8) if (row_change_mask & _BV(i))
+    for (uint8_t i = 0; i < 8; ++i) if (row_change_mask & _BV(i))
       refresh_line(i);
 
   // After resume() automatically do a refresh()

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -94,13 +94,13 @@ void Mixer::normalize(const uint8_t tool_index) {
 void Mixer::reset_vtools() {
   // Virtual Tools 0, 1, 2, 3 = Filament 1, 2, 3, 4, etc.
   // Every virtual tool gets a pure filament
-  LOOP_L_N(t, _MIN(MIXING_VIRTUAL_TOOLS, MIXING_STEPPERS))
+  for (uint8_t t = 0; t < _MIN(MIXING_VIRTUAL_TOOLS, MIXING_STEPPERS); ++t)
     MIXER_STEPPER_LOOP(i)
       color[t][i] = (t == i) ? COLOR_A_MASK : 0;
 
   // Remaining virtual tools are 100% filament 1
   #if MIXING_VIRTUAL_TOOLS > MIXING_STEPPERS
-    LOOP_S_L_N(t, MIXING_STEPPERS, MIXING_VIRTUAL_TOOLS)
+    for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; ++t)
       MIXER_STEPPER_LOOP(i)
         color[t][i] = (i == 0) ? COLOR_A_MASK : 0;
   #endif

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -403,7 +403,7 @@ void MMU2::tx_str(FSTR_P fstr) {
 void MMU2::tx_printf(FSTR_P format, int argument = -1) {
   clear_rx_buffer();
   const uint8_t len = sprintf_P(tx_buffer, FTOP(format), argument);
-  LOOP_L_N(i, len) MMU2_SERIAL.write(tx_buffer[i]);
+  for (uint8_t i = 0; i < len; ++i) MMU2_SERIAL.write(tx_buffer[i]);
   prev_request = millis();
 }
 
@@ -413,7 +413,7 @@ void MMU2::tx_printf(FSTR_P format, int argument = -1) {
 void MMU2::tx_printf(FSTR_P format, int argument1, int argument2) {
   clear_rx_buffer();
   const uint8_t len = sprintf_P(tx_buffer, FTOP(format), argument1, argument2);
-  LOOP_L_N(i, len) MMU2_SERIAL.write(tx_buffer[i]);
+  for (uint8_t i = 0; i < len; ++i) MMU2_SERIAL.write(tx_buffer[i]);
   prev_request = millis();
 }
 
@@ -467,7 +467,7 @@ inline void beep_bad_cmd() { BUZZ(400, 40); }
   bool MMU2::load_to_gears() {
     command(MMU_CMD_C0);
     manage_response(true, true);
-    LOOP_L_N(i, MMU2_C0_RETRY) {  // Keep loading until filament reaches gears
+    for (uint8_t i = 0; i < MMU2_C0_RETRY; ++i) {  // Keep loading until filament reaches gears
       if (mmu2s_triggered) break;
       command(MMU_CMD_C0);
       manage_response(true, true);
@@ -900,7 +900,7 @@ void MMU2::filament_runout() {
     int filament_detected_count = 0;
     const int steps = (MMU2_CAN_LOAD_RETRACT) / (MMU2_CAN_LOAD_INCREMENT);
     DEBUG_ECHOLNPGM("MMU can_load:");
-    LOOP_L_N(i, steps) {
+    for (uint8_t i = 0; i < steps; ++i) {
       execute_extruder_sequence(can_load_increment_sequence, COUNT(can_load_increment_sequence));
       check_filament(); // Don't trust the idle function
       DEBUG_CHAR(mmu2s_triggered ? 'O' : 'o');
@@ -1047,7 +1047,7 @@ void MMU2::execute_extruder_sequence(const E_Step * sequence, int steps) {
 
   const E_Step *step = sequence;
 
-  LOOP_L_N(i, steps) {
+  for (uint8_t i = 0; i < steps; ++i) {
     const float es = pgm_read_float(&(step->extrude));
     const feedRate_t fr_mm_m = pgm_read_float(&(step->feedRate));
     DEBUG_ECHO_MSG("E step ", es, "/", fr_mm_m);

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -630,7 +630,7 @@ void PrintJobRecovery::resume() {
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
           DEBUG_ECHOLNPGM("repeat index: ", info.stored_repeat.index);
-          LOOP_L_N(i, info.stored_repeat.index)
+          for (uint8_t i = 0; i < info.stored_repeat.index; ++i)
             DEBUG_ECHOLNPGM("..... sdpos: ", info.stored_repeat.marker.sdpos, " count: ", info.stored_repeat.marker.counter);
         #endif
 

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -66,13 +66,13 @@ float ProbeTempComp::init_measurement; // = 0.0
 bool ProbeTempComp::enabled = true;
 
 void ProbeTempComp::reset() {
-  TERN_(PTC_PROBE, LOOP_L_N(i, PTC_PROBE_COUNT) z_offsets_probe[i] = z_offsets_probe_default[i]);
-  TERN_(PTC_BED, LOOP_L_N(i, PTC_BED_COUNT) z_offsets_bed[i] = z_offsets_bed_default[i]);
-  TERN_(PTC_HOTEND, LOOP_L_N(i, PTC_HOTEND_COUNT) z_offsets_hotend[i] = z_offsets_hotend_default[i]);
+  TERN_(PTC_PROBE, for (uint8_t i = 0; i < PTC_PROBE_COUNT; ++i) z_offsets_probe[i] = z_offsets_probe_default[i]);
+  TERN_(PTC_BED, for (uint8_t i = 0; i < PTC_BED_COUNT; ++i) z_offsets_bed[i] = z_offsets_bed_default[i]);
+  TERN_(PTC_HOTEND, for (uint8_t i = 0; i < PTC_HOTEND_COUNT; ++i) z_offsets_hotend[i] = z_offsets_hotend_default[i]);
 }
 
 void ProbeTempComp::clear_offsets(const TempSensorID tsi) {
-  LOOP_L_N(i, cali_info[tsi].measurements)
+  for (uint8_t i = 0; i < cali_info[tsi].measurements; ++i)
     sensor_z_offsets[tsi][i] = 0;
   calib_idx = 0;
 }
@@ -84,7 +84,7 @@ bool ProbeTempComp::set_offset(const TempSensorID tsi, const uint8_t idx, const 
 }
 
 void ProbeTempComp::print_offsets() {
-  LOOP_L_N(s, TSI_COUNT) {
+  for (uint8_t s = 0; s < TSI_COUNT; ++s) {
     celsius_t temp = cali_info[s].start_temp;
     for (int16_t i = -1; i < cali_info[s].measurements; ++i) {
       SERIAL_ECHOF(
@@ -232,7 +232,7 @@ bool ProbeTempComp::linear_regression(const TempSensorID tsi, float &k, float &d
         sum_xy = 0, sum_y = 0;
 
   float xi = static_cast<float>(start_temp);
-  LOOP_L_N(i, calib_idx) {
+  for (uint8_t i = 0; i < calib_idx; ++i) {
     const float yi = static_cast<float>(data[i]);
     xi += res_temp;
     sum_x += xi;

--- a/Marlin/src/feature/repeat.cpp
+++ b/Marlin/src/feature/repeat.cpp
@@ -66,7 +66,7 @@ void Repeat::loop() {
   }
 }
 
-void Repeat::cancel() { LOOP_L_N(i, index) marker[i].counter = 0; }
+void Repeat::cancel() { for (uint8_t i = 0; i < index; ++i) marker[i].counter = 0; }
 
 void Repeat::early_parse_M808(char * const cmd) {
   if (is_command_M808(cmd)) {

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -40,7 +40,7 @@ private:
 public:
   static void reset() { index = 0; }
   static bool is_active() {
-    LOOP_L_N(i, index) if (marker[i].counter) return true;
+    for (uint8_t i = 0; i < index; ++i) if (marker[i].counter) return true;
     return false;
   }
   static bool is_command_M808(char * const cmd) { return cmd[0] == 'M' && cmd[1] == '8' && cmd[2] == '0' && cmd[3] == '8' && !NUMERIC(cmd[4]); }

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -155,7 +155,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
         #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
           if (runout_flags) {
             SERIAL_ECHOPGM("Runout Sensors: ");
-            LOOP_L_N(i, 8) SERIAL_ECHO('0' + TEST(runout_flags, i));
+            for (uint8_t i = 0; i < 8; ++i) SERIAL_ECHO('0' + TEST(runout_flags, i));
             SERIAL_ECHOPGM(" -> ", extruder);
             if (ran_out) SERIAL_ECHOPGM(" RUN OUT");
             SERIAL_EOL();
@@ -255,7 +255,7 @@ class FilamentSensorBase {
         #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
           if (change) {
             SERIAL_ECHOPGM("Motion detected:");
-            LOOP_L_N(e, TERN(FILAMENT_SWITCH_AND_MOTION, NUM_MOTION_SENSORS, NUM_RUNOUT_SENSORS))
+            for (uint8_t e = 0; e < TERN(FILAMENT_SWITCH_AND_MOTION, NUM_MOTION_SENSORS, NUM_RUNOUT_SENSORS); ++e)
               if (TEST(change, e)) SERIAL_CHAR(' ', '0' + e);
             SERIAL_EOL();
           }
@@ -304,7 +304,7 @@ class FilamentSensorBase {
       static void block_completed(const block_t * const) {}
 
       static void run() {
-        LOOP_L_N(s, NUM_RUNOUT_SENSORS) {
+        for (uint8_t s = 0; s < NUM_RUNOUT_SENSORS; ++s) {
           const bool out = poll_runout_state(s);
           if (!out) filament_present(s);
           #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
@@ -364,9 +364,9 @@ class FilamentSensorBase {
       static float runout_distance_mm;
 
       static void reset() {
-        LOOP_L_N(i, NUM_RUNOUT_SENSORS) filament_present(i);
+        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
         #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-          LOOP_L_N(i, NUM_MOTION_SENSORS) filament_motion_present(i);
+          for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i) filament_motion_present(i);
         #endif
       }
 
@@ -376,10 +376,10 @@ class FilamentSensorBase {
           const millis_t ms = millis();
           if (ELAPSED(ms, t)) {
             t = millis() + 1000UL;
-            LOOP_L_N(i, NUM_RUNOUT_SENSORS)
+            for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i)
               SERIAL_ECHOF(i ? F(", ") : F("Runout remaining mm: "), mm_countdown.runout[i]);
             #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-              LOOP_L_N(i, NUM_MOTION_SENSORS)
+              for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i)
                 SERIAL_ECHOF(i ? F(", ") : F("Motion remaining mm: "), mm_countdown.motion[i]);
             #endif
             SERIAL_EOL();
@@ -389,9 +389,9 @@ class FilamentSensorBase {
 
       static uint8_t has_run_out() {
         uint8_t runout_flags = 0;
-        LOOP_L_N(i, NUM_RUNOUT_SENSORS) if (mm_countdown.runout[i] < 0) SBI(runout_flags, i);
+        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (mm_countdown.runout[i] < 0) SBI(runout_flags, i);
         #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-          LOOP_L_N(i, NUM_MOTION_SENSORS) if (mm_countdown.motion[i] < 0) SBI(runout_flags, i);
+          for (uint8_t i = 0; i < NUM_MOTION_SENSORS; ++i) if (mm_countdown.motion[i] < 0) SBI(runout_flags, i);
         #endif
         return runout_flags;
       }
@@ -432,16 +432,16 @@ class FilamentSensorBase {
 
     public:
       static void reset() {
-        LOOP_L_N(i, NUM_RUNOUT_SENSORS) filament_present(i);
+        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) filament_present(i);
       }
 
       static void run() {
-        LOOP_L_N(i, NUM_RUNOUT_SENSORS) if (runout_count[i] >= 0) runout_count[i]--;
+        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] >= 0) runout_count[i]--;
       }
 
       static uint8_t has_run_out() {
         uint8_t runout_flags = 0;
-        LOOP_L_N(i, NUM_RUNOUT_SENSORS) if (runout_count[i] < 0) SBI(runout_flags, i);
+        for (uint8_t i = 0; i < NUM_RUNOUT_SENSORS; ++i) if (runout_count[i] < 0) SBI(runout_flags, i);
         return runout_flags;
       }
 

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -145,7 +145,7 @@ void TWIBus::echodata(uint8_t bytes, FSTR_P const pref, uint8_t adr, const uint8
 
 void TWIBus::echobuffer(FSTR_P const prefix, uint8_t adr) {
   echoprefix(buffer_s, prefix, adr);
-  LOOP_L_N(i, buffer_s) SERIAL_CHAR(buffer[i]);
+  for (uint8_t i = 0; i < buffer_s; ++i) SERIAL_CHAR(buffer[i]);
   SERIAL_EOL();
 }
 

--- a/Marlin/src/feature/x_twist.cpp
+++ b/Marlin/src/feature/x_twist.cpp
@@ -43,12 +43,12 @@ void XATC::reset() {
 
 void XATC::print_points() {
   SERIAL_ECHOLNPGM(" X-Twist Correction:");
-  LOOP_L_N(x, XATC_MAX_POINTS) {
+  for (uint8_t x = 0; x < XATC_MAX_POINTS; ++x) {
     SERIAL_CHAR(' ');
     if (!isnan(z_offset[x]))
       serial_offset(z_offset[x]);
     else
-      LOOP_L_N(i, 6) SERIAL_CHAR(i ? '=' : ' ');
+      for (uint8_t i = 0; i < 6; ++i) SERIAL_CHAR(i ? '=' : ' ');
   }
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -707,7 +707,7 @@ void GcodeSuite::G26() {
       #error "A_CNT must be a positive value. Please change A_INT."
     #endif
     float trig_table[A_CNT];
-    LOOP_L_N(i, A_CNT)
+    for (uint8_t i = 0; i < A_CNT; ++i)
       trig_table[i] = INTERSECTION_CIRCLE_RADIUS * cos(RADIANS(i * A_INT));
 
   #endif // !ARC_SUPPORT

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -97,7 +97,7 @@ void GcodeSuite::G35() {
   bool err_break = false;
 
   // Probe all positions
-  LOOP_L_N(i, G35_PROBE_COUNT) {
+  for (uint8_t i = 0; i < G35_PROBE_COUNT; ++i) {
     const float z_probed_height = probe.probe_at_point(tramming_points[i], PROBE_PT_RAISE);
     if (isnan(z_probed_height)) {
       SERIAL_ECHOPGM("G35 failed at point ", i + 1, " (");
@@ -122,7 +122,7 @@ void GcodeSuite::G35() {
     const float threads_factor[] = { 0.5, 0.7, 0.8 };
 
     // Calculate adjusts
-    LOOP_S_L_N(i, 1, G35_PROBE_COUNT) {
+    for (uint8_t i = 1; i < G35_PROBE_COUNT; ++i) {
       const float diff = z_measured[0] - z_measured[i],
                   adjust = ABS(diff) < 0.001f ? 0 : diff / threads_factor[(screw_thread - 30) / 10];
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -728,7 +728,7 @@ G29_TYPE GcodeSuite::G29() {
 
       // Probe at 3 arbitrary points
 
-      LOOP_L_N(i, 3) {
+      for (uint8_t i = 0; i < 3; ++i) {
         if (abl.verbose_level) SERIAL_ECHOLNPGM("Probing point ", i + 1, "/3.");
         TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %i/3"), GET_TEXT(MSG_PROBING_POINT), int(i + 1)));
 
@@ -839,7 +839,7 @@ G29_TYPE GcodeSuite::G29() {
         auto print_topo_map = [&](FSTR_P const title, const bool get_min) {
           SERIAL_ECHOF(title);
           for (int8_t yy = abl.grid_points.y - 1; yy >= 0; yy--) {
-            LOOP_L_N(xx, abl.grid_points.x) {
+            for (uint8_t xx = 0; xx < abl.grid_points.x; ++xx) {
               const int ind = abl.indexIntoAB[xx][yy];
               xyz_float_t tmp = { abl.eqnAMatrix[ind + 0 * abl.abl_points],
                                   abl.eqnAMatrix[ind + 1 * abl.abl_points], 0 };

--- a/Marlin/src/gcode/bedlevel/abl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/M421.cpp
@@ -56,8 +56,8 @@ void GcodeSuite::M421() {
       const float zval = parser.value_linear_units();
       uint8_t sx = ix >= 0 ? ix : 0, ex = ix >= 0 ? ix : GRID_MAX_POINTS_X - 1,
               sy = iy >= 0 ? iy : 0, ey = iy >= 0 ? iy : GRID_MAX_POINTS_Y - 1;
-      LOOP_S_LE_N(x, sx, ex) {
-        LOOP_S_LE_N(y, sy, ey) {
+      for (uint8_t x = sx; x <= ex; ++x) {
+        for (uint8_t y = sy; y <= ey; ++y) {
           bedlevel.z_values[x][y] = zval + (hasQ ? bedlevel.z_values[x][y] : 0);
           TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, bedlevel.z_values[x][y]));
         }

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -204,7 +204,7 @@ void GcodeSuite::G34() {
         float z_measured_max = -100000.0f;
 
         // Probe all positions (one per Z-Stepper)
-        LOOP_L_N(i, NUM_Z_STEPPERS) {
+        for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
           // iteration odd/even --> downward / upward stepper sequence
           const uint8_t iprobe = (iteration & 1) ? NUM_Z_STEPPERS - 1 - i : i;
 
@@ -255,14 +255,14 @@ void GcodeSuite::G34() {
           // This allows the actual adjustment logic to be shared by both algorithms.
           linear_fit_data lfd;
           incremental_LSF_reset(&lfd);
-          LOOP_L_N(i, NUM_Z_STEPPERS) {
+          for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
             SERIAL_ECHOLNPGM("PROBEPT_", i, ": ", z_measured[i]);
             incremental_LSF(&lfd, z_stepper_align.xy[i], z_measured[i]);
           }
           finish_incremental_LSF(&lfd);
 
           z_measured_min = 100000.0f;
-          LOOP_L_N(i, NUM_Z_STEPPERS) {
+          for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
             z_measured[i] = -(lfd.A * z_stepper_align.stepper_xy[i].x + lfd.B * z_stepper_align.stepper_xy[i].y + lfd.D);
             z_measured_min = _MIN(z_measured_min, z_measured[i]);
           }
@@ -330,12 +330,12 @@ void GcodeSuite::G34() {
 
           // Calculate mean value as a reference
           float z_measured_mean = 0.0f;
-          LOOP_L_N(zstepper, NUM_Z_STEPPERS) z_measured_mean += z_measured[zstepper];
+          for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) z_measured_mean += z_measured[zstepper];
           z_measured_mean /= NUM_Z_STEPPERS;
 
           // Calculate the sum of the absolute deviations from the mean value
           float z_align_level_indicator = 0.0f;
-          LOOP_L_N(zstepper, NUM_Z_STEPPERS)
+          for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper)
             z_align_level_indicator += ABS(z_measured[zstepper] - z_measured_mean);
 
           // If it's getting worse, stop and throw an error
@@ -350,7 +350,7 @@ void GcodeSuite::G34() {
 
         bool success_break = true;
         // Correct the individual stepper offsets
-        LOOP_L_N(zstepper, NUM_Z_STEPPERS) {
+        for (uint8_t zstepper = 0; zstepper < NUM_Z_STEPPERS; ++zstepper) {
           // Calculate current stepper move
           float z_align_move = z_measured[zstepper] - z_measured_min;
           const float z_align_abs = ABS(z_align_move);
@@ -529,7 +529,7 @@ void GcodeSuite::M422() {
 
 void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, F(STR_Z_AUTO_ALIGN));
-  LOOP_L_N(i, NUM_Z_STEPPERS) {
+  for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(
       PSTR("  M422 S"), i + 1,
@@ -538,7 +538,7 @@ void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
     );
   }
   #if HAS_Z_STEPPER_ALIGN_STEPPER_XY
-    LOOP_L_N(i, NUM_Z_STEPPERS) {
+    for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(
         PSTR("  M422 W"), i + 1,

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -171,7 +171,7 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
 #if HAS_HOTEND_OFFSET
 
   inline void normalize_hotend_offsets() {
-    LOOP_S_L_N(e, 1, HOTENDS)
+    for (uint8_t e = 1; e < HOTENDS; ++e)
       hotend_offset[e] -= hotend_offset[0];
     hotend_offset[0].reset();
   }
@@ -618,7 +618,7 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     // This function requires normalize_hotend_offsets() to be called
     //
     inline void report_hotend_offsets() {
-      LOOP_S_L_N(e, 1, HOTENDS)
+      for (uint8_t e = 1; e < HOTENDS; ++e)
         SERIAL_ECHOLNPGM_P(PSTR("T"), e, PSTR(" Hotend Offset X"), hotend_offset[e].x, SP_Y_STR, hotend_offset[e].y, SP_Z_STR, hotend_offset[e].z);
     }
   #endif

--- a/Marlin/src/gcode/calibrate/M100.cpp
+++ b/Marlin/src/gcode/calibrate/M100.cpp
@@ -163,14 +163,14 @@ inline int32_t count_test_bytes(const char * const start_free_memory) {
     while (start_free_memory < end_free_memory) {
       print_hex_address(start_free_memory);             // Print the address
       SERIAL_CHAR(':');
-      LOOP_L_N(i, 16) {  // and 16 data bytes
+      for (uint8_t i = 0; i < 16; ++i) {  // and 16 data bytes
         if (i == 8) SERIAL_CHAR('-');
         print_hex_byte(start_free_memory[i]);
         SERIAL_CHAR(' ');
       }
       serial_delay(25);
       SERIAL_CHAR('|');                   // Point out non test bytes
-      LOOP_L_N(i, 16) {
+      for (uint8_t i = 0; i < 16; ++i) {
         char ccc = (char)start_free_memory[i]; // cast to char before automatically casting to char on assignment, in case the compiler is broken
         ccc = (ccc == TEST_BYTE) ? ' ' : '?';
         SERIAL_CHAR(ccc);

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -148,7 +148,7 @@ void GcodeSuite::M48() {
 
     float sample_sum = 0.0;
 
-    LOOP_L_N(n, n_samples) {
+    for (uint8_t n = 0; n < n_samples; ++n) {
       #if HAS_STATUS_MESSAGE
         // Display M48 progress in the status bar
         ui.status_printf(0, F(S_FMT ": %d/%d"), GET_TEXT(MSG_M48_POINT), int(n + 1), int(n_samples));
@@ -175,7 +175,7 @@ void GcodeSuite::M48() {
         }
 
         // Move from leg to leg in rapid succession
-        LOOP_L_N(l, n_legs - 1) {
+        for (uint8_t l = 0; l < n_legs - 1; ++l) {
 
           // Move some distance around the perimeter
           float delta_angle;
@@ -243,7 +243,7 @@ void GcodeSuite::M48() {
       // Calculate the standard deviation so far.
       // The value after the last sample will be the final output.
       float dev_sum = 0.0;
-      LOOP_LE_N(j, n) dev_sum += sq(sample_set[j] - mean);
+      for (uint8_t j = 0; j <= n; ++j) dev_sum += sq(sample_set[j] - mean);
       sigma = SQRT(dev_sum / (n + 1));
 
       if (verbose_level > 1) {

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -168,7 +168,7 @@ void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
   #endif
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    LOOP_L_N(i, E_STEPPERS) {
+    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(
           PSTR("  M201 T"), i
@@ -224,7 +224,7 @@ void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
   #endif
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    LOOP_L_N(i, E_STEPPERS) {
+    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
       if (!forReplay) SERIAL_ECHO_START();
       SERIAL_ECHOLNPGM_P(
           PSTR("  M203 T"), i

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -64,7 +64,7 @@ void GcodeSuite::M218() {
 
 void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_HOTEND_OFFSETS));
-  LOOP_S_L_N(e, 1, HOTENDS) {
+  for (uint8_t e = 1; e < HOTENDS; ++e) {
     report_echo_start(forReplay);
     SERIAL_ECHOPGM_P(
       PSTR("  M218 T"), e,

--- a/Marlin/src/gcode/config/M281.cpp
+++ b/Marlin/src/gcode/config/M281.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M281() {
 
 void GcodeSuite::M281_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_SERVO_ANGLES));
-  LOOP_L_N(i, NUM_SERVOS) {
+  for (uint8_t i = 0; i < NUM_SERVOS; ++i) {
     switch (i) {
       default: break;
       #if ENABLED(SWITCHING_EXTRUDER)

--- a/Marlin/src/gcode/config/M305.cpp
+++ b/Marlin/src/gcode/config/M305.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::M305() {
         SERIAL_ECHO_MSG("!Invalid Steinhart-Hart C coeff. (-0.01 < C < +0.01)");
   }                       // If not setting then report parameters
   else if (t_index < 0) { // ...all user thermistors
-    LOOP_L_N(i, USER_THERMISTORS)
+    for (uint8_t i = 0; i < USER_THERMISTORS; ++i)
       thermalManager.M305_report(i);
   }
   else                    // ...one user thermistor

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -61,7 +61,7 @@ inline void toggle_pins() {
             end = PARSED_PIN_INDEX('L', NUM_DIGITAL_PINS - 1),
             wait = parser.intval('W', 500);
 
-  LOOP_S_LE_N(i, start, end) {
+  for (uint8_t i = start; i <= end; ++i) {
     pin_t pin = GET_PIN_MAP_PIN_M43(i);
     if (!VALID_PIN(pin)) continue;
     if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) {
@@ -189,7 +189,7 @@ inline void servo_probe_test() {
       // DEPLOY and STOW 4 times and see if the signal follows
       // Then it is a mechanical switch
       SERIAL_ECHOLNPGM(". Deploy & stow 4 times");
-      LOOP_L_N(i, 4) {
+      for (uint8_t i = 0; i < 4; ++i) {
         servo[probe_index].move(servo_angles[Z_PROBE_SERVO_NR][0]); // Deploy
         safe_delay(500);
         deploy_state = READ(PROBE_TEST_PIN);
@@ -328,7 +328,7 @@ void GcodeSuite::M43() {
     const uint8_t pin_count = last_pin - first_pin + 1;
     uint8_t pin_state[pin_count];
     bool can_watch = false;
-    LOOP_S_LE_N(i, first_pin, last_pin) {
+    for (uint8_t i = first_pin; i <= last_pin; ++i) {
       pin_t pin = GET_PIN_MAP_PIN_M43(i);
       if (!VALID_PIN(pin)) continue;
       if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
@@ -371,7 +371,7 @@ void GcodeSuite::M43() {
     #endif
 
     for (;;) {
-      LOOP_S_LE_N(i, first_pin, last_pin) {
+      for (uint8_t i = first_pin; i <= last_pin; ++i) {
         const pin_t pin = GET_PIN_MAP_PIN_M43(i);
         if (!VALID_PIN(pin)) continue;
         if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
@@ -400,7 +400,7 @@ void GcodeSuite::M43() {
   }
   else {
     // Report current state of selected pin(s)
-    LOOP_S_LE_N(i, first_pin, last_pin) {
+    for (uint8_t i = first_pin; i <= last_pin; ++i) {
       const pin_t pin = GET_PIN_MAP_PIN_M43(i);
       if (VALID_PIN(pin)) report_pin_state_extended(pin, ignore_protection, true);
     }

--- a/Marlin/src/gcode/config/M672.cpp
+++ b/Marlin/src/gcode/config/M672.cpp
@@ -54,7 +54,7 @@
 //  b3 b2 b1 b0 ~b0  ... lo bits, NOT last bit
 //
 void M672_send(uint8_t b) {    // bit rate requirement: 1kHz +/- 30%
-  LOOP_L_N(bits, 14) {
+  for (uint8_t bits = 0; bits < 14; ++bits) {
     switch (bits) {
       default: { OUT_WRITE(SMART_EFFECTOR_MOD_PIN, !!(b & 0x80)); b <<= 1; break; } // send bit, shift next into place
       case  7:

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -115,7 +115,7 @@ void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/
   #endif
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    LOOP_L_N(i, E_STEPPERS) {
+    for (uint8_t i = 0; i < E_STEPPERS; ++i) {
       if (e >= 0 && i != e) continue;
       report_echo_start(forReplay);
       SERIAL_ECHOLNPGM_P(

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -46,7 +46,7 @@ void GcodeSuite::M111() {
   SERIAL_ECHOPGM(STR_DEBUG_PREFIX);
   if (marlin_debug_flags) {
     uint8_t comma = 0;
-    LOOP_L_N(i, COUNT(debug_strings)) {
+    for (uint8_t i = 0; i < COUNT(debug_strings); ++i) {
       if (TEST(marlin_debug_flags, i)) {
         if (comma++) SERIAL_CHAR(',');
         SERIAL_ECHOPGM_P((PGM_P)pgm_read_ptr(&debug_strings[i]));

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -84,7 +84,7 @@
 
     inline void spin_photo_pin() {
       static constexpr uint32_t sequence[] = PHOTO_PULSES_US;
-      LOOP_L_N(i, COUNT(sequence))
+      for (uint8_t i = 0; i < COUNT(sequence); ++i)
         pulse_photo_pin(sequence[i], !(i & 1));
     }
 

--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -51,7 +51,7 @@ void GcodeSuite::M907() {
     if (!parser.seen("BS" STR_AXES_LOGICAL))
       return M907_report();
 
-    if (parser.seenval('S')) LOOP_L_N(i, MOTOR_CURRENT_COUNT) stepper.set_digipot_current(i, parser.value_int());
+    if (parser.seenval('S')) for (uint8_t i = 0; i < MOTOR_CURRENT_COUNT; ++i) stepper.set_digipot_current(i, parser.value_int());
     LOOP_LOGICAL_AXES(i) if (parser.seenval(IAXIS_CHAR(i))) stepper.set_digipot_current(i, parser.value_int());    // X Y Z (I J K U V W) E (map to drivers according to DIGIPOT_CHANNELS. Default with NUM_AXES 3: map X Y Z E to X Y Z E0)
     // Additional extruders use B,C.
     // TODO: Change these parameters because 'E' is used and D should be reserved for debugging. B<index>?
@@ -82,7 +82,7 @@ void GcodeSuite::M907() {
         #endif
       )) return M907_report();
 
-      if (parser.seenval('S')) LOOP_L_N(a, MOTOR_CURRENT_COUNT) stepper.set_digipot_current(a, parser.value_int());
+      if (parser.seenval('S')) for (uint8_t a = 0; a < MOTOR_CURRENT_COUNT; ++a) stepper.set_digipot_current(a, parser.value_int());
 
       #if HAS_X_Y_XY_I_J_K_U_V_W
         if (NUM_AXIS_GANG(
@@ -104,7 +104,7 @@ void GcodeSuite::M907() {
 
   #if HAS_MOTOR_CURRENT_I2C
     // this one uses actual amps in floating point
-    if (parser.seenval('S')) LOOP_L_N(q, DIGIPOT_I2C_NUM_CHANNELS) digipot_i2c.set_current(q, parser.value_float());
+    if (parser.seenval('S')) for (uint8_t q = 0; q < DIGIPOT_I2C_NUM_CHANNELS; ++q) digipot_i2c.set_current(q, parser.value_float());
       LOOP_LOGICAL_AXES(i) if (parser.seenval(IAXIS_CHAR(i))) digipot_i2c.set_current(i, parser.value_float());      // X Y Z (I J K U V W) E (map to drivers according to pots adresses. Default with NUM_AXES 3 X Y Z E: map to X Y Z E0)
     // Additional extruders use B,C,D.
     // TODO: Change these parameters because 'E' is used and because 'D' should be reserved for debugging. B<index>?

--- a/Marlin/src/gcode/feature/leds/M7219.cpp
+++ b/Marlin/src/gcode/feature/leds/M7219.cpp
@@ -79,7 +79,7 @@ void GcodeSuite::M7219() {
   }
 
   if (parser.seen('P')) {
-    LOOP_L_N(r, MAX7219_LINES) {
+    for (uint8_t r = 0; r < MAX7219_LINES; ++r) {
       SERIAL_ECHOPGM("led_line[");
       if (r < 10) SERIAL_CHAR(' ');
       SERIAL_ECHO(r);

--- a/Marlin/src/gcode/feature/network/M552-M554.cpp
+++ b/Marlin/src/gcode/feature/network/M552-M554.cpp
@@ -46,7 +46,7 @@ void MAC_report() {
   if (ethernet.hardware_enabled) {
     Ethernet.MACAddress(mac);
     SERIAL_ECHOPGM("  MAC: ");
-    LOOP_L_N(i, 6) {
+    for (uint8_t i = 0; i < 6; ++i) {
       if (mac[i] < 16) SERIAL_CHAR('0');
       SERIAL_PRINT(mac[i], PrintBase::Hex);
       if (i < 5) SERIAL_CHAR(':');
@@ -59,7 +59,7 @@ void MAC_report() {
 // otherwise show the stored values
 void ip_report(const uint16_t cmd, FSTR_P const post, const IPAddress &ipo) {
   SERIAL_CHAR('M'); SERIAL_ECHO(cmd); SERIAL_CHAR(' ');
-  LOOP_L_N(i, 4) {
+  for (uint8_t i = 0; i < 4; ++i) {
     SERIAL_ECHO(ipo[i]);
     if (i < 3) SERIAL_CHAR('.');
   }

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -30,7 +30,7 @@
 
   void report_all_axis_pos(const xyze_pos_t &pos, const uint8_t n=LOGICAL_AXES, const uint8_t precision=3) {
     char str[12];
-    LOOP_L_N(a, n) {
+    for (uint8_t a = 0; a < n; ++a) {
       SERIAL_ECHOPGM_P((PGM_P)pgm_read_ptr(&SP_AXIS_LBL[a]));
       if (pos[a] >= 0) SERIAL_CHAR(' ');
       SERIAL_ECHO(dtostrf(pos[a], 1, precision, str));

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -81,7 +81,7 @@ void GcodeSuite::M115() {
     // Although this code should work on all STM32 based boards
     SERIAL_ECHOPGM(" UUID:");
     uint32_t *uid_address = (uint32_t*)UID_BASE;
-    LOOP_L_N(i, 3) {
+    for (uint8_t i = 0; i < 3; ++i) {
       const uint32_t UID = uint32_t(READ_REG(*(uid_address)));
       uid_address += 4U;
       for (int B = 24; B >= 0; B -= 8) print_hex_byte(UID >> B);

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -62,7 +62,7 @@ void GcodeSuite::M145() {
 
 void GcodeSuite::M145_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, F(STR_MATERIAL_HEATUP));
-  LOOP_L_N(i, PREHEAT_COUNT) {
+  for (uint8_t i = 0; i < PREHEAT_COUNT; ++i) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(
       PSTR("  M145 S"), i

--- a/Marlin/src/gcode/probe/M423.cpp
+++ b/Marlin/src/gcode/probe/M423.cpp
@@ -88,7 +88,7 @@ void GcodeSuite::M423() {
 void GcodeSuite::M423_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, F("X-Twist Correction"));
   SERIAL_ECHOLNPGM("  M423 A", xatc.start, " I", xatc.spacing);
-  LOOP_L_N(x, XATC_MAX_POINTS) {
+  for (uint8_t x = 0; x < XATC_MAX_POINTS; ++x) {
     const float z = xatc.z_offset[x];
     SERIAL_ECHOPGM("  M423 X", x, " Z");
     serial_offset(isnan(z) ? 0 : z);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -294,7 +294,7 @@ static bool serial_data_available(serial_index_t index) {
 #if NO_TIMEOUTS > 0
   // Multiserial already handles dispatch to/from multiple ports
   static bool any_serial_data_available() {
-    LOOP_L_N(p, NUM_SERIAL)
+    for (uint8_t p = 0; p < NUM_SERIAL; ++p)
       if (serial_data_available(p))
         return true;
     return false;
@@ -313,7 +313,7 @@ inline int read_serial(const serial_index_t index) { return SERIAL_IMPL.read(ind
    */
   void GCodeQueue::flush_rx() {
     // Flush receive buffer
-    LOOP_L_N(p, NUM_SERIAL) {
+    for (uint8_t p = 0; p < NUM_SERIAL; ++p) {
       if (!serial_data_available(p)) continue; // No data for this port? Skip.
       while (SERIAL_IMPL.available(p)) (void)read_serial(p);
     }
@@ -441,7 +441,7 @@ void GCodeQueue::get_serial_commands() {
     // Unless a serial port has data, this will exit on next iteration
     hadData = false;
 
-    LOOP_L_N(p, NUM_SERIAL) {
+    for (uint8_t p = 0; p < NUM_SERIAL; ++p) {
       // Check if the queue is full and exit if it is.
       if (ring_buffer.full()) return;
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1496,7 +1496,7 @@
 
 #ifdef GRID_MAX_POINTS_X
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
-  #define GRID_LOOP(A,B) LOOP_L_N(A, GRID_MAX_POINTS_X) LOOP_L_N(B, GRID_MAX_POINTS_Y)
+  #define GRID_LOOP(A,B) for (uint8_t A = 0; A < GRID_MAX_POINTS_X; ++A) for (uint8_t B = 0; B < GRID_MAX_POINTS_Y; ++B)
 #endif
 
 // Slim menu optimizations

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -130,7 +130,7 @@
 
 static void createChar_P(const char c, const byte * const ptr) {
   byte temp[8];
-  LOOP_L_N(i, 8)
+  for (uint8_t i = 0; i < 8; ++i)
     temp[i] = pgm_read_byte(&ptr[i]);
   lcd.createChar(c, temp);
 }
@@ -440,7 +440,7 @@ void MarlinUI::clear_lcd() { lcd.clear(); }
     else {
       PGM_P p = FTOP(ftxt);
       int dly = time / _MAX(slen, 1);
-      LOOP_LE_N(i, slen) {
+      for (uint8_t i = 0; i <= slen; ++i) {
 
         // Print the text at the correct place
         lcd_put_u8str_max_P(col, line, p, len);

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -155,7 +155,7 @@ bool MarlinUI::detected() { return true; }
         #if DISABLED(CUSTOM_BOOTSCREEN_ANIMATED_FRAME_TIME)
           constexpr millis_t frame_time = CUSTOM_BOOTSCREEN_FRAME_TIME;
         #endif
-        LOOP_L_N(f, COUNT(custom_bootscreen_animation))
+        for (uint8_t f = 0; f < COUNT(custom_bootscreen_animation); ++f)
       #endif
         {
           #if ENABLED(CUSTOM_BOOTSCREEN_ANIMATED_FRAME_TIME)
@@ -228,7 +228,7 @@ bool MarlinUI::detected() { return true; }
       draw_bootscreen_bmp(start_bmp);
     #else
       constexpr millis_t frame_time = MARLIN_BOOTSCREEN_FRAME_TIME;
-      LOOP_L_N(f, COUNT(marlin_bootscreen_animation)) {
+      for (uint8_t f = 0; f < COUNT(marlin_bootscreen_animation); ++f) {
         draw_bootscreen_bmp((uint8_t*)pgm_read_ptr(&marlin_bootscreen_animation[f]));
         if (frame_time) safe_delay(frame_time);
       }

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -672,7 +672,7 @@ void MarlinUI::draw_status_screen() {
   if (PAGE_UNDER(6 + 1 + 12 + 1 + 6 + 1)) {
     // Extruders
     #if DO_DRAW_HOTENDS
-      LOOP_L_N(e, MAX_HOTEND_DRAW) _draw_hotend_status((heater_id_t)e, blink);
+      for (uint8_t e = 0; e < MAX_HOTEND_DRAW; ++e) _draw_hotend_status((heater_id_t)e, blink);
     #endif
 
     // Laser / Spindle

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -237,7 +237,7 @@ void ST7920_Lite_Status_Screen::clear_ddram() {
 
 /* This fills the entire graphics buffer with zeros */
 void ST7920_Lite_Status_Screen::clear_gdram() {
-  LOOP_L_N(y, BUFFER_HEIGHT) {
+  for (uint8_t y = 0; y < BUFFER_HEIGHT; ++y) {
     set_gdram_address(0, y);
     begin_data();
     for (uint8_t i = (BUFFER_WIDTH) / 16; i--;) write_word(0);
@@ -435,7 +435,7 @@ void ST7920_Lite_Status_Screen::draw_degree_symbol(uint8_t x, uint8_t y, const b
     const uint8_t x_word  = x >> 1,
                   y_top   = degree_symbol_y_top,
                   y_bot   = y_top + COUNT(degree_symbol);
-    LOOP_S_L_N(i, y_top, y_bot) {
+    for (uint8_t i = y_top; i < y_bot; ++i) {
       uint8_t byte = pgm_read_byte(p_bytes++);
       set_gdram_address(x_word, i + y * 16);
       begin_data();
@@ -754,10 +754,10 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
     // This drawing is a mess and only produce readable result around 25% steps
     // i.e. 74-76% look fine [||||||||||||||||||||||||        ], but 73% look like this: [||||||||||||||||       |        ]
     // meaning partially filled bytes produce only single vertical line, and i bet they're not supposed to!
-    LOOP_S_LE_N(y, top, bottom) {
+    for (uint8_t y = top; y <= bottom; ++y) {
       set_gdram_address(left, y);
       begin_data();
-      LOOP_L_N(x, width) {
+      for (uint8_t x = 0; x < width; ++x) {
         uint16_t gfx_word = 0x0000;
         if ((x + 1) * char_pcnt <= value)
           gfx_word = 0xFFFF;                                              // Draw completely filled bytes

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -87,11 +87,11 @@ void clear_graphics_DRAM(u8g_t *u8g, u8g_dev_t *dev) {
   u8g_SetAddress(u8g, dev, 0);         // cmd mode
   u8g_WriteByte(u8g, dev, 0x08);       //display off, cursor+blink off
   u8g_WriteByte(u8g, dev, 0x3E);       //extended mode + GDRAM active
-  LOOP_L_N(y, (LCD_PIXEL_HEIGHT) / 2) { //clear GDRAM
+  for (uint8_t y = 0; y < (LCD_PIXEL_HEIGHT) / 2; ++y) { //clear GDRAM
     u8g_WriteByte(u8g, dev, 0x80 | y); //set y
     u8g_WriteByte(u8g, dev, 0x80);     //set x = 0
     u8g_SetAddress(u8g, dev, 1);                  /* data mode */
-    LOOP_L_N(i, 2 * (LCD_PIXEL_WIDTH) / 8) //2x width clears both segments
+    for (uint8_t i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; ++i) //2x width clears both segments
       u8g_WriteByte(u8g, dev, 0);
     u8g_SetAddress(u8g, dev, 0);           /* cmd mode */
   }

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -298,10 +298,10 @@ static void setWindow(u8g_t *u8g, u8g_dev_t *dev, uint16_t Xmin, uint16_t Ymin, 
           v = color;
         else
           v = TFT_MARLINBG_COLOR;
-        LOOP_L_N(n, GRAPHICAL_TFT_UPSCALE) buffer[k++] = v;
+        for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = v;
       }
       #if HAS_LCD_IO
-        LOOP_S_L_N(n, 1, GRAPHICAL_TFT_UPSCALE)
+        for (uint8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
           for (uint16_t l = 0; l < UPSCALE0(length); l++)
             buffer[l + n * UPSCALE0(length)] = buffer[l];
 
@@ -412,16 +412,16 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
       if (TERN0(HAS_TOUCH_BUTTONS_SLEEP, touchBt.isSleeping())) break;
       if (++page > (HEIGHT / PAGE_HEIGHT)) return 1;
 
-      LOOP_L_N(y, PAGE_HEIGHT) {
+      for (uint8_t y = 0; y < PAGE_HEIGHT; ++y) {
         uint32_t k = 0;
         TERN_(HAS_LCD_IO, buffer = (y & 1) ? bufferB : bufferA);
         for (uint16_t i = 0; i < (uint32_t)pb->width; i++) {
           const uint8_t b = *(((uint8_t *)pb->buf) + i);
           const uint16_t c = TEST(b, y) ? TFT_MARLINUI_COLOR : TFT_MARLINBG_COLOR;
-          LOOP_L_N(n, GRAPHICAL_TFT_UPSCALE) buffer[k++] = c;
+          for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE; ++n) buffer[k++] = c;
         }
         #if HAS_LCD_IO
-          LOOP_S_L_N(n, 1, GRAPHICAL_TFT_UPSCALE)
+          for (uint8_t n = 1; n < GRAPHICAL_TFT_UPSCALE; ++n)
             for (uint16_t l = 0; l < UPSCALE0(WIDTH); l++)
               buffer[l + n * UPSCALE0(WIDTH)] = buffer[l];
 
@@ -429,7 +429,7 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
         #else
           uint8_t *bufptr = (uint8_t*) buffer;
           for (uint8_t i = GRAPHICAL_TFT_UPSCALE; i--;) {
-            LOOP_S_L_N(n, 0, GRAPHICAL_TFT_UPSCALE * 2) {
+            for (uint8_t n = 0; n < GRAPHICAL_TFT_UPSCALE * 2; ++n) {
               u8g_WriteSequence(u8g, dev, WIDTH, &bufptr[WIDTH * n]);
             }
           }

--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -38,8 +38,8 @@ uint8_t databuf[26] = { 0 };
 // Send the data in the buffer plus the packet tail
 void DWIN_Send(size_t &i) {
   ++i;
-  LOOP_L_N(n, i) { LCD_SERIAL.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
-  LOOP_L_N(n, 4) { LCD_SERIAL.write(DWIN_BufTail[n]); delayMicroseconds(1); }
+  for (uint8_t n = 0; n < i; ++n) { LCD_SERIAL.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
+  for (uint8_t n = 0; n < 4; ++n) { LCD_SERIAL.write(DWIN_BufTail[n]); delayMicroseconds(1); }
 }
 
 /*-------------------------------------- System variable function --------------------------------------*/

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1891,7 +1891,7 @@ void Redraw_SD_List() {
 
   if (card.isMounted()) {
     // As many files as will fit
-    LOOP_L_N(i, _MIN(nr_sd_menu_items(), MROWS))
+    for (uint8_t i = 0; i < _MIN(nr_sd_menu_items(), MROWS); ++i)
       Draw_SDItem(i, i + 1);
 
     TERN_(SCROLL_LONG_FILENAMES, Init_SDItem_Shift());
@@ -2038,7 +2038,7 @@ void Draw_Info_Menu() {
   DWIN_Draw_String(false, font8x16, Color_White, Color_Bg_Black, (DWIN_WIDTH - strlen(CORP_WEBSITE) * MENU_CHR_W) / 2, 268, F(CORP_WEBSITE));
 
   Draw_Back_First();
-  LOOP_L_N(i, 3) {
+  for (uint8_t i = 0; i < 3; ++i) {
     DWIN_ICON_Show(ICON, ICON_PrintSize + i, 26, 99 + i * 73);
     DWIN_Draw_Line(Line_Color, 16, MBASE(2) + i * 73, 256, 156 + i * 73);
   }
@@ -2390,7 +2390,7 @@ void Draw_Move_Menu() {
   if (select_axis.now != CASE_BACK) Draw_Menu_Cursor(select_axis.now);
 
   // Draw separators and icons
-  LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MoveX + i);
+  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) Draw_Menu_Line(i + 1, ICON_MoveX + i);
 }
 
 void Item_Adv_HomeOffsets(const uint8_t row) {
@@ -3264,7 +3264,7 @@ void Draw_Max_Speed_Menu() {
   }
 
   Draw_Back_First();
-  LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MaxSpeedX + i);
+  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) Draw_Menu_Line(i + 1, ICON_MaxSpeedX + i);
   Draw_Edit_Integer4(1, planner.settings.max_feedrate_mm_s[X_AXIS]);
   Draw_Edit_Integer4(2, planner.settings.max_feedrate_mm_s[Y_AXIS]);
   Draw_Edit_Integer4(3, planner.settings.max_feedrate_mm_s[Z_AXIS]);
@@ -3318,7 +3318,7 @@ void Draw_Max_Accel_Menu() {
   }
 
   Draw_Back_First();
-  LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MaxAccX + i);
+  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) Draw_Menu_Line(i + 1, ICON_MaxAccX + i);
   Draw_Edit_Integer4(1, planner.settings.max_acceleration_mm_per_s2[X_AXIS]);
   Draw_Edit_Integer4(2, planner.settings.max_acceleration_mm_per_s2[Y_AXIS]);
   Draw_Edit_Integer4(3, planner.settings.max_acceleration_mm_per_s2[Z_AXIS]);
@@ -3377,7 +3377,7 @@ void Draw_Max_Accel_Menu() {
     }
 
     Draw_Back_First();
-    LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MaxSpeedJerkX + i);
+    for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) Draw_Menu_Line(i + 1, ICON_MaxSpeedJerkX + i);
     Draw_Edit_Float3(1, planner.max_jerk.x * MINUNITMULT);
     Draw_Edit_Float3(2, planner.max_jerk.y * MINUNITMULT);
     Draw_Edit_Float3(3, planner.max_jerk.z * MINUNITMULT);
@@ -3428,7 +3428,7 @@ void Draw_Steps_Menu() {
   }
 
   Draw_Back_First();
-  LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_StepX + i);
+  for (uint8_t i = 0; i < 3 + ENABLED(HAS_HOTEND); ++i) Draw_Menu_Line(i + 1, ICON_StepX + i);
   Draw_Edit_Float3(1, planner.settings.axis_steps_per_mm[X_AXIS] * MINUNITMULT);
   Draw_Edit_Float3(2, planner.settings.axis_steps_per_mm[Y_AXIS] * MINUNITMULT);
   Draw_Edit_Float3(3, planner.settings.axis_steps_per_mm[Z_AXIS] * MINUNITMULT);

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -594,7 +594,7 @@ void CrealityDWINClass::Draw_Menu(const uint8_t menu, const uint8_t select/*=0*/
   active_menu = menu;
   Clear_Screen();
   Draw_Title(Get_Menu_Title(menu));
-  LOOP_L_N(i, TROWS) Menu_Item_Handler(menu, i + scrollpos);
+  for (uint8_t i = 0; i < TROWS; ++i) Menu_Item_Handler(menu, i + scrollpos);
   DWIN_Draw_Rectangle(1, GetColor(eeprom_settings.cursor_color, Rectangle_Color), 0, MBASE(selection - scrollpos) - 18, 14, MBASE(selection - scrollpos) + 33);
 }
 
@@ -814,9 +814,9 @@ void CrealityDWINClass::Draw_SD_Item(const uint8_t item, const uint8_t row) {
     len = pos;
     if (len > max) len = max;
     char name[len + 1];
-    LOOP_L_N(i, len) name[i] = filename[i];
+    for (uint8_t i = 0; i < len; ++i) name[i] = filename[i];
     if (pos > max)
-      LOOP_S_L_N(i, len - 3, len) name[i] = '.';
+      for (uint8_t i = len - 3; i < len; ++i) name[i] = '.';
     name[len] = '\0';
     Draw_Menu_Item(row, card.flag.filenameIsDir ? ICON_More : ICON_File, name);
   }
@@ -829,7 +829,7 @@ void CrealityDWINClass::Draw_SD_List(const bool removed/*=false*/) {
   scrollpos = 0;
   process = File;
   if (card.isMounted() && !removed) {
-    LOOP_L_N(i, _MIN(card.get_num_items() + 1, TROWS))
+    for (uint8_t i = 0; i < _MIN(card.get_num_items() + 1, TROWS); ++i)
       Draw_SD_Item(i, i);
   }
   else {
@@ -4664,12 +4664,12 @@ void CrealityDWINClass::Modify_Option(const uint8_t value, const char * const * 
 
 void CrealityDWINClass::Update_Status(const char * const text) {
   if (strncmp_P(text, PSTR("<F>"), 3) == 0) {
-    LOOP_L_N(i, _MIN((size_t)LONG_FILENAME_LENGTH, strlen(text))) filename[i] = text[i + 3];
+    for (uint8_t i = 0; i < _MIN((size_t)LONG_FILENAME_LENGTH, strlen(text)); ++i) filename[i] = text[i + 3];
     filename[_MIN((size_t)LONG_FILENAME_LENGTH - 1, strlen(text))] = '\0';
     Draw_Print_Filename(true);
   }
   else {
-    LOOP_L_N(i, _MIN((size_t)64, strlen(text))) statusmsg[i] = text[i];
+    for (uint8_t i = 0; i < _MIN((size_t)64, strlen(text)); ++i) statusmsg[i] = text[i];
     statusmsg[_MIN((size_t)64, strlen(text))] = '\0';
   }
 }

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -569,7 +569,7 @@ void DWIN_Print_Header(const char *text = nullptr) {
   static char headertxt[31] = "";  // Print header text
   if (text) {
     const int8_t size = _MIN(30U, strlen_P(text));
-    LOOP_L_N(i, size) headertxt[i] = text[i];
+    for (uint8_t i = 0; i < size; ++i) headertxt[i] = text[i];
     headertxt[size] = '\0';
   }
   if (checkkey == PrintProcess || checkkey == PrintDone) {
@@ -938,7 +938,7 @@ void Draw_Print_File_Menu() {
   if (card.isMounted()) {
     if (SET_MENU(FileMenu, MSG_MEDIA_MENU, nr_sd_menu_items() + 1)) {
       BACK_ITEM(Goto_Main_Menu);
-      LOOP_L_N(i, nr_sd_menu_items()) {
+      for (uint8_t i = 0; i < nr_sd_menu_items(); ++i) {
         MenuItemAdd(onDrawFileName, onClickSDItem);
       }
     }
@@ -1040,7 +1040,7 @@ void Draw_Info_Menu() {
   DWINUI::Draw_CenteredString(122, F(MACHINE_SIZE));
   DWINUI::Draw_CenteredString(195, F(SHORT_BUILD_VERSION));
 
-  LOOP_L_N(i, 3) {
+  for (uint8_t i = 0; i < 3; ++i) {
     DWINUI::Draw_Icon(ICON_PrintSize + i, ICOX, 99 + i * 73);
     DWIN_Draw_HLine(HMI_data.SplitLine_Color, 16, MBASE(2) + i * 73, 240);
   }
@@ -2413,9 +2413,9 @@ void TramC () { Tram(4); }
     DWINUI::Draw_CenteredString(160, F("and relative heights"));
     safe_delay(1000);
     float avg = 0.0f;
-    LOOP_L_N(x, 2) LOOP_L_N(y, 2) avg += zval[x][y];
+    for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) avg += zval[x][y];
     avg /= 4.0f;
-    LOOP_L_N(x, 2) LOOP_L_N(y, 2) zval[x][y] -= avg;
+    for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) zval[x][y] -= avg;
     MeshViewer.DrawMesh(zval, 2, 2);
     ui.reset_status();
 
@@ -2428,7 +2428,7 @@ void TramC () { Tram(4); }
       float max = 0;
       FSTR_P plabel;
       bool s = true;
-      LOOP_L_N(x, 2) LOOP_L_N(y, 2) {
+      for (uint8_t x = 0; x < 2; ++x) for (uint8_t y = 0; y < 2; ++y) {
         const float d = ABS(zval[x][y]);
         if (max < d) {
           s = (zval[x][y] >= 0);
@@ -3771,7 +3771,7 @@ void Draw_Steps_Menu() {
   }
 
   void UBLSmartFillMesh() {
-    LOOP_L_N(x, GRID_MAX_POINTS_Y) bedlevel.smart_fill_mesh();
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_Y; ++x) bedlevel.smart_fill_mesh();
     LCD_MESSAGE(MSG_UBL_MESH_FILLED);
   }
 

--- a/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
@@ -126,9 +126,9 @@ void DWIN_WriteToMem(uint8_t mem, uint16_t addr, uint16_t length, uint8_t *data)
     DWIN_Byte(i, mem);
     DWIN_Word(i, addr + indx); // start address of the data block
     ++i;
-    LOOP_L_N(j, i) { LCD_SERIAL.write(DWIN_SendBuf[j]); delayMicroseconds(1); }  // Buf header
+    for (uint8_t j = 0; j < i; ++j) { LCD_SERIAL.write(DWIN_SendBuf[j]); delayMicroseconds(1); }  // Buf header
     for (uint16_t j = indx; j <= indx + to_send - 1; j++) LCD_SERIAL.write(*(data + j)); delayMicroseconds(1);  // write block of data
-    LOOP_L_N(j, 4) { LCD_SERIAL.write(DWIN_BufTail[j]); delayMicroseconds(1); }
+    for (uint8_t j = 0; j < 4; ++j) { LCD_SERIAL.write(DWIN_BufTail[j]); delayMicroseconds(1); }
     block++;
     pending -= to_send;
   }

--- a/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
@@ -60,7 +60,7 @@ void MeshViewerClass::DrawMesh(bed_mesh_t zval, const uint8_t sizex, const uint8
   #define DrawMeshHLine(yp) DWIN_Draw_HLine(HMI_data.SplitLine_Color, px(0), py(yp), DWIN_WIDTH - 2 * mx)
   #define DrawMeshVLine(xp) DWIN_Draw_VLine(HMI_data.SplitLine_Color, px(xp), py(sizey - 1), DWIN_WIDTH - 2 * my)
   int16_t maxz =-32000; int16_t minz = 32000;
-  LOOP_L_N(y, sizey) LOOP_L_N(x, sizex) {
+  for (uint8_t y = 0; y < sizey; ++y) for (uint8_t x = 0; x < sizex; ++x) {
     const float v = isnan(zval[x][y]) ? 0 : round(zval[x][y] * 100);
     zmesh[x][y] = v;
     NOLESS(maxz, v);
@@ -70,11 +70,11 @@ void MeshViewerClass::DrawMesh(bed_mesh_t zval, const uint8_t sizex, const uint8
   min = (float)minz / 100;
   DWINUI::ClearMainArea();
   DWIN_Draw_Rectangle(0, HMI_data.SplitLine_Color, px(0), py(0), px(sizex - 1), py(sizey - 1));
-  LOOP_S_L_N(x, 1, sizex - 1) DrawMeshVLine(x);
-  LOOP_S_L_N(y, 1, sizey - 1) DrawMeshHLine(y);
-  LOOP_L_N(y, sizey) {
+  for (uint8_t x = 1; x < sizex - 1; ++x) DrawMeshVLine(x);
+  for (uint8_t y = 1; y < sizey - 1; ++y) DrawMeshHLine(y);
+  for (uint8_t y = 0; y < sizey; ++y) {
     hal.watchdog_refresh();
-    LOOP_L_N(x, sizex) {
+    for (uint8_t x = 0; x < sizex; ++x) {
       uint16_t color = DWINUI::RainbowInt(zmesh[x][y], _MIN(-5, minz), _MAX(5, maxz));
       uint8_t radius = rm(zmesh[x][y]);
       DWINUI::Draw_FillCircle(color, px(x), py(y), radius);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -672,7 +672,7 @@ namespace Anycubic {
       // On:  5A A5 05 82 00 82 00 00
       // Off: 5A A5 05 82 00 82 00 64
       uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, 0x00, 0x82, 0x00, uint8_t(recovery.enabled ? 0x00 : 0x64) };
-      LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+      for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
     }
 
     void DgusTFT::powerLossRecovery() {
@@ -722,30 +722,30 @@ namespace Anycubic {
 
   void DgusTFT::sendValueToTFT(const uint16_t value, const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF), uint8_t(value >> 8), uint8_t(value & 0xFF) };
-    LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::requestValueFromTFT(const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x04, 0x83, uint8_t(address >> 8), uint8_t(address & 0xFF), 0x01 };
-    LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::sendTxtToTFT(const char *pdata, const uint16_t address) {
     uint8_t data_len = strlen(pdata);
     uint8_t data[] = { 0x5A, 0xA5, uint8_t(data_len + 5), 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF) };
-    LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
-    LOOP_L_N(i, data_len) TFTSer.write(pdata[i]);
+    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < data_len; ++i) TFTSer.write(pdata[i]);
     TFTSer.write(0xFF); TFTSer.write(0xFF);
   }
 
   void DgusTFT::sendColorToTFT(const uint16_t color, const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF), uint8_t(color >> 8), uint8_t(color & 0xFF) };
-    LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {
     uint8_t data[] = { 0x5A, 0xA5, 0x04, 0x83, uint8_t(address >> 8), uint8_t(address & 0xFF), number };
-    LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
   void DgusTFT::changePageOfTFT(const uint16_t page_index, const bool no_send/*=false*/) {
@@ -775,7 +775,7 @@ namespace Anycubic {
 
     if (!no_send) {
       uint8_t data[] = { 0x5A, 0xA5, 0x07, 0x82, 0x00, 0x84, 0x5A, 0x01, uint8_t(data_temp >> 8), uint8_t(data_temp & 0xFF) };
-      LOOP_L_N(i, COUNT(data)) TFTSer.write(data[i]);
+      for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
     }
 
     page_index_last_2 = page_index_last;
@@ -801,7 +801,7 @@ namespace Anycubic {
     // On:  5A A5 07 82 00 80 5A 00 00 1A
     // Off: 5A A5 07 82 00 80 5A 00 00 12
     uint8_t data[] = { 0x5A, 0xA5, 0x07, 0x82, 0x00, 0x80, 0x5A, 0x00, 0x00, uint8_t(audio_on ? 0x1A : 0x12) };
-    LOOP_L_N(i, 10) TFTSer.write(data[i]);
+    for (uint8_t i = 0; i < 10; ++i) TFTSer.write(data[i]);
   }
 
   bool DgusTFT::readTFTCommand() {

--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandlerBase.h
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandlerBase.h
@@ -184,7 +184,7 @@ public:
     if (!var.memadr) return;
     union { unsigned char tmp[sizeof(T)]; T t; } x;
     unsigned char *ptr = (unsigned char*)val_ptr;
-    LOOP_L_N(i, sizeof(T)) x.tmp[i] = ptr[sizeof(T) - i - 1];
+    for (uint8_t i = 0; i < sizeof(T); ++i) x.tmp[i] = ptr[sizeof(T) - i - 1];
     *(T*)var.memadr = x.t;
   }
 

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
@@ -124,7 +124,7 @@ public:
     } src, dst;
 
     src.val = value;
-    LOOP_L_N(i, sizeof(T)) dst.byte[i] = src.byte[sizeof(T) - i - 1];
+    for (uint8_t i = 0; i < sizeof(T); ++i) dst.byte[i] = src.byte[sizeof(T) - i - 1];
     return dst.val;
   }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/cyrillic_char_set.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/cyrillic_char_set.cpp
@@ -58,11 +58,11 @@
     cyrillic_fm.stride = 20;
     cyrillic_fm.width  = 40;
     cyrillic_fm.height = 49;
-    LOOP_L_N(i, 127)
+    for (uint8_t i = 0; i < 127; ++i)
       cyrillic_fm.char_widths[i] = 0;
 
     // For cyrillic characters, copy the character widths from the widths tables
-    LOOP_L_N(i, NUM_ELEMENTS(cyrillic_font_widths)) {
+    for (uint8_t i = 0; i < NUM_ELEMENTS(cyrillic_font_widths); ++i) {
       cyrillic_fm.char_widths[i] = cyrillic_font_widths[i];
     }
     CLCD::mem_write_bulk(addr, &cyrillic_fm,  148);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/western_char_set.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/western_char_set.cpp
@@ -342,11 +342,11 @@
     alt_fm.stride = 19;
     alt_fm.width  = 38;
     alt_fm.height = 49;
-    LOOP_L_N(i, 127)
+    for (uint8_t i = 0; i < 127; ++i)
       alt_fm.char_widths[i] = 0;
 
     // For special characters, copy the character widths from the char tables
-    LOOP_L_N(i, NUM_ELEMENTS(char_recipe)) {
+    for (uint8_t i = 0; i < NUM_ELEMENTS(char_recipe); ++i) {
       uint8_t std_char, alt_char, alt_data;
       get_char_data(i, std_char, alt_char, alt_data);
       if (std_char == 0)

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/move_axis_screen.cpp
@@ -37,7 +37,7 @@ void BaseMoveAxisScreen::onEntry() {
   // ourselves. The relative distances are reset to zero whenever this
   // screen is entered.
 
-  LOOP_L_N(i, ExtUI::extruderCount) {
+  for (uint8_t i = 0; i < ExtUI::extruderCount; ++i) {
     mydata.e_rel[i] = 0;
   }
   BaseNumericAdjustmentScreen::onEntry();

--- a/Marlin/src/lcd/extui/malyan/malyan.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan.cpp
@@ -79,7 +79,7 @@ void write_to_lcd(FSTR_P const fmsg) {
   char encoded_message[MAX_CURLY_COMMAND];
   uint8_t message_length = _MIN(strlen_P(pmsg), sizeof(encoded_message));
 
-  LOOP_L_N(i, message_length)
+  for (uint8_t i = 0; i < message_length; ++i)
     encoded_message[i] = pgm_read_byte(&pmsg[i]) | 0x80;
 
   LCD_SERIAL.Print::write(encoded_message, message_length);
@@ -89,7 +89,7 @@ void write_to_lcd(const char * const cmsg) {
   char encoded_message[MAX_CURLY_COMMAND];
   const uint8_t message_length = _MIN(strlen(cmsg), sizeof(encoded_message));
 
-  LOOP_L_N(i, message_length)
+  for (uint8_t i = 0; i < message_length; ++i)
     encoded_message[i] = cmsg[i] | 0x80;
 
   LCD_SERIAL.Print::write(encoded_message, message_length);

--- a/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
@@ -379,7 +379,7 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
 
   static void dosName2LongName(const char dosName[11], char *longName) {
     uint8_t j = 0;
-    LOOP_L_N(i, 11) {
+    for (uint8_t i = 0; i < 11; ++i) {
       if (i == 8) longName[j++] = '.';
       if (dosName[i] == '\0' || dosName[i] == ' ') continue;
       longName[j++] = dosName[i];

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1289,7 +1289,7 @@ void MarlinUI::init() {
         thermalManager.current_ADCKey_raw = HAL_ADC_RANGE;
         thermalManager.ADCKey_count = 0;
         if (currentkpADCValue < adc_other_button)
-          LOOP_L_N(i, ADC_KEY_NUM) {
+          for (uint8_t i = 0; i < ADC_KEY_NUM; ++i) {
             const raw_adc_t lo = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMin),
                             hi = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMax);
             if (WITHIN(currentkpADCValue, lo, hi)) return pgm_read_byte(&stADCKeyTable[i].ADCKeyNo);
@@ -1380,7 +1380,7 @@ void MarlinUI::init() {
           uint8_t val = 0;
           WRITE(SHIFT_LD_PIN, LOW);
           WRITE(SHIFT_LD_PIN, HIGH);
-          LOOP_L_N(i, 8) {
+          for (uint8_t i = 0; i < 8; ++i) {
             val >>= 1;
             if (READ(SHIFT_OUT_PIN)) SBI(val, 7);
             WRITE(SHIFT_CLK_PIN, HIGH);

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -727,7 +727,7 @@ public:
        * printer unusable in practice.
        */
       static bool hw_button_pressed() {
-        LOOP_L_N(s, ENCODER_SAMPLES) {
+        for (uint8_t s = 0; s < ENCODER_SAMPLES; ++s) {
           if (!BUTTON_CLICK()) return false;
           safe_delay(1);
         }

--- a/Marlin/src/lcd/menu/game/brickout.cpp
+++ b/Marlin/src/lcd/menu/game/brickout.cpp
@@ -44,7 +44,7 @@ brickout_data_t &bdat = marlin_game_data.brickout;
 
 inline void reset_bricks(const uint16_t v) {
   bdat.brick_count = (BRICK_COLS) * (BRICK_ROWS);
-  LOOP_L_N(i, BRICK_ROWS) bdat.bricks[i] = v;
+  for (uint8_t i = 0; i < BRICK_ROWS; ++i) bdat.bricks[i] = v;
 }
 
 void reset_ball() {
@@ -138,13 +138,13 @@ void BrickoutGame::game_screen() {
 
   // Draw bricks
   if (PAGE_CONTAINS(BRICK_TOP, BRICK_BOT)) {
-    LOOP_L_N(y, BRICK_ROWS) {
+    for (uint8_t y = 0; y < BRICK_ROWS; ++y) {
       const uint8_t yy = y * BRICK_H + BRICK_TOP;
       if (PAGE_CONTAINS(yy, yy + BRICK_H - 1)) {
-        LOOP_L_N(x, BRICK_COLS) {
+        for (uint8_t x = 0; x < BRICK_COLS; ++x) {
           if (TEST(bdat.bricks[y], x)) {
             const uint8_t xx = x * BRICK_W;
-            LOOP_L_N(v, BRICK_H - 1)
+            for (uint8_t v = 0; v < BRICK_H - 1; ++v)
               if (PAGE_CONTAINS(yy + v, yy + v))
                 u8g.drawHLine(xx, yy + v, BRICK_W - 1);
           }

--- a/Marlin/src/lcd/menu/game/invaders.cpp
+++ b/Marlin/src/lcd/menu/game/invaders.cpp
@@ -166,29 +166,29 @@ inline void update_invader_data() {
   uint8_t inv_mask = 0;
   // Get a list of all active invaders
   uint8_t sc = 0;
-  LOOP_L_N(y, INVADER_ROWS) {
+  for (uint8_t y = 0; y < INVADER_ROWS; ++y) {
     uint8_t m = idat.bugs[y];
     if (m) idat.botmost = y + 1;
     inv_mask |= m;
-    LOOP_L_N(x, INVADER_COLS)
+    for (uint8_t x = 0; x < INVADER_COLS; ++x)
       if (TEST(m, x)) idat.shooters[sc++] = (y << 4) | x;
   }
   idat.leftmost = 0;
-  LOOP_L_N(i, INVADER_COLS)            { if (TEST(inv_mask, i)) break; idat.leftmost -= INVADER_COL_W; }
+  for (uint8_t i = 0; i < INVADER_COLS; ++i) { if (TEST(inv_mask, i)) break; idat.leftmost -= INVADER_COL_W; }
   idat.rightmost = LCD_PIXEL_WIDTH - (INVADERS_WIDE);
   for (uint8_t i = INVADER_COLS; i--;) { if (TEST(inv_mask, i)) break; idat.rightmost += INVADER_COL_W; }
   if (idat.count == 2) idat.dir = idat.dir > 0 ? INVADER_VEL + 1 : -(INVADER_VEL + 1);
 }
 
 inline void reset_bullets() {
-  LOOP_L_N(i, COUNT(idat.bullet)) idat.bullet[i].v = 0;
+  for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) idat.bullet[i].v = 0;
 }
 
 inline void reset_invaders() {
   idat.pos.x = 0; idat.pos.y = INVADER_TOP;
   idat.dir = INVADER_VEL;
   idat.count = (INVADER_COLS) * (INVADER_ROWS);
-  LOOP_L_N(i, INVADER_ROWS) idat.bugs[i] = _BV(INVADER_COLS) - 1;
+  for (uint8_t i = 0; i < INVADER_ROWS; ++i) idat.bugs[i] = _BV(INVADER_COLS) - 1;
   update_invader_data();
   reset_bullets();
 }
@@ -274,7 +274,7 @@ void InvadersGame::game_screen() {
 
           // Find a free bullet
           laser_t *b = nullptr;
-          LOOP_L_N(i, COUNT(idat.bullet)) if (!idat.bullet[i].v) { b = &idat.bullet[i]; break; }
+          for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) if (!idat.bullet[i].v) { b = &idat.bullet[i]; break; }
           if (b) {
             // Pick a random shooter and update the bullet
             //SERIAL_ECHOLNPGM("free bullet found");
@@ -322,7 +322,7 @@ void InvadersGame::game_screen() {
       } // laser in invader zone
 
       // Handle alien bullets
-      LOOP_L_N(s, COUNT(idat.bullet)) {
+      for (uint8_t s = 0; s < COUNT(idat.bullet); ++s) {
         laser_t *b = &idat.bullet[s];
         if (b->v) {
           // Update alien bullet position
@@ -371,11 +371,11 @@ void InvadersGame::game_screen() {
   // Draw invaders
   if (PAGE_CONTAINS(idat.pos.y, idat.pos.y + idat.botmost * (INVADER_ROW_H) - 2 - 1)) {
     int8_t yy = idat.pos.y;
-    LOOP_L_N(y, INVADER_ROWS) {
+    for (uint8_t y = 0; y < INVADER_ROWS; ++y) {
       const uint8_t type = inv_type[y];
       if (PAGE_CONTAINS(yy, yy + INVADER_H - 1)) {
         int8_t xx = idat.pos.x;
-        LOOP_L_N(x, INVADER_COLS) {
+        for (uint8_t x = 0; x < INVADER_COLS; ++x) {
           if (TEST(idat.bugs[y], x))
             u8g.drawBitmapP(xx, yy, 2, INVADER_H, invader[type][idat.game_blink]);
           xx += INVADER_COL_W;
@@ -398,7 +398,7 @@ void InvadersGame::game_screen() {
     u8g.drawVLine(idat.laser.x, idat.laser.y, LASER_H);
 
   // Draw invader bullets
-  LOOP_L_N (i, COUNT(idat.bullet)) {
+  for (uint8_t i = 0; i < COUNT(idat.bullet); ++i) {
     if (idat.bullet[i].v && PAGE_CONTAINS(idat.bullet[i].y - (SHOT_H - 1), idat.bullet[i].y))
       u8g.drawVLine(idat.bullet[i].x, idat.bullet[i].y - (SHOT_H - 1), SHOT_H);
   }

--- a/Marlin/src/lcd/menu/game/maze.cpp
+++ b/Marlin/src/lcd/menu/game/maze.cpp
@@ -83,7 +83,7 @@ void MazeGame::game_screen() {
   if (PAGE_UNDER(HEADER_H)) lcd_put_int(0, HEADER_H - 1, score);
 
   // Draw the maze
-  // LOOP_L_N(n, head_ind) {
+  // for (uint8_t n = 0; n < head_ind; ++n) {
   //   const pos_t &p = maze_walls[n], &q = maze_walls[n + 1];
   //   if (p.x == q.x) {
   //     const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));

--- a/Marlin/src/lcd/menu/game/snake.cpp
+++ b/Marlin/src/lcd/menu/game/snake.cpp
@@ -84,14 +84,14 @@ void shorten_tail() {
   }
   if (shift) {
     sdat.head_ind--;
-    LOOP_LE_N(i, sdat.head_ind)
+    for (uint8_t i = 0; i <= sdat.head_ind; ++i)
       sdat.snake_tail[i] = sdat.snake_tail[i + 1];
   }
 }
 
 // The food is on a line
 inline bool food_on_line() {
-  LOOP_L_N(n, sdat.head_ind) {
+  for (uint8_t n = 0; n < sdat.head_ind; ++n) {
     pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
     if (p.x == q.x) {
       if ((sdat.foodx == p.x - 1 || sdat.foodx == p.x) && WITHIN(sdat.foody, _MIN(p.y, q.y), _MAX(p.y, q.y)))
@@ -151,7 +151,7 @@ bool snake_overlap() {
   // VERTICAL head segment?
   if (h1.x == h2.x) {
     // Loop from oldest to segment two away from head
-    LOOP_L_N(n, sdat.head_ind - 2) {
+    for (uint8_t n = 0; n < sdat.head_ind - 2; ++n) {
       // Segment p to q
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x != q.x) {
@@ -163,7 +163,7 @@ bool snake_overlap() {
   }
   else {
     // Loop from oldest to segment two away from head
-    LOOP_L_N(n, sdat.head_ind - 2) {
+    for (uint8_t n = 0; n < sdat.head_ind - 2; ++n) {
       // Segment p to q
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.y != q.y) {
@@ -240,7 +240,7 @@ void SnakeGame::game_screen() {
   #if SNAKE_WH < 2
 
     // At this scale just draw a line
-    LOOP_L_N(n, sdat.head_ind) {
+    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));
@@ -256,7 +256,7 @@ void SnakeGame::game_screen() {
   #elif SNAKE_WH == 2
 
     // At this scale draw two lines
-    LOOP_L_N(n, sdat.head_ind) {
+    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = GAMEY(_MIN(p.y, q.y)), y2 = GAMEY(_MAX(p.y, q.y));
@@ -275,7 +275,7 @@ void SnakeGame::game_screen() {
   #else
 
     // Draw a series of boxes
-    LOOP_L_N(n, sdat.head_ind) {
+    for (uint8_t n = 0; n < sdat.head_ind; ++n) {
       const pos_t &p = sdat.snake_tail[n], &q = sdat.snake_tail[n + 1];
       if (p.x == q.x) {
         const int8_t y1 = _MIN(p.y, q.y), y2 = _MAX(p.y, q.y);

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -460,7 +460,7 @@ void menu_backlash();
       EDIT_ITEM_FAST_N(float5, E_AXIS, MSG_VMAX_N, &planner.settings.max_feedrate_mm_s[E_AXIS_N(active_extruder)], 1, max_fr_edit_scaled.e);
     #endif
     #if ENABLED(DISTINCT_E_FACTORS)
-      LOOP_L_N(n, E_STEPPERS)
+      for (uint8_t n = 0; n < E_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(float5, n, MSG_VMAX_EN, &planner.settings.max_feedrate_mm_s[E_AXIS_N(n)], 1, max_fr_edit_scaled.e);
     #endif
 
@@ -532,7 +532,7 @@ void menu_backlash();
 
     #if ENABLED(DISTINCT_E_FACTORS)
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(active_extruder)], 100, max_accel_edit_scaled.e, []{ planner.refresh_acceleration_rates(); });
-      LOOP_L_N(n, E_STEPPERS)
+      for (uint8_t n = 0; n < E_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{
           if (MenuItemBase::itemIndex == active_extruder)
             planner.refresh_acceleration_rates();
@@ -656,7 +656,7 @@ void menu_advanced_steps_per_mm() {
     EDIT_ITEM_FAST_N(float72, a, MSG_N_STEPS, &planner.settings.axis_steps_per_mm[a], 5, 9999, []{ planner.refresh_positioning(); });
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    LOOP_L_N(n, E_STEPPERS)
+    for (uint8_t n = 0; n < E_STEPPERS; ++n)
       EDIT_ITEM_FAST_N(float72, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{
         const uint8_t e = MenuItemBase::itemIndex;
         if (e == active_extruder)

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -657,7 +657,7 @@ void menu_configuration() {
 
   // Preheat configurations
   #if HAS_PREHEAT && DISABLED(SLIM_LCD_MENUS)
-    LOOP_L_N(m, PREHEAT_COUNT)
+    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m)
       SUBMENU_N_f(m, ui.get_preheat_label(m), MSG_PREHEAT_M_SETTINGS, _menu_configuration_preheat_settings);
   #endif
 

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -96,7 +96,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   if (LCD_HEIGHT >= 4) STATIC_ITEM_F(change_filament_header(mode), SS_DEFAULT|SS_INVERT);
   BACK_ITEM(MSG_BACK);
   #if HAS_PREHEAT
-    LOOP_L_N(m, PREHEAT_COUNT)
+    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m)
       ACTION_ITEM_N_f(m, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
   #endif
   EDIT_ITEM_FAST_N(int3, extruder, MSG_PREHEAT_CUSTOM, &thermalManager.temp_hotend[extruder].target,
@@ -141,7 +141,7 @@ void menu_change_filament() {
         GCODES_ITEM_F(fmsg, F("M600 B0"));
     #else
       FSTR_P const fmsg = GET_TEXT_F(MSG_FILAMENTCHANGE_E);
-      LOOP_L_N(s, E_STEPPERS) {
+      for (uint8_t s = 0; s < E_STEPPERS; ++s) {
         if (thermalManager.targetTooColdToExtrude(s))
           SUBMENU_N_F(s, fmsg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex); });
         else {
@@ -166,7 +166,7 @@ void menu_change_filament() {
             GCODES_ITEM_F(msg_load, F("M701"));
         #else
           FSTR_P const msg_load = GET_TEXT_F(MSG_FILAMENTLOAD_E);
-          LOOP_L_N(s, E_STEPPERS) {
+          for (uint8_t s = 0; s < E_STEPPERS; ++s) {
             if (thermalManager.targetTooColdToExtrude(s))
               SUBMENU_N_F(s, msg_load, []{ _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, MenuItemBase::itemIndex); });
             else {
@@ -194,7 +194,7 @@ void menu_change_filament() {
               GCODES_ITEM(MSG_FILAMENTUNLOAD_ALL, F("M702"));
           #endif
           FSTR_P const msg_unload = GET_TEXT_F(MSG_FILAMENTUNLOAD_E);
-          LOOP_L_N(s, E_STEPPERS) {
+          for (uint8_t s = 0; s < E_STEPPERS; ++s) {
             if (thermalManager.targetTooColdToExtrude(s))
               SUBMENU_N_F(s, msg_unload, []{ _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, MenuItemBase::itemIndex); });
             else {

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -170,7 +170,7 @@ void lcd_mixer_mix_edit() {
 
     #if CHANNEL_MIX_EDITING
 
-      LOOP_S_LE_N(n, 1, MIXING_STEPPERS)
+      for (uint8_t n = 1; n <= MIXING_STEPPERS; ++n)
         EDIT_ITEM_FAST_N(float42_52, n, MSG_MIX_COMPONENT_N, &mixer.collector[n-1], 0, 10);
 
       ACTION_ITEM(MSG_CYCLE_MIX, _lcd_mixer_cycle_mix);

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -85,7 +85,7 @@ void Password::authentication_done() {
 // A single digit was completed
 void Password::digit_entered() {
   uint32_t multiplier = CAT(1e, PASSWORD_LENGTH); // 1e5 = 100000
-  LOOP_LE_N(i, digit_no) multiplier /= 10;
+  for (uint8_t i = 0; i <= digit_no; ++i) multiplier /= 10;
   value_entry += editable.uint8 * multiplier;
   string[digit_no++] = '0' + editable.uint8;
 

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -179,7 +179,7 @@ void menu_temperature() {
   #endif
 
   #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
-    LOOP_S_L_N(e, 1, EXTRUDERS)
+    for (uint8_t e = 1; e < EXTRUDERS; ++e)
       EDIT_ITEM_FAST_N(int3, e, MSG_NOZZLE_STANDBY, &thermalManager.singlenozzle_temp[e], 0, thermalManager.hotend_max_target(0));
   #endif
 
@@ -266,7 +266,7 @@ void menu_temperature() {
     //
     // Preheat for all Materials
     //
-    LOOP_L_N(m, PREHEAT_COUNT) {
+    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m) {
       editable.int8 = m;
       #if HAS_MULTI_HOTEND || HAS_HEATED_BED
         SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);
@@ -293,7 +293,7 @@ void menu_temperature() {
     START_MENU();
     BACK_ITEM(MSG_MAIN_MENU);
 
-    LOOP_L_N(m, PREHEAT_COUNT) {
+    for (uint8_t m = 0; m < PREHEAT_COUNT; ++m) {
       editable.int8 = m;
       #if HAS_MULTI_HOTEND || HAS_HEATED_BED
         SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -135,7 +135,7 @@ void menu_tune() {
   #endif
 
   #if ENABLED(SINGLENOZZLE_STANDBY_TEMP)
-    LOOP_S_L_N(e, 1, EXTRUDERS)
+    for (uint8_t e = 1; e < EXTRUDERS; ++e)
       EDIT_ITEM_FAST_N(int3, e, MSG_NOZZLE_STANDBY, &thermalManager.singlenozzle_temp[e], 0, thermalManager.hotend_max_target(0));
   #endif
 

--- a/Marlin/src/lcd/menu/menu_x_twist.cpp
+++ b/Marlin/src/lcd/menu/menu_x_twist.cpp
@@ -150,12 +150,12 @@ void xatc_wizard_goto_next_point() {
   else {
     // Compute the z-offset by averaging the values found with this wizard
     z_offset = 0;
-    LOOP_L_N(i, XATC_MAX_POINTS) z_offset += xatc.z_offset[i];
+    for (uint8_t i = 0; i < XATC_MAX_POINTS; ++i) z_offset += xatc.z_offset[i];
     z_offset /= XATC_MAX_POINTS;
 
     // Subtract the average from the values found with this wizard.
     // This way they are indipendent from the z-offset
-    LOOP_L_N(i, XATC_MAX_POINTS) xatc.z_offset[i] -= z_offset;
+    for (uint8_t i = 0; i < XATC_MAX_POINTS; ++i) xatc.z_offset[i] -= z_offset;
 
     ui.goto_screen(xatc_wizard_update_z_offset);
   }

--- a/Marlin/src/libs/BL24CXX.cpp
+++ b/Marlin/src/libs/BL24CXX.cpp
@@ -141,7 +141,7 @@ void IIC::nAck() {
 void IIC::send_byte(uint8_t txd) {
   SDA_OUT();
   IIC_SCL_0(); // Pull down the clock to start data transmission
-  LOOP_L_N(t, 8) {
+  for (uint8_t t = 0; t < 8; ++t) {
     // IIC_SDA = (txd & 0x80) >> 7;
     if (txd & 0x80) IIC_SDA_1(); else IIC_SDA_0();
     txd <<= 1;
@@ -157,7 +157,7 @@ void IIC::send_byte(uint8_t txd) {
 uint8_t IIC::read_byte(unsigned char ack_chr) {
   unsigned char receive = 0;
   SDA_IN(); // SDA is set as input
-  LOOP_L_N(i, 8) {
+  for (uint8_t i = 0; i < 8; ++i) {
     IIC_SCL_0();
     delay_us(2);
     IIC_SCL_1();
@@ -228,7 +228,7 @@ void BL24CXX::writeOneByte(uint16_t WriteAddr, uint8_t DataToWrite) {
 // DataToWrite: the first address of the data array
 // Len: The length of the data to be written 2, 4
 void BL24CXX::writeLenByte(uint16_t WriteAddr, uint32_t DataToWrite, uint8_t Len) {
-  LOOP_L_N(t, Len)
+  for (uint8_t t = 0; t < Len; ++t)
     writeOneByte(WriteAddr + t, (DataToWrite >> (8 * t)) & 0xFF);
 }
 
@@ -239,7 +239,7 @@ void BL24CXX::writeLenByte(uint16_t WriteAddr, uint32_t DataToWrite, uint8_t Len
 // Len: The length of the data to be read 2,4
 uint32_t BL24CXX::readLenByte(uint16_t ReadAddr, uint8_t Len) {
   uint32_t temp = 0;
-  LOOP_L_N(t, Len) {
+  for (uint8_t t = 0; t < Len; ++t) {
     temp <<= 8;
     temp += readOneByte(ReadAddr + Len - t - 1);
   }

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -63,7 +63,7 @@ Nozzle nozzle;
       #endif
 
       // Start the stroke pattern
-      LOOP_L_N(i, strokes >> 1) {
+      for (uint8_t i = 0; i < strokes >> 1; ++i) {
         #if ENABLED(NOZZLE_CLEAN_NO_Y)
           do_blocking_move_to_x(end.x);
           do_blocking_move_to_x(start.x);
@@ -105,7 +105,7 @@ Nozzle nozzle;
       const bool horiz = ABS(diff.x) >= ABS(diff.y);    // Do a horizontal wipe?
       const float P = (horiz ? diff.x : diff.y) / zigs; // Period of each zig / zag
       const xyz_pos_t *side;
-      LOOP_L_N(j, strokes) {
+      for (uint8_t j = 0; j < strokes; ++j) {
         for (int8_t i = 0; i < zigs; i++) {
           side = (i & 1) ? &end : &start;
           if (horiz)
@@ -143,8 +143,8 @@ Nozzle nozzle;
       #endif
       TERN(NOZZLE_CLEAN_NO_Z, do_blocking_move_to_xy, do_blocking_move_to)(start);
 
-      LOOP_L_N(s, strokes)
-        LOOP_L_N(i, NOZZLE_CLEAN_CIRCLE_FN)
+      for (uint8_t s = 0; s < strokes; ++s)
+        for (uint8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; ++i)
           do_blocking_move_to_xy(
             middle.x + sin((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
             middle.y + cos((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius

--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -93,8 +93,8 @@ void matrix_3x3::apply_rotation_xyz(float &_x, float &_y, float &_z) {
 
 // Reset to identity. No rotate or translate.
 void matrix_3x3::set_to_identity() {
-  LOOP_L_N(i, 3)
-    LOOP_L_N(j, 3)
+  for (uint8_t i = 0; i < 3; ++i)
+    for (uint8_t j = 0; j < 3; ++j)
       vectors[i][j] = float(i == j);
 }
 
@@ -131,16 +131,16 @@ matrix_3x3 matrix_3x3::create_look_at(const vector_3 &target) {
 // Get a transposed copy of the matrix
 matrix_3x3 matrix_3x3::transpose(const matrix_3x3 &original) {
   matrix_3x3 new_matrix;
-  LOOP_L_N(i, 3)
-    LOOP_L_N(j, 3)
+  for (uint8_t i = 0; i < 3; ++i)
+    for (uint8_t j = 0; j < 3; ++j)
       new_matrix.vectors[i][j] = original.vectors[j][i];
   return new_matrix;
 }
 
 void matrix_3x3::debug(FSTR_P const title) {
   if (title) SERIAL_ECHOLNF(title);
-  LOOP_L_N(i, 3) {
-    LOOP_L_N(j, 3) {
+  for (uint8_t i = 0; i < 3; ++i) {
+    for (uint8_t j = 0; j < 3; ++j) {
       serial_offset(vectors[i][j], 2);
       SERIAL_CHAR(' ');
     }

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -480,7 +480,7 @@ void __O2 Endstops::report_states() {
   #endif
   #if MULTI_FILAMENT_SENSOR
     #define _CASE_RUNOUT(N) case N: pin = FIL_RUNOUT##N##_PIN; state = FIL_RUNOUT##N##_STATE; break;
-    LOOP_S_LE_N(i, 1, NUM_RUNOUT_SENSORS) {
+    for (uint8_t i = 1; i <= NUM_RUNOUT_SENSORS; ++i) {
       pin_t pin;
       uint8_t state;
       switch (i) {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1520,7 +1520,7 @@ void Planner::check_axes_activity() {
    * The multiplier converts a given E value into a length.
    */
   void Planner::calculate_volumetric_multipliers() {
-    LOOP_L_N(i, COUNT(filament_size)) {
+    for (uint8_t i = 0; i < COUNT(filament_size); ++i) {
       volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
       refresh_e_factor(i);
     }
@@ -2260,7 +2260,7 @@ bool Planner::_populate_block(
       #if ENABLED(DISABLE_OTHER_EXTRUDERS) // Enable only the selected extruder
 
         // Count down all steppers that were recently moved
-        LOOP_L_N(i, E_STEPPERS)
+        for (uint8_t i = 0; i < E_STEPPERS; ++i)
           if (extruder_last_move[i]) extruder_last_move[i]--;
 
         // Switching Extruder uses one E stepper motor per two nozzles

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -650,7 +650,7 @@ class Planner {
         filament_size[e] = v;
         if (v > 0) volumetric_area_nominal = CIRCLE_AREA(v * 0.5); //TODO: should it be per extruder
         // make sure all extruders have some sane value for the filament size
-        LOOP_L_N(i, COUNT(filament_size))
+        for (uint8_t i = 0; i < COUNT(filament_size); ++i)
           if (!filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
       }
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -811,7 +811,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_p
 
       #if EXTRA_PROBING > 0
         // Insert Z measurement into probes[]. Keep it sorted ascending.
-        LOOP_LE_N(i, p) {                                             // Iterate the saved Zs to insert the new Z
+        for (uint8_t i = 0; i <= p; ++i) {                            // Iterate the saved Zs to insert the new Z
           if (i == p || probes[i] > z) {                              // Last index or new Z is smaller than this Z
             for (int8_t m = p; --m >= i;) probes[m + 1] = probes[m];  // Shift items down after the insertion point
             probes[i] = z;                                            // Insert the new Z measurement
@@ -849,7 +849,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/, const_float_t z_min_p
           max_avg_idx--; else min_avg_idx++;
 
       // Return the average value of all remaining probes.
-      LOOP_S_LE_N(i, min_avg_idx, max_avg_idx)
+      for (uint8_t i = min_avg_idx; i <= max_avg_idx; ++i)
         probes_z_sum += probes[i];
 
     #endif

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -874,7 +874,7 @@ void MarlinSettings::postprocess() {
     {
       #if HAS_HOTEND_OFFSET
         // Skip hotend 0 which must be 0
-        LOOP_S_L_N(e, 1, HOTENDS)
+        for (uint8_t e = 1; e < HOTENDS; ++e)
           EEPROM_WRITE(hotend_offset[e]);
       #endif
     }
@@ -1885,7 +1885,7 @@ void MarlinSettings::postprocess() {
       {
         #if HAS_HOTEND_OFFSET
           // Skip hotend 0 which must be 0
-          LOOP_S_L_N(e, 1, HOTENDS)
+          for (uint8_t e = 1; e < HOTENDS; ++e)
             EEPROM_READ(hotend_offset[e]);
         #endif
       }
@@ -3294,7 +3294,7 @@ void MarlinSettings::reset() {
     #if HAS_FAN
       constexpr uint8_t fpre[] = { REPEAT2_S(1, INCREMENT(PREHEAT_COUNT), _PITEM, FAN_SPEED) };
     #endif
-    LOOP_L_N(i, PREHEAT_COUNT) {
+    for (uint8_t i = 0; i < PREHEAT_COUNT; ++i) {
       TERN_(HAS_HOTEND,     ui.material_preset[i].hotend_temp = hpre[i]);
       TERN_(HAS_HEATED_BED, ui.material_preset[i].bed_temp = bpre[i]);
       TERN_(HAS_FAN,        ui.material_preset[i].fan_speed = fpre[i]);
@@ -3435,10 +3435,10 @@ void MarlinSettings::reset() {
 
   #if DISABLED(NO_VOLUMETRICS)
     parser.volumetric_enabled = ENABLED(VOLUMETRIC_DEFAULT_ON);
-    LOOP_L_N(q, COUNT(planner.filament_size))
+    for (uint8_t q = 0; q < COUNT(planner.filament_size); ++q)
       planner.filament_size[q] = DEFAULT_NOMINAL_FILAMENT_DIA;
     #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-      LOOP_L_N(q, COUNT(planner.volumetric_extruder_limit))
+      for (uint8_t q = 0; q < COUNT(planner.volumetric_extruder_limit); ++q)
         planner.volumetric_extruder_limit[q] = DEFAULT_VOLUMETRIC_EXTRUDER_LIMIT;
     #endif
   #endif
@@ -3469,7 +3469,7 @@ void MarlinSettings::reset() {
 
   #if HAS_MOTOR_CURRENT_PWM
     constexpr uint32_t tmp_motor_current_setting[MOTOR_CURRENT_COUNT] = PWM_MOTOR_CURRENT;
-    LOOP_L_N(q, MOTOR_CURRENT_COUNT)
+    for (uint8_t q = 0; q < MOTOR_CURRENT_COUNT; ++q)
       stepper.set_digipot_current(q, (stepper.motor_current_setting[q] = tmp_motor_current_setting[q]));
   #endif
 
@@ -3479,7 +3479,7 @@ void MarlinSettings::reset() {
   #if HAS_MOTOR_CURRENT_SPI
     static constexpr uint32_t tmp_motor_current_setting[] = DIGIPOT_MOTOR_CURRENT;
     DEBUG_ECHOLNPGM("Writing Digipot");
-    LOOP_L_N(q, COUNT(tmp_motor_current_setting))
+    for (uint8_t q = 0; q < COUNT(tmp_motor_current_setting); ++q)
       stepper.set_digipot_current(q, tmp_motor_current_setting[q]);
     DEBUG_ECHOLNPGM("Digipot Written");
   #endif
@@ -3686,8 +3686,8 @@ void MarlinSettings::reset() {
       #if ENABLED(MESH_BED_LEVELING)
 
         if (leveling_is_valid()) {
-          LOOP_L_N(py, GRID_MAX_POINTS_Y) {
-            LOOP_L_N(px, GRID_MAX_POINTS_X) {
+          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
+            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
               CONFIG_ECHO_START();
               SERIAL_ECHOPGM("  G29 S3 I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(bedlevel.z_values[px][py]), 5);
@@ -3712,8 +3712,8 @@ void MarlinSettings::reset() {
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
         if (leveling_is_valid()) {
-          LOOP_L_N(py, GRID_MAX_POINTS_Y) {
-            LOOP_L_N(px, GRID_MAX_POINTS_X) {
+          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
+            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
               CONFIG_ECHO_START();
               SERIAL_ECHOPGM("  G29 W I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(bedlevel.z_values[px][py]), 5);
@@ -3765,7 +3765,7 @@ void MarlinSettings::reset() {
     TERN_(PIDTEMPCHAMBER, gcode.M309_report(forReplay));
 
     #if HAS_USER_THERMISTORS
-      LOOP_L_N(i, USER_THERMISTORS)
+      for (uint8_t i = 0; i < USER_THERMISTORS; ++i)
         thermalManager.M305_report(i, forReplay);
     #endif
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2842,7 +2842,7 @@ void Stepper::init() {
   #if MB(ALLIGATOR)
     const float motor_current[] = MOTOR_CURRENT;
     unsigned int digipot_motor = 0;
-    LOOP_L_N(i, 3 + EXTRUDERS) {
+    for (uint8_t i = 0; i < 3 + EXTRUDERS; ++i) {
       digipot_motor = 255 * (motor_current[i] / 2.5);
       dac084s085::setValue(i, digipot_motor);
     }
@@ -3725,7 +3725,7 @@ void Stepper::report_positions() {
 
   void Stepper::refresh_motor_power() {
     if (!initialized) return;
-    LOOP_L_N(i, COUNT(motor_current_setting)) {
+    for (uint8_t i = 0; i < COUNT(motor_current_setting); ++i) {
       switch (i) {
         #if ANY_PIN(MOTOR_CURRENT_PWM_XY, MOTOR_CURRENT_PWM_X, MOTOR_CURRENT_PWM_Y, MOTOR_CURRENT_PWM_I, MOTOR_CURRENT_PWM_J, MOTOR_CURRENT_PWM_K, MOTOR_CURRENT_PWM_U, MOTOR_CURRENT_PWM_V, MOTOR_CURRENT_PWM_W)
           case 0:
@@ -3821,7 +3821,7 @@ void Stepper::report_positions() {
         SPI.begin();
         SET_OUTPUT(DIGIPOTSS_PIN);
 
-        LOOP_L_N(i, COUNT(motor_current_setting))
+        for (uint8_t i = 0; i < COUNT(motor_current_setting); ++i)
           set_digipot_current(i, motor_current_setting[i]);
 
       #elif HAS_MOTOR_CURRENT_PWM

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -501,7 +501,7 @@ enum StealthIndex : uint8_t {
       struct {
         const void *ptr[TMCAxis::TOTAL];
         bool began(const TMCAxis a, const void * const p) {
-          LOOP_L_N(i, a) if (p == ptr[i]) return true;
+          for (uint8_t i = 0; i < a; ++i) if (p == ptr[i]) return true;
           ptr[a] = p; return false;
         };
       } sp_helper;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1400,7 +1400,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
     }while(0)
 
     uint8_t fanDone = 0;
-    LOOP_L_N(f, COUNT(fanBit)) {
+    for (uint8_t f = 0; f < COUNT(fanBit); ++f) {
       const uint8_t realFan = pgm_read_byte(&fanBit[f]);
       if (TEST(fanDone, realFan)) continue;
       const bool fan_on = TEST(fanState, realFan);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -273,7 +273,7 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
       base::reset();
       prev_e_pos = 0;
       lpq_ptr = 0;
-      LOOP_L_N(i, LPQ_ARR_SZ) lpq[i] = 0;
+      for (uint8_t i = 0; i < LPQ_ARR_SZ; ++i) lpq[i] = 0;
     }
 
     float get_extrusion_scale_output(const bool is_active, const int32_t e_position, const float e_mm_per_step, const int16_t lpq_len) {
@@ -877,7 +877,7 @@ class Temperature {
     #if HAS_FAN
 
       static uint8_t fan_speed[FAN_COUNT];
-      #define FANS_LOOP(I) LOOP_L_N(I, FAN_COUNT)
+      #define FANS_LOOP(I) for (uint8_t I = 0; I < FAN_COUNT; ++I)
 
       static void set_fan_speed(const uint8_t fan, const uint16_t speed);
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -250,7 +250,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 #elif ENABLED(PARKING_EXTRUDER)
 
   void pe_solenoid_init() {
-    LOOP_LE_N(n, 1) pe_solenoid_set_pin_state(n, !PARKING_EXTRUDER_SOLENOIDS_PINS_ACTIVE);
+    for (uint8_t n = 0; n <= 1; ++n) pe_solenoid_set_pin_state(n, !PARKING_EXTRUDER_SOLENOIDS_PINS_ACTIVE);
   }
 
   void pe_solenoid_set_pin_state(const uint8_t extruder_num, const uint8_t state) {

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -206,7 +206,7 @@ inline void report_pin_state_extended(const pin_t pin, const bool ignore, const 
     return true;
   };
 
-  LOOP_L_N(x, COUNT(pin_array))  {    // scan entire array and report all instances of this pin
+  for (uint8_t x = 0; x < COUNT(pin_array); ++x)  {    // scan entire array and report all instances of this pin
     if (GET_ARRAY_PIN(x) == pin) {
       if (!found) {    // report digital and analog pin number only on the first time through
         if (start_string) SERIAL_ECHOF(start_string);

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -74,7 +74,7 @@
   #else
     static uint8_t CRC7(const uint8_t *data, uint8_t n) {
       uint8_t crc = 0;
-      LOOP_L_N(i, n) {
+      for (uint8_t i = 0; i < n; ++i) {
         uint8_t d = data[i];
         d ^= crc << 1;
         if (d & 0x80) d ^= 9;
@@ -111,7 +111,7 @@ uint8_t DiskIODriver_SPI_SD::cardCommand(const uint8_t cmd, const uint32_t arg) 
     d[5] = CRC7(d, 5);
 
     // Send message
-    LOOP_L_N(k, 6) spiSend(d[k]);
+    for (uint8_t k = 0; k < 6; ++k) spiSend(d[k]);
 
   #else
     // Send command
@@ -268,7 +268,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
   spiInit(spiRate_);
 
   // Must supply min of 74 clock cycles with CS high.
-  LOOP_L_N(i, 10) spiSend(0xFF);
+  for (uint8_t i = 0; i < 10; ++i) spiSend(0xFF);
 
   hal.watchdog_refresh(); // In case init takes too long
 
@@ -294,7 +294,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
     }
 
     // Get the last byte of r7 response
-    LOOP_L_N(i, 4) status_ = spiRec();
+    for (uint8_t i = 0; i < 4; ++i) status_ = spiRec();
     if (status_ == 0xAA) {
       type(SD_CARD_TYPE_SD2);
       break;
@@ -325,7 +325,7 @@ bool DiskIODriver_SPI_SD::init(const uint8_t sckRateID, const pin_t chipSelectPi
     }
     if ((spiRec() & 0xC0) == 0xC0) type(SD_CARD_TYPE_SDHC);
     // Discard rest of ocr - contains allowed voltage range
-    LOOP_L_N(i, 3) spiRec();
+    for (uint8_t i = 0; i < 3; ++i) spiRec();
   }
   chipDeselect();
 

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -209,7 +209,7 @@ bool SdBaseFile::dirEntry(dir_t *dir) {
  */
 void SdBaseFile::dirName(const dir_t &dir, char *name) {
   uint8_t j = 0;
-  LOOP_L_N(i, 11) {
+  for (uint8_t i = 0; i < 11; ++i) {
     if (dir.name[i] == ' ')continue;
     if (i == 8) name[j++] = '.';
     name[j++] = dir.name[i];
@@ -350,10 +350,10 @@ int8_t SdBaseFile::lsPrintNext(const uint8_t flags, const uint8_t indent) {
         && DIR_IS_FILE_OR_SUBDIR(&dir)) break;
   }
   // indent for dir level
-  LOOP_L_N(i, indent) SERIAL_CHAR(' ');
+  for (uint8_t i = 0; i < indent; ++i) SERIAL_CHAR(' ');
 
   // print name
-  LOOP_L_N(i, 11) {
+  for (uint8_t i = 0; i < 11; ++i) {
     if (dir.name[i] == ' ')continue;
     if (i == 8) {
       SERIAL_CHAR('.');
@@ -504,7 +504,7 @@ bool SdBaseFile::mkdir(SdBaseFile * const parent, const uint8_t dname[11]
   dir_t d;
   memcpy(&d, p, sizeof(d));
   d.name[0] = '.';
-  LOOP_S_L_N(i, 1, 11) d.name[i] = ' ';
+  for (uint8_t i = 1; i < 11; ++i) d.name[i] = ' ';
 
   // cache block for '.'  and '..'
   uint32_t block = vol_->clusterStartBlock(firstCluster_);
@@ -771,7 +771,7 @@ bool SdBaseFile::open(SdBaseFile * const dirFile, const uint8_t dname[11]
       if (!dirFile->seekSet(32 * index)) return false;
 
       // Dir entries write loop: [LFN] + SFN(1)
-      LOOP_L_N(dirWriteIdx, reqEntriesNum) {
+      for (uint8_t dirWriteIdx = 0; dirWriteIdx < reqEntriesNum; ++dirWriteIdx) {
         index = (dirFile->curPosition_ / 32) & 0xF;
         p = dirFile->readDirCache();
         // LFN or SFN Entry?
@@ -1137,7 +1137,7 @@ bool SdBaseFile::openNext(SdBaseFile *dirFile, const uint8_t oflag) {
    */
   void SdBaseFile::getLFNName(vfat_t *pFatDir, char *lname, const uint8_t sequenceNumber) {
     const uint8_t startOffset = (sequenceNumber - 1) * FILENAME_LENGTH;
-    LOOP_L_N(i, FILENAME_LENGTH) {
+    for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
       const uint16_t utf16_ch = (i >= 11) ? pFatDir->name3[i - 11] : (i >= 5) ? pFatDir->name2[i - 5] : pFatDir->name1[i];
       #if ENABLED(UTF_FILENAME_SUPPORT)
         // We can't reconvert to UTF-8 here as UTF-8 is variable-size encoding, but joining LFN blocks
@@ -1158,7 +1158,7 @@ bool SdBaseFile::openNext(SdBaseFile *dirFile, const uint8_t oflag) {
   void SdBaseFile::setLFNName(vfat_t *pFatDir, char *lname, const uint8_t sequenceNumber) {
     const uint8_t startOffset = (sequenceNumber - 1) * FILENAME_LENGTH,
                   nameLength = strlen(lname);
-    LOOP_L_N(i, FILENAME_LENGTH) {
+    for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
       uint16_t ch = 0;
       if ((startOffset + i) < nameLength)
         ch = lname[startOffset + i];
@@ -1479,7 +1479,7 @@ int8_t SdBaseFile::readDir(dir_t * const dir, char * const longFilename) {
 
               n = (seq - 1) * (FILENAME_LENGTH);
 
-              LOOP_L_N(i, FILENAME_LENGTH) {
+              for (uint8_t i = 0; i < FILENAME_LENGTH; ++i) {
                 const uint16_t utf16_ch = (i >= 11) ? VFAT->name3[i - 11] : (i >= 5) ? VFAT->name2[i - 5] : VFAT->name1[i];
                 #if ENABLED(UTF_FILENAME_SUPPORT)
                   // We can't reconvert to UTF-8 here as UTF-8 is variable-size encoding, but joining LFN blocks
@@ -1627,7 +1627,7 @@ bool SdBaseFile::remove() {
     // Check if the entry has a LFN
     bool lastEntry = false;
     // loop back to search for any LFN entries related to this file
-    LOOP_S_LE_N(sequenceNumber, 1, VFAT_ENTRIES_LIMIT) {
+    for (uint8_t sequenceNumber = 1; sequenceNumber <= VFAT_ENTRIES_LIMIT; ++sequenceNumber) {
       dirIndex_ = (dirIndex_ - 1) & 0xF;
       if (dirBlock_ == 0) break;
       if (dirIndex_ == 0xF) dirBlock_--;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -190,7 +190,7 @@ CardReader::CardReader() {
 //
 char *createFilename(char * const buffer, const dir_t &p) {
   char *pos = buffer;
-  LOOP_L_N(i, 11) {
+  for (uint8_t i = 0; i < 11; ++i) {
     if (p.name[i] == ' ') continue;
     if (i == 8) *pos++ = '.';
     *pos++ = p.name[i];
@@ -650,7 +650,7 @@ void CardReader::getAbsFilenameInCWD(char *dst) {
     if (cnt < MAXPATHNAMELENGTH) { *dst = '/'; dst++; cnt++; }
   };
 
-  LOOP_L_N(i, workDirDepth)                // Loop down to current work dir
+  for (uint8_t i = 0; i < workDirDepth; ++i)                // Loop down to current work dir
     appendAtom(workDirParents[i]);
 
   if (cnt < MAXPATHNAMELENGTH - (FILENAME_LENGTH) - 1) {    // Leave room for filename and nul
@@ -1377,7 +1377,7 @@ void CardReader::cdroot() {
       #if ENABLED(SDSORT_DYNAMIC_RAM)
         delete [] sort_order;
         #if ENABLED(SDSORT_CACHE_NAMES)
-          LOOP_L_N(i, sort_count) {
+          for (uint8_t i = 0; i < sort_count; ++i) {
             free(sortshort[i]); // strdup
             free(sortnames[i]); // strdup
           }


### PR DESCRIPTION
Marlin's potential to attract developers has been stifled by these macros. This PR removes them in favor of familiar and beloved `for` loops.