### PR TITLE
Simplify BTT Octopus Max EZ LCD Pins

### DIFF
--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -399,38 +399,37 @@
 //
 // LCDs and Controllers
 //
-#if HAS_WIRED_LCD
-  #if ENABLED(BTT_MINI_12864_V1) // BTT Mini 12864 V2.0 connected via 18-pin FCP cable
 
-    #define BEEPER_PIN                 EXP1_01_PIN
-    #define BTN_ENC                    EXP1_02_PIN
-    #define LCD_PINS_RS                EXP1_04_PIN
+#if ENABLED(BTT_MINI_12864_V1)                    // BTT Mini 12864 V2.0 connected via 18-pin FCP cable
 
-    #define BTN_EN1                    EXP2_03_PIN
-    #define BTN_EN2                    EXP2_05_PIN
+  #define BEEPER_PIN                 EXP1_01_PIN
+  #define BTN_ENC                    EXP1_02_PIN
+  #define LCD_PINS_RS                EXP1_04_PIN
 
-    #define LCD_PINS_EN                EXP1_03_PIN
-    #define LCD_PINS_D4                EXP1_05_PIN
-    #define LCD_PINS_D5                EXP1_06_PIN
-    #define LCD_PINS_D6                EXP1_07_PIN
-    #define LCD_PINS_D7                EXP1_08_PIN
+  #define BTN_EN1                    EXP2_03_PIN
+  #define BTN_EN2                    EXP2_05_PIN
 
-    #define DOGLCD_CS                  EXP1_03_PIN
-    #define DOGLCD_A0                  EXP1_04_PIN
-    #define DOGLCD_SCK                 EXP2_02_PIN
-    #define DOGLCD_MOSI                EXP2_06_PIN
+  #define LCD_PINS_EN                EXP1_03_PIN
+  #define LCD_PINS_D4                EXP1_05_PIN
+  #define LCD_PINS_D5                EXP1_06_PIN
+  #define LCD_PINS_D6                EXP1_07_PIN
+  #define LCD_PINS_D7                EXP1_08_PIN
 
-    #define SOFTWARE_SPI
-    #define FORCE_SOFT_SPI                          // Use this if default of hardware SPI causes display problems
-                                                    //   results in LCD soft SPI mode 3, SD soft SPI mode 0
+  #define DOGLCD_CS                  EXP1_03_PIN
+  #define DOGLCD_A0                  EXP1_04_PIN
+  #define DOGLCD_SCK                 EXP2_02_PIN
+  #define DOGLCD_MOSI                EXP2_06_PIN
 
-    //#define LCD_BACKLIGHT_PIN           -1
-    #define LCD_RESET_PIN              EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-    #define NEOPIXEL_PIN               EXP1_06_PIN
+  #define SOFTWARE_SPI
+  #define FORCE_SOFT_SPI                          // Use this if Hardware SPI causes display problems.
+                                                  // Results in LCD Software SPI mode 3, SD Software SPI mode 0.
 
-  #else
-    #error "Only BTT_MINI_12864_V1 is currently supported on the BIGTREE_OCTOPUS_MAX_EZ."
-  #endif
+  //#define LCD_BACKLIGHT_PIN               -1
+  #define LCD_RESET_PIN              EXP1_05_PIN  // Must be high or open for LCD to operate normally.
+  #define NEOPIXEL_PIN               EXP1_06_PIN
+
+#elif HAS_WIRED_LCD
+  #error "Only BTT_MINI_12864_V1 is currently supported on the BIGTREE_OCTOPUS_MAX_EZ."
 #endif
 
 //
@@ -439,28 +438,26 @@
 #ifndef NEOPIXEL_PIN
   #define NEOPIXEL_PIN                      PE10
 #endif
-
 #ifndef NEOPIXEL2_PIN
   #define NEOPIXEL2_PIN                     PE9
 #endif
 
+//
+// WIFI
+//
 #if ENABLED(WIFISUPPORT)
