### PR TITLE
Fix / Improve TFT Color UI layout

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -396,9 +396,9 @@
     FORCE_INLINE constexpr T operator|(T x, T y) { return static_cast<T>(static_cast<int>(x) | static_cast<int>(y)); } \
     FORCE_INLINE constexpr T operator^(T x, T y) { return static_cast<T>(static_cast<int>(x) ^ static_cast<int>(y)); } \
     FORCE_INLINE constexpr T operator~(T x)      { return static_cast<T>(~static_cast<int>(x)); } \
-    FORCE_INLINE T & operator&=(T &x, T y) { return x &= y; } \
-    FORCE_INLINE T & operator|=(T &x, T y) { return x |= y; } \
-    FORCE_INLINE T & operator^=(T &x, T y) { return x ^= y; }
+    FORCE_INLINE T & operator&=(T &x, T y) { x = x & y; return x; } \
+    FORCE_INLINE T & operator|=(T &x, T y) { x = x | y; return x; } \
+    FORCE_INLINE T & operator^=(T &x, T y) { x = x ^ y; return x; }
 
   // C++11 solution that is standard compliant. <type_traits> is not available on all platform
   namespace Private {

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1720,8 +1720,13 @@
   #endif
   #define GRAPHICAL_TFT_UPSCALE 2
 #elif ENABLED(TFT_RES_480x272)
-  #define TFT_WIDTH  480
-  #define TFT_HEIGHT 272
+  #if ENABLED(TFT_COLOR_UI_PORTRAIT)
+    #define TFT_WIDTH  272
+    #define TFT_HEIGHT 480
+  #else
+    #define TFT_WIDTH  480
+    #define TFT_HEIGHT 272
+  #endif
   #define GRAPHICAL_TFT_UPSCALE 2
 #elif ENABLED(TFT_RES_480x320)
   #if ENABLED(TFT_COLOR_UI_PORTRAIT)
@@ -1733,8 +1738,13 @@
   #endif
   #define GRAPHICAL_TFT_UPSCALE 3
 #elif ENABLED(TFT_RES_1024x600)
-  #define TFT_WIDTH  1024
-  #define TFT_HEIGHT 600
+  #if ENABLED(TFT_COLOR_UI_PORTRAIT)
+    #define TFT_WIDTH   600
+    #define TFT_HEIGHT 1024
+  #else
+    #define TFT_WIDTH  1024
+    #define TFT_HEIGHT  600
+  #endif
   #if ENABLED(TOUCH_SCREEN)
     #define GRAPHICAL_TFT_UPSCALE 6
     #define TFT_PIXEL_OFFSET_X 120
@@ -1781,14 +1791,21 @@
 #elif ANY(TFT_1024x600_LTDC, TFT_1024x600_SIM)
   #define HAS_UI_1024x600 1
 #endif
+
+// Number of text lines the screen can display (may depend on font used)
+// Touch screens leave space for extra buttons at the bottom
 #if ANY(HAS_UI_320x240, HAS_UI_480x320, HAS_UI_480x272)
   #if ENABLED(TFT_COLOR_UI_PORTRAIT)
-    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 8, 9) // Fewer lines with touch buttons onscreen
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 8, 9)
   #else
-    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 6, 7) // Fewer lines with touch buttons onscreen
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 6, 7)
   #endif
 #elif HAS_UI_1024x600
-  #define LCD_HEIGHT TERN(TOUCH_SCREEN, 12, 13) // Fewer lines with touch buttons onscreen
+  #if ENABLED(TFT_COLOR_UI_PORTRAIT)
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 18, 19)
+  #else
+    #define LCD_HEIGHT TERN(TOUCH_SCREEN, 12, 13)
+  #endif
 #endif
 
 // This emulated DOGM has 'touch/xpt2046', not 'tft/xpt2046'

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -787,3 +787,11 @@
 #if HAL_ADC_VREF_MV < 5000 && ANY_THERMISTOR_IS(-1) && DISABLED(ALLOW_AD595_3V3_VREF)
   #warning "The (-1) AD595 Thermocouple Amplifier requires 5V input supply! Use AD8495 for 3.3V ADC."
 #endif
