### PR TITLE
update BOARD_CREALITY_CR4NTXXC10 pins and  env:STM32F401RE_freeruns

### DIFF
--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -673,7 +673,6 @@
   #error "SDIO_SUPPORT is now ONBOARD_SDIO."
 #endif
 
-
 // L64xx stepper drivers have been removed
 #define _L6470              0x6470
 #define _L6474              0x6474

--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -669,7 +669,10 @@
   #error "Z_PROBE_OFFSET_RANGE_(MIN|MAX) is now PROBE_OFFSET_Z(MIN|MAX)."
 #elif defined(LARGE_MOVE_ITEMS)
   #error "LARGE_MOVE_ITEMS is obsolete. Instead define MANUAL_MOVE_DISTANCE_MM and MANUAL_MOVE_DISTANCE_IN."
+#elif defined(SDIO_SUPPORT)
+  #error "SDIO_SUPPORT is now ONBOARD_SDIO."
 #endif
+
 
 // L64xx stepper drivers have been removed
 #define _L6470              0x6470

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -804,3 +804,10 @@
 #if HAL_ADC_VREF_MV < 5000 && ANY_THERMISTOR_IS(-1) && DISABLED(ALLOW_AD595_3V3_VREF)
   #warning "The (-1) AD595 Thermocouple Amplifier requires 5V input supply! Use AD8495 for 3.3V ADC."
 #endif
+
+/**
+ * No PWM on the Piezo Beeper?
+ */
+#if PIN_EXISTS(BEEPER) && ALL(SPEAKER, NO_SPEAKER)
+  #warning "The BEEPER cannot produce tones so you can disable SPEAKER."
+#endif

--- a/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
@@ -33,10 +33,6 @@
   #define LCD_PINS_D7                          6
 #endif
 
-#ifndef SPEAKER
-  #define SPEAKER                                 // The speaker can produce tones
-#endif
-
 #if IS_NEWPANEL
   #define BTN_EN1                             16
   #define BTN_EN2                             17

--- a/Marlin/src/pins/mega/pins_GT2560_V4_A20.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V4_A20.h
@@ -35,10 +35,6 @@
   #define LCD_PINS_D7                          6
 #endif
 
-#ifndef SPEAKER
-  #define SPEAKER                                 // The speaker can produce tones
-#endif
-
 #if IS_NEWPANEL
   #define BTN_EN1                             16
   #define BTN_EN2                             17

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -228,7 +228,7 @@
 
     #ifndef BEEPER_PIN
       #define BEEPER_PIN             EXP1_01_PIN
-      #undef SPEAKER
+      #define NO_SPEAKER
     #endif
 
   #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -281,7 +281,7 @@
 
     #ifndef BEEPER_PIN
       #define BEEPER_PIN             EXP1_01_PIN
-      #undef SPEAKER
+      #define NO_SPEAKER
     #endif
 
   #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)

--- a/Marlin/src/pins/stm32f4/pins_BLACKPILL_CUSTOM.h
+++ b/Marlin/src/pins/stm32f4/pins_BLACKPILL_CUSTOM.h
@@ -114,7 +114,7 @@
 
 #define SD_DETECT_PIN                       -1
 #define SDCARD_CONNECTION                ONBOARD
-//#define SDIO_SUPPORT
+//#define ONBOARD_SDIO
 #define NO_SD_HOST_DRIVE                          // This board's SD is only seen by the printer
 
 #if SD_CONNECTION_IS(ONBOARD)

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -72,9 +72,7 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN                           PA5
-#define X_MAX_PIN                           PA4
-
+#define X_STOP_PIN                          PA5
 #define Y_STOP_PIN                          PA6
 
 #if ENABLED(BLTOUCH)
@@ -188,9 +186,9 @@
 //
 // SD Card
 //
+#define SD_DETECT_PIN                       PC1
 #define SDCARD_CONNECTION                ONBOARD
 #define ONBOARD_SDIO
-#define SD_DETECT_PIN                       PC1
 #define SDIO_CLOCK                       4500000
 #define SDIO_READ_RETRIES                     16
 #define NO_SD_HOST_DRIVE                  // This board's SD is only seen by the printer

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -240,13 +240,3 @@
   #endif
 
 #endif
