### PR TITLE
🐛 Fix hangs in DUE native USB

### DIFF
--- a/Marlin/src/HAL/DUE/usb/README.md
+++ b/Marlin/src/HAL/DUE/usb/README.md
@@ -1,0 +1,29 @@
+# USB Files Source Documentation
+
+## Source
+
+The USB files in this project were sourced from the Atmel ASF (Advanced Software Framework). The framework provides a variety of examples, which were utilized in this project.
+
+Atmel does not provide these files in a source repository, but they can be extracted from ASF, which can be downloaded from Atmel.
+
+[Advanced Software Framework](https://www.microchip.com/en-us/tools-resources/develop/libraries/advanced-software-framework)
+
+## Modifications
+
+While the files are mostly unmodified except for minor cosmetic changes, some more significant changes have been required.
+
+The change which prompted the addition of this file is below. Other changes may have been made prior to this.
+
+1. uotghs_device_due.c was modified to resolve race conditions which could leave interrupts asserted when freezing the peripheral clock. This resulted in hangs and watchdog resets due to the ensuing interrupt storm.
+
+## Version Information
+
+The exact version of ASF used as the source is currently unknown. However, the copyright information in the files indicates they are from the year 2015.
+
+## Upgrade Considerations
+
+A comparison was made with the ASF 3.52.0 files released in 2022. No immediate benefits were identified that would justify an upgrade. It's important to note that the files in Marlin do not follow the same folder structure as the files in ASF, which complicates the process of comparing and consuming updated files.
+
+When these files are updated, it is important that they are carefully compared to those in Marlin, to migrate forward any improvements made in the Marlin source code.
+
+It would be best if the Marlin directory structure could be made to align with the ASF structure, or to at least document the source of each file to ease future updates.

--- a/Marlin/src/HAL/DUE/usb/README.md
+++ b/Marlin/src/HAL/DUE/usb/README.md
@@ -2,28 +2,28 @@
 
 ## Source
 
-The USB files in this project were sourced from the Atmel ASF (Advanced Software Framework). The framework provides a variety of examples, which were utilized in this project.
+We sourced the USB files in Marlin from the Atmel ASF (Advanced Software Framework). The framework provides a variety of examples which were utilized in this project.
 
-Atmel does not provide these files in a source repository, but they can be extracted from ASF, which can be downloaded from Atmel.
+Atmel doesn't provide these files in a source repository but they can be extracted from ASF, which can be downloaded from Atmel.
 
 [Advanced Software Framework](https://www.microchip.com/en-us/tools-resources/develop/libraries/advanced-software-framework)
 
 ## Modifications
 
-While the files are mostly unmodified except for minor cosmetic changes, some more significant changes have been required.
+The files are mostly unmodified except for minor cosmetic changes but some more significant changes were needed.
 
-The change which prompted the addition of this file is below. Other changes may have been made prior to this.
+The changes that prompted the addition of this README file are listed below. Other changes may have been made prior to this.
 
-1. uotghs_device_due.c was modified to resolve race conditions which could leave interrupts asserted when freezing the peripheral clock. This resulted in hangs and watchdog resets due to the ensuing interrupt storm.
+1. Modified `uotghs_device_due.c` to resolve race conditions that could leave interrupts asserted when freezing the peripheral clock, resulting in hangs and watchdog resets due to the ensuing interrupt storm.
 
 ## Version Information
 
-The exact version of ASF used as the source is currently unknown. However, the copyright information in the files indicates they are from the year 2015.
+We don't know the exact version of ASF used as the source. However, the copyright information in the files indicates they are from 2015.
 
 ## Upgrade Considerations
 
-A comparison was made with the ASF 3.52.0 files released in 2022. No immediate benefits were identified that would justify an upgrade. It's important to note that the files in Marlin do not follow the same folder structure as the files in ASF, which complicates the process of comparing and consuming updated files.
+We looked at the ASF 3.52.0 files released in 2022 but saw no immediate benefits to justify an upgrade. It's important to note that the files in Marlin don't follow the same folder structure as the files in ASF, which complicates the process of comparing and applying updated files.
 
-When these files are updated, it is important that they are carefully compared to those in Marlin, to migrate forward any improvements made in the Marlin source code.
+When these files are updated it's important to carefully compare them to Marlin's versions so any improvements in the Marlin sources are brought forward.
 
-It would be best if the Marlin directory structure could be made to align with the ASF structure, or to at least document the source of each file to ease future updates.
+It would be best to make Marlin's directory structure align with ASF or at least document the source of each file to ease future updates.

--- a/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
@@ -116,6 +116,20 @@
 //#define dbg_print printf
 #define dbg_print(...)
 
+// Marlin versions of macros to freeze/unfreeze add memory barriers
+// to ensure that any accesses to USB registers aren't re-ordered
+// to occur while the clock is frozen.
+#define marlin_otg_freeze_clock() do { \
+  __DSB(); \
+  Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
+} while (0)
+
+#define marlin_otg_unfreeze_clock()                \
+do {                                        \
+  Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
+  __DSB();                                \
+} while (0)
+
 /**
  * \ingroup udd_group
  * \defgroup udd_udphs_group USB On-The-Go High-Speed Port for device mode (UOTGHS)
@@ -587,11 +601,11 @@ ISR(UDD_USB_INT_FUN)
 	}
 
 	if (Is_udd_suspend_interrupt_enabled() && Is_udd_suspend()) {
-		otg_unfreeze_clock();
+		marlin_otg_unfreeze_clock();
 		// The suspend interrupt is automatic acked when a wakeup occur
 		udd_disable_suspend_interrupt();
 		udd_enable_wake_up_interrupt();
-		otg_freeze_clock(); // Mandatory to exit of sleep mode after a wakeup event
+		marlin_otg_freeze_clock(); // Mandatory to exit of sleep mode after a wakeup event
 		udd_sleep_mode(false);  // Enter in SUSPEND mode
 #ifdef UDC_SUSPEND_EVENT
 		UDC_SUSPEND_EVENT();
@@ -601,7 +615,7 @@ ISR(UDD_USB_INT_FUN)
 
 	if (Is_udd_wake_up_interrupt_enabled() && Is_udd_wake_up()) {
 		// Ack wakeup interrupt and enable suspend interrupt
-		otg_unfreeze_clock();
+		marlin_otg_unfreeze_clock();
 		// Check USB clock ready after suspend and eventually sleep USB clock
 		while (!Is_otg_clock_usable()) {
 			if (Is_udd_suspend()) {
@@ -611,6 +625,15 @@ ISR(UDD_USB_INT_FUN)
 		// The wakeup interrupt is automatic acked when a suspend occur
 		udd_disable_wake_up_interrupt();
 		udd_enable_suspend_interrupt();
+
+		// The following interrupts can only be enabled while the clock
+        // is unfrozen, which is why they were left disabled in udd_attach
+		udd_enable_reset_interrupt();
+		udd_enable_sof_interrupt();
+#ifdef USB_DEVICE_HS_SUPPORT
+		udd_enable_msof_interrupt();
+#endif
+
 		udd_sleep_mode(true); // Enter in IDLE mode
 #ifdef UDC_RESUME_EVENT
 		UDC_RESUME_EVENT();
@@ -621,9 +644,9 @@ ISR(UDD_USB_INT_FUN)
 	if (Is_otg_vbus_transition()) {
 		dbg_print("VBus ");
 		// Ack Vbus transition and send status to high level
-		otg_unfreeze_clock();
+		marlin_otg_unfreeze_clock();
 		otg_ack_vbus_transition();
-		otg_freeze_clock();
+		marlin_otg_freeze_clock();
 #ifndef USB_DEVICE_ATTACH_AUTO_DISABLE
 		if (Is_otg_vbus_high()) {
 			udd_attach();
@@ -704,7 +727,7 @@ void udd_enable(void)
 #endif // USB_DEVICE_LOW_SPEED
 
 	// Check USB clock
-	otg_unfreeze_clock();
+	marlin_otg_unfreeze_clock();
 	while (!Is_otg_clock_usable());
 
 	// Reset internal variables
@@ -719,7 +742,7 @@ void udd_enable(void)
 		otg_raise_vbus_transition();
 	}
 	otg_enable_vbus_interrupt();
-	otg_freeze_clock();
+	marlin_otg_freeze_clock();
 
 #ifndef UDD_NO_SLEEP_MGR
 	if (!udd_b_sleep_initialized) {
@@ -744,7 +767,7 @@ void udd_disable(void)
 # ifdef USB_ID_GPIO
 	if (Is_otg_id_host()) {
 		// Freeze clock to switch mode
-		otg_freeze_clock();
+		marlin_otg_freeze_clock();
 		udd_detach();
 		otg_disable();
 		return; // Host mode running, ignore UDD disable
@@ -757,7 +780,7 @@ void udd_disable(void)
 #endif
 
 	flags = cpu_irq_save();
-	otg_unfreeze_clock();
+	marlin_otg_unfreeze_clock();
 	udd_detach();
 #ifndef UDD_NO_SLEEP_MGR
 	if (udd_b_sleep_initialized) {
@@ -776,6 +799,23 @@ void udd_disable(void)
 	cpu_irq_restore(flags);
 }
 
+// Disable and ACK interrupts that cannot be handled when the clock is frozen.
+static void disable_and_ack_sync_interrupts()
+{
+	// Disable USB line events
+	udd_disable_reset_interrupt();
+	udd_disable_sof_interrupt();
+#ifdef USB_DEVICE_HS_SUPPORT
+	udd_disable_msof_interrupt();
+#endif
+	// Clear interrupt bits which cannot be cleared while the clock
+    // is frozen. Add barriers to ensure proper execution order.
+	__DSB();
+	udd_ack_reset();
+	udd_ack_sof();
+	udd_ack_msof();
+	__DSB();
+}
 
 void udd_attach(void)
 {
@@ -785,7 +825,7 @@ void udd_attach(void)
 	// At startup the USB bus state is unknown,
 	// therefore the state is considered IDLE to not miss any USB event
 	udd_sleep_mode(true);
-	otg_unfreeze_clock();
+	marlin_otg_unfreeze_clock();
 
 	// This section of clock check can be improved with a check of
 	// USB clock source via sysclk()
@@ -796,35 +836,32 @@ void udd_attach(void)
 	udd_attach_device();
 
 	// Enable USB line events
-	udd_enable_reset_interrupt();
 	udd_enable_suspend_interrupt();
 	udd_enable_wake_up_interrupt();
-	udd_enable_sof_interrupt();
-#ifdef USB_DEVICE_HS_SUPPORT
-	udd_enable_msof_interrupt();
-#endif
-	// Reset following interrupts flag
-	udd_ack_reset();
-	udd_ack_sof();
-	udd_ack_msof();
+
+    // Several interrupts cannot be handled while the
+    // clock is frozen. Ensure they are disabled and
+    // defer until the wake interrupt enables them.
+	disable_and_ack_sync_interrupts();
 
 	// The first suspend interrupt must be forced
 	// The first suspend interrupt is not detected else raise it
 	udd_raise_suspend();
-
 	udd_ack_wake_up();
-	otg_freeze_clock();
+
+	marlin_otg_freeze_clock();
 	cpu_irq_restore(flags);
 }
 
 
 void udd_detach(void)
 {
-	otg_unfreeze_clock();
+	marlin_otg_unfreeze_clock();
 
 	// Detach device from the bus
 	udd_detach_device();
-	otg_freeze_clock();
+	disable_and_ack_sync_interrupts();
+	marlin_otg_freeze_clock();
 	udd_sleep_mode(false);
 }
 
@@ -870,7 +907,7 @@ void udd_send_remotewakeup(void)
 #endif
 	{
 		udd_sleep_mode(true); // Enter in IDLE mode
-		otg_unfreeze_clock();
+		marlin_otg_unfreeze_clock();
 		udd_initiate_remote_wake_up();
 	}
 }
@@ -2043,6 +2080,7 @@ static bool udd_ep_interrupt(void)
 				dbg_print("I ");
 				udd_disable_in_send_interrupt(ep);
 				// One bank is free then send a ZLP
+				__DSB(); // Barrier to ensure in_send is disabled before it is cleared
 				udd_ack_in_send(ep);
 				udd_ack_fifocon(ep);
 				udd_ep_finish_job(ptr_job, false, ep);

--- a/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
@@ -813,7 +813,9 @@ static void disable_and_ack_sync_interrupts()
 	__DSB();
 	udd_ack_reset();
 	udd_ack_sof();
+#ifdef USB_DEVICE_HS_SUPPORT
 	udd_ack_msof();
+#endif
 	__DSB();
 }
 

--- a/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
@@ -630,10 +630,10 @@ ISR(UDD_USB_INT_FUN)
 		udd_enable_suspend_interrupt();
 
 		// Marlin modification: The RESET, SOF, and MSOF interrupts were previously
-    // enabled in udd_attach, which caused a race condition where they could
-    // be raised and unclearable with the clock is frozen. They are now
-    // enabled here, after the clock has been unfrozen in response to the wake
-    // interrupt.
+		// enabled in udd_attach, which caused a race condition where they could
+		// be raised and unclearable with the clock is frozen. They are now
+		// enabled here, after the clock has been unfrozen in response to the wake
+		// interrupt.
 		udd_enable_reset_interrupt();
 		udd_enable_sof_interrupt();
 #ifdef USB_DEVICE_HS_SUPPORT
@@ -849,19 +849,19 @@ void udd_attach(void)
 	udd_enable_suspend_interrupt();
 	udd_enable_wake_up_interrupt();
 
-  // Marlin modification: The RESET, SOF, and MSOF interrupts were previously
-  // enabled here, which caused a race condition where they could be raised
-  // and unclearable with the clock is frozen. They are now enabled in the
-  // wake interrupt handler, after the clock has been unfrozen. They are now
-  // explicitly disabled here to ensure that they cannot be raised before
-  // the clock is frozen.
+	// Marlin modification: The RESET, SOF, and MSOF interrupts were previously
+	// enabled here, which caused a race condition where they could be raised
+	// and unclearable with the clock is frozen. They are now enabled in the
+	// wake interrupt handler, after the clock has been unfrozen. They are now
+	// explicitly disabled here to ensure that they cannot be raised before
+	// the clock is frozen.
 	disable_and_ack_sync_interrupts();
 
 	// The first suspend interrupt must be forced
 	// The first suspend interrupt is not detected else raise it
 	udd_raise_suspend();
-	udd_ack_wake_up();
 
+	udd_ack_wake_up();
 	otg_freeze_clock();
 	cpu_irq_restore(flags);
 }
@@ -874,9 +874,9 @@ void udd_detach(void)
 	// Detach device from the bus
 	udd_detach_device();
 
-  // Marlin modification: Added the explicit disabling of the RESET, SOF, and
-  // MSOF interrupts here, to ensure that they cannot be raised after the
-  // clock is frozen.
+	// Marlin modification: Added the explicit disabling of the RESET, SOF, and
+	// MSOF interrupts here, to ensure that they cannot be raised after the
+	// clock is frozen.
 	disable_and_ack_sync_interrupts();
 
 	otg_freeze_clock();
@@ -2099,9 +2099,9 @@ static bool udd_ep_interrupt(void)
 				udd_disable_in_send_interrupt(ep);
 				// One bank is free then send a ZLP
 
-        // Marlin modification: Add a barrier to ensure in_send is disabled
-        // before it is cleared. This was not an observed problem, but
-        // other interrupts were seen to misbehave without this barrier.
+				// Marlin modification: Add a barrier to ensure in_send is disabled
+				// before it is cleared. This was not an observed problem, but
+				// other interrupts were seen to misbehave without this barrier.
 				__DSB();
 
 				udd_ack_in_send(ep);

--- a/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
@@ -120,14 +120,14 @@
 // to ensure that any accesses to USB registers aren't re-ordered
 // to occur while the clock is frozen.
 #define marlin_otg_freeze_clock() do { \
-  __DSB(); \
-  Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
+	__DSB(); \
+	Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
 } while (0)
 
-#define marlin_otg_unfreeze_clock()                \
-do {                                        \
-  Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
-  __DSB();                                \
+#define marlin_otg_unfreeze_clock() \
+do { \
+	Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK); \
+	__DSB(); \
 } while (0)
 
 /**
@@ -627,7 +627,7 @@ ISR(UDD_USB_INT_FUN)
 		udd_enable_suspend_interrupt();
 
 		// The following interrupts can only be enabled while the clock
-        // is unfrozen, which is why they were left disabled in udd_attach
+		// is unfrozen, which is why they were left disabled in udd_attach
 		udd_enable_reset_interrupt();
 		udd_enable_sof_interrupt();
 #ifdef USB_DEVICE_HS_SUPPORT
@@ -809,7 +809,7 @@ static void disable_and_ack_sync_interrupts()
 	udd_disable_msof_interrupt();
 #endif
 	// Clear interrupt bits which cannot be cleared while the clock
-    // is frozen. Add barriers to ensure proper execution order.
+	// is frozen. Add barriers to ensure proper execution order.
 	__DSB();
 	udd_ack_reset();
 	udd_ack_sof();
@@ -839,9 +839,9 @@ void udd_attach(void)
 	udd_enable_suspend_interrupt();
 	udd_enable_wake_up_interrupt();
 
-    // Several interrupts cannot be handled while the
-    // clock is frozen. Ensure they are disabled and
-    // defer until the wake interrupt enables them.
+	// Several interrupts cannot be handled while the
+	// clock is frozen. Ensure they are disabled and
+	// defer until the wake interrupt enables them.
 	disable_and_ack_sync_interrupts();
 
 	// The first suspend interrupt must be forced

--- a/buildroot/tests/DUE_archim
+++ b/buildroot/tests/DUE_archim
@@ -16,6 +16,7 @@ exec_test $1 $2 "Archim 1 base configuration" "$3"
 # Test Archim 2
 #
 use_example_configs UltiMachine/Archim2
+opt_set USB_FLASH_DRIVE_SUPPORT
 exec_test $1 $2 "Archim 2 base configuration" "$3"
 
 restore_configs

--- a/buildroot/tests/DUE_archim
+++ b/buildroot/tests/DUE_archim
@@ -16,7 +16,7 @@ exec_test $1 $2 "Archim 1 base configuration" "$3"
 # Test Archim 2
 #
 use_example_configs UltiMachine/Archim2
-opt_set USB_FLASH_DRIVE_SUPPORT
+opt_enable USB_FLASH_DRIVE_SUPPORT
 exec_test $1 $2 "Archim 2 base configuration" "$3"
 
 restore_configs


### PR DESCRIPTION
### Description

The USB OTG implementation in the DUE HAL could leave interrupts active after the clock had been frozen. This prevented the interrupts from being cleared until the clock was un-frozen. This most readily manifested when no USB cable is attached, as a watchdog reset. Several changes were made to resolve this:

1. Delay enabling some interrupts until the WAKE interrupt handler, which unfreezes the clock.
2. Override helpers to enforce memory barriers around freeze/unfreeze operations
3. Add memory barriers when interrupts are cleared (ACKed) just after disabling the interrupt, to ensure the interrupt is not re-asserted before the clock is frozen.
4. Add comments and a README.md in an attempt to prevent regressions when this code is maintained and possibly updated in the future.
5. Add `USB_FLASH_DRIVE_SUPPORT` to DUE_archim test cases to ensure code paths are fully enabled.

### Requirements

DUE-based board such as an Archim2

### Benefits

Prevents random hangs and watchdog reboots when operating without a USB connection to a host.

### Configurations

This was debugged using a Taz Pro configuration from the LulzBot repo.

### Related Issues

I found two existing issues that are may likely be related to this, although I have not specifically investigated either of these:

#23733 - Possible bug with SAM3X8E (DUE- native USB comm )
(Possibly related)

#17444 - Disconnecting USB sometimes causes Archim to reboot
(Very likely related)

