### PR TITLE
fix missed case conversion from issue 25914

### DIFF
--- a/Marlin/src/lcd/tft/canvas.cpp
+++ b/Marlin/src/lcd/tft/canvas.cpp
@@ -85,10 +85,10 @@ void Canvas::addText(uint16_t x, uint16_t y, uint16_t color, uint16_t *string, u
     if (stringWidth + pGlyph->BBXWidth > maxWidth) break;
     switch (getFontType()) {
       case FONT_MARLIN_GLYPHS_1BPP:
-        addImage(x + stringWidth + pGlyph->BBXOffsetX, y + getFontAscent() - pGlyph->BBXHeight - pGlyph->BBXOffsetY, pGlyph->BBXWidth, pGlyph->BBXHeight, GREYSCALE1, ((uint8_t *)glyph) + sizeof(glyph_t), &color);
+        addImage(x + stringWidth + pGlyph->BBXOffsetX, y + getFontAscent() - pGlyph->BBXHeight - pGlyph->BBXOffsetY, pGlyph->BBXWidth, pGlyph->BBXHeight, GREYSCALE1, ((uint8_t *)pGlyph) + sizeof(glyph_t), &color);
         break;
       case FONT_MARLIN_GLYPHS_2BPP:
-        addImage(x + stringWidth + pGlyph->BBXOffsetX, y + getFontAscent() - pGlyph->BBXHeight - pGlyph->BBXOffsetY, pGlyph->BBXWidth, pGlyph->BBXHeight, GREYSCALE2, ((uint8_t *)glyph) + sizeof(glyph_t), colors);
+        addImage(x + stringWidth + pGlyph->BBXOffsetX, y + getFontAscent() - pGlyph->BBXHeight - pGlyph->BBXOffsetY, pGlyph->BBXWidth, pGlyph->BBXHeight, GREYSCALE2, ((uint8_t *)pGlyph) + sizeof(glyph_t), colors);
         break;
     }
     stringWidth += pGlyph->DWidth;


### PR DESCRIPTION
### Description

After #25914 text in tft displays is corrupted

Image from discord user whom reported the issue

![20230602_184440](https://github.com/MarlinFirmware/Marlin/assets/530024/4eed11cc-3fe3-4f67-9f81-7528c6c8430b)
 
### Requirements

A Marlin drawn TFT display such as TFT_COLOR_UI on MKS_TS35_V2_0

### Benefits

Text works as expected

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
https://github.com/MarlinFirmware/Marlin/pull/25914
