### PR TITLE
Probe Z offset only used when homing with probe (and with probing)

### DIFF
--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -242,7 +242,7 @@ void home_delta() {
   #endif
 
   // Move all carriages together linearly until an endstop is hit.
-  current_position.z = DIFF_TERN(HAS_BED_PROBE, delta_height + 10, probe.offset.z);
+  current_position.z = TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING,  delta_height + 10, probe.offset.z), delta_height + 10);
   line_to_current_position(homing_feedrate(Z_AXIS));
   planner.synchronize();
   TERN_(HAS_DELTA_SENSORLESS_PROBING, endstops.report_states());

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -242,7 +242,7 @@ void home_delta() {
   #endif
 
   // Move all carriages together linearly until an endstop is hit.
-  current_position.z = TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING,  delta_height + 10, probe.offset.z), delta_height + 10);
+  current_position.z = DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height + 10, probe.offset.z);
   line_to_current_position(homing_feedrate(Z_AXIS));
   planner.synchronize();
   TERN_(HAS_DELTA_SENSORLESS_PROBING, endstops.report_states());

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -892,7 +892,7 @@ void restore_feedrate_and_scaling() {
     #elif ENABLED(DELTA)
 
       soft_endstop.min[axis] = base_min_pos(axis);
-      soft_endstop.max[axis] = (axis == Z_AXIS) ? TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) , delta_height) : base_home_pos(axis);
+      soft_endstop.max[axis] = (axis == Z_AXIS) ? DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) : base_home_pos(axis);
 
       switch (axis) {
         case X_AXIS:
@@ -2468,7 +2468,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
   #if ANY(MORGAN_SCARA, AXEL_TPARA)
     scara_set_axis_is_at_home(axis);
   #elif ENABLED(DELTA)
-    current_position[axis] = (axis == Z_AXIS) ? TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) , delta_height) : base_home_pos(axis);
+    current_position[axis] = (axis == Z_AXIS) ? DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) : base_home_pos(axis);
   #else
     current_position[axis] = SUM_TERN(HAS_HOME_OFFSET, base_home_pos(axis), home_offset[axis]);
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -892,7 +892,7 @@ void restore_feedrate_and_scaling() {
     #elif ENABLED(DELTA)
 
       soft_endstop.min[axis] = base_min_pos(axis);
-      soft_endstop.max[axis] = (axis == Z_AXIS) ? DIFF_TERN(HAS_BED_PROBE, delta_height, probe.offset.z) : base_max_pos(axis);
+      soft_endstop.max[axis] = (axis == Z_AXIS) ? TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) , delta_height) : base_home_pos(axis);
 
       switch (axis) {
         case X_AXIS:
@@ -2468,7 +2468,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
   #if ANY(MORGAN_SCARA, AXEL_TPARA)
     scara_set_axis_is_at_home(axis);
   #elif ENABLED(DELTA)
-    current_position[axis] = (axis == Z_AXIS) ? DIFF_TERN(HAS_BED_PROBE, delta_height, probe.offset.z) : base_home_pos(axis);
+    current_position[axis] = (axis == Z_AXIS) ? TERN(HAS_BED_PROBE, DIFF_TERN(USE_PROBE_FOR_Z_HOMING, delta_height, probe.offset.z) , delta_height) : base_home_pos(axis);
   #else
     current_position[axis] = SUM_TERN(HAS_HOME_OFFSET, base_home_pos(axis), home_offset[axis]);
   #endif


### PR DESCRIPTION
There are three scenarios where the current Marlin firmware is incorrectly including the bed probe's Z offset:

1. On delta printers with bed probes, the Z MAX reported by M114 is the sum of bed probe's Z offset and Z_MAX_POS.  It should only be Z_MAX_POS because the bed probe is not involved in setting the Z location during G28.  Delta printers always home in the + direction using endstops.  They also usually have a bed probe.
2. When doing a G29 P4 fine tune, the initial down movement goes to Z_CLEARANCE_DEPLOY_PROBE height, then to the H offset/shim height.  If the bed probe's Z offset is greater than the H setting, the head will crash into the bed.  This is a result of item 1.
3. When setting the Z_MAX soft endstop. 

This PR changes the logic so that the bed probe's Z offset is added to Z_MAX_POS and Z_MAX soft endstop only when USE_PROBE_FOR_Z_HOMING is enabled.

This was tested on a Tevo Little Monster delta printer.