### PR TITLE
Sanity Check TMC_HOME_PHASE and CORE / MARKFORGED Kinematics

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3017,6 +3017,29 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #error "STEALTHCHOP_XY and STEALTHCHOP_Z must be the same on DELTA."
 #endif
 
+#ifdef TMC_HOME_PHASE
+  #if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX)
+    constexpr float phases[] = TMC_HOME_PHASE;
+    static_assert(COUNT(phases) == NUM_AXES, "TMC_HOME_PHASE must have " _NUM_AXES_STR " elements (and no others).");
+    NUM_AXIS_CODE(
+      static_assert(phases[X_AXIS] == -1 || NONE(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX), "TMC_HOME_PHASE.X is incompatible with CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX. Set TMC_HOME_PHASE.X to -1"),
+      static_assert(phases[Y_AXIS] == -1 || NONE(CORE_IS_XY, CORE_IS_YZ, MARKFORGED_XY, MARKFORGED_YX), "TMC_HOME_PHASE.Y is incompatible with CORE_IS_XY, CORE_IS_YZ, MARKFORGED_XY, MARKFORGED_YX. Set TMC_HOME_PHASE.Y to -1"),
+      static_assert(phases[Z_AXIS] == -1 || NONE(CORE_IS_XZ, CORE_IS_YZ), "TMC_HOME_PHASE.Z is incompatible with CORE_IS_XZ, CORE_IS_YZ. Set TMC_HOME_PHASE.Z to -1")
+    );
+    NUM_AXIS_CODE(
+      static_assert(phases[X_AXIS] >= -1 || phases[X_AXIS] <= 1023, "TMC_HOME_PHASE.X must be between -1 and 1023"),
+      static_assert(phases[Y_AXIS] >= -1 || phases[Y_AXIS] <= 1023, "TMC_HOME_PHASE.Y must be between -1 and 1023"),
+      static_assert(phases[Z_AXIS] >= -1 || phases[Z_AXIS] <= 1023, "TMC_HOME_PHASE.Z must be between -1 and 1023"),
+      static_assert(phases[I_AXIS] >= -1 || phases[I_AXIS] <= 1023, "TMC_HOME_PHASE.I must be between -1 and 1023"),
+      static_assert(phases[J_AXIS] >= -1 || phases[J_AXIS] <= 1023, "TMC_HOME_PHASE.J must be between -1 and 1023"),
+      static_assert(phases[K_AXIS] >= -1 || phases[K_AXIS] <= 1023, "TMC_HOME_PHASE.K must be between -1 and 1023"),
+      static_assert(phases[U_AXIS] >= -1 || phases[U_AXIS] <= 1023, "TMC_HOME_PHASE.U must be between -1 and 1023"),
+      static_assert(phases[V_AXIS] >= -1 || phases[V_AXIS] <= 1023, "TMC_HOME_PHASE.V must be between -1 and 1023"),
+      static_assert(phases[W_AXIS] >= -1 || phases[W_AXIS] <= 1023, "TMC_HOME_PHASE.W must be between -1 and 1023")
+    );
+ #endif
+#endif
+
 #if ENABLED(SENSORLESS_HOMING)
   // Require STEALTHCHOP for SENSORLESS_HOMING on DELTA as the transition from spreadCycle to stealthChop
   // is necessary in order to reset the stallGuard indication between the initial movement of all three

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3017,27 +3017,26 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #error "STEALTHCHOP_XY and STEALTHCHOP_Z must be the same on DELTA."
 #endif
 
