### PR TITLE
Report fan speed

### DIFF
--- a/Marlin/src/gcode/temp/M105.cpp
+++ b/Marlin/src/gcode/temp/M105.cpp
@@ -39,6 +39,13 @@ void GcodeSuite::M105() {
 
     SERIAL_EOL();
 
+    #if FAN_COUNT > 0 && ENABLED(REPORT_FAN_CHANGE)
+      FANS_LOOP(i) {
+        thermalManager.report_fan_speed(i);
+        SERIAL_EOL();
+      }
+    #endif
+
   #else
 
     SERIAL_ECHOLNPGM(" T:0"); // Some hosts send M105 to test the serial connection

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -4263,6 +4263,12 @@ void Temperature::isr() {
       HOTEND_LOOP() s.append(F(" @"), e, ':', getHeaterPower((heater_id_t)e));
     #endif
     s.echo();
+    #if FAN_COUNT > 0 && ENABLED(REPORT_FAN_CHANGE)
+      FANS_LOOP(i) {
+        thermalManager.report_fan_speed(i);
+        SERIAL_EOL();
+      }
+    #endif
   }
 
   #if ENABLED(AUTO_REPORT_TEMPERATURES)


### PR DESCRIPTION
Add  report fans speed +  report fans speed in temp auto report

Doesn't exist in marlin , impossible to read the current value of speed in a distant host ,  the host can just apply value

Now , in your octoprint for ex , you can see in the terminal page , the report of the fan speed and the value of the moment

Thks