### PR TITLE
Append ".bin" to Creality Firmware Builds

### DIFF
--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -118,7 +118,7 @@ extends              = env:STM32F103RE_maple
 build_flags          = ${env:STM32F103RE_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = creality.ld
-board_build.rename   = firmware-{date}-{time}
+board_build.rename   = firmware-{date}-{time}.bin
 debug_tool           = jlink
 upload_protocol      = jlink
 
@@ -130,7 +130,7 @@ extends              = env:STM32F103RC_maple
 build_flags          = ${env:STM32F103RC_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = creality.ld
-board_build.rename   = firmware-{date}-{time}
+board_build.rename   = firmware-{date}-{time}.bin
 debug_tool           = jlink
 upload_protocol      = jlink
 
@@ -398,7 +398,7 @@ extends              = env:STM32F103RE_maple
 build_flags          = ${STM32F1_maple.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
 board_build.ldscript = sovol.ld
-board_build.rename   = firmware-{date}-{time}
+board_build.rename   = firmware-{date}-{time}.bin
 extra_scripts        = ${STM32F1_maple.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
 debug_tool           = jlink

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -121,7 +121,7 @@ debug_tool                  = stlink
 extends                     = stm32_variant
 board_build.variant         = MARLIN_F103Rx
 board_build.offset          = 0x7000
-board_build.rename          = firmware-{date}-{time}
+board_build.rename          = firmware-{date}-{time}.bin
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}
                               -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -684,7 +684,7 @@ board                       = genericSTM32F401RC
 board_build.variant         = MARLIN_CREALITY_STM32F401RC
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
-board_build.rename          = firmware-{date}-{time}
+board_build.rename          = firmware-{date}-{time}.bin
 build_flags                 = ${stm32_variant.build_flags} -DMCU_STM32F401RC -DSTM32F4
                               -DSS_TIMER=4 -DTIMER_SERVO=TIM5
                               -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
@@ -709,7 +709,7 @@ extends                     = stm32_variant
 board                       = marlin_CREALITY_STM32F401RE
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
-board_build.rename          = firmware-{date}-{time}
+board_build.rename          = firmware-{date}-{time}.bin
 build_flags                 = ${stm32_variant.build_flags} -DSTM32F401xE -DSTM32F4 -DSTM32F4_UPDATE_FOLDER
 build_unflags               = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC
 monitor_speed               = 115200


### PR DESCRIPTION
### Description

Append ".bin" to Creality firmware builds / followup to https://github.com/MarlinFirmware/Marlin/pull/25957

### Benefits

`firmware-{date}-{time}.bin` will be generated correctly.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/25960
- https://github.com/MarlinFirmware/Marlin/pull/25957
