### PR TITLE
G30 response precision

### DIFF
--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -82,9 +82,9 @@ void GcodeSuite::G30() {
     if (!isnan(measured_z)) {
       const xy_pos_t lpos = probepos.asLogical();
       SString<30> msg(
-        F("Bed X:"), p_float_t(lpos.x, 1),
-        F(  " Y:"), p_float_t(lpos.y, 1),
-        F(  " Z:"), p_float_t(measured_z, 2)
+        F("Bed X:"), p_float_t(lpos.x, 2),
+        F(  " Y:"), p_float_t(lpos.y, 2),
+        F(  " Z:"), p_float_t(measured_z, 3)
       );
       msg.echoln();
       #if ANY(DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR increases the precision of the G30 response with one digit. So X and Y has now 2 digits precision and Z has 3 digits precision. I use G30 for corner leveling and my probe has a greater precision than 2 digits. Having more precision helps obtaining a more precisely adjusted bed.

