### PR TITLE
add missed if ENABLED block for EDITABLE_STEPS_PER_UNIT

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1861,8 +1861,10 @@ void MarlinSettings::postprocess() {
 
         EEPROM_READ(planner.settings.min_segment_time_us);
 
-        float tmp2[NUM_AXES + e_factors];
-        EEPROM_READ((uint8_t *)tmp2, sizeof(tmp2)); // axis_steps_per_mm
+        #if ENABLED(EDITABLE_STEPS_PER_UNIT)
+          float tmp2[NUM_AXES + e_factors];
+          EEPROM_READ((uint8_t *)tmp2, sizeof(tmp2)); // axis_steps_per_mm
+        #endif
 
         feedRate_t tmp3[NUM_AXES + e_factors];
         EEPROM_READ((uint8_t *)tmp3, sizeof(tmp3)); // max_feedrate_mm_s


### PR DESCRIPTION
### Description

With EDITABLE_STEPS_PER_UNIT disabled, eeprom says it is corrupted every roboot

The issue a missing #if ENABLED(EDITABLE_STEPS_PER_UNIT) block in settings.cpp

Added missing code.

### Requirements

Disable EDITABLE_STEPS_PER_UNIT

### Benefits

EEPROM works as expected

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/26618#issuecomment-1890806807
https://github.com/MarlinFirmware/Marlin/issues/26678