### PR TITLE
🔨 Update signature.py / schema.py / configuration.py scripts

### DIFF
--- a/Marlin/config.ini
+++ b/Marlin/config.ini
@@ -3,10 +3,50 @@
 # config.ini - Options to apply before the build
 #
 [config:base]
+#
+# ini_use_config - A comma-separated list of actions to apply to the Configuration files.
+#                  The actions will be applied in the listed order.
+#  - none
+#    Ignore this file and don't apply any configuration options
+#
+#  - base
+#    Just apply the options in config:base to the configuration
+#
+#  - minimal
+#    Just apply the options in config:minimal to the configuration
+#
+#  - all
+#    Apply all 'config:*' sections in this file to the configuration
+#
+#  - another.ini
+#    Load another INI file with a path relative to this config.ini file (i.e., within Marlin/)
+#
+#  - https://me.myserver.com/path/to/configs
+#    Fetch configurations from any URL.
+#
+#  - example/Creality/Ender-5 Plus @ bugfix-2.1.x
+#    Fetch example configuration files from the MarlinFirmware/Configurations repository
+#    https://raw.githubusercontent.com/MarlinFirmware/Configurations/bugfix-2.1.x/config/examples/Creality/Ender-5%20Plus/
+#
+#  - example/default @ release-2.0.9.7
+#    Fetch default configuration files from the MarlinFirmware/Configurations repository
+#    https://raw.githubusercontent.com/MarlinFirmware/Configurations/release-2.0.9.7/config/default/
+#
+#  - [disable]
+#    Comment out all #defines in both Configuration.h and Configuration_adv.h. This is useful
+#    to start with a clean slate before applying any config: options, so only the options explicitly
+#    set in config.ini will be enabled in the configuration.
+#
+#  - [flatten] (Not yet implemented)
+#    Produce a flattened set of Configuration.h and Configuration_adv.h files with only the enabled
+#    #defines and no comments. A clean look, but context-free.
+#
 ini_use_config                           = none
 
 # Load all config: sections in this file
 ;ini_use_config                          = all
+# Disable everything and apply subsequent config:base options
+;ini_use_config                          = [disable], base
 # Load config file relative to Marlin/
 ;ini_use_config                          = another.ini
 # Download configurations from GitHub

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -1,8 +1,9 @@
+#!/usr/bin/env python3
 #
 # configuration.py
 # Apply options from config.ini to the existing Configuration headers
 #
-import re, shutil, configparser
+import re, shutil, configparser, datetime
 from pathlib import Path
 
 verbose = 0
@@ -43,6 +44,7 @@ def apply_opt(name, val, conf=None):
                 if val in ("on", "", None):
                     newline = re.sub(r'^(\s*)//+\s*(#define)(\s{1,3})?(\s*)', r'\1\2 \4', line)
                 elif val == "off":
+                    # TODO: Comment more lines in a multi-line define with \ continuation
                     newline = re.sub(r'^(\s*)(#define)(\s{1,3})?(\s*)', r'\1//\2 \4', line)
                 else:
                     # For options with values, enable and set the value
@@ -88,8 +90,37 @@ def apply_opt(name, val, conf=None):
                 elif not isdef:
                     break
                 linenum += 1
-            lines.insert(linenum, f"{prefix}#define {added:30} // Added by config.ini\n")
+            currtime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            lines.insert(linenum, f"{prefix}#define {added:30} // Added by config.ini {currtime}\n")
             fullpath.write_text(''.join(lines), encoding='utf-8')
+
+# Disable all (most) defined options in the configuration files.
+# Everything in the named sections. Section hint for exceptions may be added.
+def disable_all_options():
+    # Create a regex to match the option and capture parts of the line
+    regex = re.compile(r'^(\s*)(#define\s+)([A-Z0-9_]+\b)(\s?)(\s*)(.*?)(\s*)(//.*)?$', re.IGNORECASE)
+
+    # Disable all enabled options in both Config files
+    for file in ("Configuration.h", "Configuration_adv.h"):
+        fullpath = config_path(file)
+        lines = fullpath.read_text(encoding='utf-8').split('\n')
+        found = False
+        for i in range(len(lines)):
+            line = lines[i]
+            match = regex.match(line)
+            if match:
+                name = match[3].upper()
+                if name in ('CONFIGURATION_H_VERSION', 'CONFIGURATION_ADV_H_VERSION'): continue
+                if name.startswith('_'): continue
+                found = True
+                # Comment out the define
+                # TODO: Comment more lines in a multi-line define with \ continuation
+                lines[i] = re.sub(r'^(\s*)(#define)(\s{1,3})?(\s*)', r'\1//\2 \4', line)
+                blab(f"Disable {name}")
+
+        # If the option was found, write the modified lines
+        if found:
+            fullpath.write_text('\n'.join(lines), encoding='utf-8')
 
 # Fetch configuration files from GitHub given the path.
 # Return True if any files were fetched.
