### PR TITLE
Add SKR Mini E3 V3.0.1 XFER Build

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3988,8 +3988,8 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 #endif
 
 // Check requirements for upload.py
-#if ENABLED(XFER_BUILD) && !ALL(BINARY_FILE_TRANSFER, CUSTOM_FIRMWARE_UPLOAD)
-  #error "BINARY_FILE_TRANSFER and CUSTOM_FIRMWARE_UPLOAD are required for custom upload."
+#if ENABLED(XFER_BUILD) && !ALL(SDSUPPORT, BINARY_FILE_TRANSFER, CUSTOM_FIRMWARE_UPLOAD)
+  #error "SDSUPPORT, BINARY_FILE_TRANSFER, and CUSTOM_FIRMWARE_UPLOAD are required for custom upload."
 #endif
 
 /**

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -613,7 +613,7 @@
 #elif MB(BTT_MANTA_M8P_V1_1)
   #include "stm32g0/pins_BTT_MANTA_M8P_V1_1.h"    // STM32G0                              env:STM32G0B1VE_btt env:STM32G0B1VE_btt_xfer
 #elif MB(BTT_SKR_MINI_E3_V3_0_1)
-  #include "stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h"// STM32F4                              env:STM32F401RC_btt
+  #include "stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h"// STM32F4                              env:STM32F401RC_btt env:STM32F401RC_btt_xfer
 #elif MB(BTT_SKR_MINI_MZ_V1_0)
   #include "stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 #elif MB(BTT_SKR_E3_DIP)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -744,6 +744,20 @@ upload_protocol             = stlink
 debug_tool                  = stlink
 
 #
+# BigTreeTech SKR Mini E3 V3.0.1 (STM32F401RCT6 ARM Cortex-M0+)
+# Custom upload to SD via Marlin with Binary Protocol
+# Requires Marlin with BINARY_FILE_TRANSFER already installed on the target board.
+# If CUSTOM_FIRMWARE_UPLOAD is also installed, Marlin will reboot the board to install the firmware.
+# Currently CUSTOM_FIRMWARE_UPLOAD must also be enabled to use 'xfer' build envs.
+#
+[env:STM32F401RC_btt_xfer]
+extends         = env:STM32F401RC_btt
+build_flags     = ${env:STM32F401RC_btt.build_flags} -DXFER_BUILD
+extra_scripts   = ${env:STM32F401RC_btt.extra_scripts}
+                  pre:buildroot/share/scripts/upload.py
+upload_protocol = custom
+
+#
 # MKS SKIPR v1.0 all-in-one board (STM32F407VE)
 #
 [env:mks_skipr_v1]


### PR DESCRIPTION
### Description

- Add SKR Mini E3 V3.0.1 `*_xfer` environment, similar to SKR Mini E3 V3.0's `*_xfer` environment.
- Add `SDSUPPORT` to `XFER_BUILD` sanity check. `BINARY_FILE_TRANSFER` & `CUSTOM_FIRMWARE_UPLOAD` require the `HAS_MEDIA` flag to be set, but users shouldn't define `HAS_MEDIA` directly. Since `SDSUPPORT` = `HAS_MEDIA`, check that `SDSUPPORT` is enabled.

_Note: I can't test this since I don't own an SKR Mini E3 V3.0.1, but it's identical to the SKR Mini E3's `*_xfer` environment._

### Requirements

SKR Mini E3 V3.0.1

### Benefits

Users with an SKR Mini E3 V3.0.1 can upload firmware to the board via `BINARY_FILE_TRANSFER` over USB.

### Configurations

```cpp
#define MOTHERBOARD BOARD_BTT_SKR_MINI_E3_V3_0_1
#define SERIAL_PORT -1
#define SDSUPPORT
#define BINARY_FILE_TRANSFER
#define CUSTOM_FIRMWARE_UPLOAD
```
```ini
default_envs = STM32F401RC_btt_xfer
```

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/24245
