### PR TITLE
M111/M115 Followup

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3836,38 +3836,6 @@
  */
 //#define CNC_COORDINATE_SYSTEMS
 
-// @section reporting
-
-/**
- * Auto-report fan speed with M123 S<seconds>
- * Requires fans with tachometer pins
- */
-//#define AUTO_REPORT_FANS
-
-/**
- * Auto-report temperatures with M155 S<seconds>
- */
-#define AUTO_REPORT_TEMPERATURES
-#if ENABLED(AUTO_REPORT_TEMPERATURES) && TEMP_SENSOR_REDUNDANT
-  //#define AUTO_REPORT_REDUNDANT // Include the "R" sensor in the auto-report
-#endif
-
-/**
- * Auto-report position with M154 S<seconds>
- */
-//#define AUTO_REPORT_POSITION
-#if ENABLED(AUTO_REPORT_POSITION)
-  //#define AUTO_REPORT_REAL_POSITION // Auto-report the real position
-#endif
-
-/**
- * Include capabilities in M115 output
- */
-#define EXTENDED_CAPABILITIES_REPORT
-#if ENABLED(EXTENDED_CAPABILITIES_REPORT)
-  //#define M115_GEOMETRY_REPORT
-#endif
-
 // @section security
 
 /**
@@ -3910,12 +3878,49 @@
 
 // @section reporting
 
-// Extra options for the M114 "Current Position" report
+/**
+ * Extra options for the M114 "Current Position" report
+ */
 //#define M114_DETAIL         // Use 'M114` for details to check planner calculations
 //#define M114_REALTIME       // Real current position based on forward kinematics
 //#define M114_LEGACY         // M114 used to synchronize on every call. Enable if needed.
 
+
+/**
+ * Auto-report fan speed with M123 S<seconds>
+ * Requires fans with tachometer pins
+ */
+//#define AUTO_REPORT_FANS
 //#define REPORT_FAN_CHANGE   // Report the new fan speed when changed by M106 (and others)
+
+/**
+ * Auto-report temperatures with M155 S<seconds>
+ */
+#define AUTO_REPORT_TEMPERATURES
+#if ENABLED(AUTO_REPORT_TEMPERATURES) && TEMP_SENSOR_REDUNDANT
+  //#define AUTO_REPORT_REDUNDANT // Include the "R" sensor in the auto-report
+#endif
+
+/**
+ * Auto-report position with M154 S<seconds>
+ */
+//#define AUTO_REPORT_POSITION
+#if ENABLED(AUTO_REPORT_POSITION)
+  //#define AUTO_REPORT_REAL_POSITION // Auto-report the real position
+#endif
+
+/**
+ * M115 - Report capabilites. Disable to save ~1150 bytes of flash.
+ *        Some hosts (and serial TFT displays) rely on this feature.
+ */
+#define REPORT_CAPABILITIES
+#if ENABLED(REPORT_CAPABILITIES)
+  // Include capabilities in M115 output
+  #define EXTENDED_CAPABILITIES_REPORT
+  #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
+    //#define M115_GEOMETRY_REPORT
+  #endif
+#endif
 
 // @section gcode
 
@@ -3928,7 +3933,9 @@
   //#define GCODE_QUOTED_STRINGS  // Support for quoted string parameters
 #endif
 
-// Support for MeatPack G-code compression (https://github.com/scottmudge/OctoPrint-MeatPack)
+/**
+ * Support for MeatPack G-code compression (https://github.com/scottmudge/OctoPrint-MeatPack)
+ */
 //#define MEATPACK_ON_SERIAL_PORT_1
 //#define MEATPACK_ON_SERIAL_PORT_2
 
@@ -3941,12 +3948,6 @@
  * Disable to save some flash. Some hosts (Repetier Host) may rely on this feature.
  */
 #define DEBUG_FLAGS_GCODE
-
-/**
- * M115 - Report capabilites. Disable to save ~1150 bytes of flash.
- *        Some hosts (and serial TFT displays) rely on this feature.
- */
-#define REPORT_CAPABILITIES_GCODE
 
 /**
  * Enable this option for a leaner build of Marlin that removes

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3891,6 +3891,7 @@
  * Requires fans with tachometer pins
  */
 //#define AUTO_REPORT_FANS
