### PR TITLE
Fixed MMU initialization after 30 seconds has passed from printer start.

### DIFF
--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -160,7 +160,7 @@ void MMU2::mmu_loop() {
         MMU2_SEND("S1");    // Read Version
         state = -2;
       }
-      else if (millis() > 30000) { // 30sec after reset disable MMU
+      else if (ELAPSED(millis(), prev_request + 30000)) { // 30sec after reset disable MMU
         SERIAL_ECHOLNPGM("MMU not responding - DISABLED");
         state = 0;
       }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR is about MMU initialization. In the current branch, after sending an `MMU2::rx_start()` it waits for 30 seconds for a response. But this 30 seconds is calculated from the printer start. And if the user sends a `MMU2::reset()` after this 30 seconds has passed, and if the MMU2s doesn't respond with an answer quickly enough they are immediately responded with a `MMU not responding - DISABLED` message as the 30 seconds has already passed.

My commit solved that by calculating the 30 seconds from the previous request.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Proper MMU2 reset after 30 second has passed from the printer start.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

No related issue...
