### PR TITLE
Follow up to "📝 Community Reporting"

### DIFF
--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -30,7 +30,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing [marlin-firmware@thinkyhead.com](mailto:marlin-firmware@thinkyhead.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by following GitHub's [reporting abuse or spam article](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 
 ## Attribution
 

--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -30,7 +30,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by messaging @MarlinFirmware/moderators on the relevant issue, [or privately](//github.com/orgs/MarlinFirmware/teams/moderators). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing [marlin-firmware@thinkyhead.com](mailto:marlin-firmware@thinkyhead.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 
 ## Attribution
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -26,7 +26,7 @@ The following is a set of guidelines for contributing to Marlin, hosted by the [
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Marlin Code of Conduct](code_of_conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by messaging @MarlinFirmware/moderators on the relevant issue, [or privately](//github.com/orgs/MarlinFirmware/teams/moderators).
+This project and everyone participating in it is governed by the [Marlin Code of Conduct](code_of_conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by emailing [marlin-firmware@thinkyhead.com](mailto:marlin-firmware@thinkyhead.com).
 
 ## I don't want to read this whole thing I just have a question!!!
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -30,7 +30,8 @@ This project and everyone participating in it is governed by the [Marlin Code of
 
 ## I don't want to read this whole thing I just have a question!!!
 
-> **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
+> [!NOTE]
+> Please don't file an issue to ask a question. You'll get faster results by using the resources below.
 
 We have a Message Board and a Facebook group where our knowledgable user community can provide helpful advice if you have questions.
 
@@ -55,7 +56,8 @@ This section guides you through submitting a Bug Report for Marlin. Following th
 
 Before creating a Bug Report, please test the "nightly" development branch, as you might find out that you don't need to create one. When you are creating a Bug Report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE/bug_report.yml), the information it asks for helps us resolve issues faster.
 
-> **Note:** Regressions can happen. If you find a **Closed** issue that seems like your issue, go ahead and open a new issue and include a link to the original issue in the body of your new one. All you need to create a link is the issue number, preceded by #. For example, #8888.
+> [!NOTE]
+> Regressions can happen. If you find a **Closed** issue that seems like your issue, go ahead and open a new issue and include a link to the original issue in the body of your new one. All you need to create a link is the issue number, preceded by #. For example, #8888.
 
 #### How Do I Submit A (Good) Bug Report?
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -26,7 +26,7 @@ The following is a set of guidelines for contributing to Marlin, hosted by the [
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Marlin Code of Conduct](code_of_conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by emailing [marlin-firmware@thinkyhead.com](mailto:marlin-firmware@thinkyhead.com).
+This project and everyone participating in it is governed by the [Marlin Code of Conduct](code_of_conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by following GitHub's [reporting abuse or spam article](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).
 
 ## I don't want to read this whole thing I just have a question!!!
 


### PR DESCRIPTION
### Description

Follow up to "📝 Community Reporting" / 45a6e96.

You can't "message" users on GitHub and Organization Teams are not visible outside of the org, so I've replaced that text with the email address listed on the [main MarlinFirmware org page](https://github.com/MarlinFirmware).

### Benefits

Users will be able to report unacceptable behavior.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26285
- 45a6e96
