### PR TITLE
Add auto restart on power loss if PLR is enabled.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,3 +1,4 @@
+
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
@@ -1806,6 +1807,7 @@
     //#define BACKUP_POWER_SUPPLY           // Backup power / UPS to move the steppers on power-loss
     #if ENABLED(BACKUP_POWER_SUPPLY)
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
+      //#define PLR_REBOOT_TIMEOUT       60 // (seconds) Restart after power loss if UPS never lost power
     #endif
 
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -958,6 +958,18 @@ void minkill(const bool steppers_off/*=false*/) {
 
   #else
 
+   #if defined(PLR_REBOOT_TIMEOUT)
+    if (PrintJobRecovery::power_lost) {
+      for (uint16_t i = 0; i < PLR_REBOOT_TIMEOUT * 1000; i++) {
+        DELAY_US(1000);
+        if (i % 1000 == 0)
+          hal.watchdog_refresh();
+      }
+      if (READ(POWER_LOSS_PIN) != POWER_LOSS_STATE)
+        hal.reboot();
+    }
+    #endif
+
     for (;;) hal.watchdog_refresh();  // Wait for RESET button or power-cycle
 
   #endif

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -42,6 +42,10 @@ bool PrintJobRecovery::enabled; // Initialized by settings.load
   celsius_t PrintJobRecovery::bed_temp_threshold; // Initialized by settings.load
 #endif
 
+#if PIN_EXISTS(POWER_LOSS)
+  bool PrintJobRecovery::power_lost;
+#endif
+
 MediaFile PrintJobRecovery::file;
 job_recovery_info_t PrintJobRecovery::info;
 const char PrintJobRecovery::filename[5] = "/PLR";
@@ -317,6 +321,7 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
       lock = true;
     #endif
 
+    power_lost = true;
     #if POWER_LOSS_ZRAISE
       // Get the limited Z-raise to do now or on resume
       const float zraise = _MAX(0, _MIN(current_position.z + POWER_LOSS_ZRAISE, Z_MAX_POS - 1) - current_position.z);

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -210,6 +210,7 @@ class PrintJobRecovery {
     static void save(const bool force=ENABLED(SAVE_EACH_CMD_MODE), const float zraise=POWER_LOSS_ZRAISE, const bool raised=false);
 
     #if PIN_EXISTS(POWER_LOSS)
+      static bool power_lost;
       static void outage() {
         static constexpr uint8_t OUTAGE_THRESHOLD = 3;
         static uint8_t outage_counter = 0;


### PR DESCRIPTION
Implements  **[FR] Power Loss Recovery with UPS: auto resume printing if power was immediately restored. #26604**

This PR adds option for auto reboot if **Auto power loss print resume with temperature limitation #26649** is enabled.

Usage scenario is if printer has UPS and power restored within seconds, while UPS still has a power, printer is stuck at "Restart" message, though it's desirable to continue immediately while the bed/chamber are still hot.