### PR TITLE
Specific Temperature Report Precision (M105)

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -4205,12 +4205,14 @@ void Temperature::isr() {
         case H_REDUNDANT: k = 'R'; break;
       #endif
     }
-    #define SFP _MIN(SERIAL_FLOAT_PRECISION, 2)
+    #ifndef HEATER_STATE_FLOAT_PRECISION
+      #define HEATER_STATE_FLOAT_PRECISION _MIN(SERIAL_FLOAT_PRECISION, 2)
+    #endif
 
     SString<50> s(' ', k);
     if (TERN0(HAS_MULTI_HOTEND, e >= 0)) s += char('0' + e);
-    s += ':'; s += p_float_t(c, SFP);
-    if (show_t) { s += F(" /"); s += p_float_t(t, SFP); }
+    s += ':'; s += p_float_t(c, HEATER_STATE_FLOAT_PRECISION);
+    if (show_t) { s += F(" /"); s += p_float_t(t, HEATER_STATE_FLOAT_PRECISION); }
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       // Temperature MAX SPI boards do not have an OVERSAMPLENR defined
       s.append(F(" ("), TERN(HAS_MAXTC_LIBRARIES, k == 'T', false) ? r : r * RECIPROCAL(OVERSAMPLENR), ')');


### PR DESCRIPTION
In reference to #26171…

Add an option to override the customary heater state M105 report / temperature autoreport format, which currently emits no more than 2 digits of precision, a standard established in #20602.

Most situations do not need more than 0.01°C of temperature precision, which is well within the margin of error for most temperature sensors.

So, this is mainly useful for special cases such as using Marlin with BTT TFT screen firmware which requires 4 digits of precision and cannot parse M105 reports with any other number format.