### PR TITLE
Fix SPI TFT Compile Errors on SKR V3/EZ & V2

### DIFF
--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -377,9 +377,9 @@
 
 #if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
 
-  #define TFT_A0_PIN                          43
   #define TFT_CS_PIN                          49
   #define TFT_DC_PIN                          43
+  #define TFT_A0_PIN                  TFT_DC_PIN
   #define TFT_SCK_PIN                 SD_SCK_PIN
   #define TFT_MISO_PIN               SD_MISO_PIN
   #define TFT_MOSI_PIN               SD_MOSI_PIN

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -329,8 +329,21 @@
     #endif
 
     #if ENABLED(BTT_TFT35_SPI_V1_0)
-      // 480x320, 3.5", SPI Display with Rotary Encoder.
-      // Stock Display for the BIQU B1 SE.
+
+      /**
+       *            ------                       ------
+       *    BEEPER | 1  2 | LCD-BTN        MISO | 1  2 | CLK
+       *    T_MOSI | 3  4 | T_CS       LCD-ENCA | 3  4 | TFTCS
+       *     T_CLK | 5  6   T_MISO     LCD-ENCB | 5  6   MOSI
+       *    PENIRQ | 7  8 | F_CS             RS | 7  8 | RESET
+       *       GND | 9 10 | VCC             GND | 9 10 | NC
+       *            ------                       ------
+       *             EXP1                         EXP2
+       *
+       * 480x320, 3.5", SPI Display with Rotary Encoder.
+       * Stock Display for the BIQU B1 SE Series.
+       * Schematic: https://github.com/bigtreetech/TFT35-SPI/blob/master/v1/Hardware/BTT%20TFT35-SPI%20V1-SCH.pdf
+       */
       #define TFT_CS_PIN             EXP2_04_PIN
       #define TFT_DC_PIN             EXP2_07_PIN
 
@@ -342,6 +355,15 @@
 
     #elif ENABLED(MKS_TS35_V2_0)
 
+      /**                      ------                                   ------
+       *               BEEPER | 1  2 | BTN_ENC               SPI1_MISO | 1  2 | SPI1_SCK
+       *     TFT_BKL / LCD_EN | 3  4 | TFT_RESET / LCD_RS      BTN_EN1 | 3  4 | SPI1_CS
+       *    TOUCH_CS / LCD_D4 | 5  6   TOUCH_INT / LCD_D5      BTN_EN2 | 5  6   SPI1_MOSI
+       *     SPI1_CS / LCD_D6 | 7  8 | SPI1_RS / LCD_D7       SPI1_RS  | 7  8 | RESET
+       *                  GND | 9 10 | VCC                         GND | 9 10 | VCC
+       *                       ------                                   ------
+       *                        EXP1                                     EXP2
+       */
       #define TFT_CS_PIN             EXP1_07_PIN
       #define TFT_DC_PIN             EXP1_08_PIN
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -319,7 +319,7 @@
     #define BTN_EN1                  EXP2_03_PIN
     #define BTN_EN2                  EXP2_05_PIN
 
-    #define TFT_DC_PIN                TFT_A0_PIN
+    #define TFT_A0_PIN                TFT_DC_PIN
 
     #ifndef TFT_WIDTH
       #define TFT_WIDTH                      480
@@ -332,7 +332,7 @@
       // 480x320, 3.5", SPI Display with Rotary Encoder.
       // Stock Display for the BIQU B1 SE.
       #define TFT_CS_PIN             EXP2_04_PIN
-      #define TFT_A0_PIN             EXP2_07_PIN
+      #define TFT_DC_PIN             EXP2_07_PIN
 
       #define TOUCH_CS_PIN           EXP1_04_PIN
       #define TOUCH_SCK_PIN          EXP1_05_PIN
@@ -343,7 +343,7 @@
     #elif ENABLED(MKS_TS35_V2_0)
 
       #define TFT_CS_PIN             EXP1_07_PIN
-      #define TFT_A0_PIN             EXP1_08_PIN
+      #define TFT_DC_PIN             EXP1_08_PIN
 
       #define TFT_RESET_PIN          EXP1_04_PIN
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -396,8 +396,8 @@
 
   #elif HAS_SPI_TFT                               // Config for Classic UI (emulated DOGM) and Color UI
     #define TFT_CS_PIN               EXP1_07_PIN
-    #define TFT_A0_PIN               EXP1_08_PIN
     #define TFT_DC_PIN               EXP1_08_PIN
+    #define TFT_A0_PIN                TFT_DC_PIN
     #define TFT_MISO_PIN             EXP2_01_PIN
     #define TFT_BACKLIGHT_PIN        EXP1_03_PIN
     #define TFT_RESET_PIN            EXP1_04_PIN

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -295,8 +295,8 @@
 
   #elif HAS_SPI_TFT                               // Config for Classic UI (emulated DOGM) and Color UI
     #define TFT_CS_PIN               EXP1_07_PIN
-    #define TFT_A0_PIN               EXP1_08_PIN
     #define TFT_DC_PIN               EXP1_08_PIN
