### PR TITLE
add missing POLAR to features.ini

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -365,6 +365,7 @@ NEED_LSF                               = build_src_filter=+<src/libs/least_squar
 NOZZLE_PARK_FEATURE                    = build_src_filter=+<src/libs/nozzle.cpp> +<src/gcode/feature/pause/G27.cpp>
 NOZZLE_CLEAN_FEATURE                   = build_src_filter=+<src/libs/nozzle.cpp> +<src/gcode/feature/clean>
 DELTA                                  = build_src_filter=+<src/module/delta.cpp> +<src/gcode/calibrate/M666.cpp>
+POLAR                                  = build_src_filter=+<src/module/polar.cpp>
 POLARGRAPH                             = build_src_filter=+<src/module/polargraph.cpp>
 BEZIER_CURVE_SUPPORT                   = build_src_filter=+<src/module/planner_bezier.cpp> +<src/gcode/motion/G5.cpp>
 PRINTCOUNTER                           = build_src_filter=+<src/module/printcounter.cpp>


### PR DESCRIPTION
### Description

Enabling POLAR results in compile errors due to polar.cpp not being included in source list

### Requirements

#define POLAR

### Benefits

Builds as expected

### Configurations

https://github.com/MarlinFirmware/Marlin/files/13937879/Config.zip

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/26685