### PR TITLE
Add feature that opens File Explorer to firmware .bin on build

### DIFF
--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -67,3 +67,5 @@ if pioutil.is_pio_build():
             env['PROGNAME'] = path.splitext(_newpath)[0]
 
         marlin.add_post_action(rename_target)
+        import open_explorer
+        open_explorer.open_file_explorer()

--- a/buildroot/share/PlatformIO/scripts/open_explorer.py
+++ b/buildroot/share/PlatformIO/scripts/open_explorer.py
@@ -1,0 +1,16 @@
+#
+# open_explorer.py
+#
+def open_file_explorer():
+    import subprocess
+    from pathlib import Path
+    from SCons.Script import Import
+    from SCons.Script import DefaultEnvironment
+    env = DefaultEnvironment()
+    Import("env")
+    BUILD_PATH = Path(env['PROJECT_BUILD_DIR'], env['PIOENV'])
+    script = f'Explorer.exe "{BUILD_PATH}"'
+    try:
+        subprocess.run(["bash", "-c", script])
+    except Exception as e:
+        print(f"Could not open File Explorer, an error occurred: {e}")


### PR DESCRIPTION


<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

I wanted to have the ability to have the folder where the .bin firmware opens on build like it does with AutoBuildMarlin.

opens .pio/build/< build_envs >/firmware.bin folder on build
added function to offset_and_rename.py

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
any _env:_ which uses **offset_and_rename.py**
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
wanted this to open after it is all done.
if someone can suggest how that can be done let me know.
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
