### PR TITLE
Fixed crash on SKR Mini E3 v3 with MMU upon calling sscanf command …

### DIFF
--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -210,7 +210,12 @@ void MMU2::mmu_loop() {
 
     case -4:
       if (rx_ok()) {
-        sscanf(rx_buffer, "%hhuok\n", &finda);
+        // sscanf(rx_buffer, "%hhuok\n", &finda);
+        if (rx_buffer[0] == '0'){
+          finda = 0;
+        } else if (rx_buffer[0] == '1'){
+          finda = 1;
+        }
 
         DEBUG_ECHOLNPGM("MMU => ", finda, "\nMMU - ENABLED");
 
@@ -283,7 +288,12 @@ void MMU2::mmu_loop() {
 
     case 2:   // response to command P0
       if (rx_ok()) {
-        sscanf(rx_buffer, "%hhuok\n", &finda);
+        // sscanf(rx_buffer, "%hhuok\n", &finda);
+        if (rx_buffer[0] == '0'){
+          finda = 0;
+        } else if (rx_buffer[0] == '1'){
+          finda = 1;
+        }
 
         // This is super annoying. Only activate if necessary
         //if (finda_runout_valid) DEBUG_ECHOLNPGM("MMU <= 'P0'\nMMU => ", p_float_t(finda, 6));

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -146,13 +146,6 @@ void mmu2_attn_buzz(const bool two=false) {
 }
 
 // Avoiding sscanf significantly reduces build size
-static uint16_t strtoint(char * str) {
-  uint16_t outval = 0;
-  for (char c; NUMERIC((c = *str)); ++str)
-    outval = outval * 10 + c - '0';
-  return outval;
-}
-
 void MMU2::mmu_loop() {
 
   switch (state) {
@@ -175,7 +168,7 @@ void MMU2::mmu_loop() {
 
     case -2:
       if (rx_ok()) {
-        const uint16_t version = strtoint(rx_buffer);
+        const uint16_t version = uint16_t(strtoul(rx_buffer, nullptr, 10));
         DEBUG_ECHOLNPGM("MMU => ", version, "\nMMU <= 'S2'");
         MMU2_SEND("S2");    // Read Build Number
         state = -3;
@@ -184,7 +177,7 @@ void MMU2::mmu_loop() {
 
     case -3:
       if (rx_ok()) {
-        const uint16_t buildnr = strtoint(rx_buffer);
+        const uint16_t buildnr = uint16_t(strtoul(rx_buffer, nullptr, 10));
         DEBUG_ECHOLNPGM("MMU => ", buildnr);
 
         check_version(buildnr);

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -146,6 +146,14 @@ void mmu2_attn_buzz(const bool two=false) {
   if (two) { BUZZ(10, 0); BUZZ(200, 404); }
 }
 
+// Avoiding sscanf significantly reduces build size
+static uint16_t strtoint(char * str) {
+  uint16_t outval = 0;
+  for (char c; NUMERIC((c = *str)); ++str)
+    outval = outval * 10 + c - '0';
+  return outval;
+}
+
 void MMU2::mmu_loop() {
 
   switch (state) {
@@ -168,7 +176,7 @@ void MMU2::mmu_loop() {
 
     case -2:
       if (rx_ok()) {
-        sscanf(rx_buffer, "%huok\n", &version);
+        version = strtoint(rx_buffer);
         DEBUG_ECHOLNPGM("MMU => ", version, "\nMMU <= 'S2'");
         MMU2_SEND("S2");    // Read Build Number
         state = -3;
@@ -177,8 +185,7 @@ void MMU2::mmu_loop() {
 
     case -3:
       if (rx_ok()) {
-        sscanf(rx_buffer, "%huok\n", &buildnr);
-
+        buildnr = strtoint(rx_buffer);
         DEBUG_ECHOLNPGM("MMU => ", buildnr);
 
         check_version();
@@ -187,7 +194,6 @@ void MMU2::mmu_loop() {
           DEBUG_ECHOLNPGM("MMU <= 'M1'");
           MMU2_SEND("M1");    // Stealth Mode
           state = -5;
-
         #else
           DEBUG_ECHOLNPGM("MMU <= 'P0'");
           MMU2_SEND("P0");    // Read FINDA

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -210,12 +210,8 @@ void MMU2::mmu_loop() {
 
     case -4:
       if (rx_ok()) {
-        // sscanf(rx_buffer, "%hhuok\n", &finda);
-        if (rx_buffer[0] == '0'){
-          finda = 0;
-        } else if (rx_buffer[0] == '1'){
-          finda = 1;
-        }
+        const uint8_t findex = uint8_t(rx_buffer[0] - '0');
+        if (findex <= 1) finda = findex;
 
         DEBUG_ECHOLNPGM("MMU => ", finda, "\nMMU - ENABLED");
 
@@ -288,12 +284,8 @@ void MMU2::mmu_loop() {
 
     case 2:   // response to command P0
       if (rx_ok()) {
-        // sscanf(rx_buffer, "%hhuok\n", &finda);
-        if (rx_buffer[0] == '0'){
-          finda = 0;
-        } else if (rx_buffer[0] == '1'){
-          finda = 1;
-        }
+        const uint8_t findex = uint8_t(rx_buffer[0] - '0');
+        if (findex <= 1) finda = findex;
 
         // This is super annoying. Only activate if necessary
         //if (finda_runout_valid) DEBUG_ECHOLNPGM("MMU <= 'P0'\nMMU => ", p_float_t(finda, 6));

--- a/Marlin/src/feature/mmu/mmu2.h
+++ b/Marlin/src/feature/mmu/mmu2.h
@@ -64,7 +64,7 @@ private:
 
   static bool rx_ok();
   static bool rx_start();
-  static void check_version();
+  static void check_version(const uint16_t buildnr);
 
   static void command(const uint8_t cmd);
   static bool get_response();
@@ -90,13 +90,12 @@ private:
     static void mmu_continue_loading();
   #endif
 
-  static bool _enabled, ready, mmu_print_saved;
+  static bool _enabled, ready;
 
   static uint8_t cmd, cmd_arg, last_cmd, extruder;
   static int8_t state;
   static volatile int8_t finda;
   static volatile bool finda_runout_valid;
-  static uint16_t version, buildnr;
   static millis_t prev_request, prev_P0_request;
   static char rx_buffer[MMU_RX_SIZE], tx_buffer[MMU_TX_SIZE];
 


### PR DESCRIPTION
…with "%hhu".

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This is a very crude fix to the `sscanf` causing the printer to crash problem reported in #24677. I once read that the `sscan` with `%hhu` mask is not working properly with `STM32G0B1xx`, I don't have the source of that information at hand tbh. But, I was experiencing the crash and my proposed change fixed that. Although, my code is not good and needs review from Marlin developers.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

Enable MMU2s with SKR Mini E3 v3 board.

### Benefits

MMU2s with SKR Mini E3 v3 crashes on a certain `sscanf` call, this fixes that albeit in a very crude way.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

#24677
