### PR TITLE
Home offset to probe limits

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -267,10 +267,10 @@ public:
       );
     }
 
-    static float min_x() { return _min_x() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.x)); }
-    static float max_x() { return _max_x() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.x)); }
-    static float min_y() { return _min_y() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.y)); }
-    static float max_y() { return _max_y() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.y)); }
+    static float min_x() { return _min_x() TERN_(HAS_HOME_OFFSET, + (home_dir(X_AXIS) < 0 ? home_offset.x : 0)); }
+    static float max_x() { return _max_x() TERN_(HAS_HOME_OFFSET, - (home_dir(X_AXIS) > 0 ? home_offset.x : 0)); }
+    static float min_y() { return _min_y() TERN_(HAS_HOME_OFFSET, + (home_dir(Y_AXIS) < 0 ? home_offset.y : 0)); }
+    static float max_y() { return _max_y() TERN_(HAS_HOME_OFFSET, - (home_dir(Y_AXIS) > 0 ? home_offset.y : 0)); }
 
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {


### PR DESCRIPTION
### Description

Since PR https://github.com/MarlinFirmware/Marlin/pull/25996 Home Offset is not taken into account for probing motion limits. There's no prevention for moving elements to try to move beyond the endstops resulting in grinding and losing real coordinates.
I have home offset defined as my nozzle cannot reach the bed at 0, 0 coordinates. However if I want to make a probe let's say at the bed coordinates which correspond to the probe offset than the printer tries to move the nozzle to the bed's 0, 0 coordinate which is physically not possible.
This PR fixes this issue by limiting probing motion commands based on the defined home offset also.
