### PR TITLE
Fix E3V2 PROUI compile/upload after code refactor and restore some menu

### DIFF
--- a/Marlin/src/feature/caselight.h
+++ b/Marlin/src/feature/caselight.h
@@ -30,7 +30,7 @@
 class CaseLight {
 public:
   static bool on;
-  #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+  #if CASELIGHT_USES_BRIGHTNESS
     static uint8_t brightness;
   #endif
 

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -214,13 +214,13 @@ Menu *prepareMenu = nullptr;
   Menu *trammingMenu = nullptr;
 #endif
 Menu *moveMenu = nullptr;
-Menu *ControlMenu = nullptr;
-Menu *AdvancedSettings = nullptr;
+Menu *controlMenu = nullptr;
+Menu *advancedSettingsMenu = nullptr;
 #if HAS_HOME_OFFSET
   Menu *homeOffsetMenu = nullptr;
 #endif
 #if HAS_BED_PROBE
-  Menu *ProbeSetMenu = nullptr;
+  Menu *probeSettingsMenu = nullptr;
 #endif
 Menu *filSetMenu = nullptr;
 Menu *selectColorMenu = nullptr;
@@ -229,7 +229,7 @@ Menu *tuneMenu = nullptr;
 Menu *motionMenu = nullptr;
 Menu *filamentMenu = nullptr;
 #if ENABLED(MESH_BED_LEVELING)
-  Menu *manualMesh = nullptr;
+  Menu *manualMeshMenu = nullptr;
 #endif
 #if HAS_PREHEAT
   Menu *preheatMenu = nullptr;
@@ -251,7 +251,7 @@ Menu *stepsMenu = nullptr;
 #if ENABLED(PIDTEMPBED) && ANY(PID_EDIT_MENU, PID_AUTOTUNE_MENU)
   Menu *bedPIDMenu = nullptr;
 #endif
-#if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+#if CASELIGHT_USES_BRIGHTNESS
   Menu *caseLightMenu = nullptr;
 #endif
 #if ENABLED(LED_CONTROL_MENU)
@@ -2152,10 +2152,10 @@ void setMoveZ() { hmiValue.axis = Z_AXIS; setPFloatOnClick(Z_MIN_POS, Z_MAX_POS,
     toggleCheckboxLine(caselight.on);
     caselight.update_enabled();
   }
-  #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+  #if CASELIGHT_USES_BRIGHTNESS
     bool enableLiveCaseLightBrightness = true;
     void liveCaseLightBrightness() { caselight.brightness = menuData.value; caselight.update_brightness(); }
-    void setCaseLightBrightness() { setIntOnClick(0, 255, caselight.brightness, liveCaseLightBrightness, !enableLiveCaseLightBrightness ? nullptr : liveCaseLightBrightness); }
+    void setCaseLightBrightness() { setIntOnClick(0, 255, caselight.brightness, liveCaseLightBrightness, enableLiveCaseLightBrightness ? liveCaseLightBrightness : nullptr); }
   #endif
 #endif
 
@@ -3042,22 +3042,20 @@ void drawPrepareMenu() {
 
 void drawControlMenu() {
   checkkey = ID_Menu;
-  if (SET_MENU_R(ControlMenu, selrect({103, 1, 28, 14}), MSG_CONTROL, 11)) {
+  if (SET_MENU_R(controlMenu, selrect({103, 1, 28, 14}), MSG_CONTROL, 11)) {
     BACK_ITEM(gotoMainMenu);
     MENU_ITEM(ICON_Temperature, MSG_TEMPERATURE, onDrawTempSubMenu, drawTemperatureMenu);
     MENU_ITEM(ICON_Motion, MSG_MOTION, onDrawMotionSubMenu, drawMotionMenu);
     #if ENABLED(CASE_LIGHT_MENU)
-      // Allow live update of brightness in control menu
-      enableLiveCaseLightBrightness = true;
-      #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+      #if CASELIGHT_USES_BRIGHTNESS
+        enableLiveCaseLightBrightness = true;  // Allow live update of brightness in control menu
         MENU_ITEM(ICON_CaseLight, MSG_CASE_LIGHT, onDrawSubMenu, drawCaseLightMenu);
       #else
         MENU_ITEM(ICON_CaseLight, MSG_CASE_LIGHT, onDrawChkbMenu, setCaseLight, &caselight.on);
       #endif
     #endif
     #if ENABLED(LED_CONTROL_MENU)
-      // Allow live update of color in control menu
-      enableLiveLedColor = true;
+      enableLiveLedColor = true;  // Allow live update of color in control menu
       MENU_ITEM(ICON_LedControl, MSG_LED_CONTROL, onDrawSubMenu, drawLedControlMenu);
     #endif
     #if ENABLED(EEPROM_SETTINGS)
@@ -3069,12 +3067,12 @@ void drawControlMenu() {
     MENU_ITEM(ICON_Info, MSG_INFO_SCREEN, onDrawInfoSubMenu, gotoInfoMenu);
   }
   ui.reset_status(true);
-  updateMenu(ControlMenu);
+  updateMenu(controlMenu);
 }
 
 void drawAdvancedSettingsMenu() {
   checkkey = ID_Menu;
-  if (SET_MENU(AdvancedSettings, MSG_ADVANCED_SETTINGS, 23)) {
+  if (SET_MENU(advancedSettingsMenu, MSG_ADVANCED_SETTINGS, 23)) {
     BACK_ITEM(gotoMainMenu);
     #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(ICON_WriteEEPROM, MSG_STORE_EEPROM, onDrawMenuItem, writeEEPROM);
@@ -3136,7 +3134,7 @@ void drawAdvancedSettingsMenu() {
     #endif
   }
   ui.reset_status(true);
-  updateMenu(AdvancedSettings);
+  updateMenu(advancedSettingsMenu);
 }
 
 void drawMoveMenu() {
@@ -3187,7 +3185,7 @@ void drawMoveMenu() {
 
   void drawProbeSetMenu() {
     checkkey = ID_Menu;
-    if (SET_MENU(ProbeSetMenu, MSG_ZPROBE_SETTINGS, 9)) {
+    if (SET_MENU(probeSettingsMenu, MSG_ZPROBE_SETTINGS, 9)) {
       BACK_ITEM(drawAdvancedSettingsMenu);
       #if HAS_X_AXIS
         EDIT_ITEM(ICON_ProbeOffsetX, MSG_ZPROBE_XOFFSET, onDrawPFloatMenu, setProbeOffsetX, &probe.offset.x);
@@ -3210,7 +3208,7 @@ void drawMoveMenu() {
         MENU_ITEM(ICON_ProbeTest, MSG_M48_TEST, onDrawMenuItem, probeTest);
       #endif
     }
-    updateMenu(ProbeSetMenu);
+    updateMenu(probeSettingsMenu);
   }
 
 #endif // HAS_BED_PROBE
@@ -3334,7 +3332,7 @@ void drawTuneMenu() {
     #endif
     #if ENABLED(CASE_LIGHT_MENU)
       EDIT_ITEM(ICON_CaseLight, MSG_CASE_LIGHT, onDrawChkbMenu, setCaseLight, &caselight.on);
-      #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+      #if CASELIGHT_USES_BRIGHTNESS
         // Avoid heavy interference with print job disabling live update of brightness in tune menu
         enableLiveCaseLightBrightness = false;
         EDIT_ITEM(ICON_Brightness, MSG_CASE_LIGHT_BRIGHTNESS, onDrawPInt8Menu, setCaseLightBrightness, &caselight.brightness);
@@ -3495,7 +3493,7 @@ void drawMotionMenu() {
 
   void drawManualMeshMenu() {
     checkkey = ID_Menu;
-    if (SET_MENU(manualMesh, MSG_UBL_MANUAL_MESH, 6)) {
+    if (SET_MENU(manualMeshMenu, MSG_UBL_MANUAL_MESH, 6)) {
       BACK_ITEM(drawPrepareMenu);
       MENU_ITEM(ICON_ManualMesh, MSG_LEVEL_BED, onDrawMenuItem, manualMeshStart);
       mMeshMoveZItem = EDIT_ITEM(ICON_Zoffset, MSG_MOVE_Z, onDrawMMeshMoveZ, setMMeshMoveZ, &current_position.z);
@@ -3503,7 +3501,7 @@ void drawMotionMenu() {
       MENU_ITEM(ICON_MeshViewer, MSG_MESH_VIEW, onDrawSubMenu, dwinMeshViewer);
       MENU_ITEM(ICON_MeshSave, MSG_UBL_SAVE_MESH, onDrawMenuItem, manualMeshSave);
     }
-    updateMenu(manualMesh);
+    updateMenu(manualMeshMenu);
   }
 
 #endif // MESH_BED_LEVELING

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -3046,12 +3046,6 @@ void drawControlMenu() {
     BACK_ITEM(gotoMainMenu);
     MENU_ITEM(ICON_Temperature, MSG_TEMPERATURE, onDrawTempSubMenu, drawTemperatureMenu);
     MENU_ITEM(ICON_Motion, MSG_MOTION, onDrawMotionSubMenu, drawMotionMenu);
-    #if ENABLED(EEPROM_SETTINGS)
-      MENU_ITEM(ICON_WriteEEPROM, MSG_STORE_EEPROM, onDrawWriteEeprom, writeEEPROM);
-      MENU_ITEM(ICON_ReadEEPROM, MSG_LOAD_EEPROM, onDrawReadEeprom, readEEPROM);
-      MENU_ITEM(ICON_ResumeEEPROM, MSG_RESTORE_DEFAULTS, onDrawResetEeprom, resetEEPROM);
-    #endif
-    MENU_ITEM(ICON_Reboot, MSG_RESET_PRINTER, onDrawMenuItem, rebootPrinter);
     #if ENABLED(CASE_LIGHT_MENU)
       // Allow live update of brightness in control menu
       enableLiveCaseLightBrightness = true;
@@ -3066,6 +3060,12 @@ void drawControlMenu() {
       enableLiveLedColor = true;
       MENU_ITEM(ICON_LedControl, MSG_LED_CONTROL, onDrawSubMenu, drawLedControlMenu);
     #endif
+    #if ENABLED(EEPROM_SETTINGS)
+      MENU_ITEM(ICON_WriteEEPROM, MSG_STORE_EEPROM, onDrawWriteEeprom, writeEEPROM);
+      MENU_ITEM(ICON_ReadEEPROM, MSG_LOAD_EEPROM, onDrawReadEeprom, readEEPROM);
+      MENU_ITEM(ICON_ResumeEEPROM, MSG_RESTORE_DEFAULTS, onDrawResetEeprom, resetEEPROM);
+    #endif
+    MENU_ITEM(ICON_Reboot, MSG_RESET_PRINTER, onDrawMenuItem, rebootPrinter);
     MENU_ITEM(ICON_Info, MSG_INFO_SCREEN, onDrawInfoSubMenu, gotoInfoMenu);
   }
   ui.reset_status(true);

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -3282,7 +3282,7 @@ void drawFilSetMenu() {
 
 void drawTuneMenu() {
   checkkey = ID_Menu;
-  if (SET_MENU_R(tuneMenu, selrect({73, 2, 28, 12}), MSG_TUNE, 17)) {
+  if (SET_MENU_R(tuneMenu, selrect({73, 2, 28, 12}), MSG_TUNE, 18)) {
     BACK_ITEM(gotoPrintProcess);
     EDIT_ITEM(ICON_Speed, MSG_SPEED, onDrawSpeedItem, setSpeed, &feedrate_percentage);
     #if HAS_HOTEND
@@ -3327,6 +3327,9 @@ void drawTuneMenu() {
     #endif
     #if ENABLED(CASE_LIGHT_MENU)
       EDIT_ITEM(ICON_CaseLight, MSG_CASE_LIGHT, onDrawChkbMenu, setCaseLight, &caselight.on);
+      #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+        EDIT_ITEM(ICON_Brightness, MSG_CASE_LIGHT_BRIGHTNESS, onDrawPInt8Menu, setCaseLightBrightness, &caselight.brightness);
+      #endif
     #elif ENABLED(LED_CONTROL_MENU) && DISABLED(CASE_LIGHT_USE_NEOPIXEL)
       EDIT_ITEM(ICON_LedControl, MSG_LEDS, onDrawChkbMenu, setLedStatus, &leds.lights_on);
     #endif

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -35,6 +35,9 @@
 #include "../common/encoder.h"
 #include "../common/limits.h"
 #include "../../../libs/BL24CXX.h"
+#if ENABLED(LED_CONTROL_MENU)
+  #include "../../../feature/leds/leds.h"
+#endif
 
 #if ANY(BABYSTEPPING, HAS_BED_PROBE)
   #define HAS_ZOFFSET_ITEM 1

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -66,7 +66,7 @@
 #if ALL(LED_CONTROL_MENU, HAS_COLOR_LEDS)
   #define defColorLeds      LEDColorWhite()
 #endif
-#if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+#if CASELIGHT_USES_BRIGHTNESS
   #define defCaseLightBrightness 255
 #endif
 #ifdef Z_AFTER_HOMING

--- a/Marlin/src/lcd/e3v2/proui/menus.cpp
+++ b/Marlin/src/lcd/e3v2/proui/menus.cpp
@@ -507,25 +507,25 @@ void initMenu() {
 
 bool setMenu(Menu* &menu, FSTR_P fTitle, int8_t totalitems) {
   if (!menu) menu = new Menu();
-  const bool NotCurrent = (currentMenu != menu);
-  if (NotCurrent) {
+  const bool notCurrent = (currentMenu != menu);
+  if (notCurrent) {
     menu->menuTitle.setCaption(fTitle);
     menuItemsPrepare(totalitems);
   }
-  return NotCurrent;
+  return notCurrent;
 }
 
 bool setMenu(Menu* &menu, frame_rect_t cn, FSTR_P fTitle, int8_t totalitems) {
   if (!menu) menu = new Menu();
-  const bool NotCurrent = (currentMenu != menu);
-  if (NotCurrent) {
+  const bool notCurrent = (currentMenu != menu);
+  if (notCurrent) {
     if (cn.w != 0)
       menu->menuTitle.setFrame(cn.x, cn.y, cn.w, cn.h);
     else
       menu->menuTitle.setCaption(fTitle);
     menuItemsPrepare(totalitems);
   }
-  return NotCurrent;
+  return notCurrent;
 }
 
 void resetMenu(Menu* &menu) {

--- a/Marlin/src/lcd/e3v2/proui/menus.h
+++ b/Marlin/src/lcd/e3v2/proui/menus.h
@@ -183,13 +183,13 @@ void resetMenu(Menu* &menu);
 // Invalidate currentMenu to prepare for full menu drawing
 void invalidateMenu();
 
-//Update the Menu and Draw if it is valid
+// Update the Menu and Draw if it is valid
 void updateMenu(Menu* &menu);
 
-//Redraw the current Menu if it is valid
+// Redraw the current Menu if it is valid
 void ReDrawMenu(bool force=false);
 
-//Redraw selected menu item
+// Redraw selected menu item
 void ReDrawItem();
 
 // Clear menuItems array and free menuItems elements

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -407,7 +407,7 @@ void restore_feedrate_and_scaling();
 
 #if HAS_Z_AXIS
   #if ALL(DWIN_LCD_PROUI, INDIVIDUAL_AXIS_HOMING_SUBMENU, MESH_BED_LEVELING)
-    #define Z_POST_CLEARANCE hmiData.z_after_homing
+    #define Z_POST_CLEARANCE hmiData.zAfterHoming
   #elif defined(Z_AFTER_HOMING)
     #define Z_POST_CLEARANCE Z_AFTER_HOMING
   #else

--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -61,6 +61,9 @@ if pioutil.is_pio_build():
         def rename_target(source, target, env):
             from pathlib import Path
             from datetime import datetime
-            Path(target[0].path).replace(Path(target[0].dir.path, datetime.now().strftime(new_name.replace('{date}', '%Y%m%d').replace('{time}', '%H%M%S'))))
+            from os import path
+            _newpath = Path(target[0].dir.path, datetime.now().strftime(new_name.replace('{date}', '%Y%m%d').replace('{time}', '%H%M%S')))
+            Path(target[0].path).replace(_newpath)
+            env['PROGNAME'] = path.splitext(_newpath)[0]
 
         marlin.add_post_action(rename_target)

--- a/buildroot/share/scripts/upload.py
+++ b/buildroot/share/scripts/upload.py
@@ -157,7 +157,8 @@ def Upload(source, target, env):
     marlin_string_config_h_author = _GetMarlinEnv(MarlinEnv, 'STRING_CONFIG_H_AUTHOR')
 
     # Get firmware upload params
-    upload_firmware_source_name = str(source[0])    # Source firmware filename
+    upload_firmware_source_name = env['PROGNAME'] + '.bin' if env['PROGNAME'] else str(source[0])
+                                                    # Source firmware filename
     upload_speed = env['UPLOAD_SPEED'] if 'UPLOAD_SPEED' in env else 115200
                                                     # baud rate of serial connection
     upload_port = _GetUploadPort(env)               # Serial port to use


### PR DESCRIPTION
### Description

After a lot of code refactoring and new feature implementations (1 year ahead) I encountered some problems:
- The firmware rename (**board_build.rename**) doesn't pass the renamed filename to **extra_scripts**.
- The PROUI doesn't compile (_z_after_homing -> zAfterHoming_ and a missing include).
- The case light/led brightness menu disappears.

### Benefits

This PR addresses the described issues and adds the case light and led menu also to the tune menu.
The live update of case light brightness and led color is disabled in the tune menu to avoid heavy interference with the print job (I'm using Neopixel led), so the values are set when the user clicks on the editing item.

### Configurations

#define `LED_CONTROL_MENU`
#define `CASE_LIGHT_MENU` and `CASELIGHT_USES_BRIGHTNESS`
