### PR TITLE
Event leds include not necessary anymore

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -37,10 +37,6 @@ GCodeQueue queue;
 #include "../MarlinCore.h"
 #include "../core/bug_on.h"
 
-#if ENABLED(PRINTER_EVENT_LEDS)
-  #include "../feature/leds/printer_event_leds.h"
-#endif
-
 #if HAS_ETHERNET
   #include "../feature/ethernet.h"
 #endif

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -37,10 +37,6 @@ GCodeQueue queue;
 #include "../MarlinCore.h"
 #include "../core/bug_on.h"
 
-#if HAS_ETHERNET
-  #include "../feature/ethernet.h"
-#endif
-
 #if ENABLED(BINARY_FILE_TRANSFER)
   #include "../feature/binary_stream.h"
 #endif


### PR DESCRIPTION
Hi,

Very small PR, this `event leds` include is obsolete. Was introduced when the codebase was differently organized.
I tend to say it is the very same for the `ethernet` include

https://github.com/MarlinFirmware/Marlin/blob/6d407767e7692d66bc93a0012d71268770e4835c/Marlin/src/gcode/queue.cpp#L45

But i didn't work on something related so i couldn't test.

Regards,