### PR TITLE
add heated chamber to power loss recovery

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -229,6 +229,8 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
 
     TERN_(HAS_HEATED_BED, info.target_temperature_bed = thermalManager.degTargetBed());
 
+    TERN_(HAS_HEATED_CHAMBER, info.target_temperature_chamber = thermalManager.degTargetChamber());
+
     TERN_(HAS_FAN, COPY(info.fan_speed, thermalManager.fan_speed));
 
     #if HAS_LEVELING
@@ -382,6 +384,12 @@ void PrintJobRecovery::resume() {
   #if HAS_LEVELING
     // Make sure leveling is off before any G92 and G28
     PROCESS_SUBCOMMANDS_NOW(F("M420S0"));
+  #endif
+
+  #if HAS_HEATED_CHAMBER
+    // Restore the chamber temperature
+    const celsius_t ct = info.target_temperature_chamber;
+    if (ct) PROCESS_SUBCOMMANDS_NOW(TS(F("M191S"), ct));
   #endif
 
   #if HAS_HEATED_BED
@@ -632,6 +640,10 @@ void PrintJobRecovery::resume() {
 
         #if HAS_HEATED_BED
           DEBUG_ECHOLNPGM("target_temperature_bed: ", info.target_temperature_bed);
+        #endif
+
+        #if HAS_HEATED_CHAMBER
+          DEBUG_ECHOLNPGM("target_temperature_chamber: ", info.target_temperature_chamber);
         #endif
 
         #if HAS_FAN

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -84,6 +84,9 @@ typedef struct {
   #if HAS_HEATED_BED
     celsius_t target_temperature_bed;
   #endif
+  #if HAS_HEATED_CHAMBER
+    celsius_t target_temperature_chamber;
+  #endif
   #if HAS_FAN
     uint8_t fan_speed[FAN_COUNT];
   #endif


### PR DESCRIPTION
### Description

Add saving and restoring chamber temperature to power loss recovery
For-fills FR https://github.com/MarlinFirmware/Marlin/issues/26690 

### Requirements

Heated chamber with power loss recovery

### Benefits

Heated chamber tempature is restored after power loss

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26690


### THIS NEEDS TESTED