+
 //#define REPORT_FAN_CHANGE   // Report the new fan speed when changed by M106 (and others)
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3976,8 +3976,6 @@
   //#define VARIABLE_G0_FEEDRATE // The G0 feedrate is set by F in G0 motion mode
 #endif
 
-// @section gcode
-
 /**
  * Startup commands
  *

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3913,8 +3913,8 @@
  * M115 - Report capabilites. Disable to save ~1150 bytes of flash.
  *        Some hosts (and serial TFT displays) rely on this feature.
  */
-#define REPORT_CAPABILITIES
-#if ENABLED(REPORT_CAPABILITIES)
+#define CAPABILITIES_REPORT
+#if ENABLED(CAPABILITIES_REPORT)
   // Include capabilities in M115 output
   #define EXTENDED_CAPABILITIES_REPORT
   #if ENABLED(EXTENDED_CAPABILITIES_REPORT)

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -670,7 +670,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 92: M92(); break;                                      // M92: Set the steps-per-unit for one or more axes
       case 114: M114(); break;                                    // M114: Report current position
 
-      #if ENABLED(REPORT_CAPABILITIES)
+      #if ENABLED(CAPABILITIES_REPORT)
         case 115: M115(); break;                                  // M115: Report capabilities
       #endif
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -670,7 +670,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 92: M92(); break;                                      // M92: Set the steps-per-unit for one or more axes
       case 114: M114(); break;                                    // M114: Report current position
 
-      #if ENABLED(REPORT_CAPABILITIES_GCODE)
+      #if ENABLED(REPORT_CAPABILITIES)
         case 115: M115(); break;                                  // M115: Report capabilities
       #endif
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -149,7 +149,7 @@
  *
  * M113 - Get or set the timeout interval for Host Keepalive "busy" messages. (Requires HOST_KEEPALIVE_FEATURE)
  * M114 - Report current position.
- * M115 - Report capabilities. (Extended capabilities requires EXTENDED_CAPABILITIES_REPORT)
+ * M115 - Report capabilities. (EXTENDED_CAPABILITIES_REPORT requires REPORT_CAPABILITIES)
  * M117 - Display a message on the controller screen. (Requires an LCD)
  * M118 - Display a message in the host console.
  *
@@ -761,7 +761,7 @@ private:
 
   static void M114();
 
-  #if ENABLED(REPORT_CAPABILITIES_GCODE)
+  #if ENABLED(REPORT_CAPABILITIES)
     static void M115();
   #endif
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -149,7 +149,7 @@
  *
  * M113 - Get or set the timeout interval for Host Keepalive "busy" messages. (Requires HOST_KEEPALIVE_FEATURE)
  * M114 - Report current position.
- * M115 - Report capabilities. (EXTENDED_CAPABILITIES_REPORT requires REPORT_CAPABILITIES)
+ * M115 - Report capabilities. (Requires CAPABILITIES_REPORT)
  * M117 - Display a message on the controller screen. (Requires an LCD)
  * M118 - Display a message in the host console.
  *
@@ -761,7 +761,7 @@ private:
 
   static void M114();
 
-  #if ENABLED(REPORT_CAPABILITIES)
+  #if ENABLED(CAPABILITIES_REPORT)
     static void M115();
   #endif
 

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(REPORT_CAPABILITIES_GCODE)
+#if ENABLED(REPORT_CAPABILITIES)
 
 #include "../gcode.h"
 #include "../queue.h"           // for getting the command port
@@ -275,4 +275,4 @@ void GcodeSuite::M115() {
   #endif // EXTENDED_CAPABILITIES_REPORT
 }
 
-#endif // REPORT_CAPABILITIES_GCODE
+#endif // REPORT_CAPABILITIES

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(REPORT_CAPABILITIES)
+#if ENABLED(CAPABILITIES_REPORT)
 
 #include "../gcode.h"
 #include "../queue.h"           // for getting the command port
@@ -275,4 +275,4 @@ void GcodeSuite::M115() {
   #endif // EXTENDED_CAPABILITIES_REPORT
 }
 
-#endif // REPORT_CAPABILITIES
+#endif // CAPABILITIES_REPORT

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -46,8 +46,8 @@
   #warning "DEBUG_FLAGS_GCODE is recommended if you have space. Some hosts rely on it."
 #endif
 