+    #define TFT_A0_PIN                TFT_DC_PIN
     #define TFT_MISO_PIN             EXP2_01_PIN
     #define TFT_BACKLIGHT_PIN        EXP1_03_PIN
     #define TFT_RESET_PIN            EXP1_04_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -516,21 +516,49 @@
 
 #if HAS_SPI_TFT
 
+  #define TFT_SCK_PIN                EXP2_02_PIN
+  #define TFT_MISO_PIN               EXP2_01_PIN
+  #define TFT_MOSI_PIN               EXP2_06_PIN
+
   #define BTN_ENC                    EXP1_02_PIN
   #define BTN_EN1                    EXP2_03_PIN
   #define BTN_EN2                    EXP2_05_PIN
 
+  #ifndef TFT_WIDTH
+    #define TFT_WIDTH                      480
+  #endif
+  #ifndef TFT_HEIGHT
+    #define TFT_HEIGHT                     320
+  #endif
+
   #if ENABLED(BTT_TFT35_SPI_V1_0)
     // 480x320, 3.5", SPI Display with Rotary Encoder.
-    // Stock Display for the BIQU B1 SE.
+    // Stock Display for the BIQU B1 SE Series.
     #define TFT_CS_PIN               EXP2_04_PIN
-    #define TFT_A0_PIN               EXP2_07_PIN
+    #define TFT_DC_PIN               EXP2_07_PIN
+    #define TFT_A0_PIN               TFT_DC_PIN
 
     #define TOUCH_CS_PIN             EXP1_04_PIN
     #define TOUCH_SCK_PIN            EXP1_05_PIN
     #define TOUCH_MISO_PIN           EXP1_06_PIN
     #define TOUCH_MOSI_PIN           EXP1_03_PIN
     #define TOUCH_INT_PIN            EXP1_07_PIN
+
+    #ifndef TOUCH_CALIBRATION_X
+      #define TOUCH_CALIBRATION_X          17540
+    #endif
+    #ifndef TOUCH_CALIBRATION_Y
+      #define TOUCH_CALIBRATION_Y         -11388
+    #endif
+    #ifndef TOUCH_OFFSET_X
+      #define TOUCH_OFFSET_X                 -21
+    #endif
+    #ifndef TOUCH_OFFSET_Y
+      #define TOUCH_OFFSET_Y                 337
+    #endif
+    #ifndef TOUCH_ORIENTATION
+      #define TOUCH_ORIENTATION TOUCH_LANDSCAPE
+    #endif
 
   #elif ENABLED(MKS_TS35_V2_0)
 
@@ -544,8 +572,8 @@
      *                        EXP1                                     EXP2
      */
     #define TFT_CS_PIN               EXP1_07_PIN  // SPI1_CS
-    #define TFT_A0_PIN               EXP1_08_PIN  // SPI1_RS
-    #define TFT_DC_PIN                TFT_DC_PIN
+    #define TFT_DC_PIN               EXP1_08_PIN  // SPI1_RS
+    #define TFT_A0_PIN                TFT_DC_PIN
 
     #define TFT_RESET_PIN            EXP1_04_PIN
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -536,7 +536,7 @@
     // Stock Display for the BIQU B1 SE Series.
     #define TFT_CS_PIN               EXP2_04_PIN
     #define TFT_DC_PIN               EXP2_07_PIN
-    #define TFT_A0_PIN               TFT_DC_PIN
+    #define TFT_A0_PIN                TFT_DC_PIN
 
     #define TOUCH_CS_PIN             EXP1_04_PIN
     #define TOUCH_SCK_PIN            EXP1_05_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -532,8 +532,21 @@
   #endif
 
   #if ENABLED(BTT_TFT35_SPI_V1_0)
-    // 480x320, 3.5", SPI Display with Rotary Encoder.
-    // Stock Display for the BIQU B1 SE Series.
+
+    /**
+     *            ------                       ------
+     *    BEEPER | 1  2 | LCD-BTN        MISO | 1  2 | CLK
+     *    T_MOSI | 3  4 | T_CS       LCD-ENCA | 3  4 | TFTCS
+     *     T_CLK | 5  6   T_MISO     LCD-ENCB | 5  6   MOSI
+     *    PENIRQ | 7  8 | F_CS             RS | 7  8 | RESET
+     *       GND | 9 10 | VCC             GND | 9 10 | NC
+     *            ------                       ------
+     *             EXP1                         EXP2
+     *
+     * 480x320, 3.5", SPI Display with Rotary Encoder.
+     * Stock Display for the BIQU B1 SE Series.
+     * Schematic: https://github.com/bigtreetech/TFT35-SPI/blob/master/v1/Hardware/BTT%20TFT35-SPI%20V1-SCH.pdf
+     */
     #define TFT_CS_PIN               EXP2_04_PIN
     #define TFT_DC_PIN               EXP2_07_PIN
     #define TFT_A0_PIN                TFT_DC_PIN
@@ -592,6 +605,22 @@
     #define LCD_USE_DMA_SPI
 
     #define TFT_BUFFER_SIZE                14400
