### PR TITLE
E3S1PRO is not a T5UID1

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3123,7 +3123,7 @@
  *  - Download https://github.com/InsanityAutomation/Marlin/raw/CrealityDwin_2.0/TM3D_Combined480272_Landscape_V7.7z
  *  - Copy the downloaded DWIN_SET folder to the SD card.
  *
- * E3S1PRO (T5UID1)
+ * E3S1PRO (T5L)
  *  - Download https://github.com/CrealityOfficial/Ender-3S1/archive/3S1_Plus_Screen.zip
  *  - Copy the downloaded DWIN_SET folder to the SD card.
  *


### PR DESCRIPTION
### Description

Recently E3S1PRO (T5UID1) was added to marlin
But it is not a T5UID1 Its a T5L (according to the Config file in the DWIN zip)  
 
This is the display from a E3S1PRO (left the dacai clone, right is a dwin) 

![left dacai right dwin  Ender-3S1-3S1_Plus_Screen-back](https://github.com/MarlinFirmware/Marlin/assets/530024/999e2f9a-f80b-4011-877d-868bed18d456)

while this is a T5UID1 from a ender5+

![O3U4b](https://github.com/MarlinFirmware/Marlin/assets/530024/5e831705-3748-44a1-a34b-24d21b3ac5d8)

### Benefits

Correct notes

### Related Issues
