### PR TITLE
add uarts 7-9 to stm32

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -57,61 +57,61 @@
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
 
-#if WITHIN(SERIAL_PORT, 1, 6)
+#if WITHIN(SERIAL_PORT, 1, 9)
   #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #elif !defined(USBCON)
-  #error "SERIAL_PORT must be from 1 to 6."
+  #error "SERIAL_PORT must be from 1 to 9."
 #elif SERIAL_PORT == -1
   #define MYSERIAL1 MSerialUSB
 #else
-  #error "SERIAL_PORT must be from 1 to 6, or -1 for Native USB."
+  #error "SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
 #endif
 
 #ifdef SERIAL_PORT_2
-  #if WITHIN(SERIAL_PORT_2, 1, 6)
+  #if WITHIN(SERIAL_PORT_2, 1, 9)
     #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #elif !defined(USBCON)
-    #error "SERIAL_PORT_2 must be from 1 to 6."
+    #error "SERIAL_PORT_2 must be from 1 to 9."
   #elif SERIAL_PORT_2 == -1
     #define MYSERIAL2 MSerialUSB
   #else
-    #error "SERIAL_PORT_2 must be from 1 to 6, or -1 for Native USB."
+    #error "SERIAL_PORT_2 must be from 1 to 9, or -1 for Native USB."
   #endif
 #endif
 
 #ifdef SERIAL_PORT_3
-  #if WITHIN(SERIAL_PORT_3, 1, 6)
+  #if WITHIN(SERIAL_PORT_3, 1, 9)
     #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
   #elif !defined(USBCON)
-    #error "SERIAL_PORT_3 must be from 1 to 6."
+    #error "SERIAL_PORT_3 must be from 1 to 9."
   #elif SERIAL_PORT_3 == -1
     #define MYSERIAL3 MSerialUSB
   #else
-    #error "SERIAL_PORT_3 must be from 1 to 6, or -1 for Native USB."
+    #error "SERIAL_PORT_3 must be from 1 to 9, or -1 for Native USB."
   #endif
 #endif
 
 #ifdef MMU2_SERIAL_PORT
-  #if WITHIN(MMU2_SERIAL_PORT, 1, 6)
+  #if WITHIN(MMU2_SERIAL_PORT, 1, 9)
     #define MMU2_SERIAL MSERIAL(MMU2_SERIAL_PORT)
   #elif !defined(USBCON)
-    #error "MMU2_SERIAL_PORT must be from 1 to 6."
+    #error "MMU2_SERIAL_PORT must be from 1 to 9."
   #elif MMU2_SERIAL_PORT == -1
     #define MMU2_SERIAL MSerialUSB
   #else
-    #error "MMU2_SERIAL_PORT must be from 1 to 6, or -1 for Native USB."
+    #error "MMU2_SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
   #endif
 #endif
 
 #ifdef LCD_SERIAL_PORT
-  #if WITHIN(LCD_SERIAL_PORT, 1, 6)
+  #if WITHIN(LCD_SERIAL_PORT, 1, 9)
     #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
   #elif !defined(USBCON)
-    #error "LCD_SERIAL_PORT must be from 1 to 6."
+    #error "LCD_SERIAL_PORT must be from 1 to 9."
   #elif LCD_SERIAL_PORT == -1
     #define LCD_SERIAL MSerialUSB
   #else
-    #error "LCD_SERIAL_PORT must be from 1 to 6, or -1 for Native USB."
+    #error "LCD_SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
   #endif
   #if HAS_DGUS_LCD
     #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()

--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -37,6 +37,15 @@
 #ifndef USART5
   #define USART5 UART5
 #endif
+#ifndef USART7
+  #define USART7 UART7
+#endif
+#ifndef USART8
+  #define USART8 UART8
+#endif
+#ifndef USART9
+  #define USART9 UART9
+#endif
 
 #define DECLARE_SERIAL_PORT(ser_num) \
   void _rx_complete_irq_ ## ser_num (serial_t * obj); \

--- a/Marlin/src/HAL/STM32/MinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MinSerial.cpp
@@ -45,7 +45,7 @@ struct USARTMin {
   volatile uint32_t CR2;
 };
 
-#if WITHIN(SERIAL_PORT, 1, 6)
+#if WITHIN(SERIAL_PORT, 1, 9)
   // Depending on the CPU, the serial port is different for USART1
   static const uintptr_t regsAddr[] = {
     TERN(STM32F1xx, 0x40013800, 0x40011000), // USART1
@@ -54,6 +54,9 @@ struct USARTMin {
     0x40004C00, // UART4_BASE
     0x40005000, // UART5_BASE
     0x40011400  // USART6
+    0x40007800  // UART7_BASE
+    0x40007C00  // UART8_BASE
+    0x40011800  // UART9_BASE
   };
   static USARTMin * regs = (USARTMin*)regsAddr[SERIAL_PORT - 1];
 #endif
@@ -116,7 +119,7 @@ static void TXBegin() {
 // A SW memory barrier, to ensure GCC does not overoptimize loops
 #define sw_barrier() __asm__ volatile("": : :"memory");
 static void TX(char c) {
-  #if WITHIN(SERIAL_PORT, 1, 6)
+  #if WITHIN(SERIAL_PORT, 1, 9)
     constexpr uint32_t usart_sr_txe = _BV(7);
     while (!(regs->SR & usart_sr_txe)) {
       hal.watchdog_refresh();


### PR DESCRIPTION
### Description

Newer STM32 boards such as octopus max are using  UARTS > 6   (esp is on uart 7)   

### Requirements

A board with more than 6 hardware uarts

### Benefits

Complies as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26070


