### PR TITLE
Fix PINS_DEBUGGING for some STM32H7 boards

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_H723VG/variant_MARLIN_STM32H723VG.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H723VG/variant_MARLIN_STM32H723VG.h
@@ -161,6 +161,7 @@
 #define NUM_DIGITAL_PINS        82
 #define NUM_DUALPAD_PINS        2
 #define NUM_ANALOG_INPUTS       16
+#define NUM_ANALOG_FIRST        PA0
 
 // On-board LED pin number
 #ifndef LED_BUILTIN

--- a/buildroot/share/PlatformIO/variants/MARLIN_H723ZE/variant_MARLIN_STM32H723ZE.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H723ZE/variant_MARLIN_STM32H723ZE.h
@@ -200,6 +200,7 @@
 #define NUM_DIGITAL_PINS        114
 #define NUM_DUALPAD_PINS        2
 #define NUM_ANALOG_INPUTS       28
+#define NUM_ANALOG_FIRST        PA0
 
 // On-board LED pin number
 #ifndef LED_BUILTIN

--- a/buildroot/share/PlatformIO/variants/MARLIN_H743VI/variant_MARLIN_STM32H743VI.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H743VI/variant_MARLIN_STM32H743VI.h
@@ -160,6 +160,7 @@
 #define NUM_DIGITAL_PINS        82
 #define NUM_DUALPAD_PINS        2
 #define NUM_ANALOG_INPUTS       16
+#define NUM_ANALOG_FIRST        PA0
 
 // On-board LED pin number
 #ifndef LED_BUILTIN


### PR DESCRIPTION
### Description

Fix `PINS_DEBUGGING` for some STM32H7 boards

### Benefits

`PINS_DEBUGGING` will compile on related STM32H7 boards.
