### PR TITLE
Markforged inversed beltpath support (#26515)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -892,11 +892,16 @@
 //#define COREYX
 //#define COREZX
 //#define COREZY
-//#define MARKFORGED_XY  // MarkForged. See https://reprap.org/forum/read.php?152,504042
-//#define MARKFORGED_YX
 
-//Enable to inverse beltpath for Markforged
-//#define MARKFORGED_INVERSE  // Inverse choosen Markforged kinemtics belt path
+//
+// MarkForged Kinematics
+// See https://reprap.org/forum/read.php?152,504042
+//
+//#define MARKFORGED_XY
+//#define MARKFORGED_YX
+#if ANY(MARKFORGED_XY, MARKFORGED_YX)
+  //#define MARKFORGED_INVERSE  // Enable for an inverted Markforged kinematics belt path
+#endif
 
 // Enable for a belt style printer with endless "Z" motion
 //#define BELTPRINTER

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -895,6 +895,9 @@
 //#define MARKFORGED_XY  // MarkForged. See https://reprap.org/forum/read.php?152,504042
 //#define MARKFORGED_YX
 
+//Enable to inverse beltpath for Markforged
+//#define MARKFORGED_INVERSE  // Inverse choosen Markforged kinemtics belt path
+
 // Enable for a belt style printer with endless "Z" motion
 //#define BELTPRINTER
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2072,13 +2072,13 @@ bool Planner::_populate_block(
     #elif CORE_IS_YZ
       ABS(dist.a), ABS(dist.b + dist.c), ABS(dist.b - dist.c)
     #elif ENABLED(MARKFORGED_XY)
-      #if MARKFORGED_INVERSE
+      #if ENABLED(MARKFORGED_INVERSE)
         ABS(dist.a - dist.b), ABS(dist.b), ABS(dist.c)
       #else
         ABS(dist.a + dist.b), ABS(dist.b), ABS(dist.c)
       #endif
     #elif ENABLED(MARKFORGED_YX)
-      #if MARKFORGED_INVERSE
+      #if ENABLED(MARKFORGED_INVERSE)
         ABS(dist.a), ABS(dist.b - dist.a), ABS(dist.c)
       #else
         ABS(dist.a), ABS(dist.b + dist.a), ABS(dist.c)  

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1990,7 +1990,7 @@ bool Planner::_populate_block(
       dm.c  = (CORESIGN(dist.b - dist.c) > 0);  // Motor C direction
     #endif
   #elif ENABLED(MARKFORGED_XY)
-    #if MARKFORGED_INVERSE
+    #if ENABLED(MARKFORGED_INVERSE)
       dm.a = (dist.a - dist.b > 0);               // Motor A direction
       dm.b = (dist.b > 0);                        // Motor B direction
     #else   
@@ -1998,7 +1998,7 @@ bool Planner::_populate_block(
       dm.b = (dist.b > 0);                        // Motor B direction
     #endif
   #elif ENABLED(MARKFORGED_YX)
-    #if MARKFORGED_INVERSE
+    #if ENABLED(MARKFORGED_INVERSE)
       dm.a = (dist.a > 0);                        // Motor A direction
       dm.b = (dist.b + dist.a > 0);               // Motor B direction
     #else

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1990,21 +1990,11 @@ bool Planner::_populate_block(
       dm.c  = (CORESIGN(dist.b - dist.c) > 0);  // Motor C direction
     #endif
   #elif ENABLED(MARKFORGED_XY)
-    #if ENABLED(MARKFORGED_INVERSE)
-      dm.a = (dist.a - dist.b > 0);               // Motor A direction
-      dm.b = (dist.b > 0);                        // Motor B direction
-    #else   
-      dm.a = (dist.a + dist.b > 0);               // Motor A direction
-      dm.b = (dist.b > 0);                        // Motor B direction
-    #endif
+    dm.a = (dist.a TERN(MARKFORGED_INVERSE, -, +) dist.b > 0); // Motor A direction
+    dm.b = (dist.b > 0);                        // Motor B direction
   #elif ENABLED(MARKFORGED_YX)
-    #if ENABLED(MARKFORGED_INVERSE)
-      dm.a = (dist.a > 0);                        // Motor A direction
-      dm.b = (dist.b + dist.a > 0);               // Motor B direction
-    #else
-      dm.a = (dist.a > 0);                        // Motor A direction
-      dm.b = (dist.b - dist.a > 0);               // Motor B direction
-    #endif  
+    dm.a = (dist.a > 0);                        // Motor A direction
+    dm.b = (dist.b TERN(MARKFORGED_INVERSE, -, +) dist.a > 0); // Motor B direction
   #else
     XYZ_CODE(
       dm.x = (dist.a > 0),
@@ -2072,17 +2062,9 @@ bool Planner::_populate_block(
     #elif CORE_IS_YZ
       ABS(dist.a), ABS(dist.b + dist.c), ABS(dist.b - dist.c)
     #elif ENABLED(MARKFORGED_XY)
-      #if ENABLED(MARKFORGED_INVERSE)
-        ABS(dist.a - dist.b), ABS(dist.b), ABS(dist.c)
-      #else
-        ABS(dist.a + dist.b), ABS(dist.b), ABS(dist.c)
-      #endif
+      ABS(dist.a TERN(MARKFORGED_INVERSE, -, +) dist.b), ABS(dist.b), ABS(dist.c)
     #elif ENABLED(MARKFORGED_YX)
-      #if ENABLED(MARKFORGED_INVERSE)
-        ABS(dist.a), ABS(dist.b - dist.a), ABS(dist.c)
-      #else
-        ABS(dist.a), ABS(dist.b + dist.a), ABS(dist.c)  
-      #endif
+      ABS(dist.a), ABS(dist.b TERN(MARKFORGED_INVERSE, -, +) dist.a), ABS(dist.c)
     #elif IS_SCARA
       ABS(dist.a), ABS(dist.b), ABS(dist.c)
     #else // default non-h-bot planning
@@ -2128,19 +2110,11 @@ bool Planner::_populate_block(
       dist_mm.c      = CORESIGN(dist.b - dist.c) * mm_per_step[C_AXIS];
     #endif
   #elif ENABLED(MARKFORGED_XY)
-    #if ENABLED(MARKFORGED_INVERSE)
-      dist_mm.a = (dist.a + dist.b) * mm_per_step[A_AXIS];
-    #else
-      dist_mm.a = (dist.a - dist.b) * mm_per_step[A_AXIS];
-    #endif
+    dist_mm.a = (dist.a TERN(MARKFORGED_INVERSE, +, -) dist.b) * mm_per_step[A_AXIS];
     dist_mm.b = dist.b * mm_per_step[B_AXIS];
   #elif ENABLED(MARKFORGED_YX)
     dist_mm.a = dist.a * mm_per_step[A_AXIS];
-    #if ENABLED(MARKFORGED_INVERSE)
-      dist_mm.b = (dist.b + dist.a) * mm_per_step[B_AXIS];
-    #else
-      dist_mm.b = (dist.b - dist.a) * mm_per_step[B_AXIS];
-    #endif
+    dist_mm.b = (dist.b TERN(MARKFORGED_INVERSE, +, -) dist.a) * mm_per_step[B_AXIS];
   #else
     XYZ_CODE(
       dist_mm.a = dist.a * mm_per_step[A_AXIS],

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1990,11 +1990,21 @@ bool Planner::_populate_block(
       dm.c  = (CORESIGN(dist.b - dist.c) > 0);  // Motor C direction
     #endif
   #elif ENABLED(MARKFORGED_XY)
-    dm.a = (dist.a + dist.b > 0);               // Motor A direction
-    dm.b = (dist.b > 0);                        // Motor B direction
+    #if MARKFORGED_INVERSE
+      dm.a = (dist.a - dist.b > 0);               // Motor A direction
+      dm.b = (dist.b > 0);                        // Motor B direction
+    #else   
+      dm.a = (dist.a + dist.b > 0);               // Motor A direction
+      dm.b = (dist.b > 0);                        // Motor B direction
+    #endif
   #elif ENABLED(MARKFORGED_YX)
-    dm.a = (dist.a > 0);                        // Motor A direction
-    dm.b = (dist.b + dist.a > 0);               // Motor B direction
+    #if MARKFORGED_INVERSE
+      dm.a = (dist.a > 0);                        // Motor A direction
+      dm.b = (dist.b + dist.a > 0);               // Motor B direction
+    #else
+      dm.a = (dist.a > 0);                        // Motor A direction
+      dm.b = (dist.b - dist.a > 0);               // Motor B direction
+    #endif  
   #else
     XYZ_CODE(
       dm.x = (dist.a > 0),
@@ -2062,9 +2072,17 @@ bool Planner::_populate_block(
     #elif CORE_IS_YZ
       ABS(dist.a), ABS(dist.b + dist.c), ABS(dist.b - dist.c)
     #elif ENABLED(MARKFORGED_XY)
-      ABS(dist.a + dist.b), ABS(dist.b), ABS(dist.c)
+      #if MARKFORGED_INVERSE
+        ABS(dist.a - dist.b), ABS(dist.b), ABS(dist.c)
+      #else
+        ABS(dist.a + dist.b), ABS(dist.b), ABS(dist.c)
+      #endif
     #elif ENABLED(MARKFORGED_YX)
-      ABS(dist.a), ABS(dist.b + dist.a), ABS(dist.c)
+      #if MARKFORGED_INVERSE
+        ABS(dist.a), ABS(dist.b - dist.a), ABS(dist.c)
+      #else
+        ABS(dist.a), ABS(dist.b + dist.a), ABS(dist.c)  
+      #endif
     #elif IS_SCARA
       ABS(dist.a), ABS(dist.b), ABS(dist.c)
     #else // default non-h-bot planning
@@ -2110,11 +2128,19 @@ bool Planner::_populate_block(
       dist_mm.c      = CORESIGN(dist.b - dist.c) * mm_per_step[C_AXIS];
     #endif
   #elif ENABLED(MARKFORGED_XY)
-    dist_mm.a = (dist.a - dist.b) * mm_per_step[A_AXIS];
+    #if ENABLED(MARKFORGED_INVERSE)
+      dist_mm.a = (dist.a + dist.b) * mm_per_step[A_AXIS];
+    #else
+      dist_mm.a = (dist.a - dist.b) * mm_per_step[A_AXIS];
+    #endif
     dist_mm.b = dist.b * mm_per_step[B_AXIS];
   #elif ENABLED(MARKFORGED_YX)
     dist_mm.a = dist.a * mm_per_step[A_AXIS];
-    dist_mm.b = (dist.b - dist.a) * mm_per_step[B_AXIS];
+    #if ENABLED(MARKFORGED_INVERSE)
+      dist_mm.b = (dist.b + dist.a) * mm_per_step[B_AXIS];
+    #else
+      dist_mm.b = (dist.b - dist.a) * mm_per_step[B_AXIS];
+    #endif
   #else
     XYZ_CODE(
       dist_mm.a = dist.a * mm_per_step[A_AXIS],

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3287,9 +3287,17 @@ void Stepper::_set_position(const abce_long_t &spos) {
       // coreyz planning
       count_position.set(spos.a, spos.b + spos.c, CORESIGN(spos.b - spos.c));
     #elif ENABLED(MARKFORGED_XY)
-      count_position.set(spos.a - spos.b, spos.b, spos.c);
+        #if ENABLED(MARKFORGED_INVERSE)
+          count_position.set(spos.a + spos.b, spos.b, spos.c);
+        #else
+          count_position.set(spos.a - spos.b, spos.b, spos.c);
+        #endif
     #elif ENABLED(MARKFORGED_YX)
-      count_position.set(spos.a, spos.b - spos.a, spos.c);
+        #if ENABLED(MARKFORGED_INVERSE)
+          count_position.set(spos.a, spos.b + spos.a, spos.c);
+        #else
+          count_position.set(spos.a, spos.b - spos.a, spos.c);
+        #endif
     #endif
     SECONDARY_AXIS_CODE(
       count_position.i = spos.i,
@@ -3381,13 +3389,25 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
         : count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
       ) * double(0.5)
     #elif ENABLED(MARKFORGED_XY)
+      #if ENABLED(MARKFORGED_INVERSE)  
+      axis == CORE_AXIS_1
+        ? count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
+        : count_position[CORE_AXIS_2]
+      #else
       axis == CORE_AXIS_1
         ? count_position[CORE_AXIS_1] - count_position[CORE_AXIS_2]
         : count_position[CORE_AXIS_2]
+      #endif  
     #elif ENABLED(MARKFORGED_YX)
+      #if ENABLED(MARKFORGED_INVERSE)  
+      axis == CORE_AXIS_1
+        ? count_position[CORE_AXIS_1]
+        : count_position[CORE_AXIS_2] + count_position[CORE_AXIS_1]
+      #else
       axis == CORE_AXIS_1
         ? count_position[CORE_AXIS_1]
         : count_position[CORE_AXIS_2] - count_position[CORE_AXIS_1]
+      #endif  
     #else // !IS_CORE
       count_position[axis]
     #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3287,17 +3287,9 @@ void Stepper::_set_position(const abce_long_t &spos) {
       // coreyz planning
       count_position.set(spos.a, spos.b + spos.c, CORESIGN(spos.b - spos.c));
     #elif ENABLED(MARKFORGED_XY)
-        #if ENABLED(MARKFORGED_INVERSE)
-          count_position.set(spos.a + spos.b, spos.b, spos.c);
-        #else
-          count_position.set(spos.a - spos.b, spos.b, spos.c);
-        #endif
+      count_position.set(spos.a TERN(MARKFORGED_INVERSE, +, -) spos.b, spos.b, spos.c);
     #elif ENABLED(MARKFORGED_YX)
-        #if ENABLED(MARKFORGED_INVERSE)
-          count_position.set(spos.a, spos.b + spos.a, spos.c);
-        #else
-          count_position.set(spos.a, spos.b - spos.a, spos.c);
-        #endif
+      count_position.set(spos.a, spos.b TERN(MARKFORGED_INVERSE, +, -) spos.a, spos.c);
     #endif
     SECONDARY_AXIS_CODE(
       count_position.i = spos.i,
@@ -3389,25 +3381,13 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
         : count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
       ) * double(0.5)
     #elif ENABLED(MARKFORGED_XY)
-      #if ENABLED(MARKFORGED_INVERSE)  
       axis == CORE_AXIS_1
-        ? count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
+        ? count_position[CORE_AXIS_1] ENABLED(MARKFORGED_INVERSE, +, -) count_position[CORE_AXIS_2]
         : count_position[CORE_AXIS_2]
-      #else
-      axis == CORE_AXIS_1
-        ? count_position[CORE_AXIS_1] - count_position[CORE_AXIS_2]
-        : count_position[CORE_AXIS_2]
-      #endif  
     #elif ENABLED(MARKFORGED_YX)
-      #if ENABLED(MARKFORGED_INVERSE)  
       axis == CORE_AXIS_1
         ? count_position[CORE_AXIS_1]
-        : count_position[CORE_AXIS_2] + count_position[CORE_AXIS_1]
-      #else
-      axis == CORE_AXIS_1
-        ? count_position[CORE_AXIS_1]
-        : count_position[CORE_AXIS_2] - count_position[CORE_AXIS_1]
-      #endif  
+        : count_position[CORE_AXIS_2] ENABLED(MARKFORGED_INVERSE, +, -) count_position[CORE_AXIS_1]
     #else // !IS_CORE
       count_position[axis]
     #endif

--- a/buildroot/tests/mks_robin_mini
+++ b/buildroot/tests/mks_robin_mini
@@ -9,6 +9,7 @@ set -e
 
 use_example_configs Mks/Robin
 opt_set MOTHERBOARD BOARD_MKS_ROBIN_MINI EXTRUDERS 1 TEMP_SENSOR_1 0
+opt_enable MARKFORGED_XY MARKFORGED_INVERSE
 exec_test $1 $2 "MKS Robin mini" "$3"
 
 # cleanup


### PR DESCRIPTION
My costum printer with "Markforged" Kinematics has a different Beltpath (X Carriage is fixed on the other side of the X Belt), compared to the already support markforged kinematics type introduced by #23163 

Something like that PR should fix #26515 

Hopefully I´ve got everything right, i was only able to test Markforged_XY, but I guess the same could be usefull for YX variant.

BTW. im not familiar with Marlins coding style or Github handling at all, so please be kind ;)