### PR TITLE
Refactor usage of PLR_BED_THRESHOLD

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1746,9 +1746,9 @@
   //#define POWER_LOSS_RECOVERY
   #if ENABLED(POWER_LOSS_RECOVERY)
     #define PLR_ENABLED_DEFAULT       false // Power-Loss Recovery enabled by default. (Set with 'M413 Sn' & M500)
-    //#define PLR_BED_THRESHOLD BED_MAXTEMP // (°C) Skip user confirmation at or above this bed temperature (0 to disable)
-
-    //#define POWER_LOSS_PIN             44 // Pin to detect power-loss. Set to -1 to disable default pin on boards without module, or comment to use board default.
+    #if TEMP_SENSOR_BED
+      #define PLR_BED_THRESHOLD           0 // (°C) Skip user confirmation at or above this bed temperature (0 to disable)
+    #endif
     //#define POWER_LOSS_STATE         HIGH // State of pin indicating power-loss
     //#define POWER_LOSS_PULLUP             // Set pullup / pulldown as appropriate for your sensor
     //#define POWER_LOSS_PULLDOWN

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -1357,6 +1357,6 @@
 #endif
 
 // Power-Loss Recovery
-#if ENABLED(POWER_LOSS_RECOVERY) && defined(PLR_BED_THRESHOLD)
+#if defined(PLR_BED_THRESHOLD)
   #define HAS_PLR_BED_THRESHOLD 1
 #endif


### PR DESCRIPTION
Small fix to  **Auto power loss print resume with temperature limitation #26649** - define only if heated bed is present, make default value more clear to user, also remove excessive conditional check.