### PR TITLE
🚸 Fix LCD centering for Ender-3 V2/HD44780/TFTGLCD MarlinUI

### DIFF
--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -1179,7 +1179,7 @@ void MarlinUI::draw_status_screen() {
     int8_t llen = ftpl ? expand_u8str(estr, ftpl, itemIndex, itemStringC, itemStringF, n - vlen) : 0;
 
     bool mv_colon = false;
-    if (vlen) {
+    if (vlen && !center) {
       // Move the leading colon from the value to the label below
       mv_colon = (*vstr == ':');
       // Shorter value, wider label

--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -983,7 +983,7 @@ void MarlinUI::draw_status_screen() {
     int8_t llen = ftpl ? expand_u8str(estr, ftpl, itemIndex, itemStringC, itemStringF, n - vlen) : 0;
 
     bool mv_colon = false;
-    if (vlen) {
+    if (vlen && !center) {
       // Move the leading colon from the value to the label below
       mv_colon = (*vstr == ':');
       // Shorter value, wider label

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1384,7 +1384,19 @@ void hmiMoveDone(const AxisEnum axis) {
       dwinUpdateLCD();
       return;
     }
-    LIMIT(hmiValues.offset_value, (PROBE_OFFSET_ZMIN) * 100, (PROBE_OFFSET_ZMAX) * 100);
+
+    #ifdef PROBE_OFFSET_ZMIN
+      #define _OFFSET_ZMIN (PROBE_OFFSET_ZMIN)
+    #else
+      #define _OFFSET_ZMIN -20
+    #endif
+    #ifdef PROBE_OFFSET_ZMAX
+      #define _OFFSET_ZMAX (PROBE_OFFSET_ZMAX)
+    #else
+      #define _OFFSET_ZMAX 20
+    #endif
+    LIMIT(hmiValues.offset_value, _OFFSET_ZMIN * 100, _OFFSET_ZMAX * 100);
+
     last_zoffset = dwin_zoffset;
     dwin_zoffset = hmiValues.offset_value / 100.0f;
     #if ANY(BABYSTEP_ZPROBE_OFFSET, JUST_BABYSTEP)

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1385,12 +1385,12 @@ void hmiMoveDone(const AxisEnum axis) {
       return;
     }
 
-    #ifdef PROBE_OFFSET_ZMIN
+    #if ENABLED(BABYSTEP_ZPROBE_OFFSET) && defined(PROBE_OFFSET_ZMIN)
       #define _OFFSET_ZMIN (PROBE_OFFSET_ZMIN)
     #else
       #define _OFFSET_ZMIN -20
     #endif
-    #ifdef PROBE_OFFSET_ZMAX
+    #if ENABLED(BABYSTEP_ZPROBE_OFFSET) && defined(PROBE_OFFSET_ZMAX)
       #define _OFFSET_ZMAX (PROBE_OFFSET_ZMAX)
     #else
       #define _OFFSET_ZMAX 20

--- a/Marlin/src/lcd/e3v2/marlinui/ui_common.cpp
+++ b/Marlin/src/lcd/e3v2/marlinui/ui_common.cpp
@@ -324,7 +324,7 @@ void MarlinUI::draw_status_message(const bool blink) {
     int8_t vlen = vstr ? utf8_strlen(vstr) : 0;
 
     bool mv_colon = false;
-    if (vlen) {
+    if (vlen && !center) {
       // Move the leading colon from the value to the label below
       mv_colon = (*vstr == ':');
       // Shorter value, wider label

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -39,13 +39,6 @@
   #include "../../../feature/leds/leds.h"
 #endif
 
-#if ANY(BABYSTEPPING, HAS_BED_PROBE)
-  #define HAS_ZOFFSET_ITEM 1
-  #if !HAS_BED_PROBE
-    #define JUST_BABYSTEP 1
-  #endif
-#endif
-
 namespace GET_LANG(LCD_LANGUAGE) {
   #define _MSG_PREHEAT(N) \
     LSTR MSG_PREHEAT_##N                  = _UxGT("Preheat ") PREHEAT_## N ##_LABEL; \


### PR DESCRIPTION
### Description

Follow up to https://github.com/MarlinFirmware/Marlin/pull/26339. Applies same fix from https://github.com/MarlinFirmware/Marlin/pull/26415.

Tested on:
- `REPRAP_DISCOUNT_SMART_CONTROLLER`
- `DWIN_MARLINUI_PORTRAIT`
- `DWIN_MARLINUI_LANDSCAPE`

Not tested since I lack the hardware, but assume fix is needed there as well:
- `TFTGLCD_PANEL_SPI`
- `TFTGLCD_PANEL_I2C`

### Requirements

MarlinUI

### Benefits

Centered menu items won't run together / have missing characters.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26339
- https://github.com/MarlinFirmware/Marlin/pull/26415
