### PR TITLE
✨ BTT Octopus Pro V1.1 (STM32H723ZE)

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -472,6 +472,7 @@
 #define BOARD_BTT_SKR_V3_0            6006  // BigTreeTech SKR V3.0 (STM32H743VI / STM32H723VG)
 #define BOARD_BTT_SKR_V3_0_EZ         6007  // BigTreeTech SKR V3.0 EZ (STM32H743VI / STM32H723VG)
 #define BOARD_BTT_OCTOPUS_MAX_EZ_V1_0 6008  // BigTreeTech Octopus Max EZ V1.0 (STM32H723ZE)
+#define BOARD_BTT_OCTOPUS_PRO_V1_1    6009  // BigTreeTech Octopus Pro v1.1 (STM32H723ZE)
 
 //
 // Espressif ESP32 WiFi

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -821,6 +821,8 @@
   #include "stm32h7/pins_BTT_SKR_V3_0_EZ.h"         // STM32H7                              env:STM32H743VI_btt env:STM32H723VG_btt
 #elif MB(BTT_OCTOPUS_MAX_EZ_V1_0)
   #include "stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h"      // STM32H7                              env:STM32H723ZE_btt
+#elif MB(BTT_OCTOPUS_PRO_V1_1)
+  #include "stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h"    // STM32H7                              env:STM32H723ZE_btt
 #elif MB(TEENSY41)
   #include "teensy4/pins_TEENSY41.h"                // Teensy-4.x                           env:teensy41
 #elif MB(T41U5XBB)

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -45,11 +45,6 @@
 #define SERVO0_PIN                          PB6
 
 //
-// Misc. Functions
-//
-#define LED_PIN                             PA13
-
-//
 // Trinamic Stallguard pins
 //
 #define X_DIAG_PIN                          PG6   // X-STOP
@@ -60,13 +55,6 @@
 #define E1_DIAG_PIN                         PG13  // E1DET
 #define E2_DIAG_PIN                         PG14  // E2DET
 #define E3_DIAG_PIN                         PG15  // E3DET
-
-//
-// Z Probe (when not Z_MIN_PIN)
-//
-#ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PB7
-#endif
 
 //
 // Limit Switches
@@ -126,6 +114,13 @@
 #endif
 
 //
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB7
+#endif
+
+//
 // Filament Runout Sensor
 //
 #define FIL_RUNOUT_PIN                      PG12  // E0DET
@@ -146,6 +141,11 @@
 #ifndef POWER_LOSS_PIN
   #define POWER_LOSS_PIN                    PC0   // PWRDET
 #endif
+
+//
+// Misc. Functions
+//
+#define LED_PIN                             PA13
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -137,10 +137,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h
@@ -53,10 +53,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
@@ -55,10 +55,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
@@ -53,10 +53,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -51,10 +51,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -46,27 +46,15 @@
 #define SERVO0_PIN                          PB14
 
 //
-// Misc. Functions
-//
-#define LED_PIN                             PA14
-
-//
 // Trinamic Stallguard pins
 //
 #define X_DIAG_PIN                          PF0   // M1-STOP
 #define Y_DIAG_PIN                          PF2   // M2-STOP
 #define Z_DIAG_PIN                          PF4   // M3-STOP
-#define Z2_DIAG_PIN                         PF3   // M4-STOP
-#define E0_DIAG_PIN                         PF1   // M5-STOP
-#define E1_DIAG_PIN                         PC15  // M6-STOP
+#define Z2_DIAG_PIN                         PF3   // M4-DET
+#define E0_DIAG_PIN                         PF1   // M5-DET
+#define E1_DIAG_PIN                         PC15  // M6-DET
 #define E2_DIAG_PIN                         PF12  // PWRDET
-
-//
-// Z Probe (when not Z_MIN_PIN)
-//
-#ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PB15
-#endif
 
 //
 // Limit Switches
