### PR TITLE
✨ RLE Custom Bootscreen

### DIFF
--- a/buildroot/share/scripts/rle16_compress_cpp_image_data.py
+++ b/buildroot/share/scripts/rle16_compress_cpp_image_data.py
@@ -131,7 +131,7 @@ def addCompressedData(input_file, output_file):
 
 if len(sys.argv) <= 2:
     print("Utility to compress Marlin RGB565 TFT data to RLE16 format.")
-    print("Reads a Marlin RGB565 cpp file and generate a new file with the additional RLE16 data.")
+    print("Reads a Marlin RGB565 cpp file and generates a new file with the additional RLE16 data.")
     print("Usage: rle16_compress_cpp_image_data.py INPUT_FILE.cpp OUTPUT_FILE.cpp")
     exit(1)
 

--- a/buildroot/share/scripts/rle_compress_bitmap.py
+++ b/buildroot/share/scripts/rle_compress_bitmap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# RLE compress a Marlin mono DOGM bitmap.
+# Bitwise RLE compress a Marlin mono DOGM bitmap.
 # Input: An existing Marlin Marlin mono DOGM bitmap .cpp or .h file.
 # Output: A new file with the original and compressed data.
 #
@@ -12,23 +12,21 @@ import re
 def addCompressedData(input_file, output_file):
     ofile = open(output_file, 'wt')
 
-    c_data_section = False
-    c_skip_data = False
-    c_footer = False
     datatype = "uint8_t"
     bytewidth = 16
     raw_data = []
-    rle_value = []
-    rle_count = []
     arrname = ''
 
-    line = input_file.readline()
-    while line:
+    c_data_section = False ; c_skip_data = False ; c_footer = False
+    while True:
+        line = input_file.readline()
+        if not line: break
+
         if not c_footer:
             if not c_skip_data: ofile.write(line)
 
-        mat = re.match(r'CUSTOM_BOOTSCREEN_BMPWIDTH\s+(\d+)', line)
-        if mat: bytewidth = int(mat[1]) / 16
+        mat = re.match(r'.+CUSTOM_BOOTSCREEN_BMPWIDTH\s+(\d+)', line)
+        if mat: bytewidth = (int(mat[1]) + 7) // 8
 
         if "};" in line:
             c_skip_data = False
@@ -58,82 +56,118 @@ def addCompressedData(input_file, output_file):
                 arrname = line.split('[')[0].split(' ')[-1]
                 print("Found data array", arrname)
 
-        line = input_file.readline()
-
     input_file.close()
 
+    #print("\nRaw Bitmap Data", raw_data)
+
     #
-    # RLE (run length) encoding
-    # Convert data from raw mono bitmap to a simple run-length-encoded format.
-    # - Each sequence begins with a count byte N.
-    #   - If the high bit is set in N the run contains N & 0x7F + 1 unique bytes.
-    #   - Otherwise it repeats the following byte N + 1 times.
+    # Bitwise RLE (run length) encoding
+    # Convert data from raw mono bitmap to a bitwise run-length-encoded format.
+    # - The first nybble is the starting bit state. Changing this nybble inverts the bitmap.
+    # - The following bytes provide the runs for alternating on/off bits.
+    #   - A value of 0-14 encodes a run of 1-15.
+    #   - A value of 16 indicates a run of 16-270 calculated using the next two bytes.
     #
-    def rle_encode(data):
+    def bitwise_rle_encode(data):
         warn = "This may take a while" if len(data) > 300000 else ""
         print("Compressing image data...", warn)
