### PR TITLE
Follow up to "🔨 Specific package versions (#26265)"

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -118,6 +118,7 @@ jobs:
 
         # STM32H7
         - BTT_SKR_SE_BX
+        - STM32H743VI_btt
 
         # STM32F1 (Maple)
         - jgaurora_a5s_a1_maple

--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -31,13 +31,11 @@ if pioutil.is_pio_build():
         }
         platform_name = framewords[platform.__class__.__name__]
     else:
-        uri = PackageSpec(platform_packages[0]).uri
-        if uri is None:
-            uri = []
-        if '@' in uri:
-            platform_name = re.sub(r'@.+', '' , uri)
+        spec = PackageSpec(platform_packages[0])
+        if spec.uri and '@' in spec.uri:
+            platform_name = re.sub(r'@.+', '', spec.uri)
         else:
-            platform_name = PackageSpec(platform_packages[0]).name
+            platform_name = spec.name
 
     FRAMEWORK_DIR = Path(platform.get_package_dir(platform_name))
     assert FRAMEWORK_DIR.is_dir()

--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -32,6 +32,8 @@ if pioutil.is_pio_build():
         platform_name = framewords[platform.__class__.__name__]
     else:
         uri = PackageSpec(platform_packages[0]).uri
+        if uri is None:
+            uri = []
         if '@' in uri:
             platform_name = re.sub(r'@.+', '' , uri)
         else:

--- a/buildroot/tests/STM32H743VI_btt
+++ b/buildroot/tests/STM32H743VI_btt
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Build tests for STM32H743VI_btt
+# Ender-5 Plus with SKR V3.0 (STM32H7)
+#
+
+# exit on first failure
+set -e
+
+#
+# Build with the default configurations
+#
+use_example_configs "Creality/Ender-5 Plus/BigTreeTech SKR 3"
+exec_test $1 $2 "Creality Ender-5 Plus with BigTreeTech SKR 3" "$3"
+
+# clean up
+restore_configs


### PR DESCRIPTION
### Description

#26265 broke compiling on SKR 3:

<details><summary>error:</summary>
<p>

```prolog
TypeError: argument of type 'NoneType' is not iterable:
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/platformio/builder/main.py", line 167:
    env.SConscript(env.GetExtraScripts("pre"), exports="env")
  File "/home/runner/.platformio/packages/tool-scons/scons-local-4.5.2/SCons/Script/SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/runner/.platformio/packages/tool-scons/scons-local-4.5.2/SCons/Script/SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/buildroot/share/PlatformIO/scripts/generic_create_variant.py", line 35:
    if '@' in uri:
========================= [FAILED] Took 47.90 seconds =========================

Environment      Status    Duration
---------------  --------  ------------
STM32H743VI_btt  FAILED    00:00:47.900
==================== 1 failed, 0 succeeded in 00:00:47.900 ====================
```

</p>
</details>

Thanks @ellensp for the fix!

### Requirements

SKR 3/EZ

### Benefits

Users can now compile for these boards.

### Configurations

Any SKR 3 config / [Creality/Ender-5 Plus/BigTreeTech SKR 3](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-5%20Plus/BigTreeTech%20SKR%203)

### Related Issues

- #26420
- #26265
