### PR TITLE
Fix marlinui_TFTGLCD compile error. Update pins_K8400.h

### DIFF
--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -975,7 +975,7 @@ void MarlinUI::draw_status_screen() {
 
     uint8_t n = LCD_WIDTH;
     const bool center = bool(style & SS_CENTER), full = bool(style & SS_FULL);
-    const int8_t plen = fstr ? utf8_strlen(fstr) : 0,
+    const int8_t plen = ftpl ? utf8_strlen(ftpl) : 0,
                  vlen = vstr ? utf8_strlen(vstr) : 0;
     int8_t pad = (center || full) ? n - plen - vlen : 0;
 
@@ -983,7 +983,7 @@ void MarlinUI::draw_status_screen() {
     if (center) for (int8_t lpad = pad / 2; lpad > 0; --lpad) { lcd.write(' '); n--; }
 
     // Draw as much of the label as fits
-    if (plen) n -= lcd_put_u8str(fstr, itemIndex, itemStringC, itemStringF, n - vlen);
+    if (plen) n -= lcd_put_u8str(ftpl, itemIndex, itemStringC, itemStringF, n - vlen);
 
     if (vlen && n > 0) {
       // SS_FULL: Pad with enough space to justify the value

--- a/Marlin/src/pins/mega/pins_GT2560_V41b.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V41b.h
@@ -233,7 +233,7 @@
   #define BTN_EN2                      H2_08_PIN
   #define BTN_ENC                      H2_09_PIN
   #define BEEPER_PIN                   H2_12_PIN
-#elif ENABLED(CR10_STOCKDISPLAY)                  // Firmware compatible with stock GT 128x64 12pin LCD for the V41b 
+#elif ENABLED(CR10_STOCKDISPLAY)                  // Firmware compatible with stock GT 128x64 12pin LCD for the V41b
   #define LCD_PINS_RS                  H2_04_PIN  // DOGLCD_CS
   #define LCD_PINS_D4                  H2_05_PIN  // DOGLCD_SCK
   #define LCD_PINS_EN                  H2_03_PIN  // DOGLCD_MOSI

--- a/Marlin/src/pins/ramps/pins_K8400.h
+++ b/Marlin/src/pins/ramps/pins_K8400.h
@@ -53,6 +53,11 @@
 #define X_STOP_PIN                             3
 #define Y_STOP_PIN                            14
 
+//
+// Fans
+//
+#define FAN0_PIN                               8
+
 #if ANY(BLTOUCH, TOUCH_MI_PROBE)
   #define INVERTED_PROBE_STATE
 #endif
@@ -60,7 +65,7 @@
 #include "pins_3DRAG.h" // ... RAMPS
 
 //
-// Heaters / Fans
+// Heaters
 //
 #undef HEATER_1_PIN
 #define HEATER_1_PIN                          11


### PR DESCRIPTION
### Description

1.

Fixes build error 
[Test LPC1769] Smoothieboard with TFTGLCD_PANEL_SPI and many features...
Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp: In static member function 'static void MenuItem_static::draw(uint8_t, FSTR_P, uint8_t, const char*)':
Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp:978:25: error: 'fstr' was not declared in this scope; did you mean 'vstr'?
  978 |     const int8_t plen = fstr ? utf8_strlen(fstr) : 0,

2.

In pins_K8400.h 
FAN0_PIN  is always  8, regardless of 1 or 2 extrudes, currently 2 extruders will incorrectly move the fan0_pin to 9

### Requirements

K8400 motherboard

### Benefits

marlinui_TFTGLCD.cpp complies as expected.

Fan0 words as expected on K8400

### Configurations

https://github.com/MarlinFirmware/Marlin/files/13060791/config.zip

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/26358

Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp got broken here
https://github.com/MarlinFirmware/Marlin/commit/b0ece8f8df130709f97da6c1474cd20cbd9119ed
https://github.com/MarlinFirmware/Marlin/issues/26360