-
-//
-// M3/M4/M5 - Spindle/Laser Control
-//
-#if HAS_CUTTER
-  #define SPINDLE_LASER_ENA_PIN      EXP1_01_PIN  // FET 1
-  #define SPINDLE_LASER_PWM_PIN      EXP1_01_PIN  // Bed FET
-  #define SPINDLE_DIR_PIN            EXP1_01_PIN  // FET 4
-  //#define LASER_SOFT_PWM_PIN       EXP1_01_PIN
-#endif

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -72,7 +72,9 @@
 //
 // Limit Switches
 //
-#define X_STOP_PIN                          PA5
+#define X_MIN_PIN                           PA5
+#define X_MAX_PIN                           PA4
+
 #define Y_STOP_PIN                          PA6
 
 #if ENABLED(BLTOUCH)
@@ -100,15 +102,15 @@
 #define X_STEP_PIN                          PC2
 #define X_DIR_PIN                           PB9
 
-#define Y_ENABLE_PIN               X_ENABLE_PIN
+#define Y_ENABLE_PIN                X_ENABLE_PIN
 #define Y_STEP_PIN                          PB8
 #define Y_DIR_PIN                           PB7
 
-#define Z_ENABLE_PIN               X_ENABLE_PIN
+#define Z_ENABLE_PIN                X_ENABLE_PIN
 #define Z_STEP_PIN                          PB6
 #define Z_DIR_PIN                           PB5
 
-#define E0_ENABLE_PIN              X_ENABLE_PIN
+#define E0_ENABLE_PIN               X_ENABLE_PIN
 #define E0_STEP_PIN                         PB4
 #define E0_DIR_PIN                          PB3
 
@@ -186,64 +188,58 @@
 //
 // SD Card
 //
-#define SD_DETECT_PIN                       PC1
 #define SDCARD_CONNECTION                ONBOARD
-#define ONBOARD_SPI_DEVICE                     1
-//#define ONBOARD_SD_CS_PIN                 PA4   // SDSS
-#define SDIO_SUPPORT
+#define ONBOARD_SDIO
+#define SD_DETECT_PIN                       PC1
+#define SDIO_CLOCK                       4500000
+#define SDIO_READ_RETRIES                     16
 #define NO_SD_HOST_DRIVE                  // This board's SD is only seen by the printer
+
+/**
+ *                 ------
+ *            PC0 | 1  2 | PB2
+ *       TX2  PA2 | 3  4 | PA3  RX2
+ * SPI2_MISO PB14 | 5  6 | PB13 SPI2_SCK
+ * SPI2_NSS  PB12 | 7  8 | PB15 SPI2_MOSI
+ *            GND | 9  10| 5V
+ *                 ------
+ *                  EXP1
+ */
+#define EXP1_01_PIN                         PC0
+#define EXP1_02_PIN                         PB2
+#define EXP1_03_PIN                         PA2
+#define EXP1_04_PIN                         PA3
+#define EXP1_05_PIN                         PB14
+#define EXP1_06_PIN                         PB13
+#define EXP1_07_PIN                         PB12
+#define EXP1_08_PIN                         PB15
 
 #if ENABLED(CR10_STOCKDISPLAY)
 
-  #if ENABLED(RET6_12864_LCD)
-    // RET6 12864 LCD
-    #define LCD_PINS_RS                     PB12
-    #define LCD_PINS_EN                     PB15
-    #define LCD_PINS_D4                     PB13
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define LCD_PINS_EN                EXP1_08_PIN
+  #define LCD_PINS_D4                EXP1_06_PIN
 
-    #define BTN_ENC                         PB2
-    #define BTN_EN1                         PA2
-    #define BTN_EN2                         PB14
+  #define BTN_ENC                    EXP1_02_PIN
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_05_PIN
 
