### PR TITLE
Guard hostui.notify call in ProUI

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1722,7 +1722,7 @@ void dwinPrintAborted() {
       );
     }
   #endif
-  hostui.notify("Print Aborted");
+  TERN_(HOST_PROMPT_SUPPORT, hostui.notify(GET_TEXT_F(MSG_PRINT_ABORTED)));
   dwinPrintFinished();
 }
 


### PR DESCRIPTION
### Description

Fixes issue https://github.com/MarlinFirmware/Marlin/issues/26476 "Ender 3 v2 compile failed with ProUI"

https://github.com/MarlinFirmware/Marlin/pull/26308 added a unguarded call to hostui.notify without checking that 
HOST_PROMPT_SUPPORT was actually enabled.

In the same line they added a static string "Print Aborted", I replaced this with MSG_PRINT_ABORTED so it supports multiple languages 

### Requirements

PROUI

### Benefits

Builds as expected

### Configurations

From the issue:
https://github.com/MarlinFirmware/Marlin/files/13486261/Configuration.h.gz
https://github.com/MarlinFirmware/Marlin/files/13486262/Configuration_adv.h.gz

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/26476
https://github.com/MarlinFirmware/Marlin/pull/26308