### PR TITLE
🧑‍💻 Update pin formatting tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONTAINER_IMAGE := marlin-dev
 
 help:
 	@echo "Tasks for local development:"
-	@echo "* format-
+	@echo "* format-pins:                 Reformat all pins files
 	@echo "* tests-single-ci:             Run a single test from inside the CI"
 	@echo "* tests-single-local:          Run a single test locally"
 	@echo "* tests-single-local-docker:   Run a single test locally, using docker"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CONTAINER_IMAGE := marlin-dev
 
 help:
 	@echo "Tasks for local development:"
+	@echo "* format-
 	@echo "* tests-single-ci:             Run a single test from inside the CI"
 	@echo "* tests-single-local:          Run a single test locally"
 	@echo "* tests-single-local-docker:   Run a single test locally, using docker"
@@ -57,3 +58,12 @@ tests-all-local-docker:
 setup-local-docker:
 	$(CONTAINER_RT_BIN) build -t $(CONTAINER_IMAGE) -f docker/Dockerfile .
 .PHONY: setup-local-docker
+
+PINS := $(shell find Marlin/src/pins -mindepth 2 -name '*.h')
+
+.PHONY: $(PINS)
+
+$(PINS): %:
+	@echo "Formatting $@" && node buildroot/share/scripts/pinsformat.js $@
+
+format-pins: $(PINS)

--- a/Marlin/src/pins/gd32f1/pins_TRIGORILLA_V006.h
+++ b/Marlin/src/pins/gd32f1/pins_TRIGORILLA_V006.h
@@ -122,7 +122,7 @@
   //
   // SPI
   //
-  #define SPI_DEVICE                        -1   // Maple
+  #define SPI_DEVICE                        -1    // Maple
   #define SCK_PIN                           -1
   #define MISO_PIN                          -1
   #define MOSI_PIN                          -1

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -202,7 +202,7 @@
       #undef E1_ENABLE_PIN
     #endif
 
-  #else                                           // !SOFTWARE_DRIVER_ENABLE
+  #else // !SOFTWARE_DRIVER_ENABLE
 
     // A chip-select pin is needed for each driver.
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -422,7 +422,7 @@
 
     #define SD_DETECT_PIN            EXP2_07_PIN
 
-  #else                                           // !CR10_STOCKDISPLAY
+  #else // !CR10_STOCKDISPLAY
 
     #define LCD_PINS_RS              EXP1_04_PIN
 
@@ -463,7 +463,7 @@
         #define NEOPIXEL_PIN         EXP1_06_PIN
       #endif
 
-    #else                                         // !FYSETC_MINI_12864
+    #else // !FYSETC_MINI_12864
 
       #if ENABLED(MKS_MINI_12864)
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -372,7 +372,7 @@
       #define TFT_BACKLIGHT_PIN      EXP1_03_PIN
 
       #define TOUCH_BUTTONS_HW_SPI
-      #define TOUCH_BUTTONS_HW_SPI_DEVICE 1
+      #define TOUCH_BUTTONS_HW_SPI_DEVICE      1
 
       //#define TFT_RST_PIN          EXP2_07_PIN
       #define TFT_SCK_PIN            EXP2_02_PIN
@@ -422,7 +422,7 @@
 
     #define SD_DETECT_PIN            EXP2_07_PIN
 
-  #else // !CR10_STOCKDISPLAY
+  #else                                           // !CR10_STOCKDISPLAY
 
     #define LCD_PINS_RS              EXP1_04_PIN
 
@@ -463,7 +463,7 @@
         #define NEOPIXEL_PIN         EXP1_06_PIN
       #endif
 
-    #else // !FYSETC_MINI_12864
+    #else                                         // !FYSETC_MINI_12864
 
       #if ENABLED(MKS_MINI_12864)
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -464,7 +464,7 @@
         #define NEOPIXEL_PIN         EXP1_06_PIN
       #endif
 
-    #else                                         // !FYSETC_MINI_12864
+    #else // !FYSETC_MINI_12864
 
       #if ENABLED(MKS_MINI_12864)
         #define DOGLCD_CS            EXP1_06_PIN

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -350,7 +350,7 @@
       #define LCD_PINS_D7            EXP1_08_PIN
       #define KILL_PIN                     -1     // NC
 
-    #else                                         // !MKS_12864OLED_SSD1306
+    #else // !MKS_12864OLED_SSD1306
 
       #define LCD_PINS_RS            EXP1_04_PIN
 
@@ -385,7 +385,7 @@
           #define NEOPIXEL_PIN       EXP1_06_PIN
         #endif
 
