### PR TITLE
fix sanity check for FAN0_PIN issue 26590

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2657,7 +2657,7 @@
                      && !_IS_E_AUTO(4,F) && !_IS_E_AUTO(5,F) \
                      && !_IS_E_AUTO(6,F) && !_IS_E_AUTO(7,F))
 
-#if _HAS_FAN(0)
+#if PIN_EXISTS(FAN0) // Special case, do not use _HAS_FAN(0)
   #define HAS_FAN0 1
 #endif
 #if _HAS_FAN(1)

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2657,7 +2657,7 @@
                      && !_IS_E_AUTO(4,F) && !_IS_E_AUTO(5,F) \
                      && !_IS_E_AUTO(6,F) && !_IS_E_AUTO(7,F))
 
-#if PIN_EXISTS(FAN0) // Special case, do not use _HAS_FAN(0)
+#if _HAS_FAN(0)
   #define HAS_FAN0 1
 #endif
 #if _HAS_FAN(1)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1829,19 +1829,25 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 #undef GOOD_AXIS_PINS
 
 /**
- * Make sure auto fan pins don't conflict with the fan pin
+ * Make sure auto fan pins don't conflict with the first fan pin
  */
 #if HAS_AUTO_FAN
-  #if HAS_FAN0
-    #if PIN_EXISTS(E0_AUTO_FAN) && E0_AUTO_FAN_PIN == FAN0_PIN
-      #error "You cannot set E0_AUTO_FAN_PIN equal to FAN0_PIN."
-    #elif PIN_EXISTS(E1_AUTO_FAN) && E1_AUTO_FAN_PIN == FAN0_PIN
-      #error "You cannot set E1_AUTO_FAN_PIN equal to FAN0_PIN."
-    #elif PIN_EXISTS(E2_AUTO_FAN) && E2_AUTO_FAN_PIN == FAN0_PIN
-      #error "You cannot set E2_AUTO_FAN_PIN equal to FAN0_PIN."
-    #elif PIN_EXISTS(E3_AUTO_FAN) &&  E3_AUTO_FAN_PIN == FAN0_PIN
-      #error "You cannot set E3_AUTO_FAN_PIN equal to FAN0_PIN."
-    #endif
+  #if PIN_EXISTS(E0_AUTO_FAN) && E0_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E0_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E1_AUTO_FAN) && E1_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E1_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E2_AUTO_FAN) && E2_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E2_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E3_AUTO_FAN) &&  E3_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E3_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E4_AUTO_FAN) &&  E4_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E4_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E5_AUTO_FAN) &&  E5_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E5_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E6_AUTO_FAN) &&  E6_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E6_AUTO_FAN_PIN equal to FAN0_PIN."
+  #elif PIN_EXISTS(E7_AUTO_FAN) &&  E7_AUTO_FAN_PIN == FAN0_PIN
+    #error "You cannot set E7_AUTO_FAN_PIN equal to FAN0_PIN."
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1832,21 +1832,21 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
  * Make sure auto fan pins don't conflict with the first fan pin
  */
 #if HAS_AUTO_FAN
-  #if PIN_EXISTS(E0_AUTO_FAN) && E0_AUTO_FAN_PIN == FAN0_PIN
+  #if PINS_EXIST(E0_AUTO_FAN, FAN0) && E0_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E0_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E1_AUTO_FAN) && E1_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E1_AUTO_FAN, FAN0) && E1_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E1_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E2_AUTO_FAN) && E2_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E2_AUTO_FAN, FAN0) && E2_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E2_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E3_AUTO_FAN) &&  E3_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E3_AUTO_FAN, FAN0) &&  E3_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E3_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E4_AUTO_FAN) &&  E4_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E4_AUTO_FAN, FAN0) &&  E4_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E4_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E5_AUTO_FAN) &&  E5_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E5_AUTO_FAN, FAN0) &&  E5_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E5_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E6_AUTO_FAN) &&  E6_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E6_AUTO_FAN, FAN0) &&  E6_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E6_AUTO_FAN_PIN equal to FAN0_PIN."
-  #elif PIN_EXISTS(E7_AUTO_FAN) &&  E7_AUTO_FAN_PIN == FAN0_PIN
+  #elif PINS_EXIST(E7_AUTO_FAN, FAN0) &&  E7_AUTO_FAN_PIN == FAN0_PIN
     #error "You cannot set E7_AUTO_FAN_PIN equal to FAN0_PIN."
   #endif
 #endif

--- a/Marlin/src/pins/mega/pins_MALYAN_M180.h
+++ b/Marlin/src/pins/mega/pins_MALYAN_M180.h
@@ -96,7 +96,6 @@
 #ifndef FAN0_PIN
   #define FAN0_PIN                             7  // M106 Sxxx command supported and tested. M107 as well.
 #endif
-
-#ifndef FAN_PIN1
-  #define FAN_PIN1                            12  // Currently Unsupported by Marlin
+#ifndef FAN1_PIN
+  #define FAN1_PIN                            12  // Currently Unsupported by Marlin
 #endif


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/pull/25568 the FAN0_PIN sanity checks have been broken.
Allowing users to set auto fans and controller fans to fan0_pin.  When FAN0_PIN is always part cooling fan.

### Requirements

FAN0_PIN

### Benefits

Generates sanity check errors as expected.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26590