### PR TITLE
Fix CLASSIC_JERK to consistently respect jerk limits

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -155,7 +155,7 @@
     planner.settings.max_acceleration_mm_per_s2[X_AXIS] = 100;
     planner.settings.max_acceleration_mm_per_s2[Y_AXIS] = 100;
     TERN_(DELTA, planner.settings.max_acceleration_mm_per_s2[Z_AXIS] = 100);
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       motion_state.jerk_state = planner.max_jerk;
       planner.max_jerk.set(0, 0 OPTARG(DELTA, 0));
     #endif
@@ -167,7 +167,7 @@
     planner.settings.max_acceleration_mm_per_s2[X_AXIS] = motion_state.acceleration.x;
     planner.settings.max_acceleration_mm_per_s2[Y_AXIS] = motion_state.acceleration.y;
     TERN_(DELTA, planner.settings.max_acceleration_mm_per_s2[Z_AXIS] = motion_state.acceleration.z);
-    TERN_(HAS_CLASSIC_JERK, planner.max_jerk = motion_state.jerk_state);
+    TERN_(CLASSIC_JERK, planner.max_jerk = motion_state.jerk_state);
     planner.refresh_acceleration_rates();
   }
 

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -297,7 +297,7 @@ void GcodeSuite::M205() {
   if (parser.seenval('S')) planner.settings.min_feedrate_mm_s = parser.value_linear_units();
   if (parser.seenval('T')) planner.settings.min_travel_feedrate_mm_s = parser.value_linear_units();
   #if HAS_JUNCTION_DEVIATION
-    #if HAS_CLASSIC_JERK && AXIS_COLLISION('J')
+    #if ENABLED(CLASSIC_JERK) && AXIS_COLLISION('J')
       #error "Can't set_max_jerk for 'J' axis because 'J' is used for Junction Deviation."
     #endif
     if (parser.seenval('J')) {
@@ -310,7 +310,7 @@ void GcodeSuite::M205() {
         SERIAL_ERROR_MSG("?J out of range (0.01 to 0.3)");
     }
   #endif
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
     bool seenZ = false;
     LOGICAL_AXIS_CODE(
       if (parser.seenval('E')) planner.set_max_jerk(E_AXIS, parser.value_linear_units()),
@@ -328,14 +328,14 @@ void GcodeSuite::M205() {
       if (seenZ && planner.max_jerk.z <= 0.1f)
         SERIAL_ECHOLNPGM("WARNING! Low Z Jerk may lead to unwanted pauses.");
     #endif
-  #endif // HAS_CLASSIC_JERK
+  #endif // CLASSIC_JERK
 }
 
 void GcodeSuite::M205_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(
     "Advanced (" M205_MIN_SEG_TIME_STR "<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>"
     TERN_(HAS_JUNCTION_DEVIATION, " J<junc_dev>")
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       NUM_AXIS_GANG(
         " X<max_jerk>", " Y<max_jerk>", " Z<max_jerk>",
         " " STR_I "<max_jerk>", " " STR_J "<max_jerk>", " " STR_K "<max_jerk>",
@@ -352,7 +352,7 @@ void GcodeSuite::M205_report(const bool forReplay/*=true*/) {
     #if HAS_JUNCTION_DEVIATION
       , PSTR(" J"), LINEAR_UNIT(planner.junction_deviation_mm)
     #endif
-    #if HAS_CLASSIC_JERK && NUM_AXES
+    #if ENABLED(CLASSIC_JERK) && NUM_AXES
       , LIST_N(DOUBLE(NUM_AXES),
         SP_X_STR, LINEAR_UNIT(planner.max_jerk.x),
         SP_Y_STR, LINEAR_UNIT(planner.max_jerk.y),

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -55,7 +55,7 @@ void GcodeSuite::M92() {
           const float value = parser.value_per_axis_units((AxisEnum)(E_AXIS_N(target_extruder)));
           if (value < 20) {
             float factor = planner.settings.axis_steps_per_mm[E_AXIS_N(target_extruder)] / value; // increase e constants if M92 E14 is given for netfab.
-            #if HAS_CLASSIC_JERK && HAS_CLASSIC_E_JERK
+            #if ALL(CLASSIC_JERK, HAS_CLASSIC_E_JERK)
               planner.max_jerk.e *= factor;
             #endif
             planner.settings.max_feedrate_mm_s[E_AXIS_N(target_extruder)] *= factor;

--- a/Marlin/src/gcode/host/M360.cpp
+++ b/Marlin/src/gcode/host/M360.cpp
@@ -91,7 +91,7 @@ void GcodeSuite::M360() {
   //
   // XYZ Axis Jerk
   //
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
     if (planner.max_jerk.x == planner.max_jerk.y)
       config_line(F("XY"), planner.max_jerk.x, FPSTR(JERK_STR));
     else {
@@ -182,7 +182,7 @@ void GcodeSuite::M360() {
   config_line(F("NumExtruder"), EXTRUDERS);
   #if HAS_EXTRUDERS
     EXTRUDER_LOOP() {
-      config_line_e(e, JERK_STR, TERN(HAS_LINEAR_E_JERK, planner.max_e_jerk[E_INDEX_N(e)], TERN(HAS_CLASSIC_JERK, planner.max_jerk.e, DEFAULT_EJERK)));
+      config_line_e(e, JERK_STR, TERN(HAS_LINEAR_E_JERK, planner.max_e_jerk[E_INDEX_N(e)], TERN(CLASSIC_JERK, planner.max_jerk.e, DEFAULT_EJERK)));
       config_line_e(e, F("MaxSpeed"), planner.settings.max_feedrate_mm_s[E_AXIS_N(e)]);
       config_line_e(e, F("Acceleration"), planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(e)]);
       config_line_e(e, F("Diameter"), TERN(NO_VOLUMETRICS, DEFAULT_NOMINAL_FILAMENT_DIA, planner.filament_size[e]));

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1615,11 +1615,7 @@
   #undef DELTA_HOME_TO_SAFE_ZONE
 #endif
 
-// This flag indicates some kind of jerk storage is needed
-#if ANY(CLASSIC_JERK, IS_KINEMATIC)
-  #define HAS_CLASSIC_JERK 1
-#endif
-
+// Use Junction Deviation for motion if Jerk is disabled
 #if DISABLED(CLASSIC_JERK)
   #define HAS_JUNCTION_DEVIATION 1
 #endif

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1615,16 +1615,6 @@
   #undef DELTA_HOME_TO_SAFE_ZONE
 #endif
 
-// Use Junction Deviation for motion if Jerk is disabled
-#if DISABLED(CLASSIC_JERK)
-  #define HAS_JUNCTION_DEVIATION 1
-#endif
-
-// E jerk exists with JD disabled (of course) but also when Linear Advance is disabled on Delta/SCARA
-#if HAS_EXTRUDERS && (ENABLED(CLASSIC_JERK) || (IS_KINEMATIC && DISABLED(LIN_ADVANCE)))
-  #define HAS_CLASSIC_E_JERK 1
-#endif
-
 //
 // Serial Port Info
 //

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -302,6 +302,21 @@
   #endif
 #endif
 
+// Use Junction Deviation for motion if Jerk is disabled
+#if DISABLED(CLASSIC_JERK)
+  #define HAS_JUNCTION_DEVIATION 1
+#endif
+
+// E jerk exists with JD disabled (of course) but also when Linear Advance is disabled on Delta/SCARA
+#if HAS_EXTRUDERS && (ENABLED(CLASSIC_JERK) || (IS_KINEMATIC && DISABLED(LIN_ADVANCE)))
+  #define HAS_CLASSIC_E_JERK 1
+#endif
+
+// Linear advance uses Jerk since E is an isolated axis
+#if ALL(HAS_JUNCTION_DEVIATION, LIN_ADVANCE)
+  #define HAS_LINEAR_E_JERK 1
+#endif
+
 /**
  * Temperature Sensors; define what sensor(s) we have.
  */

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -37,11 +37,6 @@
   #define ADC_VREF_MV HAL_ADC_VREF_MV
 #endif
 
-// Linear advance uses Jerk since E is an isolated axis
-#if ALL(HAS_JUNCTION_DEVIATION, LIN_ADVANCE)
-  #define HAS_LINEAR_E_JERK 1
-#endif
-
 // Determine which type of 'EEPROM' is in use
 #if ENABLED(EEPROM_SETTINGS)
   // EEPROM type may be defined by compile flags, configs, HALs, or pins

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1225,7 +1225,7 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
  * Junction deviation is incompatible with kinematic systems.
  */
 #if HAS_JUNCTION_DEVIATION && IS_KINEMATIC
-  #error "CLASSIC_JERK is required for DELTA, SCARA, and POLAR."
+  #error "CLASSIC_JERK is required for the kinematics of DELTA, SCARA, POLAR, etc."
 #endif
 
 /**
@@ -1583,7 +1583,7 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #error "Only enable RESTORE_LEVELING_AFTER_G28 or ENABLE_LEVELING_AFTER_G28, but not both."
 #endif
 
-#if HAS_MESH && HAS_CLASSIC_JERK
+#if ALL(HAS_MESH, CLASSIC_JERK)
   static_assert(DEFAULT_ZJERK > 0.1, "Low DEFAULT_ZJERK values are incompatible with mesh-based leveling.");
 #endif
 #if HAS_MESH && DGUS_LCD_UI_IA_CREALITY && GRID_MAX_POINTS > 25

--- a/Marlin/src/lcd/e3v2/common/limits.h
+++ b/Marlin/src/lcd/e3v2/common/limits.h
@@ -67,7 +67,7 @@ constexpr xyze_float_t min_acceleration_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_A
 #define MIN_JERK_EDIT_VALUE 0.1
 #define DEFAULT_MAX_JERK_MULTIPLIER 2
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   constexpr xyze_float_t min_jerk_edit_values = LOGICAL_AXIS_ARRAY_1(MIN_JERK_EDIT_VALUE),
                          default_jerk = LOGICAL_AXIS_ARRAY(
                            DEFAULT_EJERK,

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -460,7 +460,7 @@ void drawBackFirst(const bool is_sel=true) {
 
 #define MOTION_CASE_RATE   1
 #define MOTION_CASE_ACCEL  2
-#define MOTION_CASE_JERK   (MOTION_CASE_ACCEL + ENABLED(HAS_CLASSIC_JERK))
+#define MOTION_CASE_JERK   (MOTION_CASE_ACCEL + ENABLED(CLASSIC_JERK))
 #define MOTION_CASE_STEPS  (MOTION_CASE_JERK + 1)
 #define MOTION_CASE_TOTAL  MOTION_CASE_STEPS
 
@@ -1004,7 +1004,7 @@ void drawMotionMenu() {
     itemAreaCopy(173, 133, 228, 147, MOTION_CASE_RATE);        // Max speed
     itemAreaCopy(173, 133, 200, 147, MOTION_CASE_ACCEL);       // Max...
     itemAreaCopy(28, 149, 69, 161, MOTION_CASE_ACCEL, 30, 1);  // ...Acceleration
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       itemAreaCopy(173, 133, 200, 147, MOTION_CASE_JERK);      // Max...
       itemAreaCopy(1, 180, 28, 192, MOTION_CASE_JERK, 30, 1);  // ...
       itemAreaCopy(202, 133, 228, 147, MOTION_CASE_JERK, 57);  // ...Jerk
@@ -1020,14 +1020,14 @@ void drawMotionMenu() {
     #ifdef USE_STRING_TITLES
       dwinDrawLabel(MOTION_CASE_RATE, F("Feedrate"));                 // "Feedrate"
       dwinDrawLabel(MOTION_CASE_ACCEL, GET_TEXT_F(MSG_ACCELERATION)); // "Acceleration"
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         dwinDrawLabel(MOTION_CASE_JERK, GET_TEXT_F(MSG_JERK));        // "Jerk"
       #endif
       dwinDrawLabel(MOTION_CASE_STEPS, GET_TEXT_F(MSG_STEPS_PER_MM)); // "Steps/mm"
     #else
       say_max_en(MOTION_CASE_RATE); say_speed_en(30, MOTION_CASE_RATE); // "Max Speed"
       say_max_accel_en(MOTION_CASE_ACCEL);                              // "Max Acceleration"
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         say_max_en(MOTION_CASE_JERK); say_jerk_en(MOTION_CASE_JERK);    // "Max Jerk"
       #endif
       say_steps_per_mm_en(MOTION_CASE_STEPS);                           // "Steps-per-mm"
@@ -1041,7 +1041,7 @@ void drawMotionMenu() {
   #define _MOTION_ICON(N) drawMenuLine(++i, ICON_MaxSpeed + (N) - 1)
   _MOTION_ICON(MOTION_CASE_RATE); drawMoreIcon(i);
   _MOTION_ICON(MOTION_CASE_ACCEL); drawMoreIcon(i);
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
     _MOTION_ICON(MOTION_CASE_JERK); drawMoreIcon(i);
   #endif
   _MOTION_ICON(MOTION_CASE_STEPS); drawMoreIcon(i);
@@ -1597,7 +1597,7 @@ void hmiMaxAccelerationXYZE() {
   drawEditInteger4(select_acc.now, hmiValues.maxAcceleration, true);
 }
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
 
   void hmiMaxJerkXYZE() {
     EncoderState encoder_diffState = encoderReceiveAnalyze();
@@ -1617,7 +1617,7 @@ void hmiMaxAccelerationXYZE() {
     drawEditFloat3(select_jerk.now, hmiValues.maxJerkScaled, true);
   }
 
-#endif // HAS_CLASSIC_JERK
+#endif // CLASSIC_JERK
 
 void hmiStepXYZE() {
   EncoderState encoder_diffState = encoderReceiveAnalyze();
@@ -3349,7 +3349,7 @@ void drawMaxAccelMenu() {
   #endif
 }
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   void drawMaxJerkMenu() {
     clearMainWindow();
 
@@ -3489,7 +3489,7 @@ void hmiMotion() {
         select_acc.reset();
         drawMaxAccelMenu();
         break;
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         case MOTION_CASE_JERK:
           checkkey = ID_MaxJerk;
           select_jerk.reset();
@@ -3996,7 +3996,7 @@ void hmiMaxAcceleration() {
   dwinUpdateLCD();
 }
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   // Max Jerk
   void hmiMaxJerk() {
     EncoderState encoder_diffState = get_encoder_state();
@@ -4025,7 +4025,7 @@ void hmiMaxAcceleration() {
     }
     dwinUpdateLCD();
   }
-#endif // HAS_CLASSIC_JERK
+#endif // CLASSIC_JERK
 
 // Step
 void hmiStep() {
@@ -4251,7 +4251,7 @@ void dwinHandleScreen() {
     #endif
     case ID_MaxSpeed:       hmiMaxSpeed(); break;
     case ID_MaxAcceleration: hmiMaxAcceleration(); break;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MaxJerk:      hmiMaxJerk(); break;
     #endif
     case ID_Step:           hmiStep(); break;
@@ -4274,7 +4274,7 @@ void dwinHandleScreen() {
     case ID_PrintSpeed:     hmiPrintSpeed(); break;
     case ID_MaxSpeedValue:  hmiMaxFeedspeedXYZE(); break;
     case ID_MaxAccelerationValue: hmiMaxAccelerationXYZE(); break;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MaxJerkValue: hmiMaxJerkXYZE(); break;
     #endif
     case ID_StepValue:      hmiStepXYZE(); break;

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -2333,7 +2333,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
       #define MOTION_HOMEOFFSETS (MOTION_BACK + 1)
       #define MOTION_SPEED (MOTION_HOMEOFFSETS + 1)
       #define MOTION_ACCEL (MOTION_SPEED + 1)
-      #define MOTION_JERK (MOTION_ACCEL + ENABLED(HAS_CLASSIC_JERK))
+      #define MOTION_JERK (MOTION_ACCEL + ENABLED(CLASSIC_JERK))
       #define MOTION_STEPS (MOTION_JERK + 1)
       #define MOTION_FLOW (MOTION_STEPS + ENABLED(HAS_HOTEND))
       #define MOTION_LA (MOTION_FLOW + ENABLED(LIN_ADVANCE))
@@ -2364,7 +2364,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
           else
             drawMenu(ID_MaxAcceleration);
           break;
-        #if HAS_CLASSIC_JERK
+        #if ENABLED(CLASSIC_JERK)
           case MOTION_JERK:
             if (draw)
               drawMenuItem(row, ICON_MaxJerk, GET_TEXT_F(MSG_JERK), nullptr, true);
@@ -2553,7 +2553,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
         #endif
       }
       break;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MaxJerk:
 
         #define JERK_BACK 0
@@ -4170,7 +4170,7 @@ FSTR_P JyersDWIN::getMenuTitle(const uint8_t menu) {
     case ID_HomeOffsets:    return GET_TEXT_F(MSG_SET_HOME_OFFSETS);
     case ID_MaxSpeed:       return GET_TEXT_F(MSG_MAX_SPEED);
     case ID_MaxAcceleration: return F("Max Acceleration");
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MaxJerk:      return F("Max Jerk");
     #endif
     case ID_Steps:          return GET_TEXT_F(MSG_STEPS_PER_MM);
@@ -4247,7 +4247,7 @@ uint8_t JyersDWIN::getMenuSize(const uint8_t menu) {
     case ID_HomeOffsets:    return HOMEOFFSETS_TOTAL;
     case ID_MaxSpeed:       return SPEED_TOTAL;
     case ID_MaxAcceleration: return ACCEL_TOTAL;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MaxJerk:      return JERK_TOTAL;
     #endif
     case ID_Steps:          return STEPS_TOTAL;

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -236,7 +236,7 @@ Menu *filamentMenu = nullptr;
 Menu *temperatureMenu = nullptr;
 Menu *maxSpeedMenu = nullptr;
 Menu *maxAccelMenu = nullptr;
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   Menu *maxJerkMenu = nullptr;
 #endif
 Menu *stepsMenu = nullptr;
@@ -2545,7 +2545,7 @@ void applyMaxAccel() { planner.set_max_acceleration(hmiValue.axis, menuData.valu
   void setMaxAccelE() { hmiValue.axis = E_AXIS; setIntOnClick(min_acceleration_edit_values.e, max_acceleration_edit_values.e, planner.settings.max_acceleration_mm_per_s2[E_AXIS], applyMaxAccel); }
 #endif
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   void applyMaxJerk() { planner.set_max_jerk(hmiValue.axis, menuData.value / MINUNITMULT); }
   #if HAS_X_AXIS
     void setMaxJerkX() { hmiValue.axis = X_AXIS, setFloatOnClick(min_jerk_edit_values.x, max_jerk_edit_values.x, UNITFDIGITS, planner.max_jerk.x, applyMaxJerk); }
@@ -2880,7 +2880,7 @@ void onDrawAcc(MenuItem* menuitem, int8_t line) {
   }
 #endif
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
 
   void onDrawJerk(MenuItem* menuitem, int8_t line) {
     if (hmiIsChinese()) {
@@ -2941,7 +2941,7 @@ void onDrawAcc(MenuItem* menuitem, int8_t line) {
 
   #endif
 
-#endif // HAS_CLASSIC_JERK
+#endif // CLASSIC_JERK
 
 #if HAS_X_AXIS
   void onDrawStepsX(MenuItem* menuitem, int8_t line) {
@@ -3451,7 +3451,7 @@ void drawMotionMenu() {
     BACK_ITEM(drawControlMenu);
     MENU_ITEM(ICON_MaxSpeed, MSG_SPEED, onDrawSpeed, drawMaxSpeedMenu);
     MENU_ITEM(ICON_MaxAccelerated, MSG_ACCELERATION, onDrawAcc, drawMaxAccelMenu);
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       MENU_ITEM(ICON_MaxJerk, MSG_JERK, onDrawJerk, drawMaxJerkMenu);
     #elif HAS_JUNCTION_DEVIATION
       EDIT_ITEM(ICON_JDmm, MSG_JUNCTION_DEVIATION, onDrawPFloat3Menu, setJDmm, &planner.junction_deviation_mm);
@@ -3616,7 +3616,7 @@ void drawMaxAccelMenu() {
   updateMenu(maxAccelMenu);
 }
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
 
   void drawMaxJerkMenu() {
     checkkey = ID_Menu;
@@ -3638,7 +3638,7 @@ void drawMaxAccelMenu() {
     updateMenu(maxJerkMenu);
   }
 
-#endif // HAS_CLASSIC_JERK
+#endif // CLASSIC_JERK
 
 void drawStepsMenu() {
   checkkey = ID_Menu;

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -341,7 +341,7 @@ void drawFilamentManMenu();
 void drawTemperatureMenu();
 void drawMaxSpeedMenu();
 void drawMaxAccelMenu();
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   void drawMaxJerkMenu();
 #endif
 void drawStepsMenu();

--- a/Marlin/src/lcd/extui/mks_ui/draw_jerk_settings.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_jerk_settings.cpp
@@ -22,7 +22,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#if ALL(HAS_TFT_LVGL_UI, HAS_CLASSIC_JERK)
+#if ALL(HAS_TFT_LVGL_UI, CLASSIC_JERK)
 
 #include "draw_ui.h"
 #include <lv_conf.h>
@@ -96,4 +96,4 @@ void lv_clear_jerk_settings() {
   lv_obj_del(scr);
 }
 
-#endif // HAS_TFT_LVGL_UI && HAS_CLASSIC_JERK
+#endif // HAS_TFT_LVGL_UI && CLASSIC_JERK

--- a/Marlin/src/lcd/extui/mks_ui/draw_machine_settings.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_machine_settings.cpp
@@ -46,7 +46,7 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     case ID_MACHINE_RETURN:       draw_return_ui(); break;
     case ID_MACHINE_ACCELERATION: lv_draw_acceleration_settings(); break;
     case ID_MACHINE_FEEDRATE:     lv_draw_max_feedrate_settings(); break;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       case ID_MACHINE_JERK:       lv_draw_jerk_settings(); break;
     #endif
   }
@@ -58,7 +58,7 @@ void lv_draw_machine_settings() {
   lv_screen_menu_item(scr, machine_menu.AccelerationConf, PARA_UI_POS_X, y, event_handler, ID_MACHINE_ACCELERATION, 0);
   y += PARA_UI_POS_Y;
   lv_screen_menu_item(scr, machine_menu.MaxFeedRateConf, PARA_UI_POS_X, y, event_handler, ID_MACHINE_FEEDRATE, 1);
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
     y += PARA_UI_POS_Y;
     lv_screen_menu_item(scr, machine_menu.JerkConf, PARA_UI_POS_X, y, event_handler, ID_MACHINE_JERK, 2);
   #endif

--- a/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
@@ -118,22 +118,22 @@ static void disp_key_value() {
       break;
 
     case XJerk:
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         dtostrf(planner.max_jerk.x, 1, 1, public_buf_m);
       #endif
       break;
     case YJerk:
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         dtostrf(planner.max_jerk.y, 1, 1, public_buf_m);
       #endif
       break;
     case ZJerk:
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         dtostrf(planner.max_jerk.z, 1, 1, public_buf_m);
       #endif
       break;
     case EJerk:
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         dtostrf(planner.max_jerk.e, 1, 1, public_buf_m);
       #endif
       break;
@@ -307,10 +307,10 @@ static void set_value_confirm() {
     case ZMaxFeedRate:   planner.settings.max_feedrate_mm_s[Z_AXIS] = atof(key_value); break;
     case E0MaxFeedRate:  planner.settings.max_feedrate_mm_s[E_AXIS] = atof(key_value); break;
     case E1MaxFeedRate:  planner.settings.max_feedrate_mm_s[E_AXIS_N(1)] = atof(key_value); break;
-    case XJerk: TERN_(HAS_CLASSIC_JERK, planner.max_jerk.x = atof(key_value)); break;
-    case YJerk: TERN_(HAS_CLASSIC_JERK, planner.max_jerk.y = atof(key_value)); break;
-    case ZJerk: TERN_(HAS_CLASSIC_JERK, planner.max_jerk.z = atof(key_value)); break;
-    case EJerk: TERN_(HAS_CLASSIC_JERK, planner.max_jerk.e = atof(key_value)); break;
+    case XJerk: TERN_(CLASSIC_JERK, planner.max_jerk.x = atof(key_value)); break;
+    case YJerk: TERN_(CLASSIC_JERK, planner.max_jerk.y = atof(key_value)); break;
+    case ZJerk: TERN_(CLASSIC_JERK, planner.max_jerk.z = atof(key_value)); break;
+    case EJerk: TERN_(CLASSIC_JERK, planner.max_jerk.e = atof(key_value)); break;
     case Xstep:  planner.settings.axis_steps_per_mm[X_AXIS] = atof(key_value); planner.refresh_positioning(); break;
     case Ystep:  planner.settings.axis_steps_per_mm[Y_AXIS] = atof(key_value); planner.refresh_positioning(); break;
     case Zstep:  planner.settings.axis_steps_per_mm[Z_AXIS] = atof(key_value); planner.refresh_positioning(); break;

--- a/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
@@ -951,7 +951,7 @@ void clear_cur_ui() {
     case MAXFEEDRATE_UI:              lv_clear_max_feedrate_settings(); break;
     case STEPS_UI:                    lv_clear_step_settings(); break;
     case ACCELERATION_UI:             lv_clear_acceleration_settings(); break;
-    case JERK_UI:                     TERN_(HAS_CLASSIC_JERK, lv_clear_jerk_settings()); break;
+    case JERK_UI:                     TERN_(CLASSIC_JERK, lv_clear_jerk_settings()); break;
     case MOTORDIR_UI:                 break;
     case HOMESPEED_UI:                break;
     case NOZZLE_CONFIG_UI:            break;
@@ -1061,7 +1061,7 @@ void draw_return_ui() {
       case MAXFEEDRATE_UI:              lv_draw_max_feedrate_settings(); break;
       case STEPS_UI:                    lv_draw_step_settings(); break;
       case ACCELERATION_UI:             lv_draw_acceleration_settings(); break;
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         case JERK_UI:                   lv_draw_jerk_settings(); break;
       #endif
       case MOTORDIR_UI:                 break;

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -587,7 +587,7 @@ void menu_backlash();
 
   #endif
 
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
 
     void menu_advanced_jerk() {
       START_MENU();
@@ -595,7 +595,7 @@ void menu_backlash();
 
       #if HAS_JUNCTION_DEVIATION
         EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, TERN(LIN_ADVANCE, 0.3f, 0.5f)
-          OPTARG(LIN_ADVANCE, planner.recalculate_max_e_jerk)
+          OPTARG(HAS_LINEAR_E_JERK, planner.recalculate_max_e_jerk)
         );
       #endif
 
@@ -711,12 +711,12 @@ void menu_advanced_settings() {
       if (!is_busy) SUBMENU(MSG_INPUT_SHAPING, menu_advanced_input_shaping);
     #endif
 
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       // M205 - Max Jerk
       SUBMENU(MSG_JERK, menu_advanced_jerk);
     #elif HAS_JUNCTION_DEVIATION
       EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.3f
-        OPTARG(LIN_ADVANCE, planner.recalculate_max_e_jerk)
+        OPTARG(HAS_LINEAR_E_JERK, planner.recalculate_max_e_jerk)
       );
     #endif
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2769,93 +2769,61 @@ bool Planner::_populate_block(
   #if HAS_CLASSIC_JERK
 
     /**
-     * Adapted from Průša MKS firmware
+     * Heavily modified. Original adapted from Průša MKS firmware
      * https://github.com/prusa3d/Prusa-Firmware
      */
-    // Exit speed limited by a jerk to full halt of a previous last segment
-    static float previous_safe_speed;
-
-    // Start with a safe speed (from which the machine may halt to stop immediately).
-    float safe_speed = block->nominal_speed;
-
     #ifndef TRAVEL_EXTRA_XYJERK
       #define TRAVEL_EXTRA_XYJERK 0
     #endif
     const float extra_xyjerk = TERN0(HAS_EXTRUDERS, dist.e <= 0) ? TRAVEL_EXTRA_XYJERK : 0;
 
-    uint8_t limited = 0;
-    TERN(HAS_LINEAR_E_JERK, LOOP_NUM_AXES, LOOP_LOGICAL_AXES)(i) {
-      const float jerk = ABS(current_speed[i]),   // cs : Starting from zero, change in speed for this axis
-                  maxj = (max_jerk[i] + (i == X_AXIS || i == Y_AXIS ? extra_xyjerk : 0.0f)); // mj : The max jerk setting for this axis
-      if (jerk > maxj) {                          // cs > mj : New current speed too fast?
-        if (limited) {                            // limited already?
-          const float mjerk = block->nominal_speed * maxj; // ns*mj
-          if (jerk * safe_speed > mjerk) safe_speed = mjerk / jerk; // ns*mj/cs
-        }
-        else {
-          safe_speed *= maxj / jerk;              // Initial limit: ns*mj/cs
-          ++limited;                              // Initially limited
+    float vmax_junction;
+
+    if (!moves_queued || UNEAR_ZERO(previous_nominal_speed)) {
+      // Compute "safe" speed, limited by a jerk to/from full halt.
+
+      float safe_speed_factor = 1;
+      TERN(HAS_LINEAR_E_JERK, LOOP_NUM_AXES, LOOP_LOGICAL_AXES)(i) {
+        const float jerk = ABS(current_speed[i]),   // cs : Starting from zero, change in speed for this axis
+                    maxj = (max_jerk[i] + (i == X_AXIS || i == Y_AXIS ? extra_xyjerk : 0.0f)); // mj : The max jerk setting for this axis
+        if (jerk * safe_speed_factor > maxj) {
+          safe_speed_factor = maxj / jerk;
         }
       }
-    }
-
-    float vmax_junction;
-    if (moves_queued && !UNEAR_ZERO(previous_nominal_speed)) {
-      // Estimate a maximum velocity allowed at a joint of two successive segments.
-      // If this maximum velocity allowed is lower than the minimum of the entry / exit safe velocities,
-      // then the machine is not coasting anymore and the safe entry / exit velocities shall be used.
-
-      // Factor to multiply the previous / current nominal velocities to get componentwise limited velocities.
-      float v_factor = 1;
-      limited = 0;
+      vmax_junction = block->nominal_speed * safe_speed_factor;
+      NOLESS(minimum_planner_speed_sqr, sq(vmax_junction));
+    } else {
+      // Compute the maximum velocity allowed at a joint of two successive segments.
 
       // The junction velocity will be shared between successive segments. Limit the junction velocity to their minimum.
-      // Pick the smaller of the nominal speeds. Higher speed shall not be achieved at the junction during coasting.
-      float smaller_speed_factor = 1.0f;
+      float previous_speed_factor = 1.0f;
+      float current_speed_factor = 1.0f;
       if (block->nominal_speed < previous_nominal_speed) {
         vmax_junction = block->nominal_speed;
-        smaller_speed_factor = vmax_junction / previous_nominal_speed;
-      }
-      else
+        previous_speed_factor = vmax_junction / previous_nominal_speed;
+      } else {
         vmax_junction = previous_nominal_speed;
+        current_speed_factor = vmax_junction / block->nominal_speed;
+      }
+
+      // Factor to multiply vmax_junction to get componentwise limited velocities.
+      float v_factor = 1;
 
       // Now limit the jerk in all axes.
       TERN(HAS_LINEAR_E_JERK, LOOP_NUM_AXES, LOOP_LOGICAL_AXES)(axis) {
-        // Limit an axis. We have to differentiate: coasting, reversal of an axis, full stop.
-        float v_exit = previous_speed[axis] * smaller_speed_factor,
-              v_entry = current_speed[axis];
-        if (limited) {
-          v_exit *= v_factor;
-          v_entry *= v_factor;
-        }
+        // Scale per-axis velocities for the same vmax_junction.
+        float v_exit = previous_speed[axis] * previous_speed_factor,
+              v_entry = current_speed[axis] * current_speed_factor;
 
-        // Calculate jerk depending on whether the axis is coasting in the same direction or reversing.
-        const float jerk = (v_exit > v_entry)
-            ? //                                  coasting             axis reversal
-              ( (v_entry > 0 || v_exit < 0) ? (v_exit - v_entry) : _MAX(v_exit, -v_entry) )
-            : // v_exit <= v_entry                coasting             axis reversal
-              ( (v_entry < 0 || v_exit > 0) ? (v_entry - v_exit) : _MAX(-v_exit, v_entry) );
-
+        // Jerk is the per-axis velocity difference.
+        const float jerk = ABS(v_exit - v_entry);
         const float maxj = (max_jerk[axis] + (axis == X_AXIS || axis == Y_AXIS ? extra_xyjerk : 0.0f));
-
-        if (jerk > maxj) {
-          v_factor *= maxj / jerk;
-          ++limited;
+        if (jerk * v_factor > maxj) {
+          v_factor = maxj / jerk;
         }
       }
-      if (limited) vmax_junction *= v_factor;
-      // Now the transition velocity is known, which maximizes the shared exit / entry velocity while
-      // respecting the jerk factors, it may be possible, that applying separate safe exit / entry velocities will achieve faster prints.
-      const float vmax_junction_threshold = vmax_junction * 0.99f;
-      if (previous_safe_speed > vmax_junction_threshold && safe_speed > vmax_junction_threshold)
-        vmax_junction = safe_speed;
+      vmax_junction *= v_factor;
     }
-    else
-      vmax_junction = safe_speed;
-
-    previous_safe_speed = safe_speed;
-
-    NOLESS(minimum_planner_speed_sqr, sq(safe_speed));
 
     #if HAS_JUNCTION_DEVIATION
       NOMORE(vmax_junction_sqr, sq(vmax_junction));   // Throttle down to max speed

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -155,7 +155,7 @@ float Planner::mm_per_step[DISTINCT_AXES];      // (mm) Millimeters per step
   #endif
 #endif
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
   TERN(HAS_LINEAR_E_JERK, xyz_pos_t, xyze_pos_t) Planner::max_jerk;
 #endif
 
@@ -1574,7 +1574,7 @@ void Planner::check_axes_activity() {
         saved_motion_state.acceleration.z = settings.max_acceleration_mm_per_s2[Z_AXIS];
         settings.max_acceleration_mm_per_s2[Z_AXIS] = 100;
       #endif
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         saved_motion_state.jerk_state = max_jerk;
         max_jerk.set(0, 0 OPTARG(DELTA, 0));
       #endif
@@ -1583,7 +1583,7 @@ void Planner::check_axes_activity() {
       settings.max_acceleration_mm_per_s2[X_AXIS] = saved_motion_state.acceleration.x;
       settings.max_acceleration_mm_per_s2[Y_AXIS] = saved_motion_state.acceleration.y;
       TERN_(DELTA, settings.max_acceleration_mm_per_s2[Z_AXIS] = saved_motion_state.acceleration.z);
-      TERN_(HAS_CLASSIC_JERK, max_jerk = saved_motion_state.jerk_state);
+      TERN_(CLASSIC_JERK, max_jerk = saved_motion_state.jerk_state);
     }
     refresh_acceleration_rates();
   }
@@ -2766,7 +2766,7 @@ bool Planner::_populate_block(
 
   #endif
 
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
 
     /**
      * Heavily modified. Originally adapted from Průša firmware.
@@ -2828,7 +2828,7 @@ bool Planner::_populate_block(
       vmax_junction_sqr = sq(vmax_junction);          // Go up or down to the new speed
     #endif
 
-  #endif // HAS_CLASSIC_JERK
+  #endif // CLASSIC_JERK
 
   // Max entry speed of this block equals the max exit speed of the previous block.
   block->max_entry_speed_sqr = vmax_junction_sqr;
@@ -3363,7 +3363,7 @@ void Planner::set_max_feedrate(const AxisEnum axis, float inMaxFeedrateMMS) {
   settings.max_feedrate_mm_s[axis] = inMaxFeedrateMMS;
 }
 
-#if HAS_CLASSIC_JERK
+#if ENABLED(CLASSIC_JERK)
 
   /**
    * For the specified 'axis' set the Maximum Jerk (instant change) to the given value (mm/s)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -355,7 +355,7 @@ typedef struct {
 #if ENABLED(IMPROVE_HOMING_RELIABILITY)
   struct motion_state_t {
     TERN(DELTA, xyz_ulong_t, xy_ulong_t) acceleration;
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       TERN(DELTA, xyz_float_t, xy_float_t) jerk_state;
     #endif
   };
@@ -477,7 +477,7 @@ class Planner {
       #endif
     #endif
 
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       // (mm/s^2) M205 XYZ(E) - The largest speed change requiring no acceleration.
       static TERN(HAS_LINEAR_E_JERK, xyz_pos_t, xyze_pos_t) max_jerk;
     #endif
@@ -602,7 +602,7 @@ class Planner {
     static void set_max_feedrate(const AxisEnum axis, float inMaxFeedrateMMS);
 
     // For an axis set the Maximum Jerk (instant change) in mm/s
-    #if HAS_CLASSIC_JERK
+    #if ENABLED(CLASSIC_JERK)
       static void set_max_jerk(const AxisEnum axis, float inMaxJerkMMS);
     #else
       static void set_max_jerk(const AxisEnum, const_float_t) {}

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -852,7 +852,7 @@ void MarlinSettings::postprocess() {
     {
       EEPROM_WRITE(planner.settings);
 
-      #if HAS_CLASSIC_JERK
+      #if ENABLED(CLASSIC_JERK)
         EEPROM_WRITE(planner.max_jerk);
         #if HAS_LINEAR_E_JERK
           dummyf = float(DEFAULT_EJERK);
@@ -1880,7 +1880,7 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(planner.settings.min_feedrate_mm_s);
         EEPROM_READ(planner.settings.min_travel_feedrate_mm_s);
 
-        #if HAS_CLASSIC_JERK
+        #if ENABLED(CLASSIC_JERK)
           EEPROM_READ(planner.max_jerk);
           #if HAS_LINEAR_E_JERK
             EEPROM_READ(dummyf);
@@ -3092,7 +3092,7 @@ void MarlinSettings::reset() {
   planner.settings.min_feedrate_mm_s = feedRate_t(DEFAULT_MINIMUMFEEDRATE);
   planner.settings.min_travel_feedrate_mm_s = feedRate_t(DEFAULT_MINTRAVELFEEDRATE);
 
-  #if HAS_CLASSIC_JERK
+  #if ENABLED(CLASSIC_JERK)
     #if HAS_X_AXIS && !defined(DEFAULT_XJERK)
       #define DEFAULT_XJERK 0
     #endif


### PR DESCRIPTION
Redux of #26518 by @mh-dm

### Description
This fixes 3 bugs/issues in jerk limiting:
1) Computed v_entry speed was wrong (missing a 'current_speed_factor') when the current block nominal speed was > previous nominal speed. Thus the resulting junction speed was wrong.
2) When switching directions (say nearly 180 deg) the computed jerk would be completely overridden by applying separate 'safe' exit / entry speeds. This results in basically doubling the jerk limit for sharp back and forth movements. Presumably this was done to address slowdowns, but after fixing 1) this special handling is no longer needed.
3) Jerk is a change in speed (i.e. ABS(v_exit - v_entry)) and not _MAX(v_exit, -v_entry), even in axis reversal.

Other notes:
- Less special casing, shorter, cleaner code.
- Slightly faster jerk computation as we stop having to always compute the 'safe' speed (jerk to halt speed).
- Refactored the code that computes the 'safe' speed.

### Benefits

The overall result is smoother motion when printing models that involve lots of small back and forth moves, like on thin strips in top layers. Alternatively, jerk limits can be slightly increased for faster (or sometimes higher quality) prints while keeping overall vibrations at same level.

Reduced chance of surprise layer shifts. Say you tune jerk and acceleration using some non-extreme model (say a calibration cube). Later, when printing something with a lot of sharp back and forth movements you get layer shifts.

### Configurations

Affects using `CLASSIC_JERK`. As part of a journey to getting an Ender-3 to print really fast I've tested (on top of) this change quite a bit.

### Related Issues

A bit hard find related issues as most people would tune down jerk and acceleration if the movement sounded too jerky and acceleration defaults are often conservative. I did find one case of surprise Layer shifting #23800 that mentioned "Y axis only has very small movements".

---

Here's a before/after comparison showing improvement in vibrations. I set X and Y jerk to 10mm/s (the default in marlin). X and Y acceleration are 10k and 5k respectively, with print/travel acceleration really high (20k) to make sure said limits apply. Using 100mm/s and 300mm/s print and travel speeds. (On a heavily customized Ender-3 with hardware allows said high settings.)

https://github.com/MarlinFirmware/Marlin/assets/299015/cc0e6596-2561-43ef-9337-7d9311ed6763

https://github.com/MarlinFirmware/Marlin/assets/299015/82ec2ff3-8d8f-4d04-93cd-807b52eddfa7

Test part was specifically designed/sliced to cause many small back and forth movements and to calibrate acceleration/jerk settings.

I was going to say that the print quality is exactly the same, down to the blobs on the outer walls that are there due to the random seam setting in the slicer. In the photo, before is bottom, after is top. But no, the print quality is slightly better as there are slightly fewer blobs. Note that model is sliced at high enough resolution to be processing intensive - any code speed up means the printer doesn't have to stop to process the next segment.
To make sure the jerk code is properly benchmarked, the part includes multiple rounded outer walls of varying radii which are very sensitive to the jerk setting. If not high enough (or if the junction speed is wrongly computed) the printer would have to slow down and speed up significantly for every single small segment of a curve.

![result](https://github.com/MarlinFirmware/Marlin/assets/299015/80145540-99ae-4337-a7c9-3a9b87f205cc)
