### PR TITLE
Fix SD ui.refresh with NO_SD_DETECT

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -589,9 +589,7 @@ void CardReader::release() {
   nrItems = -1;
   SERIAL_ECHO_MSG(STR_SD_CARD_RELEASED);
 
-  #if ENABLED(NO_SD_DETECT)
-  ui.refresh();
-  #endif
+  TERN_(NO_SD_DETECT, ui.refresh());
 }
 
 /**

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -588,6 +588,10 @@ void CardReader::release() {
   flag.workDirIsRoot = true;
   nrItems = -1;
   SERIAL_ECHO_MSG(STR_SD_CARD_RELEASED);
+
+  #if ENABLED(NO_SD_DETECT)
+  ui.refresh();
+  #endif
 }
 
 /**


### PR DESCRIPTION
Continuation of #26362 – which can't be further edited so recreating here.

Pretty straightforward, if it's the right solution.

---

### Description

If an sd card is removed using the menu the ui won't be updated, just update the menu if the flag NO_SD_DETECT is enabled.

### Requirements

NO_SD_DETECT must be enabled for this change to take effect

### Benefits

after removing a card with the ui, the ui itself will be updated with the new state, instead of having to move the cursor or change the page to view the ui update with the card removed information
