### PR TITLE
Fix for #26452 [BUG], warning: narrowing conversion

### DIFF
--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -389,7 +389,8 @@ private:
 
         // Draw value text on
         if (viewer_print_value) {
-          xy_int_t offset { 0, cell_height_px / 2 - 6 };
+          xy_int8_t offset;
+          offset.y = cell_height_px / 2 - 6;
           if (isnan(bedlevel.z_values[x][y])) {  // undefined
             dwinDrawString(false, font6x12, COLOR_WHITE, COLOR_BG_BLUE, start_x_px + cell_width_px / 2 - 5, start_y_px + offset.y, F("X"));
           }

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -389,8 +389,7 @@ private:
 
         // Draw value text on
         if (viewer_print_value) {
-          xy_int8_t offset;
-          offset.y = cell_height_px / 2 - 6;
+          xy_uint_t offset { 0, cell_height_px / 2 - 6 };
           if (isnan(bedlevel.z_values[x][y])) {  // undefined
             dwinDrawString(false, font6x12, COLOR_WHITE, COLOR_BG_BLUE, start_x_px + cell_width_px / 2 - 5, start_y_px + offset.y, F("X"));
           }

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -211,9 +211,9 @@ bool BedLevelTools::meshValidate() {
 
   void BedLevelTools::drawBedMesh(int16_t selected/*=-1*/, uint8_t gridline_width/*=1*/, uint16_t padding_x/*=8*/, uint16_t padding_y_top/*=(40 + 53 - 7)*/) {
     drawing_mesh = true;
-    const uint16_t total_width_px = DWIN_WIDTH - padding_x - padding_x;
-    const uint16_t cell_width_px  = total_width_px / (GRID_MAX_POINTS_X);
-    const uint16_t cell_height_px = total_width_px / (GRID_MAX_POINTS_Y);
+    const uint16_t total_width_px = DWIN_WIDTH - padding_x - padding_x,
+                   cell_width_px  = total_width_px / (GRID_MAX_POINTS_X),
+                   cell_height_px = total_width_px / (GRID_MAX_POINTS_Y);
     const float v_max = abs(getMaxValue()), v_min = abs(getMinValue()), rmax = _MAX(v_min, v_max);
 
     // Clear background from previous selection and select new square
@@ -247,8 +247,7 @@ bool BedLevelTools::meshValidate() {
       // Draw value text on
       const uint8_t fs = DWINUI::fontWidth(meshfont);
       if (viewer_print_value) {
-        xy_int8_t offset;
-        offset.y = cell_height_px / 2 - fs;
+        xy_uint_t offset { 0, cell_height_px / 2 - fs };
         if (isnan(bedlevel.z_values[x][y])) {  // undefined
           dwinDrawString(false, meshfont, COLOR_WHITE, COLOR_BG_BLUE, start_x_px + cell_width_px / 2 - 5, start_y_px + offset.y, F("X"));
         }

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -247,7 +247,8 @@ bool BedLevelTools::meshValidate() {
       // Draw value text on
       const uint8_t fs = DWINUI::fontWidth(meshfont);
       if (viewer_print_value) {
-        xy_int_t offset { 0, cell_height_px / 2 - fs };
+        xy_int8_t offset;
+        offset.y = cell_height_px / 2 - fs;
         if (isnan(bedlevel.z_values[x][y])) {  // undefined
           dwinDrawString(false, meshfont, COLOR_WHITE, COLOR_BG_BLUE, start_x_px + cell_width_px / 2 - 5, start_y_px + offset.y, F("X"));
         }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
eventhough "🚸 Fix, clean up ProUI (#26434)" tried to solve this issue, the warning still persisted.

This is a fix for [BUG] Still receiving warning: narrowing conversion from 'int' to 'short int' #26452

**proui/bedlevel_tools.cpp**
**jyersui/dwin.cpp**

`xy_int_t` changed back to `xy_int8_t`, but initialize "offset"

```diff
-xy_int_t offset { 0, cell_height_px / 2 - fs };
+xy_int8_t offset;
+offset.y = cell_height_px / 2 - fs;
```
this change is similar for **JyersUI**, "fs" is replaced with "6"
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
warning goes away


<!-- What does this PR fix or improve? -->

### Configurations
`DWIN_LCD_PROUI`  
`DWIN_CREALITY_LCD_JYERSUI`
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
