### PR TITLE
Fix Z jerk menu to use 0.1 step.

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -263,10 +263,13 @@
 #endif
 #if NUM_AXES >= 1
   #define HAS_X_AXIS 1
+  #define HAS_A_AXIS 1
   #if NUM_AXES >= XY
     #define HAS_Y_AXIS 1
+    #define HAS_B_AXIS 1
     #if NUM_AXES >= XYZ
       #define HAS_Z_AXIS 1
+      #define HAS_C_AXIS 1
       #if NUM_AXES >= 4
         #define HAS_I_AXIS 1
         #if NUM_AXES >= 5

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -605,7 +605,7 @@ void menu_backlash();
       ;
 
       LOOP_LOGICAL_AXES(a) {
-        if (TERN0(HAS_C_AXIS, a == C_AXIS) || TERN0(HAS_EXTRUDERS, a == E_AXIS))
+        if (TERN0(HAS_Z_AXIS, a == Z_AXIS) || TERN0(HAS_EXTRUDERS, a == E_AXIS))
           EDIT_ITEM_FAST_N(float52sign, a, MSG_VN_JERK, &planner.max_jerk[a], 0.1f, max_jerk_edit[a]);
         else
           EDIT_ITEM_FAST_N(float3, a, MSG_VN_JERK, &planner.max_jerk[a], 1.0f, max_jerk_edit[a]);

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -605,7 +605,7 @@ void menu_backlash();
       ;
 
       LOOP_LOGICAL_AXES(a) {
-        if (TERN0(HAS_Z_AXIS, a == Z_AXIS) || TERN0(HAS_EXTRUDERS, a == E_AXIS))
+        if (TERN0(HAS_C_AXIS, a == C_AXIS) || TERN0(HAS_EXTRUDERS, a == E_AXIS))
           EDIT_ITEM_FAST_N(float52sign, a, MSG_VN_JERK, &planner.max_jerk[a], 0.1f, max_jerk_edit[a]);
         else
           EDIT_ITEM_FAST_N(float3, a, MSG_VN_JERK, &planner.max_jerk[a], 1.0f, max_jerk_edit[a]);


### PR DESCRIPTION
Currently for whatever reasons classic jerk menu uses define `HAS_C_AXIS`, which is not defined anywhere, resulting in usage step 0.1 for Z axis. This PR use `HAS_Z_AXIS` definition.

Another option is to define `HAS_C_AXIS` anywhere (what is its meaning?).