### PR TITLE
Updates to pins_GT2560_V41b.h and board.h

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -396,7 +396,7 @@
 #define BOARD_ZONESTAR_ZM3E4V2        5064  // Zonestar ZM3E4 V2 (STM32F103VC)
 #define BOARD_ERYONE_ERY32_MINI       5065  // Eryone Ery32 mini (STM32F103VE)
 #define BOARD_PANDA_PI_V29            5066  // Panda Pi V2.9 - Standalone (STM32F103RC)
-#define BOARD_SOVOL_V131              5067  // Sovol V1.3.1 (GD32F103RET6)
+#define BOARD_SOVOL_V131              5067  // Sovol V1.3.1 (GD32F103RE)
 #define BOARD_TRIGORILLA_V006         5068  // Trigorilla V0.0.6 (GD32F103RE)
 #define BOARD_KEDI_CONTROLLER_V1_2    5069  // EDUTRONICS Kedi Controller V1.2 (STM32F103RC)
 

--- a/Marlin/src/pins/mega/pins_GT2560_V41b.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V41b.h
@@ -233,10 +233,10 @@
   #define BTN_EN2                      H2_08_PIN
   #define BTN_ENC                      H2_09_PIN
   #define BEEPER_PIN                   H2_12_PIN
-#elif ENABLED(CR10_STOCKDISPLAY)
-  #define LCD_PINS_RS                  H2_04_PIN  // LCD_RS / DOGLCD_CS
-  #define LCD_PINS_D4                  H2_05_PIN  // LCD_D4 / DOGLCD_SCK
-  #define LCD_PINS_EN                  H2_03_PIN  // LCD_EN / DOGLCD_MOSI
+#elif ENABLED(CR10_STOCKDISPLAY)                  // Firmware compatible with stock GT 128x64 12pin LCD for the V41b 
+  #define LCD_PINS_RS                  H2_04_PIN  // DOGLCD_CS
+  #define LCD_PINS_D4                  H2_05_PIN  // DOGLCD_SCK
+  #define LCD_PINS_EN                  H2_03_PIN  // DOGLCD_MOSI
   #define BTN_EN1                      H2_07_PIN
   #define BTN_EN2                      H2_08_PIN
   #define BTN_ENC                      H2_09_PIN

--- a/Marlin/src/pins/mega/pins_GT2560_V41b.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V41b.h
@@ -209,40 +209,39 @@
  *                  H2
  */
 
-#define LCM_D4                                16  // Used as BTN_EN1 for YHCB2004 LCD Module
-#define LCM_D5                                21  // YHCB2004_SCK_PIN
-#define LCM_D6                                 5  // YHCB2004_SS_PIN
-#define LCM_D7                                36  // YHCB2004_MOSI_PIN
-#define LCM_EN                                17  // BTN_EN2
-#define EC_PRESS                              19  // BTN_ENC
-#define BEEP                                  18
+//#define H2_01_PIN                           5V
+//#define H2_02_PIN                          GND
+#define H2_03_PIN                             36  // LCM_D7
+#define H2_04_PIN                              5  // LCM_D6
+#define H2_05_PIN                             21  // LCM_D5
+//#define H2_06_PIN                          GND
+#define H2_07_PIN                             16  // LCM_D4
+#define H2_08_PIN                             17  // LCM_EN
+#define H2_09_PIN                             19  // EC_PRESS
+//#define H2_10_PIN                          GND
+//#define H2_11_PIN                        RESET
+#define H2_12_PIN                             18  // BEEP
 
-#define BEEPER_PIN                          BEEP
 #define LCM_RS                                20  // Pin named and connected to 10k pull-up resistor but unused
 
 #if ENABLED(YHCB2004)
-  #define YHCB2004_SS_PIN                 LCM_D6
-  #define YHCB2004_SCK_PIN                LCM_D5
-  #define YHCB2004_MOSI_PIN               LCM_D7
+  #define YHCB2004_SS_PIN              H2_04_PIN
+  #define YHCB2004_SCK_PIN             H2_05_PIN
+  #define YHCB2004_MOSI_PIN            H2_03_PIN
   #define YHCB2004_MISO_PIN               LCM_RS  // Unused on V4.1b board
+  #define BTN_EN1                      H2_07_PIN
+  #define BTN_EN2                      H2_08_PIN
+  #define BTN_ENC                      H2_09_PIN
+  #define BEEPER_PIN                   H2_12_PIN
+#elif ENABLED(CR10_STOCKDISPLAY)
+  #define LCD_PINS_RS                  H2_04_PIN  // LCD_RS / DOGLCD_CS
+  #define LCD_PINS_D4                  H2_05_PIN  // LCD_D4 / DOGLCD_SCK
+  #define LCD_PINS_EN                  H2_03_PIN  // LCD_EN / DOGLCD_MOSI
+  #define BTN_EN1                      H2_07_PIN
+  #define BTN_EN2                      H2_08_PIN
+  #define BTN_ENC                      H2_09_PIN
+  #define BEEPER_PIN                   H2_12_PIN
 #elif HAS_WIRED_LCD
   #error "GT2560 V4.1b requires an adapter for common LCDs."
-  /*  Cannot use because V4.1b board has not LCD_PINS_RS wired to display connector
-  #define LCD_PINS_RS                         20
-  #define LCD_PINS_EN                         17
-  #define LCD_PINS_D4                         16
-  #define LCD_PINS_D5                         21
-  #define LCD_PINS_D6                          5
-  #define LCD_PINS_D7                         36
-  //*/
-#endif
-
-#if ENABLED(YHCB2004)
-  #define BTN_EN1                         LCM_D4
-  #define BTN_EN2                         LCM_EN
-  #define BTN_ENC                       EC_PRESS
-#elif IS_NEWPANEL
-  #define BTN_EN1                             42
-  #define BTN_EN2                             40
-  #define BTN_ENC                             19
+  /*  Cannot use because V4.1b board has not LCD_PINS_RS wired to display connector */
 #endif

--- a/Marlin/src/pins/mega/pins_GT2560_V41b.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V41b.h
@@ -204,7 +204,7 @@
  *   (LCM_D5) 21 | 5  6 | GND
  *   (LCM_D4) 16 | 7  8 | 17 (LCM_EN)
  * (EC_PRESS) 19 | 9 10 | GND
- *       (RESET) |11 12 | 19 (BEEP)
+ *       (RESET) |11 12 | 18 (BEEP)
  *                ------
  *                  H2
  */


### PR DESCRIPTION
### Description

1) Minor typo in lcd connector pins description.
  Circuit diagram shows BEEP is on PD3 (D18) 
  And code also says `#define BEEP                                  18`
 -  But the comment says 
    ` *       (RESET) |11 12 | 19 (BEEP)`
  - Updated to  
    ` *       (RESET) |11 12 | 18 (BEEP)`

2) Remove T6 from GD32F103RET6 comment as T6 has no bearing on firmware.

3) Update `pins_GT2560_V41b.h` so user can enable `CR10_STOCKDISPLAY`. The default 128x64 12 pin display from geeetech that is paired with this board is firmware compatible with the `CR10_STOCKDISPLAY`, so I have added this to the pins file.

### Requirements

GT2560_V41b motherboard

### Benefits

Correct information, add stock 128x64 LCD support 

### Related Issues
#25888
