### PR TITLE
🩹 Fix runout state in menu

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -250,6 +250,12 @@ static FSTR_P pause_header() {
 }while(0)
 
 void menu_pause_option() {
+  #if HAS_FILAMENT_SENSOR
+    const bool still_out = runout.filament_ran_out;
+  #else
+    constexpr bool still_out = false;
+  #endif
+
   START_MENU();
   #if LCD_HEIGHT > 2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_OPTION_HEADER);
@@ -257,11 +263,8 @@ void menu_pause_option() {
   ACTION_ITEM(MSG_FILAMENT_CHANGE_OPTION_PURGE, []{ pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE; });
 
   #if HAS_FILAMENT_SENSOR
-    const bool still_out = runout.filament_ran_out;
     if (still_out)
       EDIT_ITEM(bool, MSG_RUNOUT_SENSOR, &runout.enabled, runout.reset);
-  #else
-    constexpr bool still_out = false;
   #endif
 
   if (!still_out)


### PR DESCRIPTION
Get the `runout.filament_ran_out` state outside the menu loop to hopefully fix #26386.