### PR TITLE
Use LPC Ethernet Buffer for Input Shaping

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -247,11 +247,13 @@ uint32_t Stepper::advance_divisor = 0,
 
 #if HAS_ZV_SHAPING
   shaping_time_t      ShapingQueue::now = 0;
-  #if NONE(MCU_LPC1768, MCU_LPC1769)
-    shaping_time_t    ShapingQueue::times[shaping_echoes];
+  #if ANY(MCU_LPC1768, MCU_LPC1769) && DISABLED(NO_LPC_ETHERNET_BUFFER)
+    // Use the 16K LPC Ethernet buffer: https://github.com/MarlinFirmware/Marlin/issues/25432#issuecomment-1450420638
+    #define _ATTR_BUFFER __attribute__((section("AHBSRAM1"),aligned))
   #else
-    shaping_time_t    ShapingQueue::times[shaping_echoes] __attribute__((section("AHBSRAM1"),aligned)); // Unused LPC ethernet buffer: https://github.com/MarlinFirmware/Marlin/issues/25432#issuecomment-1450420638
+    #define _ATTR_BUFFER
   #endif
+  shaping_time_t      ShapingQueue::times[shaping_echoes] _ATTR_BUFFER;
   shaping_echo_axis_t ShapingQueue::echo_axes[shaping_echoes];
   uint16_t            ShapingQueue::tail = 0;
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -247,7 +247,7 @@ uint32_t Stepper::advance_divisor = 0,
 
 #if HAS_ZV_SHAPING
   shaping_time_t      ShapingQueue::now = 0;
-  #if NOT_TARGET(MCU_LPC1768, MCU_LPC1769)
+  #if NONE(MCU_LPC1768, MCU_LPC1769)
     shaping_time_t    ShapingQueue::times[shaping_echoes];
   #else
     shaping_time_t    ShapingQueue::times[shaping_echoes] __attribute__((section("AHBSRAM1"),aligned)); // Unused LPC ethernet buffer: https://github.com/MarlinFirmware/Marlin/issues/25432#issuecomment-1450420638

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -247,7 +247,11 @@ uint32_t Stepper::advance_divisor = 0,
 
 #if HAS_ZV_SHAPING
   shaping_time_t      ShapingQueue::now = 0;
-  shaping_time_t      ShapingQueue::times[shaping_echoes];
+  #if NOT_TARGET(MCU_LPC1768, MCU_LPC1769)
+    shaping_time_t    ShapingQueue::times[shaping_echoes];
+  #else
+    shaping_time_t    ShapingQueue::times[shaping_echoes] __attribute__((section("AHBSRAM1"),aligned)); // Unused LPC ethernet buffer: https://github.com/MarlinFirmware/Marlin/issues/25432#issuecomment-1450420638
+  #endif
   shaping_echo_axis_t ShapingQueue::echo_axes[shaping_echoes];
   uint16_t            ShapingQueue::tail = 0;
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -120,7 +120,7 @@
 #ifdef __MARLIN_DEPS__
   #define NOT_TARGET(V...) 0
 #else
-  #define NOT_TARGET(V...) NONE(V)
+  #define NOT_TARGET NONE
 #endif
 
 //


### PR DESCRIPTION
### Description

LPC-based boards can run tight on RAM with Input Shaping, so let's utilize the unused ethernet buffer to squeak out 1,208 more bytes. That's **15.4%**!

From discussions between @ellensp & @p3p: https://github.com/MarlinFirmware/Marlin/issues/25432#issuecomment-1450420638:

> This moves one input shaping buffer into that 16k block. The other input shaping buffer is still in the main 32k block
This seems to be the best way to use as much of the 16k block as practical.

Basic SKR 1.3 (LPC1768) + Input Shaping RAM usage before this PR:
```prolog
RAM:   [===       ]  25.8% (used 8432 bytes from 32736 bytes)
```

Basic SKR 1.3 (LPC1768) + Input Shaping RAM usage after this PR:
```prolog
RAM:   [==        ]  22.1% (used 7224 bytes from 32736 bytes)
```

### Requirements

LPC-based board with `INPUT_SHAPING_X` / `INPUT_SHAPING_Y`.

### Benefits

Users can probably squeeze Input Shaping into maxed out LPC configs.

### Configurations

<details><summary>Basic SKR 1.3 (LPC1768) Diff:</summary>
<p>

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index b573d2d..04890a9 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -67,7 +67,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_BTT_SKR_V1_3
 #endif
 
 /**
diff --git a/Marlin/Configuration_adv.h b/Marlin/Configuration_adv.h
index eee111a..a19f6b4 100644
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1173,8 +1173,8 @@
  *  X<1>         Set the given parameters only for the X axis.
  *  Y<1>         Set the given parameters only for the Y axis.
  */
-//#define INPUT_SHAPING_X
-//#define INPUT_SHAPING_Y
+#define INPUT_SHAPING_X
+#define INPUT_SHAPING_Y
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y)
   #if ENABLED(INPUT_SHAPING_X)
     #define SHAPING_FREQ_X  40          // (Hz) The default dominant resonant frequency on the X axis.
diff --git a/platformio.ini b/platformio.ini
index e3bdb6f..eaf82f8 100644
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = LPC1768
 include_dir  = Marlin
 extra_configs =
     Marlin/config.ini

```

</p>
</details>

...or a .zip if you prefer: [SKR_1_3_Input_Shaping_Ethernet_Buffer.zip](https://github.com/MarlinFirmware/Marlin/files/11890978/SKR_1_3_Input_Shaping_Ethernet_Buffer.zip)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/25432

### Other

I don't know if Fixed-time-based Motion Control could benefit from a similar change, or if it's even needed, but I'm writing this comment since I just thought of it.
