### PR TITLE
Restrict Hilbert curve to rectangular beds

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4113,6 +4113,13 @@ static_assert(WITHIN(MULTISTEPPING_LIMIT, 1, 128) && IS_POWER_OF_2(MULTISTEPPING
   #endif
 #endif
 
+/**
+  * HILBERT_CURVE limitation
+ */
+#if ENABLED(UBL_HILBERT_CURVE) && ANY(DELTA, SCARA, POLARGRAPH, MORGAN_SCARA, MP_SCARA)
+  #error "ERROR: UBL_HILBERT_CURVE can only be used with rectangular bed shapes."
+#endif
+
 // Misc. Cleanup
 #undef _TEST_PWM
 #undef _NUM_AXES_STR

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1517,6 +1517,8 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
     #error "AUTO_BED_LEVELING_UBL requires EEPROM_SETTINGS."
   #elif !WITHIN(GRID_MAX_POINTS_X, 3, 255) || !WITHIN(GRID_MAX_POINTS_Y, 3, 255)
     #error "GRID_MAX_POINTS_[XY] must be between 3 and 255."
+  #elif ALL(UBL_HILBERT_CURVE, DELTA)
+    #error "UBL_HILBERT_CURVE can only be used with a square / rectangular printable area."
   #endif
 #elif ENABLED(MESH_BED_LEVELING)
   #if ENABLED(DELTA)
@@ -4111,13 +4113,6 @@ static_assert(WITHIN(MULTISTEPPING_LIMIT, 1, 128) && IS_POWER_OF_2(MULTISTEPPING
   #elif !defined(HAS_MARLINUI_MENU)
     #error "ONE_CLICK_PRINT needs a display that has Marlin UI menus."
   #endif
-#endif
-
-/**
-  * HILBERT_CURVE limitation
- */
-#if ENABLED(UBL_HILBERT_CURVE) && ANY(DELTA, SCARA, POLARGRAPH, MORGAN_SCARA, MP_SCARA)
-  #error "ERROR: UBL_HILBERT_CURVE can only be used with rectangular bed shapes."
 #endif
 
 // Misc. Cleanup


### PR DESCRIPTION
The option **UBL_HILBERT_CURVE** is only applicable to rectangular beds.

This PR adds a sanity check to enforce that restriction.

I noticed this on my Delta printer.  G26 stopped early when **UBL_HILBERT_CURVE** was enabled.

---

I believe the problem is that the a Hilbert Curve assumes a rectangular region.  I haven't found the smoking gun but I believe the problem happens when the algorithm generates a destination outside the delta radius .  This then causes the code to stop looking for unvisited points.

Another potential issue is, several of the Hilbert Curve sources mention that the curve can only be applied to "powers of 2" matices (2x2, 4x4, 8x8, 16x16, ...) .  If that is correct with the Marlin code, then a 7x7 matix (or an 8x8 with an inset) will also terminate early.