### PR TITLE
Add CI test for STM32G0 (BigTreeTech SKR Mini E3 V3.0)

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -133,6 +133,9 @@ jobs:
         #- STM32F103RC_btt_maple
         #- STM32F103RE_creality_maple
 
+        # STM32G0
+        - STM32G0B1RE_btt
+
         # LPC176x - Lengthy tests
         - LPC1768
         - LPC1769

--- a/buildroot/tests/STM32G0B1RE_btt
+++ b/buildroot/tests/STM32G0B1RE_btt
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Build tests for STM32G0B1RE_btt / Ender-3 with SKR Mini E3 V3.0 (STM32G0)
+#
+
+# exit on first failure
+set -e
+
+#
+# Build with the default configurations
+#
+use_example_configs "Creality/Ender-3/BigTreeTech SKR Mini E3 3.0"
+exec_test $1 $2 "Creality/Ender-3/BigTreeTech SKR Mini E3 3.0" "$3"
+
+# clean up
+restore_configs


### PR DESCRIPTION
### Description

Add CI test for STM32G0 / BigTreeTech SKR Mini E3 V3.0

### Requirements

GitHub CI

### Benefits

Allows us to test STM32G0 builds / catch buildchain issues

### Configurations

[MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 3.0](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20Mini%20E3%203.0)