### PR TITLE
update to thermistor tables 14 and 68 to constexpr

### DIFF
--- a/Marlin/src/module/thermistor/thermistor_14.h
+++ b/Marlin/src/module/thermistor/thermistor_14.h
@@ -22,7 +22,7 @@
 #pragma once
 
 // R25 = 100 kOhm, beta25 = 4092 K, 4.7 kOhm pull-up, bed thermistor
-const temp_entry_t temptable_14[] PROGMEM = {
+constexpr temp_entry_t temptable_14[] PROGMEM = {
   { OV(  23), 275 },
   { OV(  25), 270 },
   { OV(  27), 265 },

--- a/Marlin/src/module/thermistor/thermistor_68.h
+++ b/Marlin/src/module/thermistor/thermistor_68.h
@@ -24,7 +24,7 @@
 #define REVERSE_TEMP_SENSOR_RANGE_68 1
 
 // PT100 amplifier board from Dyze Design
-const temp_entry_t temptable_68[] PROGMEM = {
+constexpr temp_entry_t temptable_68[] PROGMEM = {
   { OV(273), 0   },
   { OV(294), 20  },
   { OV(315), 40  },


### PR DESCRIPTION
### Description

Setting either
#define TEMP_SENSOR_0 14 with #define HEATER_0_MAXTEMP 260
or
#define TEMP_SENSOR_0 68 
Results in a compile error
```
Marlin/src/module/temperature.cpp:307:33: error: non-constant condition for static assertion
```
The cause is the temp_entry_t are set to const, not constexpr like every other thermistor table.

This breaks the CHECK_MAXTEMP tests

This PR updated both to constexpr

### Requirements

Attempt to use thermistor table 14 ot 68 with correct MAXTEMP limits set

### Benefits

Works as expected

### Related Issues
I found this while helping out on https://reprap.org/forum/read.php?415,893882