### PR TITLE
feat: move "debug" menu item to the end of the list

### DIFF
--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -540,13 +540,6 @@ void menu_configuration() {
   START_MENU();
   BACK_ITEM(MSG_MAIN_MENU);
 
-  //
-  // Debug Menu when certain options are enabled
-  //
-  #if HAS_DEBUG_MENU
-    SUBMENU(MSG_DEBUG_MENU, menu_debug);
-  #endif
-
   #if ENABLED(CUSTOM_MENU_CONFIG)
     if (TERN1(CUSTOM_MENU_CONFIG_ONLY_IDLE, !busy)) {
       #ifdef CUSTOM_MENU_CONFIG_TITLE
@@ -648,6 +641,12 @@ void menu_configuration() {
 
   #if ENABLED(SOUND_MENU_ITEM)
     EDIT_ITEM(bool, MSG_SOUND, &ui.sound_on, []{ ui.chirp(); });
+  #endif
+
+  // Debug Menu when certain options are enabled
+  // Note: it is at the end of the list, so a more commonly used items should be placed above
+  #if HAS_DEBUG_MENU
+    SUBMENU(MSG_DEBUG_MENU, menu_debug);
   #endif
 
   #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
### Description

move "debug" menu item to the end of the list

### Requirements

`debug menu` requires `HAS_DEBUG_MENU`, so it is visible if user configures `LCD_ENDSTOP_TEST`.

### Benefits

I find `LCD_ENDSTOP_TEST` useful, however, currently `debug menu` appears as the first item. The patch moves `debug` to the end of the list, so it does not clutter the commonly used settings.

### Configurations

Add `LCD_ENDSTOP_TEST`

### Related Issues

n/a