@@ -130,7 +161,7 @@ def fetch_example(url):
 def section_items(cp, sectkey):
     return cp.items(sectkey) if sectkey in cp.sections() else []
 
-# Apply all items from a config section
+# Apply all items from a config section. Ignore ini_ items outside of config:base and config:root.
 def apply_ini_by_name(cp, sect):
     iniok = True
     if sect in ('config:base', 'config:root'):
@@ -206,7 +237,17 @@ def apply_config_ini(cp):
             fetch_example(ckey)
             ckey = 'base'
 
-        if ckey == 'all':
+        #
+        # [flatten] Write out Configuration.h and Configuration_adv.h files with
+        #           just the enabled options and all other content removed.
+        #
+        #if ckey == '[flatten]':
+        #   write_flat_configs()
+
+        if ckey == '[disable]':
+            disable_all_options()
+
+        elif ckey == 'all':
             apply_sections(cp)
 
         else:

--- a/buildroot/share/PlatformIO/scripts/schema.py
+++ b/buildroot/share/PlatformIO/scripts/schema.py
@@ -2,8 +2,10 @@
 #
 # schema.py
 #
-# Used by signature.py via common-dependencies.py to generate a schema file during the PlatformIO build.
-# This script can also be run standalone from within the Marlin repo to generate all schema files.
+# Used by signature.py via common-dependencies.py to generate a schema file during the PlatformIO build
+# when CONFIG_EXPORT is defined in the configuration.
+#
+# This script can also be run standalone from within the Marlin repo to generate JSON and YAML schema files.
 #
 # This script is a companion to abm/js/schema.js in the MarlinFirmware/AutoBuildMarlin project, which has
 # been extended to evaluate conditions and can determine what options are actually enabled, not just which
@@ -409,25 +411,35 @@ def main():
 
     if schema:
 
-        # Get the first command line argument
+        # Get the command line arguments after the script name
         import sys
-        if len(sys.argv) > 1:
-            arg = sys.argv[1]
-        else:
-            arg = 'some'
+        args = sys.argv[1:]
+        if len(args) == 0: args = ['some']
+
+        # Does the given array intersect at all with args?
+        def inargs(c): return len(set(args) & set(c)) > 0
+
+        # Help / Unknown option
+        unk = not inargs(['some','json','jsons','group','yml','yaml'])
+        if (unk): print(f"Unknown option: '{args[0]}'")
+        if inargs(['-h', '--help']) or unk:
+            print("Usage: schema.py [some|json|jsons|group|yml|yaml]...")
+            print("       some  = json + yml")
+            print("       jsons = json + group")
+            return
 
         # JSON schema
-        if arg in ['some', 'json', 'jsons']:
+        if inargs(['some', 'json', 'jsons']):
             print("Generating JSON ...")
             dump_json(schema, Path('schema.json'))
 
         # JSON schema (wildcard names)
-        if arg in ['group', 'jsons']:
+        if inargs(['group', 'jsons']):
             group_options(schema)
             dump_json(schema, Path('schema_grouped.json'))
 
         # YAML
-        if arg in ['some', 'yml', 'yaml']:
+        if inargs(['some', 'yml', 'yaml']):
             try:
                 import yaml
             except ImportError:


### PR DESCRIPTION
- More detailed description of `ini_use_config` options.
- Add a `[disable]` action to `config.ini` to disable every config define.
  After this the `config.ini` must apply all enabled options (not just those that differ from defaults).
- Add usage output to `schema.py` and `signature.py`.
- `schema.py`: Assign a bare list of integer or float type `ints`/`floats`. TODO: handle expressions
