### PR TITLE
Correct default SD-Reader to ONBOARD for CR10_STOCKDISPLAY

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -784,6 +784,7 @@
 #elif ENABLED(CR10_STOCKDISPLAY)
 
   #define IS_RRD_FG_SC 1
+  #define NO_LCD_SDCARD
   #define LCD_ST7920_DELAY_1           125
   #define LCD_ST7920_DELAY_2           125
   #define LCD_ST7920_DELAY_3           125
@@ -1684,6 +1685,7 @@
   #define TFT_DEFAULT_ORIENTATION TFT_EXCHANGE_XY
   #define TFT_RES_480x320
   #define TFT_INTERFACE_SPI
+  #define NO_LCD_SDCARD
 #elif ANY(LERDGE_TFT35, ANET_ET5_TFT35)                                       // ST7796
   #define TFT_DEFAULT_ORIENTATION TFT_EXCHANGE_XY
   #define TFT_RES_480x320

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2705,7 +2705,7 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   static_assert(strcmp(STRINGIFY(LCD_LANGUAGE_2), "zh_CN") == 0, "LCD_LANGUAGE_2 must be set to zh_CN for ANYCUBIC_LCD_VYPER.");
 #endif
 
-#if ANY(MKS_TS35_V2_0, BTT_TFT35_SPI_V1_0, CR10_STOCKDISPLAY) && SD_CONNECTION_IS(LCD)
+#if ENABLED(NO_LCD_SDCARD) && SD_CONNECTION_IS(LCD)
   #error "SDCARD_CONNECTION cannot be set to LCD for the enabled display. No available SD card reader."
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2705,8 +2705,8 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   static_assert(strcmp(STRINGIFY(LCD_LANGUAGE_2), "zh_CN") == 0, "LCD_LANGUAGE_2 must be set to zh_CN for ANYCUBIC_LCD_VYPER.");
 #endif
 
-#if ANY(MKS_TS35_V2_0, BTT_TFT35_SPI_V1_0) && SD_CONNECTION_IS(LCD)
-  #error "SDCARD_CONNECTION cannot be set to LCD for the enabled TFT. No available SD card reader."
+#if ANY(MKS_TS35_V2_0, BTT_TFT35_SPI_V1_0, CR10_STOCKDISPLAY) && SD_CONNECTION_IS(LCD)
+  #error "SDCARD_CONNECTION cannot be set to LCD for the enabled display. No available SD card reader."
 #endif
 
 /**

--- a/Marlin/src/pins/lpc1768/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/lpc1768/pins_AZSMZ_MINI.h
@@ -96,7 +96,7 @@
   #define BTN_EN1                          P4_28
   #define BTN_EN2                          P1_27
   #define BTN_ENC                          P3_26
-  #ifndef SDCARD_CONNECTION
+  #if !defined(SDCARD_CONNECTION) && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #endif
 #endif

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -119,7 +119,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -119,7 +119,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -119,9 +119,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if ENABLED(CR10_STOCKDISPLAY)
-    #define SDCARD_CONNECTION            ONBOARD
-  #elif HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -119,7 +119,9 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #define SDCARD_CONNECTION            ONBOARD
+  #elif HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
+++ b/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
@@ -160,7 +160,11 @@
 //
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION                  LCD
+  #if ENABLED(NO_LCD_SDCARD)
+    #define SDCARD_CONNECTION            ONBOARD
+  #else
+    #define SDCARD_CONNECTION                LCD
+  #endif
 #endif
 
 #if SD_CONNECTION_IS(LCD)

--- a/Marlin/src/pins/stm32f1/pins_MD_D301.h
+++ b/Marlin/src/pins/stm32f1/pins_MD_D301.h
@@ -160,8 +160,8 @@
 //
 // SD Support
 //
-#ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION LCD
+#if !defined(SDCARD_CONNECTION) && DISABLED(NO_LCD_SDCARD)
+  #define SDCARD_CONNECTION                  LCD
 #endif
 
 #define SD_DETECT_PIN                       PE3

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -235,7 +235,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -235,7 +235,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -235,7 +235,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
@@ -250,7 +250,11 @@
 //
 #if HAS_MEDIA
   #ifndef SDCARD_CONNECTION
-    #define SDCARD_CONNECTION                LCD
+    #if ENABLED(NO_LCD_SDCARD)
+      #define SDCARD_CONNECTION          ONBOARD
+    #else
+      #define SDCARD_CONNECTION              LCD
+    #endif
   #endif
   #if SD_CONNECTION_IS(ONBOARD)
     //#define SOFTWARE_SPI

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -228,7 +228,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -228,7 +228,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -228,7 +228,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
@@ -326,7 +326,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
@@ -326,7 +326,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
@@ -326,7 +326,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
@@ -272,7 +272,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
@@ -272,7 +272,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
@@ -272,7 +272,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -254,7 +254,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -246,7 +246,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -246,7 +246,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
+  #if HAS_WIRED_LCD
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -246,7 +246,7 @@
 // SD Support
 //
 #ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
+  #if HAS_WIRED_LCD && DISABLED(CR10_STOCKDISPLAY)
     #define SDCARD_CONNECTION                LCD
   #else
     #define SDCARD_CONNECTION            ONBOARD


### PR DESCRIPTION
### Description

Update the pins file for BTT SKR boards to not default to LCD sd-card reader in the case that CR10_STOCKDISPLAY is selected as the display type, because that display CANNOT support an SD-card reader.

This update *ONLY* affects printers with CR10_STOCKDISPLAY selected, and no user-defined SDCARD_CONNECTION (so should not adversely affect any users).

### Requirements

* BTT_SKR board
* CR10_STOCKDISPLAY lcd

### Benefits

* Regain access to the ONBOARD sdcard-reader when using this display with any BTT SKR-series board.

### Related Issues

Fixes loss of default access to the ONBOARD sdcard reader when using a BTT SKR board with a display that has no lcd-based card reader.
