### PR TITLE
Use PIO versioning, pin HC32 platform

### DIFF
--- a/Marlin/src/pins/hc32f4/env_validate.h
+++ b/Marlin/src/pins/hc32f4/env_validate.h
@@ -19,8 +19,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#pragma once
+#ifndef ENV_VALIDATE_H
+#define ENV_VALIDATE_H
 
 #ifndef ARDUINO_ARCH_HC32
   #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
+#endif
+
 #endif

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -27,7 +27,7 @@
 # Base Environment for all HC32F460 variants
 #
 [HC32F460_base]
-platform         = https://github.com/shadow578/platform-hc32f46x/archive/main.zip
+platform         = https://github.com/shadow578/platform-hc32f46x/archive/1.0.0.zip
 board            = generic_hc32f460
 build_src_filter = ${common.default_src_filter} +<src/HAL/HC32> +<src/HAL/shared/backtrace>
 build_type       = release

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -743,7 +743,7 @@ upload_protocol = stlink
 [env:STM32F401RC_btt]
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
-platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.6.0.zip
+platform_packages           = framework-arduinoststm32@~4.20600.231001
                               toolchain-gccarmnoneeabi@1.100301.220327
 board                       = marlin_STM32F401RC
 board_build.offset          = 0x4000

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -32,7 +32,7 @@ build_flags = -DPIN_WIRE_SCL=PB3 -DPIN_WIRE_SDA=PB4
 [env:BTT_EBB42_V1_1_filament_extruder]
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
-platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.6.0.zip
+platform_packages           = framework-arduinoststm32@~4.20600.231001
                               toolchain-gccarmnoneeabi@1.100301.220327
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
@@ -48,7 +48,7 @@ upload_command              = dfu-util -a 0 -s 0x08000000:leave -D "$SOURCE"
 [env:STM32G0B1RE_btt]
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
-platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.6.0.zip
+platform_packages           = framework-arduinoststm32@~4.20600.231001
                               toolchain-gccarmnoneeabi@1.100301.220327
 board                       = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
@@ -105,7 +105,7 @@ upload_protocol = custom
 [env:STM32G0B1VE_btt]
 extends                     = stm32_variant
 platform                    = ststm32@~14.1.0
-platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.6.0.zip
+platform_packages           = framework-arduinoststm32@~4.20600.231001
                               toolchain-gccarmnoneeabi@1.100301.220327
 board                       = marlin_STM32G0B1VE
 board_build.offset          = 0x2000


### PR DESCRIPTION
### Description

- Use PIO versioning: These are equivalent and by using [PIO's versioning](https://registry.platformio.org/tools/platformio/framework-arduinoststm32/versions), it'll list the proper `framework-arduinoststm32` version in the log output instead of `framework-arduinoststm32 @ 0.0.0`.
- Pin HC32 platform version instead of using the main branch.
- Fix up HC32 `env_validate.h` for parity with others. While testing the HC32 environment validation, I noticed that it still does not validate properly with `preflight-checkys.py` & does not provide the correct environment name:
   <details><summary>details:</summary>
   <p>

   ```prolog
   In file included from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/hc32f4/pins_AQUILA_101.h:27,
                    from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/pins.h:896,
                    from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfig.h:36,
                    from buildroot/share/PlatformIO/scripts/common-dependencies.h:29:
   buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/hc32f4/env_validate.h:26:4: error: #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
      26 |   #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
         |    ^~~~~
   Error: Failed to parse Marlin features. See previous error messages.
   ```

   </p>
   </details>