### PR TITLE
Fixes a typo in ARC code

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -346,7 +346,7 @@ void plan_arc(
         #if ENABLED(AUTO_BED_LEVELING_UBL)
           raw[axis_l] = start_L,
           raw.i = start_I, raw.j = start_J, raw.k = start_K,
-          raw.u = start_U, raw.v = start_V, raw.w = start_V
+          raw.u = start_U, raw.v = start_V, raw.w = start_W
         #else
           raw[axis_l] += per_segment_L,
           raw.i += per_segment_I, raw.j += per_segment_J, raw.k += per_segment_K,


### PR DESCRIPTION
raw.w was mistakenly assigned to start_V when
AUTO_BED_LEVELING_UBL was enabled.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Fixes a typo on the G2_G3 command where V was assigned instead of W.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
None
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Fixes a error when you use the G2_G3 command and you have AUTO_BED_LEVELING_UBL enabled.
<!-- What does this PR fix or improve? -->

### Configurations
None
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
None
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
