### PR TITLE
G2/G3: Fix Z/helix planning on UBL

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -82,6 +82,8 @@ void plan_arc(
               rt_X = cart[axis_p] - center_P,
               rt_Y = cart[axis_q] - center_Q;
 
+  // Starting position of the move for all non-arc axes
+  // i.e., only one of X, Y, or Z, plus the rest.
   ARC_LIJKUVWE_CODE(
     float start_L = current_position[axis_l],
     float start_I = current_position.i,
@@ -126,6 +128,7 @@ void plan_arc(
     min_segments = CEIL((MIN_CIRCLE_SEGMENTS) * portion_of_circle);     // Minimum segments for the arc
   }
 
+  // Total travel on all the non-arc axes
   ARC_LIJKUVWE_CODE(
     float travel_L = cart[axis_l] - start_L,
     float travel_I = cart.i       - start_I,
@@ -168,7 +171,7 @@ void plan_arc(
       plan_arc(temp_position, offset, clockwise, 0);            // Plan a single whole circle
     }
 
-    // Update starting coordinates for the remaining part
+    // Get starting coordinates for the remainder from the current position
     ARC_LIJKUVWE_CODE(
       start_L = current_position[axis_l],
       start_I = current_position.i,
@@ -179,6 +182,8 @@ void plan_arc(
       start_W = current_position.w,
       start_E = current_position.e
     );
+
+    // Update travel distance for the remainder
     ARC_LIJKUVWE_CODE(
       travel_L = cart[axis_l] - start_L,                        // Linear X, Y, or Z
       travel_I = cart.i       - start_I,                        // The rest are also non-arc
@@ -269,7 +274,7 @@ void plan_arc(
 
   xyze_pos_t raw;
 
-  // do not calculate rotation parameters for trivial single-segment arcs
+  // Don't calculate rotation parameters for trivial single-segment arcs
   if (segments > 1) {
     // Vector rotation matrix values
     const float theta_per_segment = angular_travel / segments,

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -315,7 +315,6 @@ void plan_arc(
     const float limiting_accel = _MIN(planner.settings.max_acceleration_mm_per_s2[axis_p], planner.settings.max_acceleration_mm_per_s2[axis_q]),
                 limiting_speed = _MIN(planner.settings.max_feedrate_mm_s[axis_p], planner.settings.max_feedrate_mm_s[axis_q]),
                 limiting_speed_sqr = _MIN(sq(limiting_speed), limiting_accel * radius, sq(scaled_fr_mm_s));
-    float arc_mm_remaining = flat_mm;
 
     for (uint16_t i = 1; i < segments; i++) { // Iterate (segments-1) times
 
@@ -370,7 +369,7 @@ void plan_arc(
       #endif
 
       // calculate safe speed for stopping by the end of the arc
-      arc_mm_remaining -= segment_mm;
+      const float arc_mm_remaining = flat_mm - segment_mm * i;
       hints.safe_exit_speed_sqr = _MIN(limiting_speed_sqr, 2 * limiting_accel * arc_mm_remaining);
 
       if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, hints))


### PR DESCRIPTION
### Description

The current G2/G3 Z parameter is ignored unless ABL is enabled. If high-resolution arcs are planned (small `MIN_ARC_SEGMENT_MM` or high `MIN_CIRCLE_SEGMENTS`) the accumulated error on the last segment can be significant, resulting in jitter when exiting from the planned arc.

This PR addresses both. From the commits:

When interpolating the Z (and other non-XY) axes, reconstruct the position from start of the arc and current segment index, *then* apply the modifiers, so that modifiers are not accumulated for each vertex.

Recalculating each absolute vertex location also reduces the error (and resulting jitter) of the Z/E axis for long moves at high resolution. For the same reason, this is also now done uniformly for all axes even if not affected by modifiers.

At the end of the arc planning, correctly set `current_position` to the final logical position (that is, without modifiers).

This fixes Z interpolation in arc moves in both ABL/UBL (bug https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3179), removing the need for exceptions.

### Requirements

None

### Benefits

Fix Z arc interpolation with UBL. Reduce jitter at high res. As a downside, it does require an extra multiplication per axis/iteration, so it is slightly more expensive for older cpus like AVR or without FMA.

### Configurations

Hopefully none needed. Test with UBL enabled.

### Related Issues

Originally reported here: https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3179 which includes a test-case.