### PR TITLE
Homing Z axis at a given position  for BD Sensor

### DIFF
--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -79,7 +79,7 @@ bool BDS_Leveling::check(const uint16_t data, const bool raw_data/*=false*/, con
   }
   if (raw_data == true) {
     if (hicheck && (data & 0x3FF) > 550)
-      SERIAL_ECHOLNPGM("BD Sensor mounted too far or too close the bed! Recommended distance 0.5mm~2.0mm");
+      SERIAL_ECHOLNPGM("Bad BD Sensor height! Recommended distance 0.5-2.0mm");
     else if (!good_data(data))
       SERIAL_ECHOLNPGM("Invalid data, please calibrate.");
     else
@@ -109,10 +109,8 @@ void BDS_Leveling::process() {
   static float zpos = 0.0f;
   const millis_t ms = millis();
   if (ELAPSED(ms, next_check_ms)) { // timed out (or first run)
-    if(config_state == BDS_HOMING_Z)
-      next_check_ms = ms + 1;
-    else
-      next_check_ms = ms + (config_state < BDS_IDLE ? 200 : 50);   // check at 5Hz or 20Hz
+    // Check at 1KHz, 5Hz, or 20Hz
+    next_check_ms = ms + (config_state == BDS_HOMING_Z ? 1 : (config_state < BDS_IDLE ? 200 : 50));
 
     uint16_t tmp = 0;
     const float cur_z = planner.get_axis_position_mm(Z_AXIS) - pos_zero_offset;
@@ -130,16 +128,14 @@ void BDS_Leveling::process() {
             babystep.set_mm(Z_AXIS, cur_z - z_sensor);
             DEBUG_ECHOLNPGM("BD:", z_sensor, ", Z:", cur_z, "|", current_position.z);
           }
-          else {
-            babystep.set_mm(Z_AXIS, 0);   //if (old_cur_z <= cur_z) Z_DIR_WRITE(HIGH);
-            //stepper.apply_directions();   // TODO: Remove this line as probably not needed
-          }
+          else
+            babystep.set_mm(Z_AXIS, 0);
         }
       #endif
 
       old_cur_z = cur_z;
       old_buf_z = current_position.z;
-      endstops.bdp_state_update(z_sensor <= abs(probe.offset.z) );
+      endstops.bdp_state_update(z_sensor <= abs(probe.offset.z));
 
       #if HAS_STATUS_MESSAGE
         static float old_z_sensor = 0;
@@ -154,7 +150,7 @@ void BDS_Leveling::process() {
     }
     else {
       stepper.apply_directions();
-      if(config_state == BDS_HOMING_Z){
+      if (config_state == BDS_HOMING_Z) {
         SERIAL_ECHOLNPGM("Read:", tmp);
         kill(F("BDsensor connect Err!"));
       }
@@ -237,17 +233,15 @@ void BDS_Leveling::process() {
         }
         else {
           char tmp_1[32];
-          int time_out_n=0;
           // TODO: Use prepare_internal_move_to_destination to guarantee machine space
           sprintf_P(tmp_1, PSTR("G1Z%d.%d"), int(zpos), int(zpos * 10) % 10);
           gcode.process_subcommands_now(tmp_1);
           SERIAL_ECHO(tmp_1); SERIAL_ECHOLNPGM(", Z:", current_position.z);
-          for (float tmp_k = 0; abs(zpos - tmp_k) > 0.006f;) {
+          uint16_t failcount = 300;
+          for (float tmp_k = 0; abs(zpos - tmp_k) > 0.006f && failcount--;) {
             tmp_k = planner.get_axis_position_mm(Z_AXIS) - pos_zero_offset;
             safe_delay(10);
-            time_out_n++;
-            if(time_out_n>300)
-                break;
+            if (!failcount--) break;
           }
           safe_delay(zpos <= 0.4f ? 600 : 300);
           tmp = uint16_t((zpos + 0.00001f) * 10);

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -78,7 +78,7 @@ bool BDS_Leveling::check(const uint16_t data, const bool raw_data/*=false*/, con
     return true; // error
   }
   if (raw_data == true) {
-    if (hicheck && (data & 0x3FF) > 550)
+    if (hicheck && (data & 0x3FF) > 400)
       SERIAL_ECHOLNPGM("Bad BD Sensor height! Recommended distance 0.5-2.0mm");
     else if (!good_data(data))
       SERIAL_ECHOLNPGM("Invalid data, please calibrate.");
@@ -240,7 +240,7 @@ void BDS_Leveling::process() {
             safe_delay(10);
             if (!failcount--) break;
           }
-          safe_delay(zpos <= 0.4f ? 600 : 300);
+          safe_delay(600);
           tmp = uint16_t((zpos + 0.00001f) * 10);
           BD_I2C_SENSOR.BD_i2c_write(tmp);
           SERIAL_ECHOLNPGM("w:", tmp, ", Z:", zpos);

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -135,7 +135,7 @@ void BDS_Leveling::process() {
 
       old_cur_z = cur_z;
       old_buf_z = current_position.z;
-      endstops.bdp_state_update(z_sensor <= abs(probe.offset.z));
+      endstops.bdp_state_update(z_sensor <= BD_SENSOR_HOME_Z_POSITION );
 
       #if HAS_STATUS_MESSAGE
         static float old_z_sensor = 0;

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -135,7 +135,7 @@ void BDS_Leveling::process() {
 
       old_cur_z = cur_z;
       old_buf_z = current_position.z;
-      endstops.bdp_state_update(z_sensor <= BD_SENSOR_HOME_Z_POSITION );
+      endstops.bdp_state_update(z_sensor <= BD_SENSOR_HOME_Z_POSITION);
 
       #if HAS_STATUS_MESSAGE
         static float old_z_sensor = 0;

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -148,12 +148,9 @@ void BDS_Leveling::process() {
         }
       #endif
     }
-    else {
-      stepper.apply_directions();
-      if (config_state == BDS_HOMING_Z) {
-        SERIAL_ECHOLNPGM("Read:", tmp);
-        kill(F("BDsensor connect Err!"));
-      }
+    else if (config_state == BDS_HOMING_Z) {
+      SERIAL_ECHOLNPGM("Read:", tmp);
+      kill(F("BDsensor connect Err!"));
     }
 
     DEBUG_ECHOLNPGM("BD:", tmp & 0x3FF, " Z:", cur_z, "|", current_position.z);

--- a/Marlin/src/feature/bedlevel/bdl/bdl.cpp
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.cpp
@@ -79,7 +79,7 @@ bool BDS_Leveling::check(const uint16_t data, const bool raw_data/*=false*/, con
   }
   if (raw_data == true) {
     if (hicheck && (data & 0x3FF) > 550)
-      SERIAL_ECHOLNPGM("BD Sensor mounted too high!");
+      SERIAL_ECHOLNPGM("BD Sensor mounted too far or too close the bed! Recommended distance 0.5mm~2.0mm");
     else if (!good_data(data))
       SERIAL_ECHOLNPGM("Invalid data, please calibrate.");
     else

--- a/Marlin/src/feature/bedlevel/bdl/bdl.h
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.h
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <stdint.h>
-
+#ifndef BD_SENSOR_HOME_Z_POSITION
+  #define BD_SENSOR_HOME_Z_POSITION 0.5
+#endif
 enum BDS_State : int8_t {
   BDS_IDLE,
   BDS_VERSION         = -1,

--- a/Marlin/src/feature/bedlevel/bdl/bdl.h
+++ b/Marlin/src/feature/bedlevel/bdl/bdl.h
@@ -22,9 +22,11 @@
 #pragma once
 
 #include <stdint.h>
+
 #ifndef BD_SENSOR_HOME_Z_POSITION
   #define BD_SENSOR_HOME_Z_POSITION 0.5
 #endif
+
 enum BDS_State : int8_t {
   BDS_IDLE,
   BDS_VERSION         = -1,

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -747,7 +747,7 @@ G29_TYPE GcodeSuite::G29() {
               idle_no_sleep();
             }
             //if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM_P(axis == Y_AXIS ? PSTR("Y=") : PSTR("X=", pos);
-
+            safe_delay(4);
             abl.measured_z = current_position.z - bdl.read();
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("x_cur ", planner.get_axis_position_mm(X_AXIS), " z ", abl.measured_z);
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -747,6 +747,7 @@ G29_TYPE GcodeSuite::G29() {
               idle_no_sleep();
             }
             //if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM_P(axis == Y_AXIS ? PSTR("Y=") : PSTR("X=", pos);
+
             safe_delay(4);
             abl.measured_z = current_position.z - bdl.read();
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("x_cur ", planner.get_axis_position_mm(X_AXIS), " z ", abl.measured_z);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -2479,12 +2479,12 @@ void set_axis_is_at_home(const AxisEnum axis) {
   #if HAS_BED_PROBE && Z_HOME_TO_MIN
     if (axis == Z_AXIS) {
       #if HOMING_Z_WITH_PROBE
-      #if ENABLED(BD_SENSOR)
-        safe_delay(100);
-        current_position.z = bdl.read();
-      #else
-        current_position.z -= probe.offset.z;
-      #endif
+        #if ENABLED(BD_SENSOR)
+          safe_delay(100);
+          current_position.z = bdl.read();
+        #else
+          current_position.z -= probe.offset.z;
+        #endif
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed with PROBE" TERN_(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, " (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)") " ***\n> (M851 Z", probe.offset.z, ")");
       #else
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed to ENDSTOP ***");

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -2479,7 +2479,12 @@ void set_axis_is_at_home(const AxisEnum axis) {
   #if HAS_BED_PROBE && Z_HOME_TO_MIN
     if (axis == Z_AXIS) {
       #if HOMING_Z_WITH_PROBE
+      #if ENABLED(BD_SENSOR)
+        safe_delay(100);
+        current_position.z = bdl.read();
+      #else
         current_position.z -= probe.offset.z;
+      #endif
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed with PROBE" TERN_(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, " (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)") " ***\n> (M851 Z", probe.offset.z, ")");
       #else
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed to ENDSTOP ***");

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -979,7 +979,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   do_blocking_move_to(npos, feedRate_t(XY_PROBE_FEEDRATE_MM_S));
 
   #if ENABLED(BD_SENSOR)
-
+    safe_delay(4);
     return current_position.z - bdl.read(); // Difference between Z-home-relative Z and sensor reading
 
   #else // !BD_SENSOR

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -979,6 +979,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   do_blocking_move_to(npos, feedRate_t(XY_PROBE_FEEDRATE_MM_S));
 
   #if ENABLED(BD_SENSOR)
+
     safe_delay(4);
     return current_position.z - bdl.read(); // Difference between Z-home-relative Z and sensor reading
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
 Configure `BD_SENSOR_HOME_Z_POSITION ` as the given homing position for Bed Distance Sensor;
 Add timeout while calibration;
 Kill printer if there is data error from the BDsensor while homing Z;
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->


### Benefits
No need to homing the Z axis at the zero position that can avoid toolhead crash into bed in some case.
<!-- What does this PR fix or improve? -->

### Configurations
The Z offset should be within the measure range of Bed Distane Sensor, and this value no effect probe. the recommend value is 0.5~2.0mm

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->