-#ifdef TMC_HOME_PHASE
-  #if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX)
-    constexpr float phases[] = TMC_HOME_PHASE;
-    static_assert(COUNT(phases) == NUM_AXES, "TMC_HOME_PHASE must have " _NUM_AXES_STR " elements (and no others).");
-    NUM_AXIS_CODE(
-      static_assert(phases[X_AXIS] == -1 || NONE(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX), "TMC_HOME_PHASE.X is incompatible with CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX. Set TMC_HOME_PHASE.X to -1"),
-      static_assert(phases[Y_AXIS] == -1 || NONE(CORE_IS_XY, CORE_IS_YZ, MARKFORGED_XY, MARKFORGED_YX), "TMC_HOME_PHASE.Y is incompatible with CORE_IS_XY, CORE_IS_YZ, MARKFORGED_XY, MARKFORGED_YX. Set TMC_HOME_PHASE.Y to -1"),
-      static_assert(phases[Z_AXIS] == -1 || NONE(CORE_IS_XZ, CORE_IS_YZ), "TMC_HOME_PHASE.Z is incompatible with CORE_IS_XZ, CORE_IS_YZ. Set TMC_HOME_PHASE.Z to -1")
-    );
-    NUM_AXIS_CODE(
-      static_assert(phases[X_AXIS] >= -1 || phases[X_AXIS] <= 1023, "TMC_HOME_PHASE.X must be between -1 and 1023"),
-      static_assert(phases[Y_AXIS] >= -1 || phases[Y_AXIS] <= 1023, "TMC_HOME_PHASE.Y must be between -1 and 1023"),
-      static_assert(phases[Z_AXIS] >= -1 || phases[Z_AXIS] <= 1023, "TMC_HOME_PHASE.Z must be between -1 and 1023"),
-      static_assert(phases[I_AXIS] >= -1 || phases[I_AXIS] <= 1023, "TMC_HOME_PHASE.I must be between -1 and 1023"),
-      static_assert(phases[J_AXIS] >= -1 || phases[J_AXIS] <= 1023, "TMC_HOME_PHASE.J must be between -1 and 1023"),
-      static_assert(phases[K_AXIS] >= -1 || phases[K_AXIS] <= 1023, "TMC_HOME_PHASE.K must be between -1 and 1023"),
-      static_assert(phases[U_AXIS] >= -1 || phases[U_AXIS] <= 1023, "TMC_HOME_PHASE.U must be between -1 and 1023"),
-      static_assert(phases[V_AXIS] >= -1 || phases[V_AXIS] <= 1023, "TMC_HOME_PHASE.V must be between -1 and 1023"),
-      static_assert(phases[W_AXIS] >= -1 || phases[W_AXIS] <= 1023, "TMC_HOME_PHASE.W must be between -1 and 1023")
-    );
- #endif
+// H-Bot kinematic axes can't use homing phases
+#if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX) && defined(TMC_HOME_PHASE)
+  constexpr float phases[] = TMC_HOME_PHASE;
+  static_assert(COUNT(phases) == NUM_AXES, "TMC_HOME_PHASE must have " _NUM_AXES_STR " elements (and no others).");
+  XYZ_CODE(
+    static_assert(phases[X_AXIS] == -1 || NORMAL_AXIS != X_AXIS, "TMC_HOME_PHASE.x must be set to -1 with H-bot kinematics."),
+    static_assert(phases[Y_AXIS] == -1 || NORMAL_AXIS != Y_AXIS, "TMC_HOME_PHASE.y must be set to -1 with H-bot kinematics."),
+    static_assert(phases[Z_AXIS] == -1 || NORMAL_AXIS != Z_AXIS, "TMC_HOME_PHASE.z must be set to -1 with H-bot kinematics.")
+  );
+  NUM_AXIS_CODE(
+    static_assert(WITHIN(phases[X_AXIS], -1, 1023), "TMC_HOME_PHASE.x must be between -1 and 1023."),
+    static_assert(WITHIN(phases[Y_AXIS], -1, 1023), "TMC_HOME_PHASE.y must be between -1 and 1023."),
+    static_assert(WITHIN(phases[Z_AXIS], -1, 1023), "TMC_HOME_PHASE.z must be between -1 and 1023."),
+    static_assert(WITHIN(phases[I_AXIS], -1, 1023), "TMC_HOME_PHASE.i must be between -1 and 1023."),
+    static_assert(WITHIN(phases[J_AXIS], -1, 1023), "TMC_HOME_PHASE.j must be between -1 and 1023."),
+    static_assert(WITHIN(phases[K_AXIS], -1, 1023), "TMC_HOME_PHASE.k must be between -1 and 1023."),
+    static_assert(WITHIN(phases[U_AXIS], -1, 1023), "TMC_HOME_PHASE.u must be between -1 and 1023."),
+    static_assert(WITHIN(phases[V_AXIS], -1, 1023), "TMC_HOME_PHASE.v must be between -1 and 1023."),
+    static_assert(WITHIN(phases[W_AXIS], -1, 1023), "TMC_HOME_PHASE.w must be between -1 and 1023.")
+  );
 #endif
 
 #if ENABLED(SENSORLESS_HOMING)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3019,24 +3019,21 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 
 // H-Bot kinematic axes can't use homing phases
 #if ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX) && defined(TMC_HOME_PHASE)
