### PR TITLE
Enable ONBOARD_SDIO for TriGorilla Pro

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
@@ -186,6 +186,12 @@
 // SPI1(PA7) & SPI3(PB5) not available
 #define SPI_DEVICE                             2  // Maple
 
+//
+// SD Card
+//
+#ifndef ONBOARD_SDIO
+  #define ONBOARD_SDIO
+#endif
 #if ENABLED(ONBOARD_SDIO)
   #define SD_SCK_PIN                        PB13  // SPI2 ok
   #define SD_MISO_PIN                       PB14  // SPI2 ok


### PR DESCRIPTION
### Description

Enable `ONBOARD_SDIO` for TriGorilla Pro like we do for the TriGorilla V006.

### Requirements

TriGorilla Pro

### Benefits

Ensures `ONBOARD_SDIO` is enabled for this board.

### Configurations

[Configurations/config/examples/delta/Anycubic/Predator/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/delta/Anycubic/Predator)

### Related Issues

- #25852
