### PR TITLE
Skip NEOPIXEL_PIN if using a FYSETC_MINI_12864_2_1 on MKS_MONSTER8_V2

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -59,7 +59,7 @@
 #endif
 
 #if DISABLED(FYSETC_MINI_12864_2_1)
-  #define NEOPIXEL_PIN                        PC5
+  #define NEOPIXEL_PIN                      PC5
 #endif
 
 #include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -58,7 +58,8 @@
   #define WIFI_RESET_PIN                    PD14  // MKS ESP WIFI RESET PIN
 #endif
 
-#if DISABLED(FYSETC_MINI_12864_2_1)
+// The FYSETC_MINI_12864_2_1 uses one of the EXP pins
+#if DISABLED(FYSETC_MINI_12864_2_1) && !defined(NEOPIXEL_PIN)
   #define NEOPIXEL_PIN                      PC5
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -58,6 +58,8 @@
   #define WIFI_RESET_PIN                    PD14  // MKS ESP WIFI RESET PIN
 #endif
 
-#define NEOPIXEL_PIN                        PC5
+#if DISABLED(FYSETC_MINI_12864_2_1)
+  #define NEOPIXEL_PIN                        PC5
+#endif
 
 #include "pins_MKS_MONSTER8_common.h"


### PR DESCRIPTION
### Description

When using a MKS_MONSTER8_V2 Controller the file pins_MKS_MONSTER8_V2.h sets
NEOPIXEL_PIN then includes pins_MKS_MONSTER8_common.h

If you using a FYSETC_MINI_12864_2_1 or compatible lcd which uses a neopixel for a backlight, LCD  NEOPIXEL_PIN is redefined causing numerous warnings and spooking the local wildlife.

This is repeated numerous times 
```CPP
Marlin/src/module/../inc/../pins/stm32f4/pins_MKS_MONSTER8_common.h:340: warning: "NEOPIXEL_PIN" redefined
  340 |     #define NEOPIXEL_PIN             EXP1_06_PIN
      | 
In file included from Marlin/src/module/../inc/../pins/pins.h:784,
                 from Marlin/src/module/../inc/MarlinConfig.h:36,
                 from Marlin/src/module/tool_change.h:24,
                 from Marlin/src/module/tool_change.cpp:25:
Marlin/src/module/../inc/../pins/stm32f4/pins_MKS_MONSTER8_V2.h:63: note: this is the location of the previous definition
   63 |   #define NEOPIXEL_PIN                        PC5

```

This PR skips defining of NEOPIXEL_PIN in pins_MKS_MONSTER8_V2.h when using this display.

### Requirements

BOARD_MKS_MONSTER8_V2 and a  FYSETC_MINI_12864_2_1 (or compatible neopixel back-lit lcd) 

### Benefits

The warning are gone. 
Less spooked local wildlife.

### Related Issues
https://discord.com/channels/461605380783472640/491165528295997450/1180429122946732083