-      #else                                       // !FYSETC_MINI_12864
+      #else // !FYSETC_MINI_12864
 
         #if ENABLED(MKS_MINI_12864)
           #define DOGLCD_CS          EXP1_06_PIN

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -368,7 +368,7 @@
         #define TFT_QUEUE_SIZE              6144
       #endif
 
-    #else                                         // !MKS_12864OLED_SSD1306
+    #else // !MKS_12864OLED_SSD1306
 
       #define LCD_PINS_RS            EXP1_04_PIN
 
@@ -403,7 +403,7 @@
           #define NEOPIXEL_PIN       EXP1_06_PIN
         #endif
 
-      #else                                       // !FYSETC_MINI_12864
+      #else // !FYSETC_MINI_12864
 
         #if ENABLED(MKS_MINI_12864)
           #define DOGLCD_CS          EXP1_06_PIN

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -181,7 +181,7 @@
     #define BTN_ENC                  EXP1_02_PIN
     #define SD_DETECT_PIN            EXP2_07_PIN
 
-  #else                                           // !IS_NEWPANEL
+  #else // !IS_NEWPANEL
 
     #define SHIFT_CLK_PIN            EXP2_07_PIN
     #define SHIFT_LD_PIN             EXP2_03_PIN

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -104,7 +104,7 @@
 // Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
 // Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h
 // and set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909.
