### PR TITLE
Using ui.set_status() with a PSTR leads to weird behavior

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -460,8 +460,8 @@ void GcodeSuite::G33() {
   SERIAL_ECHOLNPGM("G33 Auto Calibrate");
 
   // Report settings
-  PGM_P const checkingac = PSTR("Checking... AC");
-  SERIAL_ECHOPGM_P(checkingac);
+  SString<14> checkingac(F("Checking... AC"));
+  checkingac.echo();
   SERIAL_ECHOPGM(" at radius:", dcr);
   if (verbose_level == 0) SERIAL_ECHOPGM(" (DRY-RUN)");
   SERIAL_EOL();

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -460,9 +460,8 @@ void GcodeSuite::G33() {
   SERIAL_ECHOLNPGM("G33 Auto Calibrate");
 
   // Report settings
-  SString<14> checkingac(F("Checking... AC"));
-  checkingac.echo();
-  SERIAL_ECHOPGM(" at radius:", dcr);
+  FSTR_P const checkingac = F("Checking... AC");
+  SERIAL_ECHO(checkingac, F(" at radius:"), dcr);
   if (verbose_level == 0) SERIAL_ECHOPGM(" (DRY-RUN)");
   SERIAL_EOL();
   ui.set_status(checkingac);


### PR DESCRIPTION
Hi,

I am facing an issue when displaying "Checking... AC" on screen (and as action notification).

When monitoring a G33, i see different weird behaviors:
- non unicode character displayed
- one unicode character displayed
- infinite unicode characters displayed leading to board crash.

Example :
![image](https://github.com/MarlinFirmware/Marlin/assets/37673727/bed741d6-b826-4b94-a49b-55436766f0bf)

As discussed with @ellensp on Discord, there might be a conflict between **PGM_P** and **PSTR** macros.

The modification I submit was provided by @ellensp for bugfix-2.1.x. It uses the new String helper class (cf. https://github.com/MarlinFirmware/Marlin/pull/24390/).

For those who work with 2.1.2.1 tag, you can find a way to fix it here : https://github.com/0r31/Marlin/commit/d206ab40dc4acecd8ee826eb77db7a03c6cf5b9d

Regards,
