### PR TITLE
🐛 Fix Bed PID Autotune Output

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -849,9 +849,9 @@ volatile bool Temperature::raw_temps_ready = false;
 
         #if ANY(PIDTEMPBED, PIDTEMPCHAMBER)
           FSTR_P const estring = GHV(F("chamber"), F("bed"), FPSTR(NUL_STR));
-          say_default_(); SERIAL_ECHO(estring, F("Kp "), tune_pid.p);
-          say_default_(); SERIAL_ECHO(estring, F("Ki "), tune_pid.i);
-          say_default_(); SERIAL_ECHO(estring, F("Kd "), tune_pid.d);
+          say_default_(); SERIAL_ECHOLN(estring, F("Kp "), tune_pid.p);
+          say_default_(); SERIAL_ECHOLN(estring, F("Ki "), tune_pid.i);
+          say_default_(); SERIAL_ECHOLN(estring, F("Kd "), tune_pid.d);
         #else
           say_default_(); SERIAL_ECHOLNPGM("Kp ", tune_pid.p);
           say_default_(); SERIAL_ECHOLNPGM("Ki ", tune_pid.i);


### PR DESCRIPTION
### Description

Followup to #25928

In current bugfix the last few lines output from auto-tuning the bed PID do not contain new lines. For example:

```text
PID Autotune finished! Put the last Kp, Ki and Kd constants from below into Configuration.h
//action:notification PID tuning done
#define DEFAULT_bedKp 121.3973#define DEFAULT_bedKi 23.7104#define DEFAULT_bedKd 414.3696ok P63 B3
```

Not only is this not ideal, it breaks RepRap GCode protocol since the `ok` response is not at the beginning of the line. This will break well behaved hosts.

This behavior was introduced at https://github.com/MarlinFirmware/Marlin/pull/25928/files#diff-9c1d09e39e0d06d83cd4a44f54ff41e1cc364477c4dc39ecacf106a9b75540b7L873-R875

### Requirements

`PIDTEMPBED` or `PIDTEMPCHAMBER`

### Benefits

Output will contain newlines as appropriate, i.e.:
```text
PID Autotune finished! Put the last Kp, Ki and Kd constants from below into Configuration.h
//action:notification PID tuning done
#define DEFAULT_bedKp 104.9675
#define DEFAULT_bedKi 18.7442
#define DEFAULT_bedKd 391.8785
ok P63 B3
```

### Configurations

N/A

### Related Issues

None
