### PR TITLE
Fix rotational AxisFlags

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -159,7 +159,7 @@ template <class L, class R> struct IF<true, L, R> { typedef L type; };
 // General Flags for some number of states
 template<size_t N>
 struct Flags {
-  typedef value_t(N) flagbits_t;
+  typedef uvalue_t(N) flagbits_t;
   typedef struct { bool b0:1, b1:1, b2:1, b3:1, b4:1, b5:1, b6:1, b7:1; } N8;
   typedef struct { bool b0:1, b1:1, b2:1, b3:1, b4:1, b5:1, b6:1, b7:1, b8:1, b9:1, b10:1, b11:1, b12:1, b13:1, b14:1, b15:1; } N16;
   typedef struct { bool b0:1,  b1:1,  b2:1,  b3:1,  b4:1,  b5:1,  b6:1,  b7:1,  b8:1,  b9:1, b10:1, b11:1, b12:1, b13:1, b14:1, b15:1,

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -144,9 +144,9 @@ XYZ_DEFS(int8_t, home_dir, HOME_DIR);
 
 // Flags for rotational axes
 constexpr AxisFlags rotational{0 LOGICAL_AXIS_GANG(
-    || 0, || 0, || 0, || 0,
-    || (ENABLED(AXIS4_ROTATES)<<I_AXIS), || (ENABLED(AXIS5_ROTATES)<<J_AXIS), || (ENABLED(AXIS6_ROTATES)<<K_AXIS),
-    || (ENABLED(AXIS7_ROTATES)<<U_AXIS), || (ENABLED(AXIS8_ROTATES)<<V_AXIS), || (ENABLED(AXIS9_ROTATES)<<W_AXIS))
+    | 0, | 0, | 0, | 0,
+    | (ENABLED(AXIS4_ROTATES)<<I_AXIS), | (ENABLED(AXIS5_ROTATES)<<J_AXIS), | (ENABLED(AXIS6_ROTATES)<<K_AXIS),
+    | (ENABLED(AXIS7_ROTATES)<<U_AXIS), | (ENABLED(AXIS8_ROTATES)<<V_AXIS), | (ENABLED(AXIS9_ROTATES)<<W_AXIS))
 };
 
 inline float home_bump_mm(const AxisEnum axis) {


### PR DESCRIPTION
### Description

Fixes two issues with the recently added `rotational` flags in motion.h:

1. Uses bit-wise `|` operators to properly build the flag value. Previously using boolean `||` the value would always consolidate down to `0` or `1`.

3. Change the `Flags` template to use unsigned data types. Prior to this when using 8 axis this would be using the sign bit of the integer to store a flag. This likely worked, but it is more correct to use an unsigned integer for a bitfield.

### Requirements

This would prevent the movement commands from working when using MARLINUI.

### Benefits

- Fixes many compilation warnings, even when this variable is ultimately not used.
- Fixes the setting of initial rotational flags value.

### Configurations

- RAMPS 5 LINEAR_AXES example.

