### PR TITLE
Remove `;` from buildroot/scripts** .py files

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/file2cpp.py
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/file2cpp.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
   parser.add_argument("-d", "--deflate", action="store_true", help="Packs the data using the deflate algorithm")
   args = parser.parse_args()
 
-  varname = os.path.splitext(os.path.basename(args.input))[0];
+  varname = os.path.splitext(os.path.basename(args.input))[0]
 
   with open(args.input, "rb") as in_file:
     data = in_file.read()

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/font2cpp.py
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/font2cpp.py
@@ -77,7 +77,7 @@ class WriteSource:
     if len(self.values):
       self.blocks.append(self.values)
 
-    block_strs = [];
+    block_strs = []
     for b in self.blocks:
       data = self.convert_to_4bpp(b)
       data = ', '.join(data)

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/img2cpp.py
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/img2cpp.py
@@ -44,12 +44,12 @@ class WriteSource:
 
   def append_rgb565(self, color):
     value = ((color[0] & 0xF8) << 8) + ((color[1] & 0xFC) << 3) + ((color[2] & 0xF8) >> 3)
-    self.values.append((value & 0x00FF) >> 0);
-    self.values.append((value & 0xFF00) >> 8);
+    self.values.append((value & 0x00FF) >> 0)
+    self.values.append((value & 0xFF00) >> 8)
 
   def append_rgb332(self, color):
     value = (color[0] & 0xE0) + ((color[1] & 0xE0) >> 3) + ((color[2] & 0xC0) >> 6)
-    self.values.append(value);
+    self.values.append(value)
 
   def append_grayscale(self, color, bits):
     luminance = int(0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2])
@@ -99,7 +99,7 @@ if __name__ == "__main__":
   parser.add_argument("-m", "--mode", default="l1", help="Mode, can be l1, l2, l4, l8, rgb332 or rgb565")
   args = parser.parse_args()
 
-  varname = os.path.splitext(os.path.basename(args.input))[0];
+  varname = os.path.splitext(os.path.basename(args.input))[0]
 
   writer = WriteSource(args.mode)
 

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -9,7 +9,7 @@ if pioutil.is_pio_build():
     board = marlin.env.BoardConfig()
 
     def calculate_crc(contents, seed):
-        accumulating_xor_value = seed;
+        accumulating_xor_value = seed
 
         for i in range(0, len(contents), 4):
             value = struct.unpack('<I', contents[ i : i + 4])[0]
@@ -68,7 +68,7 @@ if pioutil.is_pio_build():
         uid_value = uuid.uuid4()
         file_key = int(uid_value.hex[0:8], 16)
 
-        xor_crc = 0xEF3D4323;
+        xor_crc = 0xEF3D4323
 
         # the input file is exepcted to be in chunks of 0x800
         # so round the size
@@ -123,4 +123,4 @@ if pioutil.is_pio_build():
         fwpath.unlink()
 
     marlin.relocate_firmware("0x08008800")
-    marlin.add_post_action(encrypt);
+    marlin.add_post_action(encrypt)

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -194,7 +194,7 @@ def apply_config_ini(cp):
             cp2 = configparser.ConfigParser()
             cp2.read(config_path(ckey))
             apply_sections(cp2, sect)
-            ckey = 'base';
+            ckey = 'base'
 
         # (Allow 'example/' as a shortcut for 'examples/')
         elif ckey.startswith('example/'):

--- a/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+++ b/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
@@ -23,7 +23,7 @@ if pioutil.is_pio_build():
 
             assert isfile(original_file) and isfile(src_file)
             shutil.copyfile(original_file, backup_file)
-            shutil.copyfile(src_file, original_file);
+            shutil.copyfile(src_file, original_file)
 
             def _touch(path):
                 with open(path, "w") as fp:

--- a/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
@@ -32,4 +32,4 @@ if pioutil.is_pio_build():
         fw_path.rename(fws_path)
 
     import marlin
-    marlin.add_post_action(addboot);
+    marlin.add_post_action(addboot)

--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -70,4 +70,4 @@ def encrypt_mks(source, target, env, new_name):
         fwpath.unlink()
 
 def add_post_action(action):
-    env.AddPostAction(str(Path("$BUILD_DIR", "${PROGNAME}.bin")), action);
+    env.AddPostAction(str(Path("$BUILD_DIR", "${PROGNAME}.bin")), action)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -90,7 +90,7 @@ if pioutil.is_pio_build():
         # Find the name.cpp.o or name.o and remove it
         #
         def rm_ofile(subdir, name):
-            build_dir = Path(env['PROJECT_BUILD_DIR'], build_env);
+            build_dir = Path(env['PROJECT_BUILD_DIR'], build_env)
             for outdir in (build_dir, build_dir / "debug"):
                 for ext in (".cpp.o", ".o"):
                     fpath = outdir / "src/src" / subdir / (name + ext)

