### PR TITLE
[FIX] fix tool_change_prime()

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -968,6 +968,8 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     feedRate_t fr_mm_s = MMM_TO_MMS(toolchange_settings.unretract_speed); // Set default speed for unretract
 
+    const float resume_current_e = current_position.e;
+
     #if ENABLED(TOOLCHANGE_FS_SLOW_FIRST_PRIME)
       /**
        * Perform first unretract movement at the slower Prime_Speed to avoid breakage on first prime
@@ -1011,6 +1013,10 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       FS_DEBUG("Performing Cutting Retraction | Distance: ", -toolchange_settings.wipe_retract, " | Speed: ", MMM_TO_MMS(toolchange_settings.retract_speed), "mm/s");
       unscaled_e_move(-toolchange_settings.wipe_retract, MMM_TO_MMS(toolchange_settings.retract_speed));
     #endif
+
+    // Leave E unchanged when priming
+    current_position.e = resume_current_e;
+    sync_plan_position_e();
 
     // Cool down with fan
     filament_swap_cooling();
@@ -1079,9 +1085,6 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
         }
       #endif
 
-      // Previous position applied
-      current_position.e = destination.e;
-      sync_plan_position_e();
       extruder_cutting_recover(destination.e); // Cutting recover
     }
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -941,19 +941,20 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
    *  sync_plan_position_e();
    */
   void extruder_cutting_recover(const_float_t e) {
-    if (!too_cold(active_extruder)) {
-      const float dist = toolchange_settings.extra_resume + toolchange_settings.wipe_retract;
-      FS_DEBUG("Performing Cutting Recover | Distance: ", dist, " | Speed: ", MMM_TO_MMS(toolchange_settings.unretract_speed), "mm/s");
-      unscaled_e_move(dist, MMM_TO_MMS(toolchange_settings.unretract_speed));
-      planner.synchronize();
-      FS_DEBUG("Set position to: ", e);
-      current_position.e = e;
-      sync_plan_position_e(); // Resume new E Position
-    }
+    if (too_cold(active_extruder)) return;
+
+    const float dist = toolchange_settings.extra_resume + toolchange_settings.wipe_retract;
+    FS_DEBUG("Performing Cutting Recover | Distance: ", dist, " | Speed: ", MMM_TO_MMS(toolchange_settings.unretract_speed), "mm/s");
+    unscaled_e_move(dist, MMM_TO_MMS(toolchange_settings.unretract_speed));
+
+    FS_DEBUG("Set E position: ", e);
+    current_position.e = e;
+    sync_plan_position_e(); // Resume new E Position
   }
 
   /**
    * Prime the currently selected extruder (Filament loading only)
+   * Leave the E position unchanged so subsequent extrusion works properly.
    *
    * If too_cold(toolID) returns TRUE -> returns without moving extruder.
    * Extruders filament = swap_length + extra prime, then performs cutting retraction if enabled.
@@ -1062,6 +1063,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
         }
       #endif
 
+      // Prime without changing E
       extruder_prime();
 
       // Move back

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1071,20 +1071,16 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
             destination.x = current_position.x;
             destination.y = current_position.y;
           #endif
-          do_blocking_move_to_xy(destination,  MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));
+          do_blocking_move_to_xy(destination, MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));
           do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
           planner.synchronize();
         }
       #endif
 
-      //Previous position applied
+      // Previous position applied
       current_position.e = destination.e;
       sync_plan_position_e();
       extruder_cutting_recover(destination.e); // Cutting recover
-
-      #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-        RESTORE(fan);
-      #endif
     }
 
     FS_DEBUG("<<< tool_change_prime");

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1068,15 +1068,23 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       #if ENABLED(TOOLCHANGE_PARK)
         if (ok) {
           #if ENABLED(TOOLCHANGE_NO_RETURN)
-            const float temp = destination.z;
-            destination = current_position;
-            destination.z = temp;
+            destination.x = current_position.x;
+            destination.y = current_position.y;
           #endif
-          prepare_internal_move_to_destination(TERN(TOOLCHANGE_NO_RETURN, planner.settings.max_feedrate_mm_s[Z_AXIS], MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE)));
+          do_blocking_move_to_xy(destination,  MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));
+          do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s[Z_AXIS]);
+          planner.synchronize();
         }
       #endif
 
+      //Previous position applied
+      current_position.e = destination.e;
+      sync_plan_position_e();
       extruder_cutting_recover(destination.e); // Cutting recover
+
+      #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
+        RESTORE(fan);
+      #endif
     }
 
     FS_DEBUG("<<< tool_change_prime");


### PR DESCRIPTION
Important fixes in tool_change_prime
- Fanspeed restoring (forgotten)
- Extruder position correction (After priming , extruder pos is higher than original destination ,  cutting recover go back and filament is unloded)
- Economy of one float in stack 🥇 

Tested every day , I use priming sequence in start gcode, more easy to write M217Q than tons of lines

Thks