### PR TITLE
Update MPC Comments

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -716,8 +716,12 @@
     //#define MPC_FAN_0_ACTIVE_HOTEND
   #endif
 
+  // Filament Heat Capacity (joules/kelvin/mm)
+  // Set at runtime with M306 H<value>
   #define FILAMENT_HEAT_CAPACITY_PERMM { 5.6e-3f }    // 0.0056 J/K/mm for 1.75mm PLA (0.0149 J/K/mm for 2.85mm PLA).
-  //#define FILAMENT_HEAT_CAPACITY_PERMM { 3.6e-3f }  // 0.0036 J/K/mm for 1.75mm PETG (0.0094 J/K/mm for 2.85mm PETG).
+                                                      // 0.0036 J/K/mm for 1.75mm PETG (0.0094 J/K/mm for 2.85mm PETG).
+                                                      // 0.00515 J/K/mm for 1.75mm ABS (0.0137 J/K/mm for 2.85mm ABS).
+                                                      // 0.00522 J/K/mm for 1.75mm Nylon (0.0138 J/K/mm for 2.85mm Nylon).
 
   // Advanced options
   #define MPC_SMOOTHING_FACTOR 0.5f                   // (0.0...1.0) Noisy temperature sensors may need a lower value for stabilization.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -692,7 +692,7 @@
  * @section mpctemp
  */
 #if ENABLED(MPCTEMP)
-  //#define MPC_AUTOTUNE                              // Include a method to do MPC auto-tuning (~6.3K bytes of flash)
+  #define MPC_AUTOTUNE                                // Include a method to do MPC auto-tuning (~6.3K bytes of flash)
   //#define MPC_EDIT_MENU                             // Add MPC editing to the "Advanced Settings" menu. (~1.3K bytes of flash)
   //#define MPC_AUTOTUNE_MENU                         // Add MPC auto-tuning to the "Advanced Settings" menu. (~350 bytes of flash)
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -688,7 +688,8 @@
  *
  * Use a physical model of the hotend to control temperature. When configured correctly
  * this gives better responsiveness and stability than PID and it also removes the need
- * for PID_EXTRUSION_SCALING and PID_FAN_SCALING. Use M306 T to autotune the model.
+ * for PID_EXTRUSION_SCALING and PID_FAN_SCALING. Enable MPC_AUTOTUNE and use M306 T to
+ * autotune the model.
  * @section mpctemp
  */
 #if ENABLED(MPCTEMP)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -686,10 +686,9 @@
 /**
  * Model Predictive Control for hotend
  *
- * Use a physical model of the hotend to control temperature. When configured correctly
- * this gives better responsiveness and stability than PID and it also removes the need
- * for PID_EXTRUSION_SCALING and PID_FAN_SCALING. Enable MPC_AUTOTUNE and use M306 T to
- * autotune the model.
+ * Use a physical model of the hotend to control temperature. When configured correctly this gives
+ * better responsiveness and stability than PID and removes the need for PID_EXTRUSION_SCALING
+ * and PID_FAN_SCALING. Enable MPC_AUTOTUNE and use M306 T to autotune the model.
  * @section mpctemp
  */
 #if ENABLED(MPCTEMP)


### PR DESCRIPTION
### Description

- Since `MPC_AUTOTUNE` is disabled by default now, remind users to enable it so `M306 T` works.
- Update Filament Heat Capacity section to remove duplicate define & add runtime reminder text along with values from [Model Predictive Temperature Control](https://marlinfw.org/docs/features/model_predictive_control.html).

### Requirements

`MPCTEMP`

### Benefits

- `M306 T`/MPC Autotune will work correctly.
- Users will see that Filament Heat Capacity is a runtime option.

### Related Issues

None, but I've seen several users report MPC autotuning not working because they didn't know it is disabled by default now.
