### PR TITLE
Fix wrong M592 report command code, report w/o parameters

### DIFF
--- a/Marlin/src/gcode/feature/nonlinear/M592.cpp
+++ b/Marlin/src/gcode/feature/nonlinear/M592.cpp
@@ -29,7 +29,7 @@
 
 void GcodeSuite::M592_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, F(STR_NONLINEAR_EXTRUSION));
-  SERIAL_ECHOLNPGM("  M593 A", stepper.ne.A, " B", stepper.ne.B, " C", stepper.ne.C);
+  SERIAL_ECHOLNPGM("  M592 A", stepper.ne.A, " B", stepper.ne.B, " C", stepper.ne.C);
 }
 
 /**
@@ -43,6 +43,8 @@ void GcodeSuite::M592_report(const bool forReplay/*=true*/) {
  * Only adjusts forward extrusions, since those are the ones affected by backpressure.
  */
 void GcodeSuite::M592() {
+  if (!parser.seen_any()) return M592_report();
+
   if (parser.seenval('A')) stepper.ne.A = parser.value_float();
   if (parser.seenval('B')) stepper.ne.B = parser.value_float();
   if (parser.seenval('C')) stepper.ne.C = parser.value_float();


### PR DESCRIPTION
Fix a typo in reporting M592 status:
```
void GcodeSuite::M592_report(const bool forReplay/*=true*/) {
  report_heading(forReplay, F(STR_NONLINEAR_EXTRUSION));
  SERIAL_ECHOLNPGM("  M593 A", stepper.ne.A, " B", stepper.ne.B, " C", stepper.ne.C);
}
```
add report if no parameters are given.

