### PR TITLE
Add M221 to M503/M502

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -699,8 +699,6 @@
 #define COOLER_AUTO_FAN_TEMPERATURE 18
 #define COOLER_AUTO_FAN_SPEED 255
 
-#define DEFAULT_EXTRUDER_FLOWRATE 100
-
 /**
  * Hotend Cooling Fans tachometers
  *
@@ -2237,6 +2235,11 @@
 #endif
 
 // @section extruder
+
+/**
+ * Default flow percentage. Override with 'M221 T<tool> S<flow>'.
+ */
+#define DEFAULT_FLOW_PERCENT 100
 
 /**
  * Linear Pressure Control v1.5

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -699,6 +699,8 @@
 #define COOLER_AUTO_FAN_TEMPERATURE 18
 #define COOLER_AUTO_FAN_SPEED 255
 
+#define DEFAULT_EXTRUDER_FLOWRATE 100
+
 /**
  * Hotend Cooling Fans tachometers
  *

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -585,6 +585,8 @@
 #define STR_E6 STR_E STR_N6
 #define STR_E7 STR_E STR_N7
 
+#define STR_FLOW_RATE "Extruder Flowrate"
+
 // Include localized LCD Menu Messages
 
 #define LANGUAGE_DATA_INCL_(M) STRINGIFY_(fontdata/langdata_##M.h)

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -293,6 +293,7 @@
 #define STR_ACCELERATION_P_R_T              "Acceleration (units/s2) (P<print-accel> R<retract-accel> T<travel-accel>)"
 #define STR_TOOL_CHANGING                   "Tool-changing"
 #define STR_HOTEND_OFFSETS                  "Hotend offsets"
+#define STR_FLOW_RATE                       "Flow Percentage"
 #define STR_SERVO_ANGLES                    "Servo Angles"
 #define STR_HOTEND_PID                      "Hotend PID"
 #define STR_BED_PID                         "Bed PID"
@@ -584,8 +585,6 @@
 #define STR_E5 STR_E STR_N5
 #define STR_E6 STR_E STR_N6
 #define STR_E7 STR_E STR_N7
-
-#define STR_FLOW_RATE "Extruder Flowrate"
 
 // Include localized LCD Menu Messages
 

--- a/Marlin/src/gcode/config/M221.cpp
+++ b/Marlin/src/gcode/config/M221.cpp
@@ -44,4 +44,13 @@ void GcodeSuite::M221() {
   }
 }
 
+void GcodeSuite::M221_report(const bool forReplay/*=true*/) {
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
+
+  report_heading_etc(forReplay, F(STR_FLOW_RATE));
+  SERIAL_ECHOPGM("  M221 S", planner.flow_percentage[target_extruder]);
+  SERIAL_EOL();
+}
+
 #endif // EXTRUDERS

--- a/Marlin/src/gcode/config/M221.cpp
+++ b/Marlin/src/gcode/config/M221.cpp
@@ -25,6 +25,15 @@
 
 #if HAS_EXTRUDERS
 
+void GcodeSuite::M221_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, F(STR_FLOW_RATE));
+  #if HAS_MULTI_EXTRUDER
+    EXTRUDER_LOOP() SERIAL_ECHOLNPGM("  M221 T", e, " S", planner.flow_percentage[e]);
+  #else
+    SERIAL_ECHOLNPGM("  M221 S", planner.flow_percentage[0]);
+  #endif
+}
+
 /**
  * M221: Set extrusion percentage (M221 T0 S95)
  */
@@ -42,15 +51,6 @@ void GcodeSuite::M221() {
     SERIAL_CHAR('%');
     SERIAL_EOL();
   }
-}
-
-void GcodeSuite::M221_report(const bool forReplay/*=true*/) {
-  const int8_t target_extruder = get_target_extruder_from_command();
-  if (target_extruder < 0) return;
-
-  report_heading_etc(forReplay, F(STR_FLOW_RATE));
-  SERIAL_ECHOPGM("  M221 S", planner.flow_percentage[target_extruder]);
-  SERIAL_EOL();
 }
 
 #endif // EXTRUDERS

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -893,6 +893,7 @@ private:
 
   #if HAS_EXTRUDERS
     static void M221();
+    static void M221_report(const bool forReplay=true);  
   #endif
 
   #if ENABLED(DIRECT_PIN_CONTROL)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -893,7 +893,7 @@ private:
 
   #if HAS_EXTRUDERS
     static void M221();