--- a/buildroot/share/scripts/MarlinBinaryProtocol.py
+++ b/buildroot/share/scripts/MarlinBinaryProtocol.py
@@ -75,7 +75,7 @@ class Protocol(object):
         self.device = device
         self.baud = baud
         self.block_size = int(bsize)
-        self.simulate_errors = max(min(simerr, 1.0), 0.0);
+        self.simulate_errors = max(min(simerr, 1.0), 0.0)
         self.connected = True
         self.response_timeout = timeout
 
@@ -237,8 +237,8 @@ class Protocol(object):
 
     # checksum 16 fletchers
     def checksum(self, cs, value):
-        cs_low = (((cs & 0xFF) + value) % 255);
-        return ((((cs >> 8) + cs_low) % 255) << 8) | cs_low;
+        cs_low = (((cs & 0xFF) + value) % 255)
+        return ((((cs >> 8) + cs_low) % 255) << 8) | cs_low
 
     def build_checksum(self, buffer):
         cs = 0
@@ -270,7 +270,7 @@ class Protocol(object):
 
     def response_ok(self, data):
         try:
-            packet_id = int(data);
+            packet_id = int(data)
         except ValueError:
             return
         if packet_id != self.sync:
@@ -279,7 +279,7 @@ class Protocol(object):
         self.packet_status = 1
 
     def response_resend(self, data):
-        packet_id = int(data);
+        packet_id = int(data)
         self.errors += 1
         if not self.syncronised:
             print("Retrying syncronisation")
@@ -330,7 +330,7 @@ class FileTransferProtocol(object):
         return self.responses.popleft()
 
     def connect(self):
-        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.QUERY);
+        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.QUERY)
 
         token, data = self.await_response()
         if token != 'PFT:version:':
@@ -352,7 +352,7 @@ class FileTransferProtocol(object):
 
         timeout = TimeOut(5000)
         token = None
-        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.OPEN, payload);
+        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.OPEN, payload)
         while token != 'PFT:success' and not timeout.timedout():
             try:
                 token, data = self.await_response(1000)
@@ -363,7 +363,7 @@ class FileTransferProtocol(object):
                     print("Broken transfer detected, purging")
                     self.abort()
                     time.sleep(0.1)
-                    self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.OPEN, payload);
+                    self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.OPEN, payload)
                     timeout.reset()
                 elif token == 'PFT:fail':
                     raise Exception("Can not open file on client")
@@ -372,10 +372,10 @@ class FileTransferProtocol(object):
         raise ReadTimeout()
 
     def write(self, data):
-        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.WRITE, data);
+        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.WRITE, data)
 
     def close(self):
-        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.CLOSE);
+        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.CLOSE)
         token, data = self.await_response(1000)
         if token == 'PFT:success':
             print("File closed")
@@ -388,7 +388,7 @@ class FileTransferProtocol(object):
             return False
 
     def abort(self):
-        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.ABORT);
+        self.protocol.send(FileTransferProtocol.protocol_id, FileTransferProtocol.Packet.ABORT)
         token, data = self.await_response()
         if token == 'PFT:success':
             print("Transfer Aborted")
@@ -432,7 +432,7 @@ class FileTransferProtocol(object):
                 self.close()
                 print("Transfer aborted due to protocol errors")
                 #raise Exception("Transfer aborted due to protocol errors")
-                return False;
+                return False
         print("\r{0:2.0f}% {1:4.2f}KiB/s {2} Errors: {3}".format(100, kibs, "[{0:4.2f}KiB/s]".format(kibs * cratio) if compression else "", self.protocol.errors)) # no one likes transfers finishing at 99.8%
 
         if not self.close():

--- a/buildroot/share/vscode/auto_build.py
+++ b/buildroot/share/vscode/auto_build.py
@@ -499,7 +499,7 @@ def get_starting_env(board_name_full, version):
   possible_envs = None
   for i, line in enumerate(pins_h):
     if 0 < line.find("Unknown MOTHERBOARD value set in Configuration.h"):
-      invalid_board();
+      invalid_board()
     if list_start_found == False and 0 < line.find('1280'):
       list_start_found = True
     elif list_start_found == False:  # skip lines until find start of CPU list


### PR DESCRIPTION
unneeded ;

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Follow up to [✨ COMPACT_CUSTOM_BOOTSCREEN (#26419)](https://github.com/MarlinFirmware/Marlin/commit/dc26531)

`;` was removed from **buildroot/share/scripts/rle16_compress_cpp_image_data.py**

This PR removes `;` from various **buildroot/scripts** _.py_ files

I went ahead and took the liberty to 'seek and destroy' the unnecessary.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
I suppose it doesn't change much, it just removes " `;` " character which is more or less inert.
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
