### PR TITLE
WIP Add `-ffile-prefix-map` to shorten static paths in included libraries.

### DIFF
--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -15,6 +15,7 @@ board_build.core = stm32
 build_flags      = ${common.build_flags} -std=gnu++14
                    -DHAL_STM32 -DPLATFORM_M997_SUPPORT
                    -DUSBCON -DUSBD_USE_CDC -DTIM_IRQ_PRIO=13 -DADC_RESOLUTION=12
+                    -ffile-prefix-map=${PROJECT_PACKAGES_DIR}=/pkgs
 build_unflags    = -std=gnu++11
 build_src_filter = ${common.default_src_filter} +<src/HAL/STM32> -<src/HAL/STM32/tft> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,6 @@ extra_configs =
 [common]
 build_flags        = -g3 -D__MARLIN_FIRMWARE__ -DNDEBUG
                      -fmax-errors=5
-                     -ffile-prefix-map=${PROJECT_PACKAGES_DIR}=/pkgs
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/configuration.py
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,6 +45,7 @@ extra_configs =
 [common]
 build_flags        = -g3 -D__MARLIN_FIRMWARE__ -DNDEBUG
                      -fmax-errors=5
+                     -ffile-prefix-map=${PROJECT_PACKAGES_DIR}=/pkgs
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/configuration.py
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py


### PR DESCRIPTION
### Description

Adds a build flag to replace user dependent directory paths with a shortened one. This enables more easily comparable builds and saves some flash (depending on where the .platformio directory resides, 20-30 bytes per occurrence).

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Removes unneccessary static strings from .bin files. In my testing, I was able to save roughly 200 bytes of flash space by changing the actual directory path to `/pkgs`.

### Configurations

This should be applicable to all configurations that use frameworks embedding static strings. I have included my Configuration files for reference.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/12388623/Configuration.zip)


### Related Issues

Fixes #26191
