### PR TITLE
Add Missing MKS Eagle Environments

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -787,7 +787,7 @@
 #elif MB(MKS_ROBIN_NANO_V1_3_F4)
   #include "stm32f4/pins_MKS_ROBIN_NANO_V1_3_F4.h"  // STM32F4                              env:mks_robin_nano_v1_3_f4 env:mks_robin_nano_v1_3_f4_usbmod
 #elif MB(MKS_EAGLE)
-  #include "stm32f4/pins_MKS_EAGLE.h"               // STM32F4                              env:mks_eagle
+  #include "stm32f4/pins_MKS_EAGLE.h"               // STM32F4                              env:mks_eagle env:mks_eagle_usb_flash_drive env:mks_eagle_usb_flash_drive_msc
 #elif MB(ARTILLERY_RUBY)
   #include "stm32f4/pins_ARTILLERY_RUBY.h"          // STM32F4                              env:Artillery_Ruby
 #elif MB(CREALITY_V24S1_301F4)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -480,7 +480,6 @@ upload_protocol             = jlink
 
 #
 # MKS Robin Nano V3 with USB Flash Drive Support
-# Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_robin_nano_v3_usb_flash_drive]
 extends           = env:mks_robin_nano_v3
@@ -493,7 +492,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 
 #
 # MKS Robin Nano V3 with USB Flash Drive Support and Shared Media
-# Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
 extends           = env:mks_robin_nano_v3_usb_flash_drive
@@ -510,7 +508,6 @@ board             = marlin_STM32F407VET6_CCM
 
 #
 # MKS Robin Nano V3.1 with USB Flash Drive Support
-# Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_robin_nano_v3_1_usb_flash_drive]
 extends           = env:mks_robin_nano_v3_usb_flash_drive
@@ -518,7 +515,6 @@ board             = marlin_STM32F407VET6_CCM
 
 #
 # MKS Robin Nano V3.1 with USB Flash Drive Support and Shared Media
-# Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_robin_nano_v3_1_usb_flash_drive_msc]
 extends           = env:mks_robin_nano_v3_usb_flash_drive_msc
@@ -543,7 +539,6 @@ upload_protocol             = jlink
 
 #
 # MKS Eagle with USB Flash Drive Support
-# Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_eagle_usb_flash_drive]
 extends           = env:mks_eagle
@@ -556,7 +551,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 
 #
 # MKS Eagle with USB Flash Drive Support and Shared Media
-# Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_eagle_usb_flash_drive_msc]
 extends           = env:mks_eagle_usb_flash_drive
@@ -588,7 +582,6 @@ upload_protocol             = jlink
 
 #
 # MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support
-# Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_monster8_usb_flash_drive]
 extends           = env:mks_monster8
@@ -601,7 +594,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flag
 
 #
 # MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support and Shared Media
-# Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_monster8_usb_flash_drive_msc]
 extends           = env:mks_monster8_usb_flash_drive


### PR DESCRIPTION
### Description

Add missing MKS Eagle environments as found in `stm32f4.ini` to `pins.h` so PIO/ABM will allow flash drive support / shared media compilation:

https://github.com/MarlinFirmware/Marlin/blob/caca5636cec69ba3afe28353abecc218dd8c05fa/ini/stm32f4.ini#L548

https://github.com/MarlinFirmware/Marlin/blob/caca5636cec69ba3afe28353abecc218dd8c05fa/ini/stm32f4.ini#L561

### Requirements

MKS Eagle

### Benefits

Flash Drive Support and Shared Media will work with MKS Eagle
