### PR TITLE
Switching nozzle  'two servos' fix and followup

### DIFF
--- a/Marlin/src/gcode/control/M280.cpp
+++ b/Marlin/src/gcode/control/M280.cpp
@@ -32,11 +32,39 @@
  * M280: Get or set servo position.
  *  P<index> - Servo index
  *  S<angle> - Angle to set, omit to read current angle, or use -1 to detach
+ *  H<0/1>   - All tools high(1) or Low(0) for two servos configuration only
+ *  C        - Active tool positionning (active tool lowered & inactive upped)
  *
  * With POLARGRAPH:
  *  T<ms>    - Duration of servo move
  */
 void GcodeSuite::M280() {
+
+  //---------------------------------------
+  #if ENABLED(SWITCHING_NOZZLE_TWO_SERVOS)
+    if (parser.seenval('H')) {
+      const int anew = parser.value_int();
+      if (anew > 0) {
+        servo[SWITCHING_NOZZLE_SERVO_NR].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][1]);
+        servo[SWITCHING_NOZZLE_E1_SERVO_NR].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][1]);
+      }
+      else {
+        servo[SWITCHING_NOZZLE_SERVO_NR].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][0]);
+        servo[SWITCHING_NOZZLE_E1_SERVO_NR].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][0]);
+      }
+      return;
+    }
+  #endif
+
+  #if ENABLED(SWITCHING_NOZZLE_TWO_SERVOS)
+    if (parser.seen('C')) {
+      servo[active_extruder? SWITCHING_NOZZLE_SERVO_NR : SWITCHING_NOZZLE_E1_SERVO_NR ].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][1]);
+      servo[active_extruder? SWITCHING_NOZZLE_E1_SERVO_NR : SWITCHING_NOZZLE_SERVO_NR ].move(servo_angles[SWITCHING_NOZZLE_SERVO_NR][0]);
+      return;
+    }
+  #endif
+
+  //-----------------------------------------------------------
 
   if (!parser.seenval('P')) return;
 


### PR DESCRIPTION
Fixes and little features for dual servos printers , i'm using one every day , the code need some fixes

Fixes :
- EDITABLE_ANGLES fix (Servos angles not working because used constant values , now uses 'editable values')
- Zraise (was totally disabled , but was a big problem, some machines use only 1mm of movement to swap, and no possiblity to raise more, now possible)
- Big bug : If no park + no return + zraise >0 (prime tower dual printing for ex) then Z recover not processed , each Z recover is under conditionals, now zraise is applied in all situations (only for dual servos carriage)

Tested two years , without adding fix 

Features : 
- Add  M280H 0/1   :  Raise or lower all tools at once (for cleaning and more )
- Add  M280C          :  Restore the two servos positions with active extruder lowered (when cleaning finished for ex)
Thks