-    #ifndef HAS_PIN_27_BOARD
-      #define BEEPER_PIN                    PC0
-    #endif
-
-  #elif ENABLED(VET6_12864_LCD)
-    // VET6 12864 LCD
-    #define LCD_PINS_RS                     PA4
-    //#define LCD_PINS_EN                   PA7
-    #define LCD_PINS_D4                     PA5
-
-    #define BTN_ENC                         PC5
-    #define BTN_EN1                         PB10
-    #define BTN_EN2                         PA6
-
-  #else
-    #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the CREALITY_CR4NTXXC10 controller."
+  #ifndef HAS_PIN_27_BOARD
+    #define BEEPER_PIN               EXP1_01_PIN
   #endif
 
 #elif ENABLED(DWIN_CREALITY_LCD)
 
-  // RET6 DWIN ENCODER LCD
-  #define BTN_ENC                           PB14
-  #define BTN_EN1                           PB15
-  #define BTN_EN2                           PB12
+  // DWIN ENCODER LCD
+  #define BTN_ENC                    EXP1_05_PIN
+  #define BTN_EN1                    EXP1_08_PIN
+  #define BTN_EN2                    EXP1_07_PIN
 
-  //#define LCD_LED_PIN                     PB2
+  //#define LCD_LED_PIN              EXP1_02_PIN
   #ifndef BEEPER_PIN
-    #define BEEPER_PIN                      PB13
+    #define BEEPER_PIN               EXP1_06_PIN
     #undef SPEAKER
   #endif
-
-#elif ENABLED(DWIN_VET6_CREALITY_LCD)
-
-  // VET6 DWIN ENCODER LCD
-  #define BTN_ENC                           PA6
-  //#define BTN_EN1                         PA7
-  #define BTN_EN2                           PA4
-
-  #define BEEPER_PIN                        PA5
 
 #endif
 
@@ -254,8 +250,8 @@
   //#undef HEATER_0_PIN
   //#undef HEATER_BED_PIN
   //#undef FAN0_PIN
-  #define SPINDLE_LASER_ENA_PIN             PC0   // FET 1
-  #define SPINDLE_LASER_PWM_PIN             PC0   // Bed FET
-  #define SPINDLE_DIR_PIN                   PC0   // FET 4
-  //#define LASER_SOFT_PWM_PIN              PC0
+  #define SPINDLE_LASER_ENA_PIN      EXP1_01_PIN  // FET 1
+  #define SPINDLE_LASER_PWM_PIN      EXP1_01_PIN   // Bed FET
+  #define SPINDLE_DIR_PIN            EXP1_01_PIN  // FET 4
+  //#define LASER_SOFT_PWM_PIN       EXP1_01_PIN
 #endif

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -249,7 +249,7 @@
   //#undef HEATER_BED_PIN
   //#undef FAN0_PIN
   #define SPINDLE_LASER_ENA_PIN      EXP1_01_PIN  // FET 1
-  #define SPINDLE_LASER_PWM_PIN      EXP1_01_PIN   // Bed FET
+  #define SPINDLE_LASER_PWM_PIN      EXP1_01_PIN  // Bed FET
   #define SPINDLE_DIR_PIN            EXP1_01_PIN  // FET 4
   //#define LASER_SOFT_PWM_PIN       EXP1_01_PIN
 #endif

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -199,7 +199,7 @@
  *       TX2  PA2 | 3  4 | PA3  RX2
  * SPI2_MISO PB14 | 5  6 | PB13 SPI2_SCK
  * SPI2_NSS  PB12 | 7  8 | PB15 SPI2_MOSI
- *            GND | 9  10| 5V
+ *            GND | 9 10 | 5V
  *                 ------
  *                  EXP1
  */
@@ -236,7 +236,7 @@
   //#define LCD_LED_PIN              EXP1_02_PIN
   #ifndef BEEPER_PIN
     #define BEEPER_PIN               EXP1_06_PIN
-    #undef SPEAKER
+    #define NO_SPEAKER
   #endif
 
 #endif
@@ -245,9 +245,6 @@
 // M3/M4/M5 - Spindle/Laser Control
 //
 #if HAS_CUTTER
