### PR TITLE
Only include u8glib when needed to avoid compilation error

### DIFF
--- a/Marlin/src/HAL/SAMD21/u8g/u8g_com_HAL_samd21_shared_hw_spi.cpp
+++ b/Marlin/src/HAL/SAMD21/u8g/u8g_com_HAL_samd21_shared_hw_spi.cpp
@@ -60,6 +60,8 @@
 
 #ifdef __SAMD21__
 
+#if HAS_MARLINUI_U8GLIB
+
 #include <U8glib-HAL.h>
 #include "SPI.h"
 
@@ -150,5 +152,7 @@ uint8_t u8g_com_samd21_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val
   }
   return 1;
 }
+
+#endif // HAS_MARLINUI_U8GLIB
 
 #endif // __SAMD21__

--- a/Marlin/src/HAL/SAMD21/u8g/u8g_com_HAL_samd21_shared_hw_spi.cpp
+++ b/Marlin/src/HAL/SAMD21/u8g/u8g_com_HAL_samd21_shared_hw_spi.cpp
@@ -60,6 +60,8 @@
 
 #ifdef __SAMD21__
 
+#include "../../../inc/MarlinConfigPre.h"
+
 #if HAS_MARLINUI_U8GLIB
 
 #include <U8glib-HAL.h>


### PR DESCRIPTION


### Description

Fixes a compilation error when not having selected a u8g display
 
### Requirements

No

### Benefits

Fixes compilation error

### Configurations
None

### Related Issues

None