-  constexpr float phases[] = TMC_HOME_PHASE;
-  static_assert(COUNT(phases) == NUM_AXES, "TMC_HOME_PHASE must have " _NUM_AXES_STR " elements (and no others).");
-  XYZ_CODE(
-    static_assert(phases[X_AXIS] == -1 || NORMAL_AXIS != X_AXIS, "TMC_HOME_PHASE.x must be set to -1 with H-bot kinematics."),
-    static_assert(phases[Y_AXIS] == -1 || NORMAL_AXIS != Y_AXIS, "TMC_HOME_PHASE.y must be set to -1 with H-bot kinematics."),
-    static_assert(phases[Z_AXIS] == -1 || NORMAL_AXIS != Z_AXIS, "TMC_HOME_PHASE.z must be set to -1 with H-bot kinematics.")
-  );
-  NUM_AXIS_CODE(
-    static_assert(WITHIN(phases[X_AXIS], -1, 1023), "TMC_HOME_PHASE.x must be between -1 and 1023."),
-    static_assert(WITHIN(phases[Y_AXIS], -1, 1023), "TMC_HOME_PHASE.y must be between -1 and 1023."),
-    static_assert(WITHIN(phases[Z_AXIS], -1, 1023), "TMC_HOME_PHASE.z must be between -1 and 1023."),
-    static_assert(WITHIN(phases[I_AXIS], -1, 1023), "TMC_HOME_PHASE.i must be between -1 and 1023."),
-    static_assert(WITHIN(phases[J_AXIS], -1, 1023), "TMC_HOME_PHASE.j must be between -1 and 1023."),
-    static_assert(WITHIN(phases[K_AXIS], -1, 1023), "TMC_HOME_PHASE.k must be between -1 and 1023."),
-    static_assert(WITHIN(phases[U_AXIS], -1, 1023), "TMC_HOME_PHASE.u must be between -1 and 1023."),
-    static_assert(WITHIN(phases[V_AXIS], -1, 1023), "TMC_HOME_PHASE.v must be between -1 and 1023."),
-    static_assert(WITHIN(phases[W_AXIS], -1, 1023), "TMC_HOME_PHASE.w must be between -1 and 1023.")
-  );
+  constexpr float _phases[] = TMC_HOME_PHASE, _vphase[9] = TMC_HOME_PHASE;
+  constexpr int _nphase = COUNT(_phases);
+  static_assert(_nphase == NUM_AXES, "TMC_HOME_PHASE must have exactly " _NUM_AXES_STR " elements.");
+  static_assert(_nphase < 0 || _vphase[0] == -1 || NORMAL_AXIS == 0, "TMC_HOME_PHASE.x must be -1 for the selected kinematics.");
+  static_assert(_nphase < 1 || _vphase[1] == -1 || NORMAL_AXIS == 1, "TMC_HOME_PHASE.y must be -1 for the selected kinematics.");
+  static_assert(_nphase < 2 || _vphase[2] == -1 || NORMAL_AXIS == 2, "TMC_HOME_PHASE.z must be -1 for the selected kinematics.");
+  static_assert(_nphase < 0 || WITHIN(_vphase[0], -1, 1023), "TMC_HOME_PHASE.x must be between -1 and 1023.");
+  static_assert(_nphase < 1 || WITHIN(_vphase[1], -1, 1023), "TMC_HOME_PHASE.y must be between -1 and 1023.");
+  static_assert(_nphase < 2 || WITHIN(_vphase[2], -1, 1023), "TMC_HOME_PHASE.z must be between -1 and 1023.");
+  static_assert(_nphase < 3 || WITHIN(_vphase[3], -1, 1023), "TMC_HOME_PHASE.i must be between -1 and 1023.");
+  static_assert(_nphase < 4 || WITHIN(_vphase[4], -1, 1023), "TMC_HOME_PHASE.j must be between -1 and 1023.");
+  static_assert(_nphase < 5 || WITHIN(_vphase[5], -1, 1023), "TMC_HOME_PHASE.k must be between -1 and 1023.");
+  static_assert(_nphase < 6 || WITHIN(_vphase[6], -1, 1023), "TMC_HOME_PHASE.u must be between -1 and 1023.");
+  static_assert(_nphase < 7 || WITHIN(_vphase[7], -1, 1023), "TMC_HOME_PHASE.v must be between -1 and 1023.");
+  static_assert(_nphase < 8 || WITHIN(_vphase[8], -1, 1023), "TMC_HOME_PHASE.w must be between -1 and 1023.");
 #endif
 
 #if ENABLED(SENSORLESS_HOMING)


### PR DESCRIPTION
### Description

Core machines can't reliably settle on the same phase for homing core axes. For instance, with CoreXY, X and Y positions depend on both A and B motors, so the homing A phase depends on exact location of X and Y (== on the position of B motor).

Fixes https://github.com/MarlinFirmware/Marlin/issues/26307

### Benefits

The more sanity checks the better.
