### PR TITLE
Fix DEBUG_LEVELING_FEATURE compile errors

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -263,7 +263,7 @@ void GcodeSuite::G28() {
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         auto debug_current = [](FSTR_P const s, const int16_t a, const int16_t b) {
-          if (DEBUGGING(LEVELING)) { DEBUG_ECHOF(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b); }
+          if (DEBUGGING(LEVELING)) { DEBUG_ECHOLN(s, F(" current: "), a, F(" -> "), b); }
         };
       #else
         #define debug_current(...)

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -1360,7 +1360,7 @@ void Endstops::update() {
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         auto debug_current = [](FSTR_P const s, const int16_t a, const int16_t b) {
-          if (DEBUGGING(LEVELING)) { DEBUG_ECHOF(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b); }
+          if (DEBUGGING(LEVELING)) { DEBUG_ECHOLN(s, F(" current: "), a, F(" -> "), b); }
         };
       #else
         #define debug_current(...)


### PR DESCRIPTION
### Description

`DEBUG_ECHOF` was replaced in #25928, but was left behind in a couple places which causes compile errors when `DEBUG_LEVELING_FEATURE` is enabled:

```prolog
Marlin/src/gcode/calibrate/G28.cpp: In lambda function:
Marlin/src/gcode/calibrate/G28.cpp:266:38: error: 'DEBUG_ECHOF' was not declared in this scope; did you mean 'DEBUG_ECHO'?
  266 |           if (DEBUGGING(LEVELING)) { DEBUG_ECHOF(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b); }
      |                                      ^~~~~~~~~~~
      |                                      DEBUG_ECHO
Compiling .pio/build/STM32H743VI_btt/src/src/gcode/control/M999.cpp.o
*** [.pio/build/STM32H743VI_btt/src/src/gcode/calibrate/G28.cpp.o] Error 1
```

### Requirements

`DEBUG_LEVELING_FEATURE`

### Benefits

Users can compile with `DEBUG_LEVELING_FEATURE` enabled.

### Related Issues

- #26493