@@ -74,16 +62,16 @@
 #ifdef X_STALL_SENSITIVITY
   #define X_STOP_PIN                  X_DIAG_PIN
   #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
+    #define X_MAX_PIN                E0_DIAG_PIN  // M4-DET
   #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // E0DET
+    #define X_MIN_PIN                E0_DIAG_PIN  // M4-DET
   #endif
 #elif NEEDS_X_MINMAX
   #ifndef X_MIN_PIN
     #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
   #endif
   #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
+    #define X_MAX_PIN                E0_DIAG_PIN  // M4-DET
   #endif
 #else
   #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
@@ -92,16 +80,16 @@
 #ifdef Y_STALL_SENSITIVITY
   #define Y_STOP_PIN                  Y_DIAG_PIN
   #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
+    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-DET
   #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // E1DET
+    #define Y_MIN_PIN                E1_DIAG_PIN  // M5-DET
   #endif
 #elif NEEDS_Y_MINMAX
   #ifndef Y_MIN_PIN
     #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-STOP
   #endif
   #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
+    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-DET
   #endif
 #else
   #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
@@ -126,24 +114,17 @@
 #endif
 
 //
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB15
+#endif
+
+//
 // Filament Runout Sensor
 //
-#define FIL_RUNOUT_PIN                      PF1   // E0DET
-#define FIL_RUNOUT2_PIN                     PF15  // E1DET
-
-//
-// Power Supply Control
-//
-#ifndef PS_ON_PIN
-  #define PS_ON_PIN                         PF13  // PS-ON
-#endif
-
-//
-// Power Loss Detection
-//
-#ifndef POWER_LOSS_PIN
-  #define POWER_LOSS_PIN                    PF12  // PWRDET
-#endif
+#define FIL_RUNOUT_PIN                      PF1   // M5-DET
+#define FIL_RUNOUT2_PIN                     PC15  // M6-DET
 
 //
 // Steppers
@@ -243,6 +224,31 @@
 #define FAN4_PIN                            PA1   // 4 wire Fan4
 #define FAN5_PIN                            PF8   // 4 wire Fan5
 #define FAN6_PIN                            PA2   // 4 wire Fan6
