### PR TITLE
Update avr sanity check for an additional common conflict.

### DIFF
--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -39,7 +39,7 @@
   || X_STEP_PIN == N || Y_STEP_PIN == N || Z_STEP_PIN  == N \
   || X_DIR_PIN  == N || Y_DIR_PIN  == N || Z_DIR_PIN   == N \
   || X_ENA_PIN  == N || Y_ENA_PIN  == N || Z_ENA_PIN   == N \
-  || BTN_EN1    == N || BTN_EN2    == N || LCD_PINS_EN == N\
+  || BTN_EN1    == N || BTN_EN2    == N || LCD_PINS_EN == N \
 )
 #if SERIAL_IN_USE(0)
   // D0-D1. No known conflicts.

--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -33,13 +33,13 @@
  * Check for common serial pin conflicts
  */
 #define CHECK_SERIAL_PIN(N) ( \
-     X_STOP_PIN == N || Y_STOP_PIN == N || Z_STOP_PIN == N \
-  || X_MIN_PIN  == N || Y_MIN_PIN  == N || Z_MIN_PIN  == N \
-  || X_MAX_PIN  == N || Y_MAX_PIN  == N || Z_MAX_PIN  == N \
-  || X_STEP_PIN == N || Y_STEP_PIN == N || Z_STEP_PIN == N \
-  || X_DIR_PIN  == N || Y_DIR_PIN  == N || Z_DIR_PIN  == N \
-  || X_ENA_PIN  == N || Y_ENA_PIN  == N || Z_ENA_PIN  == N \
-  || BTN_EN1    == N || BTN_EN2    == N \
+     X_STOP_PIN == N || Y_STOP_PIN == N || Z_STOP_PIN  == N \
+  || X_MIN_PIN  == N || Y_MIN_PIN  == N || Z_MIN_PIN   == N \
+  || X_MAX_PIN  == N || Y_MAX_PIN  == N || Z_MAX_PIN   == N \
+  || X_STEP_PIN == N || Y_STEP_PIN == N || Z_STEP_PIN  == N \
+  || X_DIR_PIN  == N || Y_DIR_PIN  == N || Z_DIR_PIN   == N \
+  || X_ENA_PIN  == N || Y_ENA_PIN  == N || Z_ENA_PIN   == N \
+  || BTN_EN1    == N || BTN_EN2    == N || LCD_PINS_EN == N\
 )
 #if SERIAL_IN_USE(0)
   // D0-D1. No known conflicts.


### PR DESCRIPTION
### Description

Add a check for AVR uart 2 and REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER conflict

UART 2 uses 17 (RX) and 16 (TX) which is in-conflict with LCD_PINS_EN (D17) and LCD_PINS_RS (D16) 


### Requirements

AVR with REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER

### Benefits

Users are warned not to enabled uart 2 when they have REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
