### PR TITLE
🔨 Use Newer Platform & Toolchain for STM32G0

### DIFF
--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -31,9 +31,9 @@ build_flags = -DPIN_WIRE_SCL=PB3 -DPIN_WIRE_SDA=PB4
 #
 [env:BTT_EBB42_V1_1_filament_extruder]
 extends                     = stm32_variant
-platform                    = ststm32@~14.1.0
+platform                    = ststm32@17.1.0
 platform_packages           = framework-arduinoststm32@~4.20600.231001
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000
@@ -47,9 +47,9 @@ upload_command              = dfu-util -a 0 -s 0x08000000:leave -D "$SOURCE"
 #
 [env:STM32G0B1RE_btt]
 extends                     = stm32_variant
-platform                    = ststm32@~14.1.0
+platform                    = ststm32@17.1.0
 platform_packages           = framework-arduinoststm32@~4.20600.231001
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
@@ -104,9 +104,9 @@ upload_protocol = custom
 #
 [env:STM32G0B1VE_btt]
 extends                     = stm32_variant
-platform                    = ststm32@~14.1.0
+platform                    = ststm32@17.1.0
 platform_packages           = framework-arduinoststm32@~4.20600.231001
-                              toolchain-gccarmnoneeabi@1.100301.220327
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32G0B1VE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -37,7 +37,9 @@ platform_packages           = framework-arduinoststm32@~4.20600.231001
 board                       = marlin_BTT_EBB42_V1_1
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000
-build_flags                 = ${stm32_variant.build_flags} ${stm32g0_I2C2.build_flags} -flto
+build_flags                 = ${stm32_variant.build_flags} ${stm32g0_I2C2.build_flags}
+                              -flto
+                              -Wl,--no-warn-rwx-segment
 debug_tool                  = stlink
 upload_protocol             = dfu
 upload_command              = dfu-util -a 0 -s 0x08000000:leave -D "$SOURCE"
@@ -58,6 +60,7 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0
+                              -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
 
@@ -116,6 +119,7 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0
+                              -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
 


### PR DESCRIPTION
### Description

Use:

- `ststm32@17.1.0` (now pinned)
- `toolchain-gccarmnoneeabi@1.120301.0` (12.3.1)

Firmware does not build with `framework-arduinoststm32@~4.20701.0` (2.7.1), so I did not update to it.

This has been tested on an SKR Mini E3 V3 & Manta M4P for ~the last month, but more testing couldn't hurt. edit: I dropped a link to this PR on Discord in the #testing channel.

Using my beta Rook config with an SKR Mini E3 V3, here are the RAM & flash changes:

Before:

```prolog
RAM:   [===       ]  31.4% (used 46256 bytes from 147456 bytes)
Flash: [=====     ]  47.6% (used 249460 bytes from 524288 bytes)
```

After:

```prolog
RAM:   [===       ]  31.6% (used 46568 bytes from 147456 bytes)
Flash: [=====     ]  47.2% (used 247468 bytes from 524288 bytes)
```

So, 312B increase in RAM and ~2KB decrease in flash.

### Requirements

STM32G0-based motherboard.

