### PR TITLE
Expose Bed Distance Sensor "No Stop" Probing Option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1430,6 +1430,9 @@
  * Uses I2C port, so it requires I2C library markyue/Panda_SoftMasterI2C.
  */
 //#define BD_SENSOR
+#if ENABLED(BD_SENSOR)
+  //#define BD_SENSOR_PROBE_NO_STOP // Probe bed without stopping at each probe point
+#endif
 
 // A probe that is deployed and stowed with a solenoid pin (SOL1_PIN)
 //#define SOLENOID_PROBE


### PR DESCRIPTION
### Description

I was watching the latest [Chris's Basement video where he covers the Bed Distance Sensor under Marlin](https://youtu.be/VLUfvkO2NFc?t=1294) and noticed that the `BD_SENSOR_PROBE_NO_STOP` option was hidden / had to be manually added to the config, so I've exposed the option in this PR to make it easier to enable.

### Requirements

[ Discovery Sky's `BD_SENSOR`](https://www.pandapi3d.com/product-page/bed-distance-sensor)

### Benefits

Easier configuration of `BD_SENSOR`