-  //#undef HEATER_0_PIN
-  //#undef HEATER_BED_PIN
-  //#undef FAN0_PIN
   #define SPINDLE_LASER_ENA_PIN      EXP1_01_PIN  // FET 1
   #define SPINDLE_LASER_PWM_PIN      EXP1_01_PIN  // Bed FET
   #define SPINDLE_DIR_PIN            EXP1_01_PIN  // FET 4

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_F401.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_F401.h
@@ -125,7 +125,7 @@
 #define SDCARD_CONNECTION               ONBOARD
 #define ONBOARD_SPI_DEVICE                     1
 #define ONBOARD_SD_CS_PIN                   PC12  // SDSS
-#define SDIO_SUPPORT
+#define ONBOARD_SDIO
 #define NO_SD_HOST_DRIVE                          // This board's SD is only seen by the printer
 
 // SPI 2

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -740,19 +740,19 @@ upload_protocol = stlink
 #
 # STM32F401RE_freeruns  Creality E3 Free-runs Silent Motherboard
 #
+#
+# STM32F401RE_freeruns  Creality E3 Free-runs Silent Motherboard
+#
 [env:STM32F401RE_freeruns]
 extends                     = stm32_variant
-board                       = genericSTM32F401RE
-board_build.variant         = marlin_STM32F401RE_freeruns
+board                       = marlin_STM32F401RE_freeruns
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
 board_build.rename          = firmware-{date}-{time}.bin
-build_flags                 = ${stm32_variant.build_flags} -DMCU_STM32F401RE -DSTM32F4
+build_flags                 = ${stm32_variant.build_flags} -DSTM32F401xE
                               -DSS_TIMER=4 -DTIMER_SERVO=TIM5
                               -DTRANSFER_CLOCK_DIV=8
 build_unflags               = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts               = ${stm32_variant.extra_scripts}
-                              pre:buildroot/share/PlatformIO/scripts/random-bin.py
 monitor_speed               = 115200
 
 [env:STM32F401RE_freeruns_jlink]

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -740,9 +740,6 @@ upload_protocol = stlink
 #
 # STM32F401RE_freeruns  Creality E3 Free-runs Silent Motherboard
 #
-#
-# STM32F401RE_freeruns  Creality E3 Free-runs Silent Motherboard
-#
 [env:STM32F401RE_freeruns]
 extends                     = stm32_variant
 board                       = marlin_STM32F401RE_freeruns


### PR DESCRIPTION
### Description

## Clean up env:STM32F401RE_freeruns

The env has 'board = genericSTM32F401RE', even though buildroot/share/PlatformIO/boards/marlin_STM32F401RE_freeruns.json was added. Updated to 'board = marlin_STM32F401RE_freeruns'

The env has 'board_build.variant = marlin_STM32F401RE_freeruns' is no longer required and has the wrong case for case sensitive systems, removed

The env has '-DMCU_STM32F401RE -DSTM32F4'replaced with '-DSTM32F401xE',  STM32F4 is defined automatically in framework-arduinostm32

The env has `extra_scripts               = ${stm32_variant.extra_scripts} 
                              pre:buildroot/share/PlatformIO/scripts/random-bin.py`
Removed as random-bin.py script no longer exists, and is not required  as stm32_variant calls offset_and_rename.py wich does the same thing. 

## Clean up pins_CREALITY_CR4NTXXC10.h

removed references to RET6_12864_LCD, VET6_12864_LCD and DWIN_VET6_CREALITY_LCD, This board only has STM32F401RE at this time.
Added standard EXP1 pins definitions

## Rename SDIO_SUPPORT => ONBOARD_SDIO 
as started by https://github.com/MarlinFirmware/Marlin/commit/921591d2b899000e3181a098a069392ac0ac4b42
Added a entry for SDIO_SUPPORT to changes.h to stop further regression.

### Requirements

#define MOTHERBOARD BOARD_CREALITY_CR4NTXXC10
#define SERIAL_PORT 1
default_envs = STM32F401RE_freeruns

### Benefits

Builds as expected, cleaner. SDIO sdcard and endstops now work 

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/25636#pullrequestreview-1794059351