-        rledata = []
-        distinct = []
+
+        def get_bit(data, n): return 1 if (data[n // 8] & (0x80 >> (n & 7))) else 0
+
+        bitslen = len(data) * 8
+        bitstate = get_bit(data, 0)
+        rledata = [ bitstate ]
+
         i = 0
-        while i < len(data):
-            v = data[i]
+        runlen = -1
+        while i <= bitslen:
+            if i < bitslen: b = get_bit(data, i)
+            runlen += 1
+            if bitstate != b or i == bitslen:
+                if i > 11 * 56 * 8: print(f'Bit change at index {i} with runlen={runlen}')
+                if runlen >= 16:
+                    rledata += [ 15, runlen // 16 - 1, runlen % 16 ]
+                    if i > 11 * 56 * 8: print(f'Storing {[ 15, runlen // 16 - 1, runlen % 16 ]}')
+                else:
+                    rledata += [ runlen - 1 ]
+                    if i > 11 * 56 * 8: print(f'Storing {[ runlen ]}')
+                bitstate ^= 1
+                runlen = 0
             i += 1
-            rsize = 1
-            for j in range(i, len(data)):
-                if v != data[j]: break
-                i += 1
-                rsize += 1
-                if rsize >= 128: break
 
-            # If the run is one, add to the distinct values
-            if rsize == 1: distinct.append(v)
+        print("\nrledata", rledata)
 
-            # If distinct length >= 127, or the repeat run is 2 or more,
-            # store the distinct run.
-            nr = len(distinct)
-            if nr and (nr >= 128 or rsize > 1 or i >= len(data)):
-                rledata += [(nr - 1) | 0x80] + distinct
-                distinct = []
+        encoded = []
+        ri = 0
+        rlen = len(rledata)
+        while ri < rlen:
+            v = rledata[ri] << 4
+            if (ri < rlen - 1): v |= rledata[ri + 1]
+            encoded += [ v ]
+            ri += 2
 
-            # If the repeat run is 2 or more, store the repeat run.
-            if rsize > 1: rledata += [rsize - 1, v]
+        print("\nencoded", encoded)
+        return encoded
 
-        return rledata
+    def bitwise_rle_decode(rledata, invert=0):
+        expanded = []
+        for n in rledata: expanded += [ n >> 4, n & 0xF ]
 
-    def append_byte(data, byte, cols=bytewidth):
-        if data == '': data = '  '
-        data += ('0x{0:02X}, '.format(byte)) # 6 characters
-        if len(data) % (cols * 6 + 2) == 0: data = data.rstrip() + "\n  "
-        return data
+        decoded = []
+        bitstate = 0 ; workbyte = 0 ; outindex = 0
+        i = 0
+        while i < len(expanded):
+            c = expanded[i]
+            i += 1
+
+            if i == 1: bitstate = c ; continue
+
+            if c == 15:
+                c = 16 * expanded[i] + expanded[i + 1] + 15
+                i += 2
+
+            for _ in range(c, -1, -1):
+                bitval = 0x80 >> (outindex & 7)
+                if bitstate: workbyte |= bitval
+                if bitval == 1:
+                    decoded += [ workbyte ]
+                    workbyte = 0
+                outindex += 1
+
+            bitstate ^= 1
+
+        print("\nDecoded RLE data:")
+        pretty = [ '{0:08b}'.format(v) for v in decoded ]
+        rows = [pretty[i:i+bytewidth] for i in range(0, len(pretty), bytewidth)]
+        for row in rows: print(f"{''.join(row)}")
+
+        return decoded
 
     def rle_emit(ofile, arrname, rledata, rawsize):
-        i = 0
-        outstr = ''
-        size = 0
-        while i < len(rledata):
-            rval = rledata[i]
-            i += 1
-            if rval & 0x80:
-                count = (rval & 0x7F) + 1
-                outstr = append_byte(outstr, rval)
-                size += 1
-                for j in range(count):
-                    outstr = append_byte(outstr, rledata[i + j])
-                    size += 1
-                i += count
-            else:
-                outstr = append_byte(outstr, rval)
-                outstr = append_byte(outstr, rledata[i])
-                i += 1
-                size += 2
 
-        outstr = outstr.rstrip()[:-1]
+        outstr = ''
+        rows = [ rledata[i:i+16] for i in range(0, len(rledata), 16) ]
+        for i in range(0, len(rows)):
+            rows[i] = [ '0x{0:02X}'.format(v) for v in rows[i] ]
+            outstr += f"  {', '.join(rows[i])},\n"
+
+        outstr = outstr[:-2]
+        size = len(rledata)
         ofile.write("\n// Saves %i bytes\n%s %s_rle[%d] PROGMEM = {\n%s\n};\n" % (rawsize - size, datatype, arrname, size, outstr))
 
     # Encode the data, write it out, close the file
-    rledata = rle_encode(raw_data)
+    rledata = bitwise_rle_encode(raw_data)
     rle_emit(ofile, arrname, rledata, len(raw_data))
     ofile.close()
+
+    # Validate that code properly compressed (and decompressed) the data
+    checkdata = bitwise_rle_decode(rledata)
+    badindex = -1
+    for i in range(0, len(checkdata)):
+        if raw_data[i] != checkdata[i]:
+            badindex = i
+            break
+    if badindex >= 0: print(f'Data mismatch at byte {badindex}')
 
 if len(sys.argv) <= 2:
     print('Usage: rle_compress_bitmap.py INPUT_FILE OUTPUT_FILE')
@@ -141,6 +175,9 @@ if len(sys.argv) <= 2:
 
 output_cpp = sys.argv[2]
 inname = sys.argv[1].replace('//', '/')
-input_cpp = open(inname)
-print("Processing", inname, "...")
-addCompressedData(input_cpp, output_cpp)
+try:
+    input_cpp = open(inname)
+    print("Processing", inname, "...")
+    addCompressedData(input_cpp, output_cpp)
+except OSError:
+    print("Can't find input file", inname)


### PR DESCRIPTION
Base Marlin code size has outgrown Melzi in some cases. Melzi that have 16K SRAM can use a compressed bootscreen to trade more SRAM usage for less flash usage. This PR includes a script to RLE compress a DOGM bitmap and additional code to decompress and draw.