### PR TITLE
Don't Auto Install DevContainer Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
+        "ms-vscode-remote.remote-containers",
         "ms-vscode.cpptools-extension-pack"
     ]
 }


### PR DESCRIPTION
### Description

VSCode auto-installs the [DevContainers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) since we have a `.devcontainer` folder, but this is not going to be used by most users, so add it to the `unwantedRecommendations` to avoid automatic installation.

Advanced users/developers can still install the extension if they so desire.

### Requirements

VSCode

### Benefits

One fewer extension to install/run for the average user compiling firmware with VSCode.

### Related Issues

None. This comes up a lot on Discord.
