### PR TITLE
📌 Specify U8glib-HAL@0.5.4

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -40,7 +40,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_LCDPRINT                           = build_src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = build_src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@~0.5.2
+HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@0.5.4
                                          build_src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = build_src_filter=+<src/lcd/tft_io>
 HAS_LTDC_TFT                           = build_src_filter=+<src/HAL/STM32/tft/tft_ltdc.cpp>


### PR DESCRIPTION
### Description

Now that [PIO's registry](https://registry.platformio.org/libraries/marlinfirmware/U8glib-HAL) has picked up `MarlinFirmware/U8glib-HAL@0.5.4`, let's pin it.

### Related Issues

- https://github.com/MarlinFirmware/U8glib-HAL/issues/32
- https://github.com/MarlinFirmware/U8glib-HAL/issues/33
- https://github.com/MarlinFirmware/Marlin/issues/26577 (boot freeze was unrelated, but it was the first opened u8glib issue)