+
+//
+// Power Supply Control
+//
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN                         PF13  // PS-ON
+#endif
+
+//
+// Power Loss Detection
+//
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                    PF12  // PWRDET
+#endif
+
+//
+// Misc. Functions
+//
+#define LED_PIN                             PA14
+#ifndef FILWIDTH_PIN
+  #define FILWIDTH_PIN                      PC0
+#endif
+#ifndef FILWIDTH2_PIN
+  #define FILWIDTH2_PIN                     PF10
+#endif
 
 //
 // SD Support

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
@@ -1,0 +1,572 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "env_validate.h"
+
+#define BOARD_INFO_NAME   "BTT OCTOPUS PRO V1.1"
+
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
+#define USES_DIAG_JUMPERS
+
+// Onboard I2C EEPROM
+#if ANY(NO_EEPROM_SELECTED, I2C_EEPROM)
+  #undef NO_EEPROM_SELECTED
+  #define I2C_EEPROM
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4K (AT24C32)
+  #define SOFT_I2C_EEPROM                         // Force the use of Software I2C
+  #define I2C_SCL_PIN                       PB8
+  #define I2C_SDA_PIN                       PB9
+#endif
+
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER 8
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PB6
+
+//
+// Misc. Functions
+//
+#define LED_PIN                             PA13
+
+//
+// Trinamic Stallguard pins
+//
+#define X_DIAG_PIN                          PG6   // X-STOP
+#define Y_DIAG_PIN                          PG9   // Y-STOP
+#define Z_DIAG_PIN                          PG10  // Z-STOP
+#define Z2_DIAG_PIN                         PG11  // Z2-STOP
+#define E0_DIAG_PIN                         PG12  // E0DET
+#define E1_DIAG_PIN                         PG13  // E1DET
+#define E2_DIAG_PIN                         PG14  // E2DET
+#define E3_DIAG_PIN                         PG15  // E3DET
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#if !defined(Z_MIN_PROBE_PIN) && DISABLED(BLTOUCH)
+  #define Z_MIN_PROBE_PIN                   PC5   // Probe (Proximity switch) port
+#endif
+
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB7
+#endif
+
+//
+// Limit Switches
+//
+#ifdef X_STALL_SENSITIVITY
+  #define X_STOP_PIN                  X_DIAG_PIN
+  #if X_HOME_TO_MIN
+    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
+  #else
+    #define X_MIN_PIN                E0_DIAG_PIN  // E0DET
+  #endif
+#elif NEEDS_X_MINMAX
+  #ifndef X_MIN_PIN
+    #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
+  #endif
+  #ifndef X_MAX_PIN
+    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
+  #endif
+#else
+  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
+#endif
+
+#ifdef Y_STALL_SENSITIVITY
+  #define Y_STOP_PIN                  Y_DIAG_PIN
+  #if Y_HOME_TO_MIN
+    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
+  #else
+    #define Y_MIN_PIN                E1_DIAG_PIN  // E1DET
+  #endif
+#elif NEEDS_Y_MINMAX
+  #ifndef Y_MIN_PIN
+    #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-STOP
+  #endif
+  #ifndef Y_MAX_PIN
+    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
+  #endif
+#else
+  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
+#endif
+
+#ifdef Z_STALL_SENSITIVITY
+  #define Z_STOP_PIN                  Z_DIAG_PIN
+  #if Z_HOME_TO_MIN
+    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
+  #else
+    #define Z_MIN_PIN                E2_DIAG_PIN  // PWRDET
+  #endif
+#elif NEEDS_Z_MINMAX
+  #ifndef Z_MIN_PIN
+    #define Z_MIN_PIN                 Z_DIAG_PIN  // Z-STOP
+  #endif
+  #ifndef Z_MAX_PIN
+    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
+  #endif
+#else
+  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
+#endif
+
+//
+// Filament Runout Sensor
+//
+#define FIL_RUNOUT_PIN                      PG12  // E0DET
+#define FIL_RUNOUT2_PIN                     PG13  // E1DET
+#define FIL_RUNOUT3_PIN                     PG14  // E2DET
+#define FIL_RUNOUT4_PIN                     PG15  // E3DET
+
+//
+// Power Supply Control
+//
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN                         PE11  // PS-ON
+#endif
+
+//
+// Power Loss Detection
+//
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                    PC0   // PWRDET
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PF13  // MOTOR 0
+#define X_DIR_PIN                           PF12
+#define X_ENABLE_PIN                        PF14
+#ifndef X_CS_PIN
+  #define X_CS_PIN                          PC4
+#endif
+
+#define Y_STEP_PIN                          PG0   // MOTOR 1
+#define Y_DIR_PIN                           PG1
+#define Y_ENABLE_PIN                        PF15
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN                          PD11
+#endif
+
+#define Z_STEP_PIN                          PF11  // MOTOR 2
+#define Z_DIR_PIN                           PG3
+#define Z_ENABLE_PIN                        PG5
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN                          PC6
+#endif
+
+#define Z2_STEP_PIN                         PG4   // MOTOR 3
+#define Z2_DIR_PIN                          PC1
+#define Z2_ENABLE_PIN                       PA2
+#ifndef Z2_CS_PIN
+  #define Z2_CS_PIN                         PC7
+#endif
+
+#define E0_STEP_PIN                         PF9   // MOTOR 4
+#define E0_DIR_PIN                          PF10
+#define E0_ENABLE_PIN                       PG2
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN                         PF2
+#endif
+
+#define E1_STEP_PIN                         PC13  // MOTOR 5
+#define E1_DIR_PIN                          PF0
+#define E1_ENABLE_PIN                       PF1
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN                         PE4
+#endif
+
+#define E2_STEP_PIN                         PE2   // MOTOR 6
+#define E2_DIR_PIN                          PE3
+#define E2_ENABLE_PIN                       PD4
+#ifndef E2_CS_PIN
+
+  #define E2_CS_PIN                         PE1
+#endif
+
+#define E3_STEP_PIN                         PE6   // MOTOR 7
+#define E3_DIR_PIN                          PA14
+#define E3_ENABLE_PIN                       PE0
+#ifndef E3_CS_PIN
+  #define E3_CS_PIN                         PD3
+#endif
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN                        PF3   // TB
+#define TEMP_1_PIN                          PF5   // TH1
+#define TEMP_2_PIN                          PF6   // TH2
+#define TEMP_3_PIN                          PF7   // TH3
+
+#if TEMP_SENSOR_0 == -5
+  #define TEMP_0_CS_PIN                     PF8   // Max31865 CS
+  #define TEMP_0_SCK_PIN                    PA5
+  #define TEMP_0_MISO_PIN                   PA6
+  #define TEMP_0_MOSI_PIN                   PA7
+  #define SOFTWARE_SPI                            // Max31865 and LCD SD share a set of SPIs, Set SD to softwareSPI for Max31865
+  #define FORCE_SOFT_SPI
+#else
+  #define TEMP_0_PIN                        PF4   // TH0
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_BED_PIN                      PA1   // Hotbed
+#define HEATER_0_PIN                        PA0   // Heater0
+#define HEATER_1_PIN                        PA3   // Heater1
+#define HEATER_2_PIN                        PB0   // Heater2
+#define HEATER_3_PIN                        PB11  // Heater3
+
+#define FAN0_PIN                            PA8   // Fan0
+#define FAN1_PIN                            PE5   // Fan1
+#define FAN2_PIN                            PD12  // Fan2
+#define FAN3_PIN                            PD13  // Fan3
+#define FAN4_PIN                            PD14  // Fan4
+#define FAN5_PIN                            PD15  // Fan5
+
+//
+// SD Support
+//
+#ifndef SDCARD_CONNECTION
+  #if HAS_WIRED_LCD
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
+#endif
+
+//
+// SPI pins for TMC2130 stepper drivers
+//
+#ifndef TMC_SPI_MOSI
+  #define TMC_SPI_MOSI                      PA7
+#endif
+#ifndef TMC_SPI_MISO
+  #define TMC_SPI_MISO                      PA6
+#endif
+#ifndef TMC_SPI_SCK
+  #define TMC_SPI_SCK                       PA5
+#endif
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+
+  #define X_SERIAL_TX_PIN                   PC4
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PD11
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PC6
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define Z2_SERIAL_TX_PIN                  PC7
+  #define Z2_SERIAL_RX_PIN      Z2_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                  PF2
+  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
+
+  #define E1_SERIAL_TX_PIN                  PE4
+  #define E1_SERIAL_RX_PIN      E1_SERIAL_TX_PIN
+
+  #define E2_SERIAL_TX_PIN                  PE1
+  #define E2_SERIAL_RX_PIN      E2_SERIAL_TX_PIN
+
+  #define E3_SERIAL_TX_PIN                  PD3
+  #define E3_SERIAL_RX_PIN      E3_SERIAL_TX_PIN
+
+  // Reduce baud rate to improve software serial reliability
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200
+  #endif
+
+#endif // HAS_TMC_UART
+
+/**               ------                                      ------
+ * (BEEPER) PE8  | 1  2 | PE7  (BTN_ENC)         (MISO) PA6  | 1  2 | PA5  (SCK)
+ * (LCD_EN) PE9  | 3  4 | PE10 (LCD_RS)       (BTN_EN1) PB2  | 3  4 | PA4  (SD_SS)
+ * (LCD_D4) PE12   5  6 | PE13 (LCD_D5)       (BTN_EN2) PB1    5  6 | PA7  (MOSI)
+ * (LCD_D6) PE14 | 7  8 | PE15 (LCD_D7)     (SD_DETECT) PC15 | 7  8 | RESET
+ *           GND | 9 10 | 5V                             GND | 9 10 | --
+ *                ------                                      ------
+ *                 EXP1                                        EXP2
+ */
+#define EXP1_01_PIN                         PE8
+#define EXP1_02_PIN                         PE7
+#define EXP1_03_PIN                         PE9
+#define EXP1_04_PIN                         PE10
+#define EXP1_05_PIN                         PE12
+#define EXP1_06_PIN                         PE13
+#define EXP1_07_PIN                         PE14
+#define EXP1_08_PIN                         PE15
+
+#define EXP2_01_PIN                         PA6
+#define EXP2_02_PIN                         PA5
+#define EXP2_03_PIN                         PB1
+#define EXP2_04_PIN                         PA4
+#define EXP2_05_PIN                         PB2
+#define EXP2_06_PIN                         PA7
+#define EXP2_07_PIN                         PC15
+#define EXP2_08_PIN                         -1
+
+//
+// Onboard SD card
+// Must use soft SPI because Marlin's default hardware SPI is tied to LCD's EXP2
+//
+#if SD_CONNECTION_IS(ONBOARD)
+  #define ONBOARD_SDIO                            // Use SDIO for onboard SD
+  #ifndef SD_DETECT_STATE
+    #define SD_DETECT_STATE HIGH
+  #elif SD_DETECT_STATE == LOW
+    #error "BOARD_BTT_OCTOPUS_V1_1 onboard SD requires SD_DETECT_STATE set to HIGH."
+  #endif
+  #define SD_DETECT_PIN                     PC14
+#elif SD_CONNECTION_IS(LCD)
+
+  #define SDSS                              PA4
+  #define SD_SS_PIN                         SDSS
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+  #define SD_DETECT_PIN                     PC15
+
+#elif SD_CONNECTION_IS(CUSTOM_CABLE)
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board"
+#endif
+
+#if ENABLED(BTT_MOTOR_EXPANSION)
+  /**
+   *         ------                  ------
+   * M3DIAG | 1  2 | M3RX     M3STP | 1  2 | M3DIR
+   * M2DIAG | 3  4 | M2RX     M2STP | 3  4 | M2DIR
+   * M1DIAG   5  6 | M1RX     M1DIR   5  6 | M1STP
+   *   M3EN | 7  8 | M2EN      M1EN | 7  8 | --
+   *    GND | 9 10 | --         GND | 9 10 | --
+   *        ------                   ------
+   *         EXP1                     EXP2
+   */
+
+  // M1 on Driver Expansion Module
+  #define E4_STEP_PIN                EXP2_06_PIN
+  #define E4_DIR_PIN                 EXP2_05_PIN
+  #define E4_ENABLE_PIN              EXP2_07_PIN
+  #define E4_DIAG_PIN                EXP1_05_PIN
+  #define E4_CS_PIN                  EXP1_06_PIN
+  #if HAS_TMC_UART
+    #define E4_SERIAL_TX_PIN         EXP1_06_PIN
+    #define E4_SERIAL_RX_PIN    E4_SERIAL_TX_PIN
+  #endif
+
+  // M2 on Driver Expansion Module
+  #define E5_STEP_PIN                EXP2_03_PIN
+  #define E5_DIR_PIN                 EXP2_04_PIN
+  #define E5_ENABLE_PIN              EXP1_08_PIN
+  #define E5_DIAG_PIN                EXP1_03_PIN
+  #define E5_CS_PIN                  EXP1_04_PIN
+  #if HAS_TMC_UART
+    #define E5_SERIAL_TX_PIN         EXP1_04_PIN
+    #define E5_SERIAL_RX_PIN    E5_SERIAL_TX_PIN
+  #endif
+
+  // M3 on Driver Expansion Module
+  #define E6_STEP_PIN                EXP2_01_PIN
+  #define E6_DIR_PIN                 EXP2_02_PIN
+  #define E6_ENABLE_PIN              EXP1_07_PIN
+  #define E6_DIAG_PIN                EXP1_01_PIN
+  #define E6_CS_PIN                  EXP1_02_PIN
+  #if HAS_TMC_UART
+    #define E6_SERIAL_TX_PIN         EXP1_02_PIN
+    #define E6_SERIAL_RX_PIN    E6_SERIAL_TX_PIN
+  #endif
+
+#endif // BTT_MOTOR_EXPANSION
+
+//
+// LCDs and Controllers
+//
+#if IS_TFTGLCD_PANEL
+
+  #if ENABLED(TFTGLCD_PANEL_SPI)
+    #define TFTGLCD_CS               EXP2_03_PIN
+  #endif
+
+#elif HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
+  /**
+   *        ------                 ------            ---
+   *       | 1  2 |               | 1  2 |            1 |
+   *       | 3  4 |            RX | 3  4 | TX       | 2 | RX
+   *   ENT   5  6 | BEEP      ENT   5  6 | BEEP     | 3 | TX
+   *     B | 7  8 | A           B | 7  8 | A        | 4 |
+   *   GND | 9 10 | VCC       GND | 9 10 | VCC        5 |
+   *        ------                 ------            ---
+   *         EXP1                   DWIN             TFT
+   *
+   * DWIN pins are labeled as printed on DWIN PCB. GND, VCC, A, B, ENT & BEEP can be connected in the same
+   * orientation as the existing plug/DWIN to EXP1. TX/RX need to be connected to the TFT port, with TX->RX, RX->TX.
+   */
+
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! Ender-3 V2 display requires a custom cable. See 'pins_BTT_OCTOPUS_V1_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
+
+  #define BEEPER_PIN                 EXP1_06_PIN
+  #define BTN_EN1                    EXP1_08_PIN
+  #define BTN_EN2                    EXP1_07_PIN
+  #define BTN_ENC                    EXP1_05_PIN
+
+#elif HAS_WIRED_LCD
+
+  #define BEEPER_PIN                 EXP1_01_PIN
+  #define BTN_ENC                    EXP1_02_PIN
+
+  #if ENABLED(CR10_STOCKDISPLAY)
+
+    #define LCD_PINS_RS              EXP1_07_PIN
+
+    #define BTN_EN1                  EXP1_03_PIN
+    #define BTN_EN2                  EXP1_05_PIN
+
+    #define LCD_PINS_EN              EXP1_08_PIN
+    #define LCD_PINS_D4              EXP1_06_PIN
+
+  #else
+
+    #define LCD_PINS_RS              EXP1_04_PIN
+
+    #define BTN_EN1                  EXP2_03_PIN
+    #define BTN_EN2                  EXP2_05_PIN
+
+    #define LCD_PINS_EN              EXP1_03_PIN
+    #define LCD_PINS_D4              EXP1_05_PIN
+
+    #if ENABLED(FYSETC_MINI_12864)
+      #define DOGLCD_CS              EXP1_03_PIN
+      #define DOGLCD_A0              EXP1_04_PIN
+      //#define LCD_BACKLIGHT_PIN           -1
+      #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
+      #if ANY(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+        #ifndef RGB_LED_R_PIN
+          #define RGB_LED_R_PIN      EXP1_06_PIN
+        #endif
+        #ifndef RGB_LED_G_PIN
+          #define RGB_LED_G_PIN      EXP1_07_PIN
+        #endif
+        #ifndef RGB_LED_B_PIN
+          #define RGB_LED_B_PIN      EXP1_08_PIN
+        #endif
+      #elif ENABLED(FYSETC_MINI_12864_2_1)
+        #define NEOPIXEL_PIN         EXP1_06_PIN
+      #endif
+    #endif // !FYSETC_MINI_12864
+
+    #if IS_ULTIPANEL
+      #define LCD_PINS_D5            EXP1_06_PIN
+      #define LCD_PINS_D6            EXP1_07_PIN
+      #define LCD_PINS_D7            EXP1_08_PIN
+
+      #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+        #define BTN_ENC_EN           LCD_PINS_D7  // Detect the presence of the encoder
+      #endif
+
+    #endif
+
+  #endif
+#endif  // HAS_WIRED_LCD
+
+// Alter timing for graphical display
+#if IS_U8GLIB_ST7920
+  #define BOARD_ST7920_DELAY_1               120
+  #define BOARD_ST7920_DELAY_2                80
+  #define BOARD_ST7920_DELAY_3               580
+#endif
+
+#if HAS_SPI_TFT
+  #define TFT_CS_PIN                 EXP2_04_PIN
+  #define TFT_A0_PIN                 EXP2_07_PIN
+  #define TFT_SCK_PIN                EXP2_02_PIN
+  #define TFT_MISO_PIN               EXP2_01_PIN
+  #define TFT_MOSI_PIN               EXP2_06_PIN
+
+  #define TOUCH_INT_PIN              EXP1_07_PIN
+  #define TOUCH_MISO_PIN             EXP1_06_PIN
+  #define TOUCH_MOSI_PIN             EXP1_03_PIN
+  #define TOUCH_SCK_PIN              EXP1_05_PIN
+  #define TOUCH_CS_PIN               EXP1_04_PIN
+
+  #define BTN_EN1                    EXP2_03_PIN
+  #define BTN_EN2                    EXP2_05_PIN
+  #define BTN_ENC                    EXP1_02_PIN
+#endif
+
+//
+// NeoPixel LED
+//
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                     PB10
+#endif
+
+#if ENABLED(WIFISUPPORT)
+  //
+  // WIFI
+  //
+
+  /**
+   *                      -------
+   *            GND | 9  |       | 8 | 3.3V
+   *  (ESP-CS) PB12 | 10 |       | 7 | PB15 (ESP-MOSI)
+   *           3.3V | 11 |       | 6 | PB14 (ESP-MISO)
+   * (ESP-IO0)  PD7 | 12 |       | 5 | PB13 (ESP-CLK)
+   * (ESP-IO4) PD10 | 13 |       | 4 | --
+   *             -- | 14 |       | 3 | PE15 (ESP-EN)
+   *  (ESP-RX)  PD8 | 15 |       | 2 | --
+   *  (ESP-TX)  PD9 | 16 |       | 1 | PE14 (ESP-RST)
+   *                      -------
+   *                       WIFI
+   */
+  #define ESP_WIFI_MODULE_COM                  3  // Must also set either SERIAL_PORT or SERIAL_PORT_2 to this
+  #define ESP_WIFI_MODULE_BAUDRATE      BAUDRATE  // Must use same BAUDRATE as SERIAL_PORT & SERIAL_PORT_2
+  #define ESP_WIFI_MODULE_RESET_PIN         PG7
+  #define ESP_WIFI_MODULE_ENABLE_PIN        PG8
+  #define ESP_WIFI_MODULE_GPIO0_PIN         PD7
+  #define ESP_WIFI_MODULE_GPIO4_PIN         PD10
+#endif

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
@@ -47,11 +47,6 @@
 #define SERVO0_PIN                          PB6
 
 //
