### PR TITLE
doc: raise a warning in case user configures PROBE_MANUALLY with UBL or MBL

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1507,9 +1507,11 @@
 #endif
 #if ENABLED(PROBE_MANUALLY)
   #if ANY(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
-    #error MESH_BED_LEVELING and AUTO_BED_LEVELING_UBL have their own manual probing procedures, so PROBE_MANUALLY is not needed for them. Please remove PROBE_MANUALLY, or use a different leveling type like AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR.
+    #undef PROBE_MANUALLY
+    #warning MESH_BED_LEVELING and AUTO_BED_LEVELING_UBL have their own manual probing procedures, so PROBE_MANUALLY is not needed for them. Please remove PROBE_MANUALLY, or use a different leveling type like AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR.
   #elif !HAS_LEVELING
-    #error No leveling type is selected, so PROBE_MANUALLY has no use. Please select leveling type, for example AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR
+    #undef PROBE_MANUALLY
+    #warning No leveling type is selected, so PROBE_MANUALLY has no use. Please select leveling type, for example AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR
   #endif
 #endif
 #if ANY(HAS_BED_PROBE, PROBE_MANUALLY, MESH_BED_LEVELING)

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1505,8 +1505,12 @@
   #undef ENABLE_LEVELING_AFTER_G28
   #undef G29_RETRY_AND_RECOVER
 #endif
-#if !HAS_LEVELING || ANY(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
-  #undef PROBE_MANUALLY
+#if ENABLED(PROBE_MANUALLY)
+  #if ANY(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
+    #error MESH_BED_LEVELING and AUTO_BED_LEVELING_UBL have their own manual probing procedures, so PROBE_MANUALLY is not needed for them. Please remove PROBE_MANUALLY, or use a different leveling type like AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR.
+  #elif !HAS_LEVELING
+    #error No leveling type is selected, so PROBE_MANUALLY has no use. Please select leveling type, for example AUTO_BED_LEVELING_3POINT, AUTO_BED_LEVELING_LINEAR, or AUTO_BED_LEVELING_BILINEAR
+  #endif
 #endif
 #if ANY(HAS_BED_PROBE, PROBE_MANUALLY, MESH_BED_LEVELING)
   #define PROBE_SELECTED 1


### PR DESCRIPTION
### Description

UBL and MBL have their own measurement procedures, so PROBE_MANUALLY is not needed for them.

### Benefits

Users would identify ignored configuration settings earlier.

The current PR raises an error, so users can identify faster that they activated "features that should not be activated at the same time".
An alternative option would be having a warning, however, if the current state is "one should not use PROBE_MANUALLY with MBL", then a clear error with "better variants" would be much better for the users.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/26267#issuecomment-1714460994