### PR TITLE
🔨 Simpler firmware unique rename

### DIFF
--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -60,6 +60,7 @@ if pioutil.is_pio_build():
 
         def rename_target(source, target, env):
             from pathlib import Path
-            Path(target[0].path).replace(Path(target[0].dir.path, new_name))
+            from datetime import datetime
+            Path(target[0].path).replace(Path(target[0].dir.path, datetime.now().strftime(new_name.replace('{date}', '%Y%m%d').replace('{time}', '%H%M%S'))))
 
         marlin.add_post_action(rename_target)

--- a/buildroot/share/PlatformIO/scripts/random-bin.py
+++ b/buildroot/share/PlatformIO/scripts/random-bin.py
@@ -1,9 +1,0 @@
-#
-# random-bin.py
-# Set a unique firmware name based on current date and time
-#
-import pioutil
-if pioutil.is_pio_build():
-    from datetime import datetime
-    Import("env")
-    env['PROGNAME'] = datetime.now().strftime("firmware-%Y%m%d-%H%M%S")

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -118,8 +118,7 @@ extends              = env:STM32F103RE_maple
 build_flags          = ${env:STM32F103RE_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = creality.ld
-extra_scripts        = ${env:STM32F103RE_maple.extra_scripts}
-                       pre:buildroot/share/PlatformIO/scripts/random-bin.py
+board_build.rename   = firmware-{date}-{time}
 debug_tool           = jlink
 upload_protocol      = jlink
 
@@ -131,8 +130,7 @@ extends              = env:STM32F103RC_maple
 build_flags          = ${env:STM32F103RC_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = creality.ld
-extra_scripts        = ${env:STM32F103RC_maple.extra_scripts}
-                       pre:buildroot/share/PlatformIO/scripts/random-bin.py
+board_build.rename   = firmware-{date}-{time}
 debug_tool           = jlink
 upload_protocol      = jlink
 
@@ -400,8 +398,8 @@ extends              = env:STM32F103RE_maple
 build_flags          = ${STM32F1_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = sovol.ld
+board_build.rename   = firmware-{date}-{time}
 extra_scripts        = ${STM32F1_maple.extra_scripts}
-  pre:buildroot/share/PlatformIO/scripts/random-bin.py
   buildroot/share/PlatformIO/scripts/custom_board.py
 debug_tool           = jlink
 upload_protocol      = jlink

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -121,6 +121,7 @@ debug_tool                  = stlink
 extends                     = stm32_variant
 board_build.variant         = MARLIN_F103Rx
 board_build.offset          = 0x7000
+board_build.rename          = firmware-{date}-{time}
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}
                               -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED
@@ -128,8 +129,6 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
 build_unflags               = ${stm32_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC
-extra_scripts               = ${stm32_variant.extra_scripts}
-                              pre:buildroot/share/PlatformIO/scripts/random-bin.py
 monitor_speed               = 115200
 debug_tool                  = jlink
 upload_protocol             = jlink

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -684,12 +684,11 @@ board                       = genericSTM32F401RC
 board_build.variant         = MARLIN_CREALITY_STM32F401RC
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
+board_build.rename          = firmware-{date}-{time}
 build_flags                 = ${stm32_variant.build_flags} -DMCU_STM32F401RC -DSTM32F4
                               -DSS_TIMER=4 -DTIMER_SERVO=TIM5
                               -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
 build_unflags               = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts               = ${stm32_variant.extra_scripts}
-                              pre:buildroot/share/PlatformIO/scripts/random-bin.py
 monitor_speed               = 115200
 
 [env:STM32F401RC_creality_jlink]
@@ -710,10 +709,9 @@ extends                     = stm32_variant
 board                       = marlin_CREALITY_STM32F401RE
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
+board_build.rename          = firmware-{date}-{time}
 build_flags                 = ${stm32_variant.build_flags} -DSTM32F401xE -DSTM32F4 -DSTM32F4_UPDATE_FOLDER
 build_unflags               = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts               = ${stm32_variant.extra_scripts}
-                              pre:buildroot/share/PlatformIO/scripts/random-bin.py
 monitor_speed               = 115200
 
 [env:STM32F401RE_creality_jlink]


### PR DESCRIPTION
Always rename the firmware binary using the `board_build.rename` field. If a distinct name is needed the name can simply include `{date}` and/or `{time}` and these will be replaced with the build date and time.