-// Misc. Functions
-//
-#define LED_PIN                             PA13
-
-//
 // Trinamic Stallguard pins
 //
 #define X_DIAG_PIN                          PG6   // X-STOP
@@ -62,17 +57,6 @@
 #define E1_DIAG_PIN                         PG13  // E1DET
 #define E2_DIAG_PIN                         PG14  // E2DET
 #define E3_DIAG_PIN                         PG15  // E3DET
-
-//
-// Z Probe (when not Z_MIN_PIN)
-//
-#if !defined(Z_MIN_PROBE_PIN) && DISABLED(BLTOUCH)
-  #define Z_MIN_PROBE_PIN                   PC5   // Probe (Proximity switch) port
-#endif
-
-#ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PB7
-#endif
 
 //
 // Limit Switches
@@ -132,6 +116,17 @@
 #endif
 
 //
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #if DISABLED(BLTOUCH)
+    #define Z_MIN_PROBE_PIN                 PC5   // Probe (Proximity switch) port
+  #else
+    #define Z_MIN_PROBE_PIN                 PB7
+  #endif
+#endif
+
+//
 // Filament Runout Sensor
 //
 #define FIL_RUNOUT_PIN                      PG12  // E0DET
@@ -152,6 +147,11 @@
 #ifndef POWER_LOSS_PIN
   #define POWER_LOSS_PIN                    PC0   // PWRDET
 #endif
