### PR TITLE
couple fixes for `POSTMORTEM_DEBUGGING` 

### DIFF
--- a/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
@@ -55,16 +55,12 @@ static const char *UnwTabGetFunctionName(const UnwindCallbacks *cb, uint32_t add
     return nullptr;
 
   if ((flag_word & 0xFF000000) == 0xFF000000) {
-    uint32_t fn_name_addr = address - 4 - (flag_word & 0x00FFFFFF);
+    const uint32_t fn_name_addr = address - 4 - (flag_word & 0x00FFFFFF);
 
-    // ensure the address is readable to avoid returning a bogus pointer
+    // Ensure the address is readable to avoid returning a bogus pointer
     uint8_t dummy = 0;
-    if(!cb->readB(fn_name_addr, &dummy))
-    {
-      return nullptr;
-    }
-
-    return (const char *)fn_name_addr;
+    if (cb->readB(fn_name_addr, &dummy))
+      return (const char *)fn_name_addr;
   }
   return nullptr;
 }

--- a/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
@@ -55,7 +55,16 @@ static const char *UnwTabGetFunctionName(const UnwindCallbacks *cb, uint32_t add
     return nullptr;
 
   if ((flag_word & 0xFF000000) == 0xFF000000) {
-    return (const char *)(address - 4 - (flag_word & 0x00FFFFFF));
+    uint32_t fn_name_addr = address - 4 - (flag_word & 0x00FFFFFF);
+
+    // ensure the address is readable to avoid returning a bogus pointer
+    uint8_t dummy = 0;
+    if(!cb->readB(fn_name_addr, &dummy))
+    {
+      return nullptr;
+    }
+
+    return (const char *)fn_name_addr;
   }
   return nullptr;
 }

--- a/Marlin/src/HAL/shared/cpu_exception/exception_arm.cpp
+++ b/Marlin/src/HAL/shared/cpu_exception/exception_arm.cpp
@@ -279,8 +279,6 @@ void CommonHandler_C(ContextStateFrame * frame, unsigned long lr, unsigned long 
   if (!faulted_from_exception) { // Not sure about the non_usage_fault, we want to try anyway, don't we ? && !non_usage_fault_occurred)
     // Try to resume to our handler here
     CFSR |= CFSR; // The ARM programmer manual says you must write to 1 all fault bits to clear them so this instruction is correct
-    // The frame will not be valid when returning anymore, let's clean it
-    savedFrame.CFSR = 0;
 
     frame->pc = (uint32_t)resume_from_fault; // Patch where to return to
     frame->lr = 0xDEADBEEF;  // If our handler returns (it shouldn't), let's make it trigger an exception immediately


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR fixes two issues i've noticed while working on `POSTMORTEM_DEBUGGING` for [HC32](https://github.com/shadow578/Marlin-H32/). I believe that these issues affect other ARM Cortex Mx boards as well, thus this PR.


1. In some circumstances, the `UnwTabGetFunctionName` would return a pointer pointing outside of the valid memory range, causing a fault when trying to print the function name in `UnwReportOut`. This PR adds a check to verify that the address calculated for the function name pointer is actually readable.


2. While the common fault handler (`CommonHandler_C`) does capture the [CFSR](https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/system-control-block/configurable-fault-status-register?lang=en) register, the captured value is cleared when not `faulted_from_exception`. I cannot see why this would be needed or useful, as all it does is hide details on the cause of the fault (e.g. divide by zero, ...).


<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

- any ARM Cortex M Board
- `POSTMORTEM_DEBUGGING` enabled

### Benefits

<!-- What does this PR fix or improve? -->

1. fixes a potential crash inside the fault handler
2. adds additional information to fault logs emmitted by `POSTMOTEM_DEBUGGING`

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

nothing special needed in configs


<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
