### PR TITLE
Skew values in realtime

### DIFF
--- a/Marlin/src/gcode/calibrate/M852.cpp
+++ b/Marlin/src/gcode/calibrate/M852.cpp
@@ -36,6 +36,19 @@
  *  K[yz_factor] - New YZ skew factor
  */
 void GcodeSuite::M852() {
+  if (parser.seenval('A')) {
+    const float a = parser.value_linear_units();
+    if (parser.seenval('B')) {
+      const float b  = parser.value_linear_units();
+      if (parser.seenval('D')) {
+        const float c = parser.value_linear_units();
+        planner.skew_factor.xy = _SKEW_FACTOR(a, b, c);
+        gcode.M852_report(0);
+      }
+    }
+  }
+
+
   if (!parser.seen("SIJK")) return M852_report();
 
   uint8_t badval = 0, setval = 0;


### PR DESCRIPTION
Feature

Apply  ' A , B , C ' value by gcode 

Why ? To print a calibration square , to pause the print , to apply dimensions , to resume printing to verify and apply new values if needed

(Before , needed to restart a print to check if skew is perfect , now can be made in one print)

Thks