+
+//
+// Misc. Functions
+//
+#define LED_PIN                             PA13
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h
@@ -542,7 +542,7 @@
 // NeoPixel LED
 //
 #ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                     PB10
+  #define NEOPIXEL_PIN                      PB10
 #endif
 
 #if ENABLED(WIFISUPPORT)

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -131,10 +131,8 @@
 //
 // Probe enable
 //
-#if ENABLED(PROBE_ENABLE_DISABLE)
-  #ifndef PROBE_ENABLE_PIN
-    #define PROBE_ENABLE_PIN          SERVO0_PIN
-  #endif
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
 #endif
 
 //

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -124,7 +124,7 @@ upload_protocol             = cmsis-dap
 debug_tool                  = cmsis-dap
 
 #
-# BigTreeTech Octopus Pro V1.0 / Octopus Max EZ V1.0 (STM32H723ZET6 ARM Cortex-M7)
+# BigTreeTech Octopus Pro V1.1 / Octopus Max EZ V1.0 (STM32H723ZET6 ARM Cortex-M7)
 #
 [env:STM32H723ZE_btt]
 extends                     = STM32H723Zx_btt


### PR DESCRIPTION
### Description

Add BTT Octopus Pro V1.1 (STM32H723ZE) based on https://github.com/MarlinFirmware/Marlin/pull/25387#issuecomment-1618156287 & request in https://github.com/MarlinFirmware/Marlin/issues/26044.

