### PR TITLE
teensy4.1 serial updates

### DIFF
--- a/Marlin/src/HAL/TEENSY40_41/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.cpp
@@ -39,8 +39,18 @@
 
 #define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false, Serial##X)
 #define IMPLEMENT_SERIAL(X)  _IMPLEMENT_SERIAL(X)
-#if WITHIN(SERIAL_PORT, 0, 3)
+#if WITHIN(SERIAL_PORT, 0, 8)
   IMPLEMENT_SERIAL(SERIAL_PORT);
+#endif
+#ifdef SERIAL_PORT_2
+  #if WITHIN(SERIAL_PORT_2, 0, 8)
+    IMPLEMENT_SERIAL(SERIAL_PORT_2);
+  #endif
+#endif
+#ifdef SERIAL_PORT_3
+  #if WITHIN(SERIAL_PORT_3, 0, 8)
+    IMPLEMENT_SERIAL(SERIAL_PORT_3);
+  #endif
 #endif
 USBSerialType USBSerial(false, SerialUSB);
 

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -80,7 +80,7 @@ extern USBSerialType USBSerial;
 #define MSERIAL(X) _MSERIAL(X)
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL1 SerialUSB
+  #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 8)
   DECLARE_SERIAL(SERIAL_PORT);
   #define MYSERIAL1 MSERIAL(SERIAL_PORT)
@@ -90,13 +90,25 @@ extern USBSerialType USBSerial;
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL2 usbSerial
+    #define MYSERIAL2 USBSerial
   #elif SERIAL_PORT_2 == -2
     #define MYSERIAL2 ethernet.telnetClient
   #elif WITHIN(SERIAL_PORT_2, 0, 8)
+    DECLARE_SERIAL(SERIAL_PORT_2);
     #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #else
     #error "SERIAL_PORT_2 must be from 0 to 8, or -1 for Native USB, or -2 for Ethernet."
+  #endif
+#endif
+
+#ifdef SERIAL_PORT_3
+  #if SERIAL_PORT_3 == -1
+    #define MYSERIAL3 USBSerial
+  #elif WITHIN(SERIAL_PORT_3, 0, 8)
+    DECLARE_SERIAL(SERIAL_PORT_3);
+    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
+  #else
+    #error "SERIAL_PORT_3 must be from 0 to 8, or -1 for Native USB."
   #endif
 #endif
 


### PR DESCRIPTION
### Description

The Teensy 4.1 HAL was a bit behind and broken serial wise.

Attempting to use -1 failed to compile
Attempting to use anything other than the special -2 (serial over Ethernet) on SERIAL_PORT_2 failed to compile
Had no support for SERIAL_PORT_3 at all. 

 ### Requirements

TEENSY41 with various SERIAL_PORT, SERIAL_PORT_2 and SERIAL_PORT_3 combinations

### Benefits

More serial options work as expected.

### Configurations

#define MOTHERBOARD BOARD_TEENSY41
various SERIAL_PORT, SERIAL_PORT_2 and SERIAL_PORT_3 combinations

### Related Issues

https://reprap.org/forum/read.php?415,893836

### NOTES

I do not have access to this hardware.
I have only tested compiling many combinations

Was confirmed as working by the reprap user.