### PR TITLE
Fix remaining width calc in EDIT_ITEM

### DIFF
--- a/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
+++ b/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
@@ -1043,7 +1043,7 @@ int lcd_put_lchar_max(const lchar_t &c, const pixel_len_t max_length) {
  * @param cb_read_byte : the callback function to read one byte from the utf8_str (from RAM or ROM)
  * @param max_length : the pixel length of the string allowed (or number of slots in HD44780)
  *
- * @return the number of pixels advanced
+ * @return the number of characters emitted
  *
  * Draw a UTF-8 string
  */

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -1210,7 +1210,8 @@ void MarlinUI::draw_status_screen() {
   void MenuEditItemBase::draw(const bool sel, const uint8_t row, FSTR_P const ftpl, const char * const inStr, const bool pgm) {
     const uint8_t vlen = inStr ? (pgm ? utf8_strlen_P(inStr) : utf8_strlen(inStr)) : 0;
     lcd_put_lchar(0, row, sel ? LCD_STR_ARROW_RIGHT[0] : ' ');
-    uint8_t n = lcd_put_u8str(ftpl, itemIndex, itemStringC, itemStringF, LCD_WIDTH - 2 - vlen);
+    uint8_t n = LCD_WIDTH - 2 - vlen;
+    n -= lcd_put_u8str(ftpl, itemIndex, itemStringC, itemStringF, n);
     if (vlen) {
       lcd_put_u8str(F(":"));
       for (; n; --n) lcd_put_u8str(F(" "));

--- a/Marlin/src/lcd/TFTGLCD/lcdprint_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/lcdprint_TFTGLCD.cpp
@@ -1041,7 +1041,7 @@ int lcd_put_lchar_max(const lchar_t &c, const pixel_len_t max_length) {
  * @param cb_read_byte : the callback function to read one byte from the utf8_str (from RAM or ROM)
  * @param max_length : the pixel length of the string allowed (or number of slots in HD44780)
  *
- * @return the number of pixels advanced
+ * @return the number of characters emitted
  *
  * Draw a UTF-8 string
  */

--- a/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
+++ b/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
@@ -26,7 +26,7 @@ void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row) { u8g.setPrintPos(co
 void lcd_put_int(const int i) { u8g.print(i); }
 
 // return < 0 on error
-// return the advanced pixels
+// return the number of pixels advanced
 int lcd_put_lchar_max(const lchar_t &c, const pixel_len_t max_length) {
   if (c < 256) {
     u8g.print((char)c);

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -41,6 +41,8 @@
  *   ~ displays  '1'....'11' for indexes 0 - 10
  *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
  *   @ displays an axis name such as XYZUVW, or E for an extruder
+ *
+ * Return the given maxlen minus the number of characters emitted, i.e., the number of unused columns
  */
 lcd_uint_t lcd_put_u8str_P(PGM_P const ptpl, const int8_t ind, const char *cstr/*=nullptr*/, FSTR_P const fstr/*=nullptr*/, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
   const uint8_t prop = USE_WIDE_GLYPH ? 2 : 1;


### PR DESCRIPTION
`lcd_put_u8str` returns number of characters emitted.
The previous code used to use that value as number of character positions remaining in that line.

This should be merged with higher priority, as it breaks drawing of longer EDIT_ITEM names and values.
