### PR TITLE
Fix DOGM centered menu items

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -423,7 +423,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     int8_t vlen = vstr ? utf8_strlen(vstr) : 0;
 
     bool mv_colon = false;
-    if (vlen) {
+    if (vlen && !center) {
       // Move the leading colon from the value to the label below
       mv_colon = (*vstr == ':');
       // Shorter value, wider label


### PR DESCRIPTION
### Description

Fixes DOGM centered menu items loosing their ": " between the variable and its value.

![whatitlookslike](https://user-images.githubusercontent.com/13375512/282240928-b22d8175-ca65-4785-b852-3c1ad6449fbc.png)

Since https://github.com/MarlinFirmware/Marlin/commit/797ea5efa741ef96827870bb44b48fac7a41f1a0

### Requirements

128x64 display,    anything using PSTRING_ITEM with SS_CENTER set, as found in LCD_INFO_MENU
 
### Benefits

Centered menus items display correctly

### Configurations

#define MOTHERBOARD BOARD_SIMULATED
#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
#define LCD_INFO_MENU

### Related Issues

Issue #26413