-  //
-  // WIFI
-  //
-
   /**
-   *                      -------
-   *            GND | 9  |       | 8 | 3.3V
-   *  (ESP-CS) PG1  | 10 |       | 7 | PB15 (ESP-MOSI)
-   *           3.3V | 11 |       | 6 | PB14 (ESP-MISO)
-   * (ESP-IO0)  PG0 | 12 |       | 5 | PB13 (ESP-CLK)
-   * (ESP-IO4) PF15 | 13 |       | 4 | --
-   *             -- | 14 |       | 3 | 3.3V (ESP-EN)
-   *  (ESP-RX)  PE7 | 15 |       | 2 | --
-   *  (ESP-TX)  PE8 | 16 |       | 1 | PB2 (ESP-RST)
-   *                      -------
-   *                       WIFI
+   *                 --------
+   *           GND  |  9   8 | 3.3V
+   *  (ESP-CS) PG1  | 10   7 | PB15 (ESP-MOSI)
+   *           3.3V | 11   6 | PB14 (ESP-MISO)
+   * (ESP-IO0) PG0  | 12   5 | PB13 (ESP-CLK)
+   * (ESP-IO4) PF15 | 13   4 | --
+   *             -- | 14   3 | 3.3V (ESP-EN)
+   *  (ESP-RX) PE7  | 15   2 | --
+   *  (ESP-TX) PE8  | 16   1 | PB2 (ESP-RST)
+   *                 --------
+   *                   WIFI
    */
   #define ESP_WIFI_MODULE_COM                  7  // Must also set either SERIAL_PORT or SERIAL_PORT_2 to this
   #define ESP_WIFI_MODULE_BAUDRATE      BAUDRATE  // Must use same BAUDRATE as SERIAL_PORT & SERIAL_PORT_2

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -325,6 +325,7 @@
 #endif // HAS_TMC_UART
 
 /**
+ *            18-pin FPC Connector
  *                    ----
  *       (MISO) PE13 | 1  |
  *        (SCK) PE12 | 2  |
@@ -398,100 +399,38 @@
 //
 // LCDs and Controllers
 //
-#if IS_TFTGLCD_PANEL
+#if HAS_WIRED_LCD
+  #if ENABLED(BTT_MINI_12864_V1) // BTT Mini 12864 V2.0 connected via 18-pin FCP cable
 
-  #if ENABLED(TFTGLCD_PANEL_SPI)
-    #define TFTGLCD_CS               EXP2_03_PIN
-  #endif
+    #define BEEPER_PIN                 EXP1_01_PIN
+    #define BTN_ENC                    EXP1_02_PIN
+    #define LCD_PINS_RS                EXP1_04_PIN
 
-#elif HAS_WIRED_LCD
+    #define BTN_EN1                    EXP2_03_PIN
+    #define BTN_EN2                    EXP2_05_PIN
 
-  #define BEEPER_PIN                 EXP1_01_PIN
-  #define BTN_ENC                    EXP1_02_PIN
+    #define LCD_PINS_EN                EXP1_03_PIN
+    #define LCD_PINS_D4                EXP1_05_PIN
+    #define LCD_PINS_D5                EXP1_06_PIN
+    #define LCD_PINS_D6                EXP1_07_PIN
+    #define LCD_PINS_D7                EXP1_08_PIN
 
-  #if ENABLED(CR10_STOCKDISPLAY)
+    #define DOGLCD_CS                  EXP1_03_PIN
+    #define DOGLCD_A0                  EXP1_04_PIN
+    #define DOGLCD_SCK                 EXP2_02_PIN
+    #define DOGLCD_MOSI                EXP2_06_PIN
 
-    #define LCD_PINS_RS              EXP1_07_PIN
+    #define SOFTWARE_SPI
+    #define FORCE_SOFT_SPI                          // Use this if default of hardware SPI causes display problems
+                                                    //   results in LCD soft SPI mode 3, SD soft SPI mode 0
 
-    #define BTN_EN1                  EXP1_03_PIN
-    #define BTN_EN2                  EXP1_05_PIN
-
-    #define LCD_PINS_EN              EXP1_08_PIN
-    #define LCD_PINS_D4              EXP1_06_PIN
+    //#define LCD_BACKLIGHT_PIN           -1
+    #define LCD_RESET_PIN              EXP1_05_PIN  // Must be high or open for LCD to operate normally.
+    #define NEOPIXEL_PIN               EXP1_06_PIN
 
   #else
-
-    #define LCD_PINS_RS              EXP1_04_PIN
-
-    #define BTN_EN1                  EXP2_03_PIN
-    #define BTN_EN2                  EXP2_05_PIN
-
-    #define LCD_PINS_EN              EXP1_03_PIN
-    #define LCD_PINS_D4              EXP1_05_PIN
-
-    #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS              EXP1_03_PIN
-      #define DOGLCD_A0              EXP1_04_PIN
-      #define DOGLCD_SCK             EXP2_02_PIN
-      #define DOGLCD_MOSI            EXP2_06_PIN
-
-      #define SOFTWARE_SPI
-      #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
-      //#define LCD_BACKLIGHT_PIN           -1
-      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
-      #if ANY(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN      EXP1_06_PIN
-        #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN      EXP1_07_PIN
-        #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN      EXP1_08_PIN
-        #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN         EXP1_06_PIN
-      #endif
-    #endif // !FYSETC_MINI_12864
-
-    #if IS_ULTIPANEL
-      #define LCD_PINS_D5            EXP1_06_PIN
-      #define LCD_PINS_D6            EXP1_07_PIN
-      #define LCD_PINS_D7            EXP1_08_PIN
-
-      #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
-        #define BTN_ENC_EN           LCD_PINS_D7  // Detect the presence of the encoder
-      #endif
-
-    #endif
-
+    #error "Only BTT_MINI_12864_V1 is currently supported on the BIGTREE_OCTOPUS_MAX_EZ."
   #endif
-#endif  // HAS_WIRED_LCD
-
-// Alter timing for graphical display
-#if IS_U8GLIB_ST7920
-  #define BOARD_ST7920_DELAY_1               120
-  #define BOARD_ST7920_DELAY_2                80
-  #define BOARD_ST7920_DELAY_3               580
-#endif
-
-#if HAS_SPI_TFT
-  #define TFT_CS_PIN                 EXP2_04_PIN
-  #define TFT_A0_PIN                 EXP2_07_PIN
-  #define TFT_SCK_PIN                EXP2_02_PIN
-  #define TFT_MISO_PIN               EXP2_01_PIN
-  #define TFT_MOSI_PIN               EXP2_06_PIN
-
-  #define TOUCH_INT_PIN              EXP1_07_PIN
-  #define TOUCH_MISO_PIN             EXP1_06_PIN
-  #define TOUCH_MOSI_PIN             EXP1_03_PIN
-  #define TOUCH_SCK_PIN              EXP1_05_PIN
-  #define TOUCH_CS_PIN               EXP1_04_PIN
-
-  #define BTN_EN1                    EXP2_03_PIN
-  #define BTN_EN2                    EXP2_05_PIN
-  #define BTN_ENC                    EXP1_02_PIN
 #endif
 
 //


### PR DESCRIPTION
### Description

The BTT Octopus Max EZ only supports `BTT_MINI_12864_V1` (well, [BTT MINI 12864 V2.0](https://biqu.equipment/products/bigtreetech-mini12864-v2-0-lcd-screen-rgb-backlight-mini-display-supports-marlin-diy-for-skr-3d-printer-part-1) with FPC connector) since the motherboard doesn't have standard EXP connectors and no FPC->2 x EXP breakout board exists.

If BTT (or someone else) eventually decides to make an 18-pin, 1mm pitch, FPC -> 2 x 10-pin EXP adapter board, we can revert these changes.

### Requirements

BTT Octopus Max EZ + BTT MINI 12864 V2.0

### Benefits

Less clutter in pins file.