### PR TITLE
Cleanup pins_BTT_SKR_MINI_E3_common.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -114,15 +114,15 @@
 #define USB_CONNECT_INVERTING              false
 
 /**
- *         SKR Mini E3 V1.0, V1.2
- *                 ------
- * (BEEPER)  PB5  | 1  2 | PB6 (BTN_ENC)
- * (BTN_EN1) PA9  | 3  4 | RESET
- * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
- * (LCD_RS)  PB8  | 7  8 | PB7  (LCD_EN)
- *            GND | 9 10 | 5V
- *                 ------
- *                  EXP1
+ *         SKR Mini E3 V1.0, V1.2                    SKR Mini E3 V2.0
+ *                 ------                                  ------
+ * (BEEPER)  PB5  | 1  2 | PB6 (BTN_ENC)   (BEEPER)  PB5  | 1  2 | PA15 (BTN_ENC)
+ * (BTN_EN1) PA9  | 3  4 | RESET           (BTN_EN1) PA9  | 3  4 | RESET
+ * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)   (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
+ * (LCD_RS)  PB8  | 7  8 | PB7  (LCD_EN)   (LCD_RS)  PB8  | 7  8 | PB15 (LCD_EN)
+ *            GND | 9 10 | 5V                         GND | 9 10 | 5V
+ *                 ------                                  ------
+ *                  EXP1                                    EXP1
  */
 #ifndef EXP1_02_PIN
   #define EXP1_02_PIN                       PB6
