### PR TITLE
hotend timeout: fix integer plus unsigned integer

### DIFF
--- a/Marlin/src/feature/hotend_idle.cpp
+++ b/Marlin/src/feature/hotend_idle.cpp
@@ -55,15 +55,15 @@ void HotendIdleProtection::check_hotends(const millis_t &ms) {
   if (!do_prot)
     next_protect_ms = 0;                          // No hotends are hot so cancel timeout
   else if (!next_protect_ms)                      // Timeout is possible?
-    next_protect_ms = ms + cfg.timeout * 1000;    // Start timeout if not already set
+    next_protect_ms = ms + ((uint32_t)cfg.timeout * 1000);  // Start timeout if not already set
 }
 
 void HotendIdleProtection::check_e_motion(const millis_t &ms) {
   static float old_e_position = 0;
   if (old_e_position != current_position.e) {
-    old_e_position = current_position.e;          // Track filament motion
-    if (next_protect_ms)                          // If some heater is on then...
-      next_protect_ms = ms + cfg.timeout * 1000;  // ...delay the timeout till later
+    old_e_position = current_position.e;            // Track filament motion
+    if (next_protect_ms)                            // If some heater is on then...
+      next_protect_ms = ms + ((uint32_t)cfg.timeout * 1000);  // ...delay the timeout till later
   }
 }
 

--- a/Marlin/src/feature/hotend_idle.h
+++ b/Marlin/src/feature/hotend_idle.h
@@ -24,7 +24,8 @@
 #include "../inc/MarlinConfig.h"
 
 typedef struct {
-  int16_t timeout, trigger, nozzle_target;
+  uint16_t timeout;
+  int16_t trigger, nozzle_target;
   #if HAS_HEATED_BED
     int16_t bed_target;
   #endif

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -289,7 +289,7 @@ void menu_advanced_settings();
     BACK_ITEM(MSG_BACK);
 
     if (c.timeout) GCODES_ITEM(MSG_HOTEND_IDLE_DISABLE, F("M87"));
-    EDIT_ITEM(int3, MSG_TIMEOUT, &c.timeout, 0, 999);
+    EDIT_ITEM(uint16_3, MSG_TIMEOUT, &c.timeout, 0, 999);
     EDIT_ITEM(int3, MSG_TEMPERATURE, &c.trigger, 0, HEATER_0_MAXTEMP);
     EDIT_ITEM(int3, MSG_HOTEND_IDLE_NOZZLE_TARGET, &c.nozzle_target, 0, HEATER_0_MAXTEMP);
     EDIT_ITEM(int3, MSG_HOTEND_IDLE_BED_TARGET, &c.bed_target, 0, BED_MAXTEMP);


### PR DESCRIPTION
### Description

This is a minor edit to the changes from [this commit](https://github.com/MarlinFirmware/Marlin/commit/402c4ef5d3de2b22efd73111222ee7d1f1f6b25f): the addition of the unsigned int and signed int causes unexpected timeouts. Change the config type to unsigned int for comparison to the unsigned int returned from millis().

### Requirements

I encountered the bug and tested the fix against the Rambo v1.4 board. Possible this is handled transparently by PIO for other architectures.

### Benefits

Prevents the unexpected timeout & disable of hotends.

### Configurations

+ #define HOTEND_IDLE_TIMEOUT
