### PR TITLE
Fix incorrect menu BACK_ITEM in ft_motion menu

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -396,7 +396,7 @@ void menu_move() {
     #endif
 
     START_MENU();
-    BACK_ITEM(MSG_ADVANCED_SETTINGS);
+    BACK_ITEM(MSG_MOTION);
 
     SUBMENU(MSG_FTM_MODE, menu_ftm_mode);
     MENU_ITEM_ADDON_START_RJ(5); lcd_put_u8str(ftmode); MENU_ITEM_ADDON_END();


### PR DESCRIPTION

### Description

Corrects `BACK_ITEM` in `FT_MOTION` menu
Go back to `MOTION` menu instead of `ADVANCED_SETTINGS` menu

### Benefits

Expected behavior