### PR TITLE
Fix Fysetc DGUS erratic bed temps

### DIFF
--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.cpp
@@ -392,7 +392,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_E1_FILAMENT_LOAD_UNLOAD, nullptr, screen.handleFilamentOption, screen.handleFilamentLoadUnload),
   #endif
   #if HAS_HEATED_BED
-    VPHELPER(VP_T_Bed_Is, &thermalManager.temp_bed.celsius, nullptr, screen.sendWordValueToDisplay),
+    VPHELPER(VP_T_Bed_Is, &thermalManager.temp_bed.celsius, nullptr, screen.sendFloatAsLongValueToDisplay<0>),
     VPHELPER(VP_T_Bed_Set, &thermalManager.temp_bed.target, screen.handleTemperatureChanged, screen.sendWordValueToDisplay),
     VPHELPER(VP_BED_CONTROL, &thermalManager.temp_bed.target, screen.handleHeaterControl, nullptr),
     VPHELPER(VP_BED_STATUS, &thermalManager.temp_bed.target, nullptr, screen.sendHeaterStatusToDisplay),


### PR DESCRIPTION
### Description

Implement an updated fix proposed in #26442 for erratic bed temperatures on a Fysetc DGUS 2.0 LCD.

I don't have this hardware, but I've asked @fortis852 to confirm if the updated fix works in `bugfix-2.1.x`. I also can't confirm if this fix is required for other DGUS LCDs, so it wasn't implemented everywhere that `screen.sendWordValueToDisplay` was found.

### Requirements

Fysetc DGUS 2.0

### Benefits

Fixes erratic bed temperatures on Fysetc DGUS 2.0 LCDs.

### Configurations

From #26442: [Marlin.zip](https://github.com/MarlinFirmware/Marlin/files/13401261/Marlin.zip)

### Related Issues

- #26442
