### PR TITLE
add Repeat get functions, fixes issue 26357

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -583,9 +583,9 @@ void PrintJobRecovery::resume() {
         DEBUG_ECHOLNPGM("zraise: ", info.zraise, " ", info.flag.raised ? "(before)" : "");
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
-          DEBUG_ECHOLNPGM("repeat index: ", info.stored_repeat.index);
-          for (uint8_t i = 0; i < info.stored_repeat.index; ++i)
-            DEBUG_ECHOLNPGM("..... sdpos: ", info.stored_repeat.marker.sdpos, " count: ", info.stored_repeat.marker.counter);
+          DEBUG_ECHOLNPGM("repeat index: ", info.stored_repeat.get_index());
+          for (uint8_t i = 0; i < info.stored_repeat.get_index(); ++i)
+            DEBUG_ECHOLNPGM("..... marker[", i, "] sdpos: ", info.stored_repeat.get_marker_sdpos(i), " count: ", info.stored_repeat.get_marker_counter(i));
         #endif
 
         #if HAS_HOME_OFFSET

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -583,9 +583,10 @@ void PrintJobRecovery::resume() {
         DEBUG_ECHOLNPGM("zraise: ", info.zraise, " ", info.flag.raised ? "(before)" : "");
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
-          DEBUG_ECHOLNPGM("repeat index: ", info.stored_repeat.get_index());
-          for (uint8_t i = 0; i < info.stored_repeat.get_index(); ++i)
-            DEBUG_ECHOLNPGM("..... marker[", i, "] sdpos: ", info.stored_repeat.get_marker_sdpos(i), " count: ", info.stored_repeat.get_marker_counter(i));
+          const uint8_t ind = info.stored_repeat.get_index();
+          DEBUG_ECHOLNPGM("repeat markers: ", ind);
+          for (uint8_t i = ind; i--;)
+            DEBUG_ECHOLNPGM("...", i, " sdpos: ", info.stored_repeat.get_marker_sdpos(i), " count: ", info.stored_repeat.get_marker_counter(i));
         #endif
 
         #if HAS_HOME_OFFSET

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -583,7 +583,7 @@ void PrintJobRecovery::resume() {
         DEBUG_ECHOLNPGM("zraise: ", info.zraise, " ", info.flag.raised ? "(before)" : "");
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
-          const uint8_t ind = info.stored_repeat.get_index();
+          const uint8_t ind = info.stored_repeat.count();
           DEBUG_ECHOLNPGM("repeat markers: ", ind);
           for (uint8_t i = ind; i--;)
             DEBUG_ECHOLNPGM("...", i, " sdpos: ", info.stored_repeat.get_marker_sdpos(i), " count: ", info.stored_repeat.get_marker_counter(i));

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -48,6 +48,9 @@ public:
   static void add_marker(const uint32_t sdpos, const uint16_t count);
   static void loop();
   static void cancel();
+  static uint8_t get_index() { return index; }
+  static uint8_t get_marker_sdpos(uint8_t i) { return marker[i].sdpos; }
+  static uint8_t get_marker_counter(uint8_t i) { return marker[i].counter; }
 };
 
 extern Repeat repeat;

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -49,8 +49,8 @@ public:
   static void loop();
   static void cancel();
   static uint8_t get_index() { return index; }
-  static uint8_t get_marker_sdpos(uint8_t i) { return marker[i].sdpos; }
-  static uint8_t get_marker_counter(uint8_t i) { return marker[i].counter; }
+  static int16_t get_marker_counter(uint8_t i) { return marker[i].counter; }
+  static uint32_t get_marker_sdpos(uint8_t i) { return marker[i].sdpos; }
 };
 
 extern Repeat repeat;

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -49,8 +49,8 @@ public:
   static void loop();
   static void cancel();
   static uint8_t get_index() { return index; }
-  static int16_t get_marker_counter(uint8_t i) { return marker[i].counter; }
-  static uint32_t get_marker_sdpos(uint8_t i) { return marker[i].sdpos; }
+  static int16_t get_marker_counter(const uint8_t i) { return marker[i].counter; }
+  static uint32_t get_marker_sdpos(const uint8_t i) { return marker[i].sdpos; }
 };
 
 extern Repeat repeat;

--- a/Marlin/src/feature/repeat.h
+++ b/Marlin/src/feature/repeat.h
@@ -48,7 +48,7 @@ public:
   static void add_marker(const uint32_t sdpos, const uint16_t count);
   static void loop();
   static void cancel();
-  static uint8_t get_index() { return index; }
+  static uint8_t count() { return index; }
   static int16_t get_marker_counter(const uint8_t i) { return marker[i].counter; }
   static uint32_t get_marker_sdpos(const uint8_t i) { return marker[i].sdpos; }
 };


### PR DESCRIPTION
### Description

#define GCODE_REPEAT_MARKERS 
with
#define DEBUG_POWER_LOSS_RECOVERY

Fails to compile as DEBUG_POWER_LOSS_RECOVERY attempts to display private variables in class Repeat

Added get functions to return the private variables

### Requirements

In Config enable
#define SDSUPPORT
#define POWER_LOSS_RECOVERY
#define GCODE_REPEAT_MARKERS            // Enable G-code M808 to set repeat markers and do looping
  
In powerloss.h enable
#define DEBUG_POWER_LOSS_RECOVERY

### Benefits

Builds as expected

### Configurations
See Requirements

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/26357