### PR TITLE
Use TEMP_SENSOR_0_IS_MAX31865 for BTT Octopus Boards

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
@@ -26,6 +26,8 @@
 //
 // Temperature Sensors
 //
+#define TEMP_0_PIN                          PF4   // TH0
+
 #if TEMP_SENSOR_0_IS_MAX31865
   #define TEMP_0_CS_PIN                     PF8   // Max31865 CS
   #define TEMP_0_SCK_PIN                    PA5
@@ -33,8 +35,6 @@
   #define TEMP_0_MOSI_PIN                   PA7
   #define SOFTWARE_SPI                            // Max31865 and LCD SD share a set of SPIs, Set SD to softwareSPI for Max31865
   #define FORCE_SOFT_SPI
-#else
-  #define TEMP_0_PIN                        PF4   // TH0
 #endif
 
 #if !defined(Z_MIN_PROBE_PIN) && DISABLED(BLTOUCH)

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
@@ -26,7 +26,7 @@
 //
 // Temperature Sensors
 //
-#if TEMP_SENSOR_0 == -5
+#if TEMP_SENSOR_0_IS_MAX31865
   #define TEMP_0_CS_PIN                     PF8   // Max31865 CS
   #define TEMP_0_SCK_PIN                    PA5
   #define TEMP_0_MISO_PIN                   PA6

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -214,6 +214,7 @@
 // Temperature Sensors
 //
 #define TEMP_BED_PIN                        PF3   // TB
+#define TEMP_0_PIN                          PF4   // TH0
 #define TEMP_1_PIN                          PF5   // TH1
 #define TEMP_2_PIN                          PF6   // TH2
 #define TEMP_3_PIN                          PF7   // TH3
@@ -225,8 +226,6 @@
   #define TEMP_0_MOSI_PIN                   PA7
   #define SOFTWARE_SPI                            // Max31865 and LCD SD share a set of SPIs, Set SD to softwareSPI for Max31865
   #define FORCE_SOFT_SPI
-#else
-  #define TEMP_0_PIN                        PF4   // TH0
 #endif
 
 //

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -218,7 +218,7 @@
 #define TEMP_2_PIN                          PF6   // TH2
 #define TEMP_3_PIN                          PF7   // TH3
 
-#if TEMP_SENSOR_0 == -5
+#if TEMP_SENSOR_0_IS_MAX31865
   #define TEMP_0_CS_PIN                     PF8   // Max31865 CS
   #define TEMP_0_SCK_PIN                    PA5
   #define TEMP_0_MISO_PIN                   PA6


### PR DESCRIPTION
### Description

Cherry-picked changes from https://github.com/MarlinFirmware/Marlin/pull/26565 to use `TEMP_SENSOR_0_IS_MAX31865` for BTT Octopus boards since I would like to keep that PR as a "clean" example of how to add new board support to Marlin.