### PR TITLE
🐛 Prevent MString infinite recursion

### DIFF
--- a/Marlin/src/tests/marlin_tests.cpp
+++ b/Marlin/src/tests/marlin_tests.cpp
@@ -52,16 +52,17 @@ void runStartupTests() {
   // 100 dashes, but chopped down to DEFAULT_MSTRING_SIZE (20)
   TSS(repchr_t('-', 100)).echoln();
 
-  // Hello World!-123456------   <spaces!
+  // Hello World!-123456------   <spaces!33
   // ^ eol! ... 1234.50*2345.602 = 2895645.67
   SString<100> str(F("Hello"));
   str.append(F(" World!"));
   str += '-';
-  str += "123";
+  str += uint8_t(123);
   str += F("456");
   str += repchr_t('-', 6);
   str += Spaces(3);
   str += "< spaces!";
+  str += int8_t(33);
   str.eol();
   str += "^ eol!";
 


### PR DESCRIPTION
Followup to #24390

- Add a single `typename T` template for `MString::append` to handle unspecified types (by appending '?' to the string). This removes the infinite recursion warning for the variadic template `MString::append(T, ...)` and may avoid actual infinite recursion if unhandled types are passed in `MString::append(T, ...)`.

- Add a standard handler for explicit `int8_t&` so this type will be handled as a small integer instead of being handled as a `char` or deferring to the fallback `typename T`.

- Suppress warnings about deprecated `sprintf` on native platforms.