+
+#if ENABLED(TFT_COLOR_UI_PORTRAIT)
+  #if ENABLED(TFT_RES_480x272)
+    #warning "TFT_COLOR_UI_PORTRAIT is not fully implemented for 480x272 TFT."
+  #elif ENABLED(TFT_RES_1024x600)
+    #warning "TFT_COLOR_UI_PORTRAIT is not fully implemented for 1024x600 TFT."
+  #endif
+#endif

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -784,6 +784,7 @@ void MarlinUI::draw_status_message(const bool blink) {
 }
 
 #if HAS_PRINT_PROGRESS
+
   #define TPOFFSET (LCD_WIDTH - 1)
   static uint8_t timepos = TPOFFSET - 6;
   static char buffer[8];
@@ -837,6 +838,7 @@ void MarlinUI::draw_status_message(const bool blink) {
       }
     }
   #endif
+
 #endif // HAS_PRINT_PROGRESS
 
 /**

--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -596,8 +596,8 @@ FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const
 
 #endif // HAS_CUTTER
 
-
 #if HAS_PRINT_PROGRESS   // UNTESTED!!!
+
   #define TPOFFSET (LCD_WIDTH - 1)
   static uint8_t timepos = TPOFFSET - 6;
 
@@ -648,6 +648,7 @@ FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const
       }
     }
   #endif
+
 #endif // HAS_PRINT_PROGRESS
 
 #if ENABLED(LCD_PROGRESS_BAR)

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -773,7 +773,7 @@ void MarlinUI::draw_status_screen() {
       u8g.drawBox(PROGRESS_BAR_X + 1, PROGRESS_BAR_Y + 1, progress_bar_solid_width, 2);
 
     // Progress strings
-    if (PAGE_CONTAINS(EXTRAS_BASELINE - INFO_FONT_ASCENT, EXTRAS_BASELINE - 1)){
+    if (PAGE_CONTAINS(EXTRAS_BASELINE - INFO_FONT_ASCENT, EXTRAS_BASELINE - 1)) {
       ui.rotate_progress();
       lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, bufferc);
     }

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -510,8 +510,8 @@ U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, 
     }
     else {
       // clear last cross
-      x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].x;
-      y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].y;
+      x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].x;
+      y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].y;
       drawCross(x, y, TFT_MARLINBG_COLOR);
     }
 
@@ -519,10 +519,10 @@ U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, 
     if (stage < CALIBRATION_SUCCESS) {
       // handle current state
       switch (stage) {
-        case CALIBRATION_TOP_LEFT: str = GET_TEXT_F(MSG_TOP_LEFT); break;
-        case CALIBRATION_BOTTOM_LEFT: str = GET_TEXT_F(MSG_BOTTOM_LEFT); break;
-        case CALIBRATION_TOP_RIGHT:  str = GET_TEXT_F(MSG_TOP_RIGHT); break;
+        case CALIBRATION_TOP_LEFT:     str = GET_TEXT_F(MSG_TOP_LEFT);     break;
+        case CALIBRATION_TOP_RIGHT:    str = GET_TEXT_F(MSG_TOP_RIGHT);    break;
         case CALIBRATION_BOTTOM_RIGHT: str = GET_TEXT_F(MSG_BOTTOM_RIGHT); break;
+        case CALIBRATION_BOTTOM_LEFT:  str = GET_TEXT_F(MSG_BOTTOM_LEFT);  break;
         default: break;
       }
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -1421,7 +1421,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
 
         case MLEVEL_BL:
           if (draw)
-            drawMenuItem(row, ICON_AxisBL, F("Bottom Left"));
+            drawMenuItem(row, ICON_AxisBL, GET_TEXT_F(MSG_BOTTOM_LEFT));
           else {
             popupHandler(Popup_MoveWait);
             if (use_probe) {
@@ -1444,7 +1444,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
           break;
         case MLEVEL_TL:
           if (draw)
-            drawMenuItem(row, ICON_AxisTL, F("Top Left"));
+            drawMenuItem(row, ICON_AxisTL, GET_TEXT_F(MSG_TOP_LEFT));
           else {
             popupHandler(Popup_MoveWait);
             if (use_probe) {
@@ -1467,7 +1467,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
           break;
         case MLEVEL_TR:
           if (draw)
-            drawMenuItem(row, ICON_AxisTR, F("Top Right"));
+            drawMenuItem(row, ICON_AxisTR, GET_TEXT_F(MSG_TOP_RIGHT));
           else {
             popupHandler(Popup_MoveWait);
             if (use_probe) {
@@ -1490,7 +1490,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
           break;
         case MLEVEL_BR:
           if (draw)
-            drawMenuItem(row, ICON_AxisBR, F("Bottom Right"));
+            drawMenuItem(row, ICON_AxisBR, GET_TEXT_F(MSG_BOTTOM_RIGHT));
           else {
             popupHandler(Popup_MoveWait);
             if (use_probe) {

--- a/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
@@ -60,10 +60,10 @@ namespace ExtUI {
   void onPrintTimerStopped() { dgus.timerEvent(AC_timer_stopped); }
   void onPrintDone() {}
 
-  void onFilamentRunout(const extruder_t)            { dgus.filamentRunout();             }
+  void onFilamentRunout(const extruder_t)            { dgus.filamentRunout();         }
 
-  void onUserConfirmRequired(const char * const msg) { dgus.confirmationRequest(msg);     }
-  void onStatusChanged(const char * const msg)       { dgus.statusChange(msg);            }
+  void onUserConfirmRequired(const char * const msg) { dgus.confirmationRequest(msg); }
+  void onStatusChanged(const char * const msg)       { dgus.statusChange(msg);        }
 
   void onHomingStart()    { dgus.homingStart(); }
   void onHomingDone()     { dgus.homingComplete(); }

--- a/Marlin/src/lcd/extui/mks_ui/draw_touch_calibration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_touch_calibration.cpp
@@ -62,8 +62,8 @@ void lv_update_touch_calibration_screen() {
   }
   else {
     // clear last cross
-    x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].x;
-    y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].y;
+    x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].x;
+    y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].y;
     drawCross(x, y, LV_COLOR_BACKGROUND.full);
   }
 
@@ -72,9 +72,9 @@ void lv_update_touch_calibration_screen() {
     // handle current state
     switch (stage) {
       case CALIBRATION_TOP_LEFT:     str = GET_TEXT(MSG_TOP_LEFT); break;
-      case CALIBRATION_BOTTOM_LEFT:  str = GET_TEXT(MSG_BOTTOM_LEFT); break;
       case CALIBRATION_TOP_RIGHT:    str = GET_TEXT(MSG_TOP_RIGHT); break;
       case CALIBRATION_BOTTOM_RIGHT: str = GET_TEXT(MSG_BOTTOM_RIGHT); break;
+      case CALIBRATION_BOTTOM_LEFT:  str = GET_TEXT(MSG_BOTTOM_LEFT); break;
       default: break;
     }
 

--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -310,7 +310,7 @@ static bool get_point(int16_t *x, int16_t *y) {
 
   #if ENABLED(TOUCH_SCREEN_CALIBRATION)
     const calibrationState state = touch_calibration.get_calibration_state();
-    if (state >= CALIBRATION_TOP_LEFT && state <= CALIBRATION_BOTTOM_RIGHT) {
+    if (WITHIN(state, CALIBRATION_TOP_LEFT, CALIBRATION_BOTTOM_LEFT)) {
       if (touch_calibration.handleTouch(*x, *y)) lv_update_touch_calibration_screen();
       return false;
     }

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -220,6 +220,45 @@ void draw_fan_status(uint16_t x, uint16_t y, const bool blink) {
   tft.add_text(tft_string.center(80) + 6, 80 + tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_FAN, tft_string);
 }
 
+/**
+ * For limited space draw the percent / time values in series.
+ * Call ui.rotate_progress within draw_status_screen to use these.
+ */
+#if ENABLED(SHOW_PROGRESS_PERCENT)
+  void MarlinUI::drawPercent() {
+    // Draw the progress percentage
+  }
+#endif
+#if ENABLED(SHOW_ELAPSED_TIME)
+  void MarlinUI::drawElapsed() {
+    // Draw the elapsed time
+  }
+#endif
+#if ENABLED(SHOW_REMAINING_TIME)
+  void MarlinUI::drawRemain() {
+    // Draw remaining time
+  }
+#endif
+#if ENABLED(SHOW_INTERACTION_TIME)
+  void MarlinUI::drawInter() {
+    // Draw interaction time
+  }
+#endif
+
+/**
+ * Draw Status Screen
+ *
+ *  - Temperatures E0 / E1 / E2 / BED / Chamber / Cooler
+ *  - Fan
+ *  - E Total or XY Positions
+ *  - Z Position
+ *  - Feed Rate
+ *  - Flow Rate
+ *  - Settings Button
+ *  - Time Elapsed and/or Remaining
+ *  - Progress Bar
+ *  - Status Message
+ */
 void MarlinUI::draw_status_screen() {
   const bool blink = get_blink();
 
@@ -257,10 +296,11 @@ void MarlinUI::draw_status_screen() {
   y += STATUS_MARGIN_SIZE + 114;
 
   // Coordinates
-  constexpr uint16_t coords_width = TFT_WIDTH - 8;
-  tft.canvas((TFT_WIDTH - coords_width) / 2, y, coords_width, FONT_LINE_HEIGHT);
+  constexpr uint16_t coords_w = TFT_WIDTH - TERN(HAS_UI_480x320, 8, 2);
+  uint16_t x = (TFT_WIDTH - coords_w) / 2;
+  tft.canvas(x, y, coords_w, FONT_LINE_HEIGHT);
   tft.set_background(COLOR_BACKGROUND);
-  tft.add_rectangle(0, 0, coords_width, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
+  tft.add_rectangle(0, 0, coords_w, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
   if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
     #if ENABLED(LCD_SHOW_E_TOTAL)
@@ -276,46 +316,46 @@ void MarlinUI::draw_status_screen() {
     // Coords in mask "X____Y____Z____"
     #if HAS_X_AXIS
       tft_string.set("X");
-      tft.add_text(coords_width / 30 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
+      tft.add_text(coords_w / 30 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
 
       const bool nhx = axis_should_home(X_AXIS);
       tft_string.set(blink && nhx ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
       tft_string.ltrim();
-      tft.add_text(coords_width / 5 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhx ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+      tft.add_text(coords_w / 5 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhx ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
     #endif
 
     #if HAS_Y_AXIS
       tft_string.set("Y");
-      tft.add_text(11 * coords_width / 30 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
+      tft.add_text(11 * coords_w / 30 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
 
       const bool nhy = axis_should_home(Y_AXIS);
       tft_string.set(blink && nhy ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
       tft_string.ltrim();
-      tft.add_text(8 * coords_width / 15 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhy ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+      tft.add_text(8 * coords_w / 15 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhy ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
     #endif
   }
 
   #if HAS_Z_AXIS
     tft_string.set("Z");
-    tft.add_text(7 * coords_width / 10 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
+    tft.add_text(7 * coords_w / 10 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_AXIS_HOMED, tft_string);
 
     const bool nhz = axis_should_home(Z_AXIS);
     tft_string.set(blink && nhz ? "?" : ftostr52sp(LOGICAL_Z_POSITION(current_position.z)));
     tft_string.ltrim();
     tft_string.rtrim();
-    tft.add_text(13 * coords_width / 15 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhz ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    tft.add_text(13 * coords_w / 15 - tft_string.width() / 2, tft_string.vcenter(FONT_LINE_HEIGHT), nhz ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   #endif
 
-  TERN_(TOUCH_SCREEN, touch.add_control(MOVE_AXIS, 4, y, TFT_WIDTH - 8, FONT_LINE_HEIGHT));
+  TERN_(TOUCH_SCREEN, touch.add_control(MOVE_AXIS, x, y, coords_w, FONT_LINE_HEIGHT));
 
-  y += STATUS_MARGIN_SIZE + 34;
+  y += STATUS_MARGIN_SIZE + 40;
 
   // Feed rate (preparing)
   tft_string.set(i16tostr3rj(feedrate_percentage));
   tft_string.add("%");
   uint16_t component_width = 36 + tft_string.width(); // 32px icon size + 4px margin before text
   uint16_t color = feedrate_percentage == 100 ? COLOR_RATE_100 : COLOR_RATE_ALTERED;
-  uint16_t x = FEEDRATE_X(component_width);
+  x = FEEDRATE_X(component_width);
 
   // Feed rate (drawing)
   tft.canvas(x, y, component_width, 32);
@@ -340,120 +380,130 @@ void MarlinUI::draw_status_screen() {
     TERN_(TOUCH_SCREEN, touch.add_control(FLOWRATE, x, y, component_width, 32, active_extruder));
   #endif
 
-  y += TERN(HAS_UI_480x272, 36, 44);
+  y += TERN(HAS_UI_480x272, 30, 38);
+
+  #if ENABLED(TOUCH_SCREEN)
+    // Settings button
+    add_control(SETTINGS_X, y, menu_main, imgSettings);
+
+    // SD-card button / Cancel button
+    #if HAS_MEDIA
+      const bool cm = card.isMounted(), pa = printingIsActive();
+      if (cm && pa)
+        add_control(SDCARD_X, y, STOP, imgCancel, true, COLOR_CONTROL_CANCEL);
+      else
+        add_control(SDCARD_X, y, menu_media, imgSD, cm && !pa, COLOR_CONTROL_ENABLED, COLOR_CONTROL_DISABLED); // 64px icon size
+    #endif
+    y += STATUS_MARGIN_SIZE + TERN(TFT_COLOR_UI_PORTRAIT, 64, 44);
+  #endif
 
   const progress_t progress = TERN(HAS_PRINT_PROGRESS_PERMYRIAD, get_progress_permyriad, get_progress_percent)();
-  #if ENABLED(SHOW_ELAPSED_TIME) && DISABLED(SHOW_REMAINING_TIME)
+
+  #if ANY(SHOW_ELAPSED_TIME, SHOW_REMAINING_TIME)
+    const duration_t elapsed = print_job_timer.duration();
+    // Same width constraints as feedrate/flowrate controls
+    constexpr uint16_t time_str_width = FONT_SIZE * 16, image_width = 36;
+    x = (TFT_WIDTH - time_str_width) / 2;
+  #endif
+
+  #if ENABLED(SHOW_ELAPSED_TIME)
+  #endif
+
+  #if ENABLED(SHOW_REMAINING_TIME)
+    auto set_remaining_string = [&]{
+      // Get the estimate, first from M73
+      uint32_t estimate_remaining = (0
+        #if ALL(SET_PROGRESS_MANUALLY, SET_REMAINING_TIME)
+          + get_remaining_time()
+        #endif
+      );
+      // If no M73 estimate is available but we have progress data, calculate time remaining assuming time elapsed is linear with progress
+      if (!estimate_remaining && progress > 0)
+        estimate_remaining = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
+
+      if (!estimate_remaining)
+        tft_string.set("-");
+      else {
+        duration_t estimation = estimate_remaining;
+        char estimate_str[TERN(SHOW_ELAPSED_TIME, 18, 22)];
+        estimation.TERN(SHOW_ELAPSED_TIME, toCompactString, toString)(estimate_str);
+        tft_string.set(estimate_str);
+      }
+    };
+  #endif
+
+  #if ALL(SHOW_REMAINING_TIME, SHOW_ELAPSED_TIME)
+
+    // Draw both elapsed and remaining
+
+    char elapsed_str[18];
+    elapsed.toCompactString(elapsed_str);
+
+    tft.canvas(96, y, image_width + time_str_width, 32);
+    tft.set_background(COLOR_BACKGROUND);
+    tft.add_image(0, 0, imgTimeElapsed, COLOR_PRINT_TIME);
+    tft_string.set(elapsed_str);
+    tft.add_text(image_width, tft_string.vcenter(29), COLOR_PRINT_TIME, tft_string);
+
+    // Print time remaining estimation - aligned under flow rate
+
+    // Generate estimated remaining time string
+    set_remaining_string();
+
+    // Push out the estimate to the screen
+    tft.canvas(x + time_str_width / 2 + 2, y, image_width + time_str_width, 32);
+    tft.set_background(COLOR_BACKGROUND);
+    color = printingIsActive() ? COLOR_PRINT_TIME : COLOR_INACTIVE;
+    tft.add_image(0, 0, imgTimeRemaining, color);
+    tft.add_text(image_width, tft_string.vcenter(29), color, tft_string);
+
+  #elif ENABLED(SHOW_ELAPSED_TIME)
     // Print duration so far (time elapsed) - centered
     char elapsed_str[22];
-    duration_t elapsed = print_job_timer.duration();
     elapsed.toString(elapsed_str);
 
-    // Same width constraints as feedrate/flowrate controls
-    constexpr uint16_t time_str_width = 288, image_width = 36;
-
-    tft.canvas((TFT_WIDTH - time_str_width) / 2, y, time_str_width, 32);
+    tft.canvas(x, y, time_str_width, 32);
     tft.set_background(COLOR_BACKGROUND);
     tft_string.set(elapsed_str);
     uint16_t text_pos_x = tft_string.center(time_str_width - image_width);
     tft.add_image(text_pos_x, 0, imgTimeElapsed, COLOR_PRINT_TIME);
     tft.add_text(text_pos_x + image_width, tft_string.vcenter(29), COLOR_PRINT_TIME, tft_string);
 
-  #elif DISABLED(SHOW_ELAPSED_TIME) && ENABLED(SHOW_REMAINING_TIME)
-    // Print time remaining estimation - centered
-    char estimate_str[22];
-    duration_t elapsed = print_job_timer.duration();
+  #elif ENABLED(SHOW_REMAINING_TIME)
+    // Remaining Print Time estimation - centered
 
-    // Get the estimate, first from M73
-    uint32_t estimate_remaining = (0
-      #if ALL(SET_PROGRESS_MANUALLY, SET_REMAINING_TIME)
-        + get_remaining_time()
-      #endif
-    );
-    // If no M73 estimate is available but we have progress data, calculate time remaining assuming time elapsed is linear with progress
-    if (!estimate_remaining && progress > 0)
-      estimate_remaining = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
+    // Generate estimated remaining time string
+    set_remaining_string();
 
-    // Generate estimate string
-    if (!estimate_remaining)
-      tft_string.set("-");
-    else {
-      duration_t estimation = estimate_remaining;
-      estimation.toString(estimate_str);
-      tft_string.set(estimate_str);
-    }
-
-    // Same width constraints as feedrate/flowrate controls
-    constexpr uint16_t time_str_width = 288, image_width = 36;
-
-    tft.canvas((TFT_WIDTH - time_str_width) / 2, y, time_str_width, 32);
+    tft.canvas(x, y, time_str_width, 32);
     tft.set_background(COLOR_BACKGROUND);
     color = printingIsActive() ? COLOR_PRINT_TIME : COLOR_INACTIVE;
     uint16_t text_pos_x = tft_string.center(time_str_width - image_width);
     tft.add_image(text_pos_x, 0, imgTimeRemaining, color);
     tft.add_text(text_pos_x + image_width, tft_string.vcenter(29), color, tft_string);
 
-  #elif ALL(SHOW_REMAINING_TIME, SHOW_ELAPSED_TIME)
-    // Print duration so far (time elapsed) - aligned under feed rate
-    char elapsed_str[18];
-    duration_t elapsed = print_job_timer.duration();
-    elapsed.toCompactString(elapsed_str);
-
-    tft.canvas(96, y, 144, 32);
-    tft.set_background(COLOR_BACKGROUND);
-    tft.add_image(0, 0, imgTimeElapsed, COLOR_PRINT_TIME);
-    tft_string.set(elapsed_str);
-    tft.add_text(36, tft_string.vcenter(29), COLOR_PRINT_TIME, tft_string);
-
-    // Print time remaining estimation - aligned under flow rate
-    char estimate_str[18];
-
-    // Get the estimate, first from M73
-    uint32_t estimate_remaining = (0
-      #if ALL(SET_PROGRESS_MANUALLY, SET_REMAINING_TIME)
-        + get_remaining_time()
-      #endif
-    );
-    // If no M73 estimate is available but we have progress data, calculate time remaining assuming time elapsed is linear with progress
-    if (!estimate_remaining && progress > 0)
-      estimate_remaining = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
-
-    // Generate estimate string
-    if (!estimate_remaining)
-      tft_string.set("-");
-    else {
-      duration_t estimation = estimate_remaining;
-      estimation.toCompactString(estimate_str);
-      tft_string.set(estimate_str);
-    }
-
-    // Push out the estimate to the screen
-    tft.canvas(256, y, 144, 32);
-    tft.set_background(COLOR_BACKGROUND);
-    color = printingIsActive() ? COLOR_PRINT_TIME : COLOR_INACTIVE;
-    tft.add_image(0, 0, imgTimeRemaining, color);
-    tft.add_text(36, tft_string.vcenter(29), color, tft_string);
   #endif
 
-  y += TERN(HAS_UI_480x272, 36, 44);
+  y += TERN(HAS_UI_480x272, 36, 44) + TERN(TFT_COLOR_UI_PORTRAIT, 20, 0);
+
+  constexpr uint16_t bar_i = TERN(HAS_UI_480x320, 8, 4),
+                     bar_w = TFT_WIDTH - bar_i,
+                     bar_h = TERN(TFT_COLOR_UI_PORTRAIT, 16, 9);
 
   // Progress bar
   // TODO: print percentage text for SHOW_PROGRESS_PERCENT
-  tft.canvas(4, y, TFT_WIDTH - 8, 9);
+  tft.canvas(bar_i / 2, y, bar_w, bar_h);
   tft.set_background(COLOR_PROGRESS_BG);
-  tft.add_rectangle(0, 0, TFT_WIDTH - 8, 9, COLOR_PROGRESS_FRAME);
-  if (progress)
-    tft.add_bar(1, 1, ((TFT_WIDTH - 10) * progress / (PROGRESS_SCALE)) / 100, 7, COLOR_PROGRESS_BAR);
+  tft.add_rectangle(0, 0, bar_w, bar_h, COLOR_PROGRESS_FRAME);
+  if (progress) tft.add_bar(1, 1, ((bar_w - 2) * progress / (PROGRESS_SCALE)) / 100, bar_h - 2, COLOR_PROGRESS_BAR);
 
-  y += 12;
   // Status message
-  // Canvas height should be 40px on 480x320 and 28 on 480x272
-  const uint16_t status_height = TFT_HEIGHT - y;
-  tft.canvas(0, y, TFT_WIDTH, status_height);
+  constexpr uint16_t status_height = FONT_LINE_HEIGHT + 4; // TERN(HAS_UI_480x272, 28, 40);
+  tft.canvas(0, TFT_HEIGHT - status_height, TFT_WIDTH, status_height);
   tft.set_background(COLOR_BACKGROUND);
   tft_string.set(status_message);
   tft_string.trim();
-  tft.add_text(tft_string.center(TFT_WIDTH), tft_string.vcenter(FONT_LINE_HEIGHT), COLOR_STATUS_MESSAGE, tft_string);
+  tft.add_text(tft_string.center(TFT_WIDTH), tft_string.vcenter(status_height), COLOR_STATUS_MESSAGE, tft_string);
 }
 
 // Low-level draw_edit_screen can be used to draw an edit screen from anyplace

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -253,8 +253,8 @@ void MarlinUI::clear_lcd() {
       stage = touch_calibration.calibration_start();
     }
     else {
-      x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].x;
-      y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_RIGHT)].y;
+      x = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].x;
+      y = touch_calibration.calibration_points[_MIN(stage - 1, CALIBRATION_BOTTOM_LEFT)].y;
       tft.canvas(x - 15, y - 15, 31, 31);
       tft.set_background(COLOR_BACKGROUND);
     }
@@ -263,10 +263,10 @@ void MarlinUI::clear_lcd() {
 
     if (stage < CALIBRATION_SUCCESS) {
       switch (stage) {
-        case CALIBRATION_TOP_LEFT: tft_string.set(GET_TEXT(MSG_TOP_LEFT)); break;
-        case CALIBRATION_BOTTOM_LEFT: tft_string.set(GET_TEXT(MSG_BOTTOM_LEFT)); break;
-        case CALIBRATION_TOP_RIGHT: tft_string.set(GET_TEXT(MSG_TOP_RIGHT)); break;
+        case CALIBRATION_TOP_LEFT:     tft_string.set(GET_TEXT(MSG_TOP_LEFT));     break;
+        case CALIBRATION_TOP_RIGHT:    tft_string.set(GET_TEXT(MSG_TOP_RIGHT));    break;
         case CALIBRATION_BOTTOM_RIGHT: tft_string.set(GET_TEXT(MSG_BOTTOM_RIGHT)); break;
+        case CALIBRATION_BOTTOM_LEFT:  tft_string.set(GET_TEXT(MSG_BOTTOM_LEFT));  break;
         default: break;
       }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -103,10 +103,10 @@ bool TouchCalibration::handleTouch(const uint16_t x, const uint16_t y) {
   }
 
   switch (calibration_state) {
-    case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
-    case CALIBRATION_BOTTOM_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
+    case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
     case CALIBRATION_TOP_RIGHT: calibration_state = CALIBRATION_BOTTOM_RIGHT; break;
-    case CALIBRATION_BOTTOM_RIGHT: validate_calibration(); break;
+    case CALIBRATION_BOTTOM_RIGHT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
+    case CALIBRATION_BOTTOM_LEFT: validate_calibration(); break;
     default: break;
   }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -43,9 +43,9 @@ typedef struct __attribute__((__packed__)) {
 
 enum calibrationState : uint8_t {
   CALIBRATION_TOP_LEFT = 0x00,
-  CALIBRATION_BOTTOM_LEFT,
   CALIBRATION_TOP_RIGHT,
   CALIBRATION_BOTTOM_RIGHT,
+  CALIBRATION_BOTTOM_LEFT,
   CALIBRATION_SUCCESS,
   CALIBRATION_FAIL,
   CALIBRATION_NONE,
@@ -73,12 +73,12 @@ public:
     calibration_state = CALIBRATION_TOP_LEFT;
     calibration_points[CALIBRATION_TOP_LEFT].x = 30;
     calibration_points[CALIBRATION_TOP_LEFT].y = 30;
-    calibration_points[CALIBRATION_BOTTOM_LEFT].x = 30;
-    calibration_points[CALIBRATION_BOTTOM_LEFT].y = TFT_HEIGHT - 31;
     calibration_points[CALIBRATION_TOP_RIGHT].x = TFT_WIDTH - 31;
     calibration_points[CALIBRATION_TOP_RIGHT].y = 30;
     calibration_points[CALIBRATION_BOTTOM_RIGHT].x = TFT_WIDTH - 31;
     calibration_points[CALIBRATION_BOTTOM_RIGHT].y = TFT_HEIGHT - 31;
+    calibration_points[CALIBRATION_BOTTOM_LEFT].x = 30;
+    calibration_points[CALIBRATION_BOTTOM_LEFT].y = TFT_HEIGHT - 31;
     failed_count = 0;
     return calibration_state;
   }

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -80,7 +80,7 @@ uint8_t TouchButtons::read_buttons() {
 
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
         const calibrationState state = touch_calibration.get_calibration_state();
-        if (WITHIN(state, CALIBRATION_TOP_LEFT, CALIBRATION_BOTTOM_RIGHT)) {
+        if (WITHIN(state, CALIBRATION_TOP_LEFT, CALIBRATION_BOTTOM_LEFT)) {
           if (touch_calibration.handleTouch(x, y)) ui.refresh();
           return 0;
         }

--- a/Marlin/src/libs/W25Qxx.cpp
+++ b/Marlin/src/libs/W25Qxx.cpp
@@ -48,10 +48,12 @@ void W25QXXFlash::init(uint8_t spiRate) {
    * STM32F1 has 3 SPI ports, SPI1 in APB2, SPI2/SPI3 in APB1
    * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
    */
-  #if SPI_DEVICE == 1
-    #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
-  #else
-    #define SPI_CLOCK_MAX SPI_CLOCK_DIV2
+  #ifndef SPI_CLOCK_MAX
+    #if SPI_DEVICE == 1
+      #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
+    #else
+      #define SPI_CLOCK_MAX SPI_CLOCK_DIV2
+    #endif
   #endif
   uint8_t clock;
   switch (spiRate) {


### PR DESCRIPTION
- Color UI Portrait layouts 272x480 and 600x1024.
- Perform touch calibration in clockwise order.
- Add sub-handlers for `MarlinUI::rotate_progress`. (May just add more `HAS_EXTRA_PROGRESS` conditions.)
- Color UI refinements to `MarlinUI::draw_status_screen` for `SHOW_ELAPSED_TIME` and `SHOW_REMAINING_TIME`.
- Minor adjustments to ColorUI layouts.