@@ -242,15 +242,15 @@
       /**
        * TFTGLCD_PANEL_SPI display pinout
        *
-       *                   Board                        Display
-       *                   ------                        ------
-       * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)      5V |10  9 | GND
-       * (MOD_RESET) PA9  | 3  4 | RESET             -- | 8  7 | (SD_DET)
-       * (SD_CS)     PA10   5  6 | PB9          (MOSI)  | 6  5 | --
-       * (LCD_CS)    PB8  | 7  8 | PB7          (SD_CS) | 4  3 | (LCD_CS)
-       *              GND | 9 10 | 5V           (SCK)   | 2  1 | (MISO)
-       *                   ------                        ------
-       *                    EXP1                          EXP1
+       *                   Board                                   Display
+       *                   ------                                  ------
+       * (SD_DET)    PB5  | 1  2 | PB6 or PA15   (BEEPER)      5V |10  9 | GND
+       * (MOD_RESET) PA9  | 3  4 | RESET                       -- | 8  7 | (SD_DET)
+       * (SD_CS)     PA10   5  6 | PB9                    (MOSI)  | 6  5 | --
+       * (LCD_CS)    PB8  | 7  8 | PB7 or PB15            (SD_CS) | 4  3 | (LCD_CS)
+       *              GND | 9 10 | 5V                     (SCK)   | 2  1 | (MISO)
+       *                   ------                                  ------
+       *                    EXP1                                    EXP1
        *
        * Needs custom cable:
        *
@@ -281,24 +281,24 @@
     /**
      * FYSETC_MINI_12864_2_1 / MKS_MINI_12864_V3 / BTT_MINI_12864 display pinout
      *
-     *       Board                      Display
-     *       ------                     ------
-     * PB5  | 1  2 | PA15       (BEEP) |10  9 | BTN_ENC
-     * PA9  | 3  4 | RESET      LCD_CS | 8  7 | LCD A0
-     * PA10 | 5  6 | PB9       LCD_RST | 6  5 | RED
-     * PB8  | 7  8 | PB15      (GREEN) | 4  3 | (BLUE)
-     * GND  | 9 10 | 5V            GND | 2  1 | 5V
-     *       ------                     ------
-     *        EXP1                       EXP1
+     *       Board                         Display
+     *       ------                        ------
+     * PB5  | 1  2 | PB6 or PA15   (BEEP) |10  9 | BTN_ENC
+     * PA9  | 3  4 | RESET         LCD_CS | 8  7 | LCD A0
+     * PA10 | 5  6 | PB9          LCD_RST | 6  5 | RED
+     * PB8  | 7  8 | PB7 or PB15  (GREEN) | 4  3 | (BLUE)
+     * GND  | 9 10 | 5V               GND | 2  1 | 5V
+     *       ------                        ------
+     *        EXP1                          EXP1
      *
-     *            ---                   ------
-     *       RST | 1 |          (MISO) |10  9 | SCK
-     * (RX2) PA3 | 2 |         BTN_EN1 | 8  7 | (SS)
-     * (TX2) PA2 | 3 |         BTN_EN2 | 6  5 | MOSI
-     *       GND | 4 |            (CD) | 4  3 | (RST)
-     *        5V | 5 |           (GND) | 2  1 | (KILL)
-     *            ---                   ------
-     *            TFT                    EXP2
+     *            ---                       ------
+     *       RST | 1 |             (MISO) |10  9 | SCK
+     * (RX2) PA3 | 2 |            BTN_EN1 | 8  7 | (SS)
+     * (TX2) PA2 | 3 |            BTN_EN2 | 6  5 | MOSI
+     *       GND | 4 |               (CD) | 4  3 | (RST)
+     *        5V | 5 |              (GND) | 2  1 | (KILL)
+     *            ---                      ------
+     *            TFT                       EXP2
      *
      * Needs custom cable:
      *
@@ -330,9 +330,9 @@
     #define DOGLCD_SCK                      PA2
     #define DOGLCD_MOSI                     PA3
 
-    #define BTN_ENC                         PA15
+    #define BTN_ENC                  EXP1_02_PIN
     #define BTN_EN1                  EXP1_06_PIN
-    #define BTN_EN2                         PB15
+    #define BTN_EN2                  EXP1_08_PIN
 
     #define FORCE_SOFT_SPI
 
@@ -351,15 +351,15 @@
   /**
    * FYSETC TFT TFT81050 display pinout
    *
-   *                   Board                            Display
-   *                   ------                           ------
-   * (SD_DET)    PB5  | 1  2 | PB6 (BEEPER)         5V |10  9 | GND
-   * (MOD_RESET) PA9  | 3  4 | RESET           (RESET) | 8  7 | (SD_DET)
-   * (SD_CS)     PA10   5  6 | PB9             (MOSI)  | 6  5 | (LCD_CS)
-   * (LCD_CS)    PB8  | 7  8 | PB7             (SD_CS) | 4  3 | (MOD_RESET)
-   *              GND | 9 10 | 5V              (SCK)   | 2  1 | (MISO)
-   *                   ------                           ------
-   *                    EXP1                             EXP1
+   *                   Board                                   Display
+   *                   ------                                  ------
+   * (SD_DET)    PB5  | 1  2 | PB6 or PA15 (BEEPER)        5V |10  9 | GND
+   * (MOD_RESET) PA9  | 3  4 | RESET                  (RESET) | 8  7 | (SD_DET)
+   * (SD_CS)     PA10   5  6 | PB9                    (MOSI)  | 6  5 | (LCD_CS)
+   * (LCD_CS)    PB8  | 7  8 | PB7 or PB15            (SD_CS) | 4  3 | (MOD_RESET)
+   *              GND | 9 10 | 5V                     (SCK)   | 2  1 | (MISO)
+   *                   ------                                  ------
+   *                    EXP1                                    EXP1
    *
    * Needs custom cable:
    *

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -244,7 +244,7 @@
        *
        *                   Board                                   Display
        *                   ------                                  ------
-       * (SD_DET)    PB5  | 1  2 | PB6 or PA15   (BEEPER)      5V |10  9 | GND
+       * (SD_DET)    PB5  | 1  2 | PB6 or PA15 (BEEPER)        5V |10  9 | GND
        * (MOD_RESET) PA9  | 3  4 | RESET                       -- | 8  7 | (SD_DET)
        * (SD_CS)     PA10   5  6 | PB9                    (MOSI)  | 6  5 | --
        * (LCD_CS)    PB8  | 7  8 | PB7 or PB15            (SD_CS) | 4  3 | (LCD_CS)


### PR DESCRIPTION
### Description

pins_BTT_SKR_MINI_E3_common.h is for SKR Mini E3 V1.0, V1.2 and  SKR Mini E3 V2.0

But the EXP1_02_PIN  and EXP1_08_PIN are different on the V2.0

Updated the pin documentation in this file to reflect this.  

Updated FYSETC_MINI_12864_2_1 pins to use correct IO pins depending on the Version of the board used.

### Benefits

Documentation is more accurate
FYSETC_MINI_12864_2_1 now works V1.0 and V1.2 boards  