Changes between Octopus Pro V1.0 & V1.1 from the [bigtreetech/BIGTREETECH-OCTOPUS-Pro](https://github.com/bigtreetech/BIGTREETECH-OCTOPUS-Pro#octopus-pro-v11) repo:

- Pinout Changes in V1.1 compared to V1.0
 Pin | Octopus Pro V1.0/V1.0.1 | Octopus Pro V1.1
  -- | -- | --
  HE0 | PA2  | PA0
  HE2 | PB10  | PB0
  Motor4-EN | PA0  | PA2
  RGB | PB0  | PB10

- V1.1 solves issue of hotend turning on while in DFU mode

### Configurations

<details><summary>Minimal Config:</summary>
<p>

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index b21eba7..2c7199f 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -67,7 +67,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_BTT_OCTOPUS_PRO_V1_1
 #endif
 
 /**
@@ -78,7 +78,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Serial Port Baud Rate
diff --git a/platformio.ini b/platformio.ini
index e3bdb6f..f54fee7 100644
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = STM32H723ZE_btt
 include_dir  = Marlin
 extra_configs =
     Marlin/config.ini
```

</p>
</details>

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26044
- https://github.com/MarlinFirmware/Marlin/pull/25387#issuecomment-1618156287

I can't test this since I don't have an Octopus Pro V1.1, but it compiles.