### PR TITLE
MMU2s C0 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ out-csv/
 out-language/
 *.gen
 *.sublime-workspace
+*.code-workspace
 
 # OS
 applet/

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -884,7 +884,11 @@ void MMU2::filament_runout() {
       // Slowly spin the extruder during C0
       else {
         while (planner.movesplanned() < 3)
-          unscaled_mmu2_e_move(0.25, MMM_TO_MMS(120), false);
+          // do nothing here as the previous implementation of
+          // "keep slowly spinning during C0" causes a huge amount of
+          // filament to be extruded and causing catastrophic/unrecoverable
+          // issues...
+          idle();
       }
     }
     mmu2s_triggered = present;


### PR DESCRIPTION
Marlin keeps extruding filament while waiting on the "C0" to be executed by the MMU2s. Incase the MMU2s is having issues, like the 5 flashing lights or some other problems that requires manual intervention and cannot respond to requests properly and the filament is already in the extruder, a huge bulge of filament on to the wipe tower is extruded which is not recoverable anymore. This fixes that by replacing the `unscaled_mmu2_e_move` call with an `idle` call.