### PR TITLE
Finish changing DWIN_LevelingDone to dwinLevelingDone

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -814,7 +814,7 @@ void unified_bed_leveling::shift_mesh_height() {
     );
 
     TERN_(EXTENSIBLE_UI, ExtUI::onLevelingDone());
-    TERN_(DWIN_LCD_PROUI, DWIN_LevelingDone());
+    TERN_(DWIN_LCD_PROUI, dwinLevelingDone());
   }
 
 #endif // HAS_BED_PROBE

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1427,7 +1427,7 @@ void DWIN_LevelingStart() {
   #endif
 }
 
-void DWIN_LevelingDone() {
+void dwinLevelingDone() {
   TERN_(HAS_MESH, Goto_MeshViewer());
 }
 

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -269,7 +269,7 @@ void dwinHomingDone();
   void DWIN_MeshUpdate(const int8_t cpos, const int8_t tpos, const_float_t zval);
 #endif
 void DWIN_LevelingStart();
-void DWIN_LevelingDone();
+void dwinLevelingDone();
 void DWIN_Print_Started();
 void DWIN_Print_Pause();
 void DWIN_Print_Resume();


### PR DESCRIPTION
PR #25939 partially implemented changing the function name `DWIN_LevelingDone` to `dwinLevelingDone`.  This PR finishes changing all occurrences of `DWIN_LevelingDone` to `dwinLevelingDone`.

Currently a compile error is generated when the [Ender 3V2 -> CrealityV422->CrealityUI example config](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3%20V2/CrealityV422/CrealityUI) is run during Klemtest.  