### PR TITLE
FT_MOTION : enable EI shaping mode with M493 S12, disable M493 S0 during a print

### DIFF
--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -169,6 +169,7 @@ void GcodeSuite::M493() {
         #if HAS_X_AXIS
           case ftMotionMode_ZV:
           case ftMotionMode_ZVD:
+          case ftMotionMode_EI:
           case ftMotionMode_2HEI:
           case ftMotionMode_3HEI:
           case ftMotionMode_MZV:

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -164,6 +164,12 @@ void GcodeSuite::M493() {
                          newmm = (ftMotionMode_t)parser.value_byte();
 
     if (newmm != oldmm) {
+
+      if (printJobOngoing()) {
+        SERIAL_ECHOLNPGM("Ongoing Job, control mode [S] forbidden.");
+        return;
+      }
+
       switch (newmm) {
         default: SERIAL_ECHOLNPGM("?Invalid control mode [S] value."); return;
         #if HAS_X_AXIS
@@ -179,7 +185,6 @@ void GcodeSuite::M493() {
         #endif
         case ftMotionMode_DISABLED:
         case ftMotionMode_ENABLED:
-          if(printJobOngoing() && ftMotionMode_DISABLED) {SERIAL_ECHOLNPGM("Ongoing Job, control mode [S] forbidden"); return;}
           fxdTiCtrl.cfg.mode = newmm;
           flag.report_h = true;
           if (oldmm == ftMotionMode_DISABLED) flag.reset_ft = true;

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -179,6 +179,7 @@ void GcodeSuite::M493() {
         #endif
         case ftMotionMode_DISABLED:
         case ftMotionMode_ENABLED:
+          if(printJobOngoing() && ftMotionMode_DISABLED) {SERIAL_ECHOLNPGM("Ongoing Job, control mode [S] forbidden"); return;}
           fxdTiCtrl.cfg.mode = newmm;
           flag.report_h = true;
           if (oldmm == ftMotionMode_DISABLED) flag.reset_ft = true;

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -164,12 +164,6 @@ void GcodeSuite::M493() {
                          newmm = (ftMotionMode_t)parser.value_byte();
 
     if (newmm != oldmm) {
-
-      if (printJobOngoing()) {
-        SERIAL_ECHOLNPGM("Ongoing Job, control mode [S] forbidden.");
-        return;
-      }
-
       switch (newmm) {
         default: SERIAL_ECHOLNPGM("?Invalid control mode [S] value."); return;
         #if HAS_X_AXIS


### PR DESCRIPTION

### Description

1. EI shaper is fully functionnal in FT_MOTION but can't be enabled with `M493 S12` because of a missing
`case` in `switch (newmm) { ...}` in `M493.cpp`
This PR only add the missing `case`.

2. Use of `M493 S0` during an ongoing print causes layer shitfing. Add a test in `M493.cpp` to avoid disabling ft_motion in this case.