-#define POWER_MONITOR_VOLTAGE_PIN             0
+#define POWER_MONITOR_VOLTAGE_PIN              0
 
 /**              LCD                             SDCARD
  *              ------                           ------

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A_PLUS.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A_PLUS.h
@@ -30,6 +30,6 @@
 
 #define BOARD_INFO_NAME "GT2560 Rev.A+"
 
-#define SERVO0_PIN  11
+#define SERVO0_PIN                            11
 
 #include "pins_GT2560_REV_A.h"

--- a/Marlin/src/pins/mega/pins_PICAOLD.h
+++ b/Marlin/src/pins/mega/pins_PICAOLD.h
@@ -25,9 +25,9 @@
 // Origin: https://github.com/mjrice/PICA/blob/97ab9e7771a8e5eef97788f3adcc17a9fa9de9b9/pica_schematic.pdf
 // ATmega2560
 
-#define HEATER_0_PIN                          9   // E0
-#define HEATER_1_PIN                         10   // E1
-#define FAN0_PIN                             11
-#define FAN2_PIN                             12
+#define HEATER_0_PIN                           9  // E0
+#define HEATER_1_PIN                          10  // E1
+#define FAN0_PIN                              11
+#define FAN2_PIN                              12
 
 #include "pins_PICA.h"

--- a/Marlin/src/pins/rambo/pins_MINIRAMBO.h
+++ b/Marlin/src/pins/rambo/pins_MINIRAMBO.h
@@ -172,7 +172,7 @@
 
       #define SD_DETECT_PIN                   72
 
-    #else                                         // !MINIRAMBO_10A
+    #else // !MINIRAMBO_10A
 
       // AUX-4
       #define BEEPER_PIN                      84

--- a/Marlin/src/pins/rambo/pins_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_RAMBO.h
@@ -232,7 +232,7 @@
 
       #define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
 
-    #else                                         // !VIKI2 && !miniVIKI
+    #else // !VIKI2 && !miniVIKI
 
       #define BEEPER_PIN                      79  // AUX-4
 
@@ -253,7 +253,7 @@
       #define BTN_ENC_EN             LCD_PINS_D7  // Detect the presence of the encoder
     #endif
 
-  #else                                           // !IS_NEWPANEL - old style panel with shift register
+  #else // !IS_NEWPANEL - old style panel with shift register
 
     // No Beeper added
     #define BEEPER_PIN                        33

--- a/Marlin/src/pins/ramps/pins_FELIX2.h
+++ b/Marlin/src/pins/ramps/pins_FELIX2.h
@@ -35,23 +35,23 @@
 //
 // Heaters / Fans
 //
-#define MOSFET_D_PIN                          7
+#define MOSFET_D_PIN                           7
 
 #include "pins_RAMPS.h"
 
 //
 // Misc. Functions
 //
-#define SDPOWER_PIN                           1
+#define SDPOWER_PIN                            1
 
-#define PS_ON_PIN                            12
+#define PS_ON_PIN                             12
 
 //
 // LCD / Controller
 //
 #if HAS_WIRED_LCD && IS_NEWPANEL
 
-  #define SD_DETECT_PIN                       6
+  #define SD_DETECT_PIN                        6
 
 #endif
 

--- a/Marlin/src/pins/ramps/pins_FORMBOT_TREX2PLUS.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_TREX2PLUS.h
@@ -141,8 +141,8 @@
 //
 #define SDSS                                  53
 #ifndef LED_PIN
-  #define LED_PIN                             13  // The Formbot v 1 board has almost no unassigned pins on it.  The Board's LED
-#endif                          // is a good place to get a signal to control the Max7219 LED Matrix.
+  #define LED_PIN                             13  // The Formbot v 1 board has almost no unassigned pins.
+#endif                                            // The Board's LED is a good place to connect the Max7219 Matrix.
 
 // Use the RAMPS 1.4 Analog input 5 on the AUX2 connector
 #define FILWIDTH_PIN                           5  // Analog Input

--- a/Marlin/src/pins/ramps/pins_MAKEBOARD_MINI.h
+++ b/Marlin/src/pins/ramps/pins_MAKEBOARD_MINI.h
@@ -28,8 +28,8 @@
 //
 // Only 3 Limit Switch plugs on Micromake C1
 //
-#define X_STOP_PIN          2
-#define Y_STOP_PIN         15
-#define Z_STOP_PIN         19
+#define X_STOP_PIN                             2
+#define Y_STOP_PIN                            15
+#define Z_STOP_PIN                            19
 
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_RAMPS_OLD.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_OLD.h
@@ -91,7 +91,7 @@
   #ifndef FAN0_PIN
     #define FAN0_PIN                          11
   #endif
-#else                                             // RAMPS_V_1_1 or RAMPS_V_1_2
+#else // RAMPS_V_1_1 or RAMPS_V_1_2
   #define HEATER_0_PIN                        10
   #define HEATER_BED_PIN                       8
   #ifndef FAN0_PIN

--- a/Marlin/src/pins/ramps/pins_RUMBA_RAISE3D.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA_RAISE3D.h
@@ -27,7 +27,7 @@
 #define DEFAULT_MACHINE_NAME "Raise3D N Series"
 
 // Raise3D uses thermocouples on the standard input pins
-#define TEMP_0_PIN         15   // Analog Input
-#define TEMP_1_PIN         14   // Analog Input
+#define TEMP_0_PIN                            15  // Analog Input
+#define TEMP_1_PIN                            14  // Analog Input
 
 #include "pins_RUMBA.h"

--- a/Marlin/src/pins/ramps/pins_TRONXY_V3_1_0.h
+++ b/Marlin/src/pins/ramps/pins_TRONXY_V3_1_0.h
@@ -38,7 +38,7 @@
 //
 // Servos
 //
-#define SERVO1_PIN         12   // 2560 PIN 25/PB6
+#define SERVO1_PIN                            12  // 2560 PIN 25/PB6
 
 //
 // Import RAMPS 1.4 pins

--- a/Marlin/src/pins/ramps/pins_ULTIMAKER.h
+++ b/Marlin/src/pins/ramps/pins_ULTIMAKER.h
@@ -138,7 +138,7 @@
 
     #define SD_DETECT_PIN                     38
 
-  #else                                           // !IS_NEWPANEL - Old style panel with shift register
+  #else // !IS_NEWPANEL - Old style panel with shift register
 
     // Buttons attached to a shift register
     #define SHIFT_CLK_PIN                     38

--- a/Marlin/src/pins/ramps/pins_ULTIMAKER_OLD.h
+++ b/Marlin/src/pins/ramps/pins_ULTIMAKER_OLD.h
@@ -195,7 +195,7 @@
 
     #define SD_DETECT_PIN                     38
 
-  #else                                           // !IS_NEWPANEL - Old style panel with shift register
+  #else // !IS_NEWPANEL - Old style panel with shift register
 
     // Buttons attached to a shift register
     #define SHIFT_CLK_PIN                     38

--- a/Marlin/src/pins/ramps/pins_ZRIB_V53.h
+++ b/Marlin/src/pins/ramps/pins_ZRIB_V53.h
@@ -374,7 +374,7 @@
   #define KILL_PIN                            -1
   #if ANY(OLED_HW_IIC, OLED_HW_SPI)
     #error "Oops! You must choose SW SPI for ZRIB V53 board and connect the OLED screen to EXP1 connector."
-  #else                                           // SW_SPI
+  #else // SW_SPI
     #define DOGLCD_A0                LCD_PINS_DC
     #define DOGLCD_MOSI                       35  // SDA
     #define DOGLCD_SCK                        37  // SCK

--- a/Marlin/src/pins/sam/pins_RAMPS4DUE.h
+++ b/Marlin/src/pins/sam/pins_RAMPS4DUE.h
@@ -45,8 +45,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          9   // Analog Input
-#define TEMP_1_PIN         -1   // Analog Input
-#define TEMP_BED_PIN       10   // Analog Input
+#define TEMP_0_PIN                             9  // Analog Input
+#define TEMP_1_PIN                            -1  // Analog Input
+#define TEMP_BED_PIN                          10  // Analog Input
 
 #include "../ramps/pins_RAMPS.h"

--- a/Marlin/src/pins/sam/pins_RAMPS_FD_V2.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_FD_V2.h
@@ -31,7 +31,7 @@
 #define BOARD_INFO_NAME "RAMPS-FD v2"
 
 #ifndef E0_CS_PIN
-  #define E0_CS_PIN        69 // moved from A13 to A15 on v2.2, if not earlier
+  #define E0_CS_PIN                           69  // moved from A13 to A15 on v2.2, if not earlier
 #endif
 
 #include "pins_RAMPS_FD_V1.h"
@@ -44,9 +44,9 @@
 #define MARLIN_EEPROM_SIZE 0x10000 // 64K in a 24C512
 
 #ifndef PS_ON_PIN
-  #define PS_ON_PIN        12
+  #define PS_ON_PIN                           12
 #endif
 
 #ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN      5   // Analog Input on AUX2
+  #define FILWIDTH_PIN                         5  // Analog Input on AUX2
 #endif

--- a/Marlin/src/pins/sanguino/pins_AZTEEG_X1.h
+++ b/Marlin/src/pins/sanguino/pins_AZTEEG_X1.h
@@ -29,6 +29,6 @@
 
 #define BOARD_INFO_NAME "Azteeg X1"
 
-#define FAN0_PIN 4
+#define FAN0_PIN                               4
 
 #include "pins_SANGUINOLOLU_12.h" // ... SANGUINOLOLU_11

--- a/Marlin/src/pins/sanguino/pins_GEN7_13.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_13.h
@@ -50,5 +50,5 @@
 
 #define BOARD_INFO_NAME "Gen7 v1.3"
 
-#define GEN7_VERSION                          13  // v1.3
+#define GEN7_VERSION 13   // v1.3
 #include "pins_GEN7_12.h"

--- a/Marlin/src/pins/sanguino/pins_GEN7_13.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_13.h
@@ -50,5 +50,5 @@
 
 #define BOARD_INFO_NAME "Gen7 v1.3"
 
-#define GEN7_VERSION 13   // v1.3
+#define GEN7_VERSION                          13  // v1.3
 #include "pins_GEN7_12.h"

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -173,7 +173,7 @@
         // Marlin so this can be used for BEEPER_PIN. You can use this pin
         // with M42 instead of BEEPER_PIN.
         #define BEEPER_PIN                    27
-      #else                                       // Sanguinololu >=1.3
+      #else // Sanguinololu >=1.3
         #define LCD_PINS_RS                    4
         #define LCD_PINS_EN                   17
         #define LCD_PINS_D4                   30
@@ -197,7 +197,7 @@
         #define BEEPER_PIN                    27
         #define DOGLCD_CS                     28
 
-      #else                                       // !MAKRPANEL
+      #else // !MAKRPANEL
 
         #define DOGLCD_CS                     29
 
@@ -250,7 +250,7 @@
       #define BTN_ENC                         30
     #endif
 
-  #else                                           // !LCD_FOR_MELZI && !ZONESTAR_LCD && !LCD_I2C_PANELOLU2
+  #else // !LCD_FOR_MELZI && !ZONESTAR_LCD && !LCD_I2C_PANELOLU2
 
     #define BTN_ENC                           16
     #ifndef LCD_SDSS

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
@@ -235,7 +235,7 @@
       //  #define NEOPIXEL_PIN       EXP1_06_PIN
       //#endif
 
-    #else                                         // !FYSETC_MINI_12864
+    #else // !FYSETC_MINI_12864
 
       #define LCD_PINS_D4            EXP1_05_PIN
       #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
@@ -242,7 +242,7 @@
       //  #define NEOPIXEL_PIN       EXP1_05_PIN
       //#endif
 
-    #else                                         // !FYSETC_MINI_12864
+    #else // !FYSETC_MINI_12864
 
       #define LCD_PINS_D4            EXP1_06_PIN
       #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -356,7 +356,7 @@
     #endif
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP1_05_PIN
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1_common.h
@@ -34,6 +34,6 @@
 #define Z_STEP_PIN                          PC14
 #define Z_DIR_PIN                           PC15
 
-#define BTN_ENC_EN                            -1
+#define BTN_ENC_EN                          -1
 
 #include "pins_MKS_ROBIN_E3_common.h"

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
@@ -121,7 +121,7 @@
     #define DOGLCD_SCK                      PB13
     #define DOGLCD_MOSI                     PB15
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP3_06_PIN
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
@@ -122,7 +122,7 @@
       #define TFTGLCD_CS                    PB11
     #endif
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PA6
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -356,7 +356,7 @@
     #endif
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PE14
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
@@ -279,7 +279,7 @@
     #define DOGLCD_SCK                      PB13
     #define DOGLCD_MOSI                     PB15
 
-  #else                                           // !MKS_MINI_12864 && !ENDER2_STOCKDISPLAY
+  #else // !MKS_MINI_12864 && !ENDER2_STOCKDISPLAY
 
     #define LCD_PINS_D4                     PF14
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -494,7 +494,7 @@
     #endif
 
   #endif
-#endif  // HAS_WIRED_LCD
+#endif // HAS_WIRED_LCD
 
 // Alter timing for graphical display
 #if IS_U8GLIB_ST7920

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -523,10 +523,10 @@
   #define BTN_EN2                    EXP2_05_PIN
 
   #ifndef TFT_WIDTH
-    #define TFT_WIDTH                      480
+    #define TFT_WIDTH                        480
   #endif
   #ifndef TFT_HEIGHT
-    #define TFT_HEIGHT                     320
+    #define TFT_HEIGHT                       320
   #endif
 
   #if ENABLED(BTT_TFT35_SPI_V1_0)
@@ -592,7 +592,7 @@
     #define TFT_BACKLIGHT_PIN  LCD_BACKLIGHT_PIN
 
     #define TOUCH_BUTTONS_HW_SPI
-    #define TOUCH_BUTTONS_HW_SPI_DEVICE 1
+    #define TOUCH_BUTTONS_HW_SPI_DEVICE        1
 
     #define TOUCH_CS_PIN             EXP1_05_PIN  // SPI1_NSS
     #define TOUCH_SCK_PIN            EXP2_02_PIN  // SPI1_SCK

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -359,7 +359,7 @@
     #endif
     //#define LCD_SCREEN_ROTATE              180  // 0, 90, 180, 270
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP1_05_PIN
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -360,7 +360,7 @@
     // Required for MKS_MINI_12864 with this board
     //#define MKS_LCD12864B
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4              EXP1_05_PIN
     #if IS_ULTIPANEL

--- a/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
@@ -336,7 +336,7 @@
     #endif
 
   #endif
-#endif  // HAS_WIRED_LCD
+#endif // HAS_WIRED_LCD
 
 // Alter timing for graphical display
 #if IS_U8GLIB_ST7920

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -506,7 +506,7 @@
     #endif
 
   #endif
-#endif  // HAS_WIRED_LCD
+#endif // HAS_WIRED_LCD
 
 // Alter timing for graphical display
 #if IS_U8GLIB_ST7920

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -536,7 +536,7 @@
       #define TFT_BACKLIGHT_PIN LCD_BACKLIGHT_PIN
 
       #define TOUCH_BUTTONS_HW_SPI
-      #define TOUCH_BUTTONS_HW_SPI_DEVICE 1
+      #define TOUCH_BUTTONS_HW_SPI_DEVICE      1
 
       #define TOUCH_CS_PIN           EXP1_05_PIN  // SPI1_NSS
       #define TOUCH_SCK_PIN          EXP2_02_PIN  // SPI1_SCK

--- a/Marlin/src/pins/teensy2/pins_SAV_MKI.h
+++ b/Marlin/src/pins/teensy2/pins_SAV_MKI.h
@@ -172,7 +172,7 @@
   #define KILL_PIN                 EXT_AUX_A2_IO
   #define HOME_PIN                 EXT_AUX_A4_IO
 
-#else                                             // Use the expansion header for spindle control
+#else // Use the expansion header for spindle control
 
   //
   // M3/M4/M5 - Spindle/Laser Control

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -80,10 +80,9 @@ function get_pin_pattern(txt) {
       }
     }
   }
-  if (max_match_index !== -1) {
-    return { match: mpatt[max_match_index], pad: ppad[max_match_index] };
-  }
-  return null;
+  if (max_match_index === -1) return null;
+
+  return { match:mpatt[max_match_index], pad:ppad[max_match_index] };
 }
 
 function process_text(txt) {

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -154,9 +154,7 @@ function process_text(txt) {
       if (do_log) console.log("alias:", line);
       line = r[1] + ' ' + r[3];
       line = line.concat_with_space(r[4].lpad(col_value_rj + 1 - line.length));
-      if (r[5]) {
-        line = line.rpad(col_comment).concat_with_space(r[5]);
-      }
+      if (r[5]) line = line.rpad(col_comment).concat_with_space(r[5]);
     }
     else if ((r = switchPatt.exec(line)) !== null) {
       //

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -89,7 +89,7 @@ function process_text(txt) {
   if (!patt) return txt;
   const pindefPatt = new RegExp(`^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(${patt.match})\\s*(//.*)?$`),
          noPinPatt = new RegExp(`^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(-1)\\s*(//.*)?$`),
-         skipPatt1 = new RegExp('^(\\s*(//)?#define)\\s+(AT90USB|USBCON|(BOARD|DAC|FLASH|HAS|IS|USE)_.+|.+_(ADDRESS|AVAILABLE|BAUDRATE|CLOCK|CONNECTION|DEFAULT|FREQ|ITEM|MODULE|NAME|ONLY|PERIOD|RANGE|RATE|SERIAL|SIZE|SPI|STATE|STEP|TIMER))\\s+(.+)\\s*(//.*)?$'),
+         skipPatt1 = new RegExp('^(\\s*(//)?#define)\\s+(AT90USB|USBCON|(BOARD|DAC|FLASH|HAS|IS|USE)_.+|.+_(ADDRESS|AVAILABLE|BASE_VERSION|BAUDRATE|CLOCK|CONNECTION|DEFAULT|ERROR|EXTRUDERS|FREQ|ITEM|MKS_BASE_VERSION|MODULE|NAME|ONLY|ORIENTATION|PERIOD|RANGE|RATE|READ_RETRIES|SERIAL|SIZE|SPI|STATE|STEP|TIMER))\\s+(.+)\\s*(//.*)?$'),
          skipPatt2 = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(0x[0-9A-Fa-f]+|\d+|.+[a-z].+)\\s*(//.*)?$'),
          aliasPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+([A-Z_][A-Z0-9_()]+)\\s*(//.*)?$'),
         switchPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -99,7 +99,7 @@ function process_text(txt) {
         switchPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),
          undefPatt = new RegExp('^(\\s*(//)?#undef)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),
            defPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+([-_\\w]+)\\s*(//.*)?$'),
-          condPatt = new RegExp('^(\\s*(//)?#(if|ifn?def|else|elif)(\\s+\\S+)*)\\s+(//.*)$'),
+          condPatt = new RegExp('^(\\s*(//)?#(if|ifn?def|elif)(\\s+\\S+)*)\\s+(//.*)$'),
           commPatt = new RegExp('^\\s{20,}(//.*)?$');
   const col_value_lj = col_comment - patt.pad - 2;
   var r, out = '', check_comment_next = false;
@@ -179,7 +179,7 @@ function process_text(txt) {
     }
     else if ((r = condPatt.exec(line)) !== null) {
       //
-      // #if, #ifdef, #ifndef, #else, #endif ...
+      // #if, #ifdef, #ifndef, #elif ...
       //
       if (do_log) console.log("cond:", line);
       line = r[1].rpad(col_comment).concat_with_space(r[5]);

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -93,7 +93,7 @@ function process_text(txt) {
   if (!patt) return txt;
   const pindefPatt = new RegExp(`^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(${patt.match})\\s*(//.*)?$`),
          noPinPatt = new RegExp(`^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(-1)\\s*(//.*)?$`),
-         skipPatt1 = new RegExp('^(\\s*(//)?#define)\\s+(AT90USB|USBCON|(BOARD|DAC|FLASH|HAS|IS|USE)_.+|.+_(ADDRESS|AVAILABLE|BASE_VERSION|BAUDRATE|CLOCK|CONNECTION|DEFAULT|ERROR|EXTRUDERS|FREQ|ITEM|MKS_BASE_VERSION|MODULE|NAME|ONLY|ORIENTATION|PERIOD|RANGE|RATE|READ_RETRIES|SERIAL|SIZE|SPI|STATE|STEP|TIMER))\\s+(.+)\\s*(//.*)?$'),
+         skipPatt1 = new RegExp('^(\\s*(//)?#define)\\s+(AT90USB|USBCON|(BOARD|DAC|FLASH|HAS|IS|USE)_.+|.+_(ADDRESS|AVAILABLE|BAUDRATE|CLOCK|CONNECTION|DEFAULT|ERROR|EXTRUDERS|FREQ|ITEM|MKS_BASE_VERSION|MODULE|NAME|ONLY|ORIENTATION|PERIOD|RANGE|RATE|READ_RETRIES|SERIAL|SIZE|SPI|STATE|STEP|TIMER|VERSION))\\s+(.+)\\s*(//.*)?$'),
          skipPatt2 = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(0x[0-9A-Fa-f]+|\d+|.+[a-z].+)\\s*(//.*)?$'),
          aliasPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+([A-Z_][A-Z0-9_()]+)\\s*(//.*)?$'),
         switchPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -30,9 +30,8 @@ String.prototype.rpad = function(len, chr) {
 // Concatenate a string, adding a space if necessary
 // to avoid merging two words
 String.prototype.concat_with_space = function(str) {
-  if (this.charAt(this.length - 1) !== ' ' && str.charAt(0) !== ' ') {
-    return this + ' ' + str;
-  }
+  if (this.charAt(this.length - 1) !== ' ' && str.charAt(0) !== ' ')
+    str = ' ' + str;
   return this + str;
 };
 
@@ -95,6 +94,7 @@ function process_text(txt) {
          noPinPatt = new RegExp(`^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(-1)\\s*(//.*)?$`),
          skipPatt1 = new RegExp('^(\\s*(//)?#define)\\s+(AT90USB|USBCON|(BOARD|DAC|FLASH|HAS|IS|USE)_.+|.+_(ADDRESS|AVAILABLE|BAUDRATE|CLOCK|CONNECTION|DEFAULT|ERROR|EXTRUDERS|FREQ|ITEM|MKS_BASE_VERSION|MODULE|NAME|ONLY|ORIENTATION|PERIOD|RANGE|RATE|READ_RETRIES|SERIAL|SIZE|SPI|STATE|STEP|TIMER|VERSION))\\s+(.+)\\s*(//.*)?$'),
          skipPatt2 = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+(0x[0-9A-Fa-f]+|\d+|.+[a-z].+)\\s*(//.*)?$'),
+         skipPatt3 = /^\s*#e(lse|ndif)\b.*$/,
          aliasPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s+([A-Z_][A-Z0-9_()]+)\\s*(//.*)?$'),
         switchPatt = new RegExp('^(\\s*(//)?#define)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),
          undefPatt = new RegExp('^(\\s*(//)?#undef)\\s+([A-Z_][A-Z0-9_]+)\\s*(//.*)?$'),
@@ -136,7 +136,7 @@ function process_text(txt) {
       line = line.rpad(col_value_lj).concat_with_space('-1');
       if (r[5]) line = line.rpad(col_comment).concat_with_space(r[5]);
     }
-    else if (skipPatt2.exec(line) !== null) {
+    else if (skipPatt2.exec(line) !== null || skipPatt3.exec(line) !== null) {
       //
       // #define SKIP_ME
       //
@@ -179,7 +179,7 @@ function process_text(txt) {
     }
     else if ((r = condPatt.exec(line)) !== null) {
       //
-      // #if ...
+      // #if, #ifdef, #ifndef, #else, #endif ...
       //
       if (do_log) console.log("cond:", line);
       line = r[1].rpad(col_comment).concat_with_space(r[5]);

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -56,6 +56,7 @@ else
 // Find the pin pattern so non-pin defines can be skipped
 function get_pin_pattern(txt) {
   var r, m = 0, match_count = [ 0, 0, 0, 0 ];
+  var max_match_count = 0, max_match_index = -1;
   definePatt.lastIndex = 0;
   while ((r = definePatt.exec(txt)) !== null) {
     let ind = -1;
@@ -65,11 +66,20 @@ function get_pin_pattern(txt) {
       return r[2].match(p);
     }) ) {
       const m = ++match_count[ind];
-      if (m >= 5) {
-        return { match: mpatt[ind], pad:ppad[ind] };
+      if (m > max_match_count) {
+        max_match_count = m;
+        max_match_index = ind;
       }
     }
   }
+  if (max_match_index !== -1) {
+    if (do_log) {
+      match_count.forEach((count, index) => {
+        console.log("Index: " + index, "Count: " + count, "Pattern: " + mpatt[index]);
+      });
+    }
+    return { match: mpatt[max_match_index], pad:ppad[max_match_index] };
+      }
   return null;
 }
 

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -30,7 +30,8 @@ String.prototype.rpad = function(len, chr) {
 // Concatenate a string, adding a space if necessary
 // to avoid merging two words
 String.prototype.concat_with_space = function(str) {
-  if (this.charAt(this.length - 1) !== ' ' && str.charAt(0) !== ' ')
+  const c = this.substr(-1), d = str.charAt(0);
+  if (c !== ' ' && c !== '' && d !== ' ' && d !== '')
     str = ' ' + str;
   return this + str;
 };

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -82,13 +82,8 @@ function get_pin_pattern(txt) {
     }
   }
   if (max_match_index !== -1) {
-    if (do_log) {
-      match_count.forEach((count, index) => {
-        console.log("Index: " + index, "Count: " + count, "Pattern: " + mpatt[index]);
-      });
-    }
-    return { match: mpatt[max_match_index], pad:ppad[max_match_index] };
-      }
+    return { match: mpatt[max_match_index], pad: ppad[max_match_index] };
+  }
   return null;
 }
 

--- a/buildroot/share/scripts/pinsformat.js
+++ b/buildroot/share/scripts/pinsformat.js
@@ -27,6 +27,15 @@ String.prototype.rpad = function(len, chr) {
   return s;
 };
 
+// Concatenate a string, adding a space if necessary
+// to avoid merging two words
+String.prototype.concat_with_space = function(str) {
+  if (this.charAt(this.length - 1) !== ' ' && str.charAt(0) !== ' ') {
+    return this + ' ' + str;
+  }
+  return this + str;
+};
+
 const mpatt = [ '-?\\d{1,3}', 'P[A-I]\\d+', 'P\\d_\\d+', 'Pin[A-Z]\\d\\b' ],
       definePatt = new RegExp(`^\\s*(//)?#define\\s+[A-Z_][A-Z0-9_]+\\s+(${mpatt[0]}|${mpatt[1]}|${mpatt[2]}|${mpatt[3]})\\s*(//.*)?$`, 'gm'),
       ppad = [ 3, 4, 5, 5 ],
@@ -120,8 +129,8 @@ function process_text(txt) {
       if (do_log) console.log("pin:", line);
       const pinnum = r[4].charAt(0) == 'P' ? r[4] : r[4].lpad(patt.pad);
       line = r[1] + ' ' + r[3];
-      line = line.rpad(col_value_lj) + pinnum;
-      if (r[5]) line = line.rpad(col_comment) + r[5];
+      line = line.rpad(col_value_lj).concat_with_space(pinnum);
+      if (r[5]) line = line.rpad(col_comment).concat_with_space(r[5]);
     }
     else if ((r = noPinPatt.exec(line)) !== null) {
       //
@@ -129,8 +138,8 @@ function process_text(txt) {
       //
       if (do_log) console.log("pin -1:", line);
       line = r[1] + ' ' + r[3];
-      line = line.rpad(col_value_lj) + '-1';
-      if (r[5]) line = line.rpad(col_comment) + r[5];
+      line = line.rpad(col_value_lj).concat_with_space('-1');
+      if (r[5]) line = line.rpad(col_comment).concat_with_space(r[5]);
     }
     else if (skipPatt2.exec(line) !== null) {
       //
@@ -144,8 +153,10 @@ function process_text(txt) {
       //
       if (do_log) console.log("alias:", line);
       line = r[1] + ' ' + r[3];
-      line += r[4].lpad(col_value_rj + 1 - line.length);
-      if (r[5]) line = line.rpad(col_comment) + r[5];
+      line = line.concat_with_space(r[4].lpad(col_value_rj + 1 - line.length));
+      if (r[5]) {
+        line = line.rpad(col_comment).concat_with_space(r[5]);
+      }
     }
     else if ((r = switchPatt.exec(line)) !== null) {
       //
@@ -153,7 +164,7 @@ function process_text(txt) {
       //
       if (do_log) console.log("switch:", line);
       line = r[1] + ' ' + r[3];
-      if (r[4]) line = line.rpad(col_comment) + r[4];
+      if (r[4]) line = line.rpad(col_comment).concat_with_space(r[4]);
       check_comment_next = true;
     }
     else if ((r = defPatt.exec(line)) !== null) {
@@ -162,7 +173,7 @@ function process_text(txt) {
       //
       if (do_log) console.log("def:", line);
       line = r[1] + ' ' + r[3] + ' ';
-      line += r[4].lpad(col_value_rj + 1 - line.length);
+      line = line.concat_with_space(r[4].lpad(col_value_rj + 1 - line.length));
       if (r[5]) line = line.rpad(col_comment - 1) + ' ' + r[5];
     }
     else if ((r = undefPatt.exec(line)) !== null) {
@@ -171,14 +182,14 @@ function process_text(txt) {
       //
       if (do_log) console.log("undef:", line);
       line = r[1] + ' ' + r[3];
-      if (r[4]) line = line.rpad(col_comment) + r[4];
+      if (r[4]) line = line.rpad(col_comment).concat_with_space(r[4]);
     }
     else if ((r = condPatt.exec(line)) !== null) {
       //
       // #if ...
       //
       if (do_log) console.log("cond:", line);
-      line = r[1].rpad(col_comment) + r[5];
+      line = r[1].rpad(col_comment).concat_with_space(r[5]);
       check_comment_next = true;
     }
     out += line + '\n';


### PR DESCRIPTION
### Description

Updated the pinsformat tooling in several ways:

1. Add a Makefile command `make format-pins` which will format all pins files.
2. Allow formatting small files. These were previously skipped because `get_pin_pattern` never found 5 pins. This now selects the regex with the _most_ matches, even if less than 5.
3. Skip several additional keywords which have likely been hand-maintained in the past
4. Add a helper to avoid accidentally concatenating longer names, by adding an extra space if needed.

All pins files were reformatted with the updated tooling, with minor changes.

### Requirements

N/A

### Benefits

- All pins file are exactly as output by the script, with no manual rework.
- Allows all files to be formatting with a single discoverable command.
- Could be easily leveraged in a PR check, to avoid the need for reviewers to pull a branch down to verify formatting.

### Configurations

N/A

### Related Issues

N/A
