### PR TITLE
fix ftostrX3sign  

### DIFF
--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -314,7 +314,7 @@ const char* ftostr51sign(const_float_t f) { return ftostrX1sign(f, 1); }
 // Convert float to string with +/ /- and 3 decimal places
 //
 inline const char* ftostrX3sign(const_float_t f, const int index, char plus/*=' '*/) {
-  long i = INTFLOAT(f, 1);
+  long i = INTFLOAT(f, 3);
   conv[index] = i ? MINUSOR(i, plus) : ' ';
   switch (index + 1) {
     case 1: conv[1] = DIGIMOD(i, 100000);


### PR DESCRIPTION
### Description

It was noticed that Probe Z offset was displaying incorrectly in Marlin Menus

When the Z Probe offset is set with `M851 Z-3.6`  the menu displays -0.039

![3](https://github.com/MarlinFirmware/Marlin/assets/530024/fe0bc8d2-58f6-4e2c-9c49-42b036922373)

Tracked the bug down to the new ftostrX3sign function incorrectly calling INTFLOAT(f, 1); not INTFLOAT(f, 3);

### Requirements

#define FIX_MOUNTED_PROBE // or any probe
#define Z_SAFE_HOMING // just to build
#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER // or Any display that uses Marlin menu 

#define PROBE_OFFSET_ZMIN -5   // needed to trigger the bug

Marlin has this code, which changes LCD_Z_OFFSET_TYPE based on PROBE_OFFSET_ZMIN value. Needs to be set to 
use float43 to see the issue. float42_52 worked without issue.

```CPP
#if HAS_BED_PROBE
  #if WITHIN(PROBE_OFFSET_ZMIN, -9, 9)
    #define LCD_Z_OFFSET_TYPE float43    // Values from -9.000 to +9.000
  #else
    #define LCD_Z_OFFSET_TYPE float42_52 // Values from -99.99 to 99.99
  #endif
#endif

```
### Benefits

Menu items using float43 displays as expected

### Related Issues

Introduced in https://github.com/MarlinFirmware/Marlin/pull/26343
https://discord.com/channels/461605380783472640/491105274464043026/1180872647219871934
 