-    static void M221_report(const bool forReplay=true);  
+    static void M221_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(DIRECT_PIN_CONTROL)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -252,7 +252,7 @@ typedef struct SettingsDataStruct {
   // Extruder Flow %
   //
   #if HAS_EXTRUDERS
-    uint16_t flow_percentage[EXTRUDERS];                // M221 T S
+    uint16_t planner_flow_percentage[EXTRUDERS];                // M221 T S
   #endif
 
   //
@@ -898,7 +898,7 @@ void MarlinSettings::postprocess() {
     // Extruder Flow %
     //
     #if HAS_EXTRUDERS
-      _FIELD_TEST(flow_percentage);
+      _FIELD_TEST(planner_flow_percentage);
       EEPROM_WRITE(planner.flow_percentage);
     #endif
 
@@ -1922,7 +1922,7 @@ void MarlinSettings::postprocess() {
       // Extruder Flow %
       //
       #if HAS_EXTRUDERS
-        _FIELD_TEST(flow_percentage);
+        _FIELD_TEST(planner_flow_percentage);
         EEPROM_READ(planner.flow_percentage);
       #endif
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -249,6 +249,13 @@ typedef struct SettingsDataStruct {
   #endif
 
   //
+  // Extruder Flow %
+  //
+  #if HAS_EXTRUDERS
+    uint16_t flow_percentage[EXTRUDERS];                // M221 T S
+  #endif
+
+  //
   // FILAMENT_RUNOUT_SENSOR
   //
   bool runout_sensor_enabled;                           // M412 S
@@ -881,13 +888,19 @@ void MarlinSettings::postprocess() {
     //
     // Hotend Offsets, if any
     //
-    {
-      #if HAS_HOTEND_OFFSET
-        // Skip hotend 0 which must be 0
-        for (uint8_t e = 1; e < HOTENDS; ++e)
-          EEPROM_WRITE(hotend_offset[e]);
-      #endif
-    }
+    #if HAS_HOTEND_OFFSET
+      // Skip hotend 0 which must be 0
+      for (uint8_t e = 1; e < HOTENDS; ++e)
+        EEPROM_WRITE(hotend_offset[e]);
+    #endif
+
+    //
+    // Extruder Flow %
+    //
+    #if HAS_EXTRUDERS
+      _FIELD_TEST(flow_percentage);
+      EEPROM_WRITE(planner.flow_percentage);
+    #endif
 
     //
     // Filament Runout Sensor
@@ -1899,13 +1912,19 @@ void MarlinSettings::postprocess() {
       //
       // Hotend Offsets, if any
       //
-      {
-        #if HAS_HOTEND_OFFSET
-          // Skip hotend 0 which must be 0
-          for (uint8_t e = 1; e < HOTENDS; ++e)
-            EEPROM_READ(hotend_offset[e]);
-        #endif
-      }
+      #if HAS_HOTEND_OFFSET
+        // Skip hotend 0 which must be 0
+        for (uint8_t e = 1; e < HOTENDS; ++e)
+          EEPROM_READ(hotend_offset[e]);
+      #endif
+
+      //
+      // Extruder Flow %
+      //
+      #if HAS_EXTRUDERS
+        _FIELD_TEST(flow_percentage);
+        EEPROM_READ(planner.flow_percentage);
+      #endif
 
       //
       // Filament Runout Sensor
@@ -3116,6 +3135,16 @@ void MarlinSettings::reset() {
   TERN_(HAS_HOTEND_OFFSET, reset_hotend_offsets());
 
   //
+  // Extruder Flow %
+  //
+  #if HAS_EXTRUDERS
+    #ifndef DEFAULT_FLOW_PERCENT
+      #define DEFAULT_FLOW_PERCENT 100
+    #endif
+    EXTRUDER_LOOP() planner.flow_percentage[e] = DEFAULT_FLOW_PERCENT;
+  #endif
+
+  //
   // Filament Runout Sensor
   //
 
@@ -3467,13 +3496,6 @@ void MarlinSettings::reset() {
     #endif
   #endif
 
-  //
-  // M221 Extruder Flowrate
-  //
-  #if HAS_EXTRUDERS  
-    planner.flow_percentage[0] = DEFAULT_EXTRUDER_FLOWRATE;
-  #endif
-
   endstops.enable_globally(ENABLED(ENDSTOPS_ALWAYS_ON_DEFAULT));
 
   reset_stepper_drivers();
@@ -3713,9 +3735,9 @@ void MarlinSettings::reset() {
     TERN_(HAS_HOTEND_OFFSET, gcode.M218_report(forReplay));
 
     //
-    // M221 Extruder Flowrate
+    // M221 Extruder Flow %
     //
-    TERN_(HAS_EXTRUDERS, gcode.M221_report(forReplay)); 
+    TERN_(HAS_EXTRUDERS, gcode.M221_report(forReplay));
 
     //
     // Bed Leveling

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3467,6 +3467,13 @@ void MarlinSettings::reset() {
     #endif
   #endif
 
+  //
+  // M221 Extruder Flowrate
+  //
+  #if HAS_EXTRUDERS  
+    planner.flow_percentage[0] = DEFAULT_EXTRUDER_FLOWRATE;
+  #endif
+
   endstops.enable_globally(ENABLED(ENDSTOPS_ALWAYS_ON_DEFAULT));
 
   reset_stepper_drivers();
@@ -3704,6 +3711,11 @@ void MarlinSettings::reset() {
     // M218 Hotend offsets
     //
     TERN_(HAS_HOTEND_OFFSET, gcode.M218_report(forReplay));
+
+    //
+    // M221 Extruder Flowrate
+    //
+    TERN_(HAS_EXTRUDERS, gcode.M221_report(forReplay)); 
 
     //
     // Bed Leveling


### PR DESCRIPTION
- add M221 to output of M503
- reset value on M502 to DEFAULT_EXTRUDER_FLOWRATE stored in configuration_adv.h 

### Description
Add M221 to the Output of M503 and reset on M502 to a value stored in configuration_adv.h

### Requirements
none

### Benefits
See value of M221 in M503

### Configurations
inside PR. One variable to add

### Related Issues
Todo:
- cover multiple extruders if present on reset, report
- cover multiple extruders if present and needed with M501
- reset DEFAULT_EXTRUDER_FLOWRATE for all extruders if present to value stored in configuration_adv.h