+
+    #ifndef TOUCH_CALIBRATION_X
+      #define TOUCH_CALIBRATION_X         -17253
+    #endif
+    #ifndef TOUCH_CALIBRATION_Y
+      #define TOUCH_CALIBRATION_Y          11579
+    #endif
+    #ifndef TOUCH_OFFSET_X
+      #define TOUCH_OFFSET_X                 514
+    #endif
+    #ifndef TOUCH_OFFSET_Y
+      #define TOUCH_OFFSET_Y                 -24
+    #endif
+    #ifndef TOUCH_ORIENTATION
+      #define TOUCH_ORIENTATION TOUCH_LANDSCAPE
+    #endif
 
   #endif
 

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -476,8 +476,21 @@
     #endif
 
     #if ENABLED(BTT_TFT35_SPI_V1_0)
-      // 480x320, 3.5", SPI Display with Rotary Encoder.
-      // Stock Display for the BIQU B1 SE Series.
+
+      /**
+       *            ------                       ------
+       *    BEEPER | 1  2 | LCD-BTN        MISO | 1  2 | CLK
+       *    T_MOSI | 3  4 | T_CS       LCD-ENCA | 3  4 | TFTCS
+       *     T_CLK | 5  6   T_MISO     LCD-ENCB | 5  6   MOSI
+       *    PENIRQ | 7  8 | F_CS             RS | 7  8 | RESET
+       *       GND | 9 10 | VCC             GND | 9 10 | NC
+       *            ------                       ------
+       *             EXP1                         EXP2
+       *
+       * 480x320, 3.5", SPI Display with Rotary Encoder.
+       * Stock Display for the BIQU B1 SE Series.
+       * Schematic: https://github.com/bigtreetech/TFT35-SPI/blob/master/v1/Hardware/BTT%20TFT35-SPI%20V1-SCH.pdf
+       */
       #define TFT_CS_PIN             EXP2_04_PIN
       #define TFT_DC_PIN             EXP2_07_PIN
       #define TFT_A0_PIN              TFT_DC_PIN

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -461,10 +461,12 @@
 
   #elif HAS_SPI_TFT                               // Config for Classic UI (emulated DOGM) and Color UI
 
+    #define TFT_SCK_PIN              EXP2_02_PIN
+    #define TFT_MISO_PIN             EXP2_01_PIN
+    #define TFT_MOSI_PIN             EXP2_06_PIN
+
     #define BTN_EN1                  EXP2_03_PIN
     #define BTN_EN2                  EXP2_05_PIN
-
-    #define TFT_DC_PIN                TFT_A0_PIN
 
     #ifndef TFT_WIDTH
       #define TFT_WIDTH                      480
@@ -475,9 +477,10 @@
 
     #if ENABLED(BTT_TFT35_SPI_V1_0)
       // 480x320, 3.5", SPI Display with Rotary Encoder.
-      // Stock Display for the BIQU B1 SE.
+      // Stock Display for the BIQU B1 SE Series.
       #define TFT_CS_PIN             EXP2_04_PIN
-      #define TFT_A0_PIN             EXP2_07_PIN
+      #define TFT_DC_PIN             EXP2_07_PIN
+      #define TFT_A0_PIN              TFT_DC_PIN
 
       #define TOUCH_CS_PIN           EXP1_04_PIN
       #define TOUCH_SCK_PIN          EXP1_05_PIN
@@ -513,7 +516,8 @@
        *                        EXP1                                     EXP2
        */
       #define TFT_CS_PIN             EXP1_07_PIN  // SPI1_CS
-      #define TFT_A0_PIN             EXP1_08_PIN  // SPI1_RS
+      #define TFT_DC_PIN             EXP1_08_PIN  // SPI1_RS
+      #define TFT_A0_PIN              TFT_DC_PIN
 
       #define TFT_RESET_PIN          EXP1_04_PIN
 


### PR DESCRIPTION
### Description

Followup to https://github.com/MarlinFirmware/Marlin/pull/25784 since enabling an SPI TFT on an SKR 3/EZ & V2 would throw several errors about variables not being declared:

```log
error: 'TFT_SCK_PIN' was not declared in this scope; did you mean 'TFT_DC_PIN'?
error: 'TFT_MOSI_PIN' was not declared in this scope; did you mean 'SD_MOSI_PIN'?
error: 'TFT_MISO_PIN' was not declared in this scope; did you mean 'SD_MISO_PIN'?
error: 'TFT_SCK_PIN' was not declared in this scope; did you mean 'TFT_DC_PIN'?
```

This reverts later changes in the original PR to be more like what I had originally.

Verified on an SKR V3.0 EZ with a BTT TFT35-SPI V1.0 and MKS TS35 V2.0

### Requirements

SKR V3/EZ with a BTT TFT35-SPI V1.0 or MKS TS35 V2.0

### Benefits

Config will compile

### Configurations

`#define MOTHERBOARD BOARD_BTT_SKR_V3_0` or `#define MOTHERBOARD BOARD_BTT_SKR_V3_0_EZ` with: `#define MKS_TS35_V2_0` or `#define BTT_TFT35_SPI_V1_0`.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/25784
