### PR TITLE
Update toolchain-gccarmnoneeabi for SKR Mini E3 V3/3.0.1, Manta Series, & EBB42

### DIFF
--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -740,6 +740,7 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0
+                              -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
 

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -731,7 +731,7 @@ upload_protocol = stlink
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32F401RC
 board_build.offset          = 0x4000
 board_upload.offset_address = 0x08004000

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -38,6 +38,7 @@ board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000
 build_flags                 = ${stm32_variant.build_flags} ${stm32g0_I2C2.build_flags} -flto
+                              -Wl,--no-warn-rwx-segment
 debug_tool                  = stlink
 upload_protocol             = dfu
 upload_command              = dfu-util -a 0 -s 0x08000000:leave -D "$SOURCE"
@@ -58,6 +59,7 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0
+                              -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
 
@@ -116,6 +118,7 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0
+                              -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
 

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -33,7 +33,7 @@ build_flags = -DPIN_WIRE_SCL=PB3 -DPIN_WIRE_SDA=PB4
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000
@@ -49,7 +49,7 @@ upload_command              = dfu-util -a 0 -s 0x08000000:leave -D "$SOURCE"
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
@@ -106,7 +106,7 @@ upload_protocol = custom
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
 platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32G0B1VE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000


### PR DESCRIPTION
### Description

Compiling for an SKR Mini E3 V3, V3.0.1, Manta Series, or BTT EBB42 V1.1, you get the following error:

```prolog
Compiling .pio/build/STM32G0B1RE_btt/SrcWrapper/src/stm32/pinmap.c.o
/.platformio/packages/framework-arduinoststm32/libraries/SrcWrapper/src/stm32/clock.c: In function 'enableClock':
/.platformio/packages/framework-arduinoststm32/libraries/SrcWrapper/src/stm32/clock.c:135:7: error: a label can only be part of a statement and a declaration is not a statement
  135 |       uint32_t HSEState = RCC_HSE_ON;
      |       ^~~~~~~~
```

This is due to using `toolchain-gccarmnoneeabi@1.100301.220327`. Updating to `toolchain-gccarmnoneeabi@1.120301.0` fixes the compile error, but creates a new warning:

```prolog
/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/bin/ld: warning: .pio/build/STM32G0B1RE_btt/firmware.elf has a LOAD segment with RWX permissions
```

That can be silenced with a `-Wl,--no-warn-rwx-segment` build flag ([source](https://community.st.com/t5/stm32-mcus-products/quot-warning-lt-elffile-gt-has-a-load-segment-with-rwx/td-p/83148)), but I'm not sure if that's the best way to handle it.


### Requirements

SKR Mini E3 V3, V3.0.1, Manta Series, or BTT EBB42 V1.1

### Benefits

Allows users to compile for these boards again.

### Configurations

[MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 3.0](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20Mini%20E3%203.0)

### Related Issues
- https://github.com/stm32duino/Arduino_Core_STM32/commit/0ffbf3e7f5ad21dcaecfb692c2d4c51531668295#commitcomment-126862592
- https://github.com/stm32duino/Arduino_Core_STM32/issues/2125
- https://github.com/platformio/platform-ststm32/issues/720