### PR TITLE
move i2c pin setup for U8GLIB_I2C_OLED

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -218,6 +218,10 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 
 void MarlinUI::init() {
 
+  #if HAS_U8GLIB_I2C_OLED && PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
+    Wire.begin(uint8_t(I2C_SDA_PIN), uint8_t(I2C_SCL_PIN));
+  #endif
+
   init_lcd();
 
   #if HAS_DIGITAL_BUTTONS
@@ -272,10 +276,6 @@ void MarlinUI::init() {
 
   #if ALL(HAS_ENCODER_ACTION, HAS_SLOW_BUTTONS)
     slow_buttons = 0;
-  #endif
-
-  #if HAS_U8GLIB_I2C_OLED && PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
-    Wire.begin(int(I2C_SDA_PIN), int(I2C_SCL_PIN));
   #endif
 
   update_buttons();


### PR DESCRIPTION
### Description

When using I2C_SDA_PIN and I2C_SCL_PIN the pins should be setup before the lcd is initiated, or the init sequence is sent to the wrong I2C ports 
 
### Requirements

HAS_U8GLIB_I2C_OLED, I2C_SCL_PIN and  I2C_SDA_PIN
 
### Benefits

I2C display works as expected

### Configurations

An example

#define MOTHERBOARD BOARD_CREALITY_V4
#define I2C_SCL_PIN PB10
#define I2C_SDA_PIN PB11
#define SERIAL_PORT 1
#define U8GLIB_SSD1306
#define FAN_SOFT_PWM

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26389