-#if DISABLED(REPORT_CAPABILITIES_GCODE)
-  #warning "REPORT_CAPABILITIES_GCODE is recommended if you have space. Some hosts rely on it."
+#if DISABLED(REPORT_CAPABILITIES)
+  #warning "REPORT_CAPABILITIES is recommended if you have space. Some hosts rely on it."
 #endif
 
 #if ENABLED(LA_DEBUG)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -46,8 +46,8 @@
   #warning "DEBUG_FLAGS_GCODE is recommended if you have space. Some hosts rely on it."
 #endif
 
-#if DISABLED(REPORT_CAPABILITIES)
-  #warning "REPORT_CAPABILITIES is recommended if you have space. Some hosts rely on it."
+#if DISABLED(CAPABILITIES_REPORT)
+  #warning "CAPABILITIES_REPORT is recommended if you have space. Some hosts rely on it."
 #endif
 
 #if ENABLED(LA_DEBUG)

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2306,7 +2306,7 @@ void setMoveZ() { hmiValue.axis = Z_AXIS; setPFloatOnClick(Z_MIN_POS, Z_MAX_POS,
   #endif
 #endif
 
-#if ENABLED(ADVANCED_PAUSE_FEATURE)
+#if ENABLED(CONFIGURE_FILAMENT_CHANGE)
   void setFilLoad()   { setPFloatOnClick(0, EXTRUDE_MAXLENGTH, UNITFDIGITS); }
   void setFilUnload() { setPFloatOnClick(0, EXTRUDE_MAXLENGTH, UNITFDIGITS); }
 #endif

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -323,7 +323,7 @@ CNC_COORDINATE_SYSTEMS                 = build_src_filter=+<src/gcode/geometry/G
 HAS_HOME_OFFSET                        = build_src_filter=+<src/gcode/geometry/M206_M428.cpp>
 EXPECTED_PRINTER_CHECK                 = build_src_filter=+<src/gcode/host/M16.cpp>
 HOST_KEEPALIVE_FEATURE                 = build_src_filter=+<src/gcode/host/M113.cpp>
-REPORT_CAPABILITIES_GCODE              = build_src_filter=+<src/gcode/host/M115.cpp>
+REPORT_CAPABILITIES                    = build_src_filter=+<src/gcode/host/M115.cpp>
 AUTO_REPORT_POSITION                   = build_src_filter=+<src/gcode/host/M154.cpp>
 REPETIER_GCODE_M360                    = build_src_filter=+<src/gcode/host/M360.cpp>
 HAS_GCODE_M876                         = build_src_filter=+<src/gcode/host/M876.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -323,7 +323,7 @@ CNC_COORDINATE_SYSTEMS                 = build_src_filter=+<src/gcode/geometry/G
 HAS_HOME_OFFSET                        = build_src_filter=+<src/gcode/geometry/M206_M428.cpp>
 EXPECTED_PRINTER_CHECK                 = build_src_filter=+<src/gcode/host/M16.cpp>
 HOST_KEEPALIVE_FEATURE                 = build_src_filter=+<src/gcode/host/M113.cpp>
-REPORT_CAPABILITIES                    = build_src_filter=+<src/gcode/host/M115.cpp>
+CAPABILITIES_REPORT                    = build_src_filter=+<src/gcode/host/M115.cpp>
 AUTO_REPORT_POSITION                   = build_src_filter=+<src/gcode/host/M154.cpp>
 REPETIER_GCODE_M360                    = build_src_filter=+<src/gcode/host/M360.cpp>
 HAS_GCODE_M876                         = build_src_filter=+<src/gcode/host/M876.cpp>


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Follow up to  
-🔧 CONFIGURE_FILAMENT_CHANGE - Optional M603 (#26613)
-🔪 Options to slim M111, remove M115 (#26603)

with Filament Load and Unload changed so `ENABLED(CONFIGURE_FILAMENT_CHANGE)`,  
functions `setFilLoad` and `setFilUnload` need to be as well.

its currently `ADVANCED_PAUSE_FEATURE`, this **PR** corrects that.

<br>

also,  
with the new `REPORT_CAPABILITIES_GCODE`, I replaced with less wordy `REPORT_CAPABILITIES` and rearrange `@section reporting` **Configuration_adv.h**
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
