### PR TITLE
Fix z_fade_height in settings.cpp

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -918,8 +918,8 @@ void MarlinSettings::postprocess() {
     // Global Leveling
     //
     {
-      const float zfh = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.z_fade_height, (DEFAULT_LEVELING_FADE_HEIGHT));
-      EEPROM_WRITE(zfh);
+      const float planner_z_fade_height = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.z_fade_height, (DEFAULT_LEVELING_FADE_HEIGHT));
+      EEPROM_WRITE(planner_z_fade_height);
     }
 
     //


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
I noticed in **settings.cpp** `zfh` is used while `planner_z_fade_height` goes unused within `SettingsDataStruct`.

so I changed the following
```diff
    {
-     const float zfh = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.z_fade_height, (DEFAULT_LEVELING_FADE_HEIGHT));
-     EEPROM_WRITE(zfh);
    }

    {
+     const float planner_z_fade_height = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.z_fade_height, (DEFAULT_LEVELING_FADE_HEIGHT));
+     EEPROM_WRITE(planner_z_fade_height);
    }
```

also I couldn't help but notice
```y
    celsius_t planner_autotemp_max, planner_autotemp_min;
    float planner_autotemp_factor;
```
`planner_autotemp_min` and `planner_autotemp_factor` are both unused here as well, the `max` one is not. so this is meant more for a placeholder? or does it matter?

