### PR TITLE
Warn on EEPROM "Errors"

### DIFF
--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -52,6 +52,7 @@
 
   #define DEBUG_ECHO_START        SERIAL_ECHO_START
   #define DEBUG_ERROR_START       SERIAL_ERROR_START
+  #define DEBUG_WARN_START        SERIAL_WARN_START
   #define DEBUG_CHAR              SERIAL_CHAR
   #define DEBUG_ECHO              SERIAL_ECHO
   #define DEBUG_ECHOLN            SERIAL_ECHOLN
@@ -63,6 +64,7 @@
   #define DEBUG_ECHOLNPGM_P       SERIAL_ECHOLNPGM_P
   #define DEBUG_ECHO_MSG          SERIAL_ECHO_MSG
   #define DEBUG_ERROR_MSG         SERIAL_ERROR_MSG
+  #define DEBUG_WARN_MSG          SERIAL_WARN_MSG
   #define DEBUG_EOL               SERIAL_EOL
   #define DEBUG_FLUSH             SERIAL_FLUSH
   #define DEBUG_POS               SERIAL_POS
@@ -75,6 +77,7 @@
   #define DEBUG_SECTION(...)        NOOP
   #define DEBUG_ECHO_START()        NOOP
   #define DEBUG_ERROR_START()       NOOP
+  #define DEBUG_WARN_START()        NOOP
   #define DEBUG_CHAR(...)           NOOP
   #define DEBUG_ECHO(...)           NOOP
   #define DEBUG_ECHOLN(...)         NOOP
@@ -84,6 +87,7 @@
   #define DEBUG_ECHOLNPGM_P(...)    NOOP
   #define DEBUG_ECHO_MSG(...)       NOOP
   #define DEBUG_ERROR_MSG(...)      NOOP
+  #define DEBUG_WARN_MSG(...)       NOOP
   #define DEBUG_EOL()               NOOP
   #define DEBUG_FLUSH()             NOOP
   #define DEBUG_POS(...)            NOOP

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -92,6 +92,7 @@ void SERIAL_ECHOLN_P(PGM_P pstr) { SERIAL_ECHO_P(pstr); SERIAL_EOL(); }
 
 void SERIAL_ECHO_START()  { SERIAL_ECHO(F("echo:")); }
 void SERIAL_ERROR_START() { SERIAL_ECHO(F("Error:")); }
+void SERIAL_WARN_START()  { SERIAL_ECHO(F("Warning:")); }
 
 void SERIAL_ECHO_SP(uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR(' '); }
 

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -161,6 +161,7 @@ void SERIAL_FLUSHTX();
 // Start an echo: or error: output
 void SERIAL_ECHO_START();
 void SERIAL_ERROR_START();
+void SERIAL_WARN_START();
 
 // Serial end-of-line
 void SERIAL_EOL();
@@ -227,6 +228,7 @@ void SERIAL_ECHOLN(T arg1, Args ... args) { SERIAL_ECHO(arg1); SERIAL_ECHO(args 
 
 #define SERIAL_ECHO_MSG(V...)  do{ SERIAL_ECHO_START();  SERIAL_ECHOLNPGM(V); }while(0)
 #define SERIAL_ERROR_MSG(V...) do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(V); }while(0)
+#define SERIAL_WARN_MSG(V...)  do{ SERIAL_WARN_START();  SERIAL_ECHOLNPGM(V); }while(0)
 
 // Print a prefix, conditional string, and suffix
 void serial_ternary(FSTR_P const pre, const bool onoff, FSTR_P const on, FSTR_P const off, FSTR_P const post=nullptr);

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2865,10 +2865,10 @@ void MarlinSettings::postprocess() {
         DEBUG_ECHO_MSG("Index: ", eeprom_index - (EEPROM_OFFSET), " Size: ", datasize());
         break;
       case ERR_EEPROM_CORRUPT:
-        DEBUG_ERROR_MSG(STR_ERR_EEPROM_CORRUPT);
+        DEBUG_ECHO_MSG("Warning:" STR_ERR_EEPROM_CORRUPT);
         break;
       case ERR_EEPROM_CRC:
-        DEBUG_ERROR_MSG("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
+        DEBUG_ECHO_MSG("Warning: EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
         TERN_(HOST_EEPROM_CHITCHAT, hostui.notify(GET_TEXT_F(MSG_ERR_EEPROM_CRC)));
         break;
       default: break;

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -758,7 +758,7 @@ void MarlinSettings::postprocess() {
 
 #if ENABLED(EEPROM_SETTINGS)
 
-  #define EEPROM_ASSERT(TST,ERR)  do{ if (!(TST)) { SERIAL_ERROR_MSG(ERR); eeprom_error = ERR_EEPROM_SIZE; } }while(0)
+  #define EEPROM_ASSERT(TST,ERR)  do{ if (!(TST)) { SERIAL_WARN_MSG(ERR); eeprom_error = ERR_EEPROM_SIZE; } }while(0)
 
   #define TWO_BYTE_HASH(A,B) uint16_t((uint16_t(A ^ 0xC3) << 4) ^ (uint16_t(B ^ 0xC3) << 12))
 
@@ -796,7 +796,7 @@ void MarlinSettings::postprocess() {
 
   EEPROM_Error MarlinSettings::size_error(const uint16_t size) {
     if (size != datasize()) {
-      DEBUG_ERROR_MSG("EEPROM datasize error."
+      DEBUG_WARN_MSG("EEPROM datasize error."
         #if ENABLED(MARLIN_DEV_MODE)
           " (Actual:", size, " Expected:", datasize(), ")"
         #endif
@@ -2865,10 +2865,10 @@ void MarlinSettings::postprocess() {
         DEBUG_ECHO_MSG("Index: ", eeprom_index - (EEPROM_OFFSET), " Size: ", datasize());
         break;
       case ERR_EEPROM_CORRUPT:
-        DEBUG_ECHO_MSG("Warning:" STR_ERR_EEPROM_CORRUPT);
+        DEBUG_WARN_MSG(STR_ERR_EEPROM_CORRUPT);
         break;
       case ERR_EEPROM_CRC:
-        DEBUG_ECHO_MSG("Warning: EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
+        DEBUG_WARN_MSG("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
         TERN_(HOST_EEPROM_CHITCHAT, hostui.notify(GET_TEXT_F(MSG_ERR_EEPROM_CRC)));
         break;
       default: break;
@@ -3048,7 +3048,7 @@ void MarlinSettings::postprocess() {
 #else // !EEPROM_SETTINGS
 
   bool MarlinSettings::save() {
-    DEBUG_ERROR_MSG("EEPROM disabled");
+    DEBUG_WARN_MSG("EEPROM disabled");
     return false;
   }
 


### PR DESCRIPTION
### Description

#26164 attempted to resolve the issue with OctoPrint sending `M112` & halting a printer before disconnecting when it sees `Error:` via serial, but this still happens due to the use of `DEBUG_ERROR_MSG()` for EEPROM errors.

Switching to `DEBUG_ECHO_MSG("Warning: "` no longer causes this `M112`/halt behavior. See my comment in https://github.com/MarlinFirmware/Marlin/pull/26164#issuecomment-1732665075 for more details.

From my testing, you can revert the changes made to the `MSG_ERR_EEPROM_*` strings (and any other LCD strings that dropped/changed the `ERROR:` text) since OctoPrint doesn't halt with those.

### Requirements

Any printer that is connected to OctoPrint via serial.

### Benefits

OctoPrint will no longer halt your printer.

### Configurations

Default config with `EEPROM_SETTINGS` will work.

### Related Issues

- #26164
- Various discussions on Discord
