### PR TITLE
Fix MSG_MAIN variable name

### DIFF
--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -4022,7 +4022,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
 
 FSTR_P JyersDWIN::getMenuTitle(const uint8_t menu) {
   switch (menu) {
-    case ID_MainMenu:       return GET_TEXT_F(MSG_MAIN_MENU);
+    case ID_MainMenu:       return GET_TEXT_F(MSG_MAIN);
     case ID_Prepare:        return GET_TEXT_F(MSG_PREPARE);
     case ID_HomeMenu:       return F("Homing Menu");
     case ID_Move:           return GET_TEXT_F(MSG_MOVE_AXIS);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

With DWIN_CREALITY_LCD_JYERSUI defined,
When compiling in VSCode with PIO,
The compiler throws the error: 'MSG_MAIN_MENU' is not a member of 'Language_en'; did you mean 'MSG_MMU2_MENU'?

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

The fix proposed on reddit by nanmetal worked fine after test.
[link here](https://www.reddit.com/r/MarlinFirmware/comments/14zk3uz/trying_to_compile_marline_2121_on_mac_fatals_need/?rdt=62548)

### Requirements

N/A
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

The compiler stops throwing error when compiling DWIN_CREALITY_LCD_JYERSUI 
<!-- What does this PR fix or improve? -->

### Configurations

N/A
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

Fix issue #26188
