### PR TITLE
Remove DEFAULT_EJERK >= 10 with LIN_ADVANCE check

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2320,9 +2320,6 @@
   #endif
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with M900 L.
   //#define LA_DEBUG              // Print debug information to serial during operation. Disable for production use.
-  #if ENABLED(CLASSIC_JERK)
-    //#define ALLOW_LOW_EJERK     // Allow a DEFAULT_EJERK value of <10. Recommended for direct drive hotends.
-  #endif
   //#define EXPERIMENTAL_I2S_LA   // Allow I2S_STEPPER_STREAM to be used with LA. Performance degrades as the LA step rate reaches ~20kHz.
 #endif
 

--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -82,6 +82,8 @@
   #error "Z_ENDSTOP_SERVO_NR is now Z_PROBE_SERVO_NR."
 #elif defined(DEFAULT_XYJERK)
   #error "DEFAULT_XYJERK is deprecated. Use DEFAULT_XJERK and DEFAULT_YJERK instead."
+#elif defined(ALLOW_LOW_EJERK)
+  #error "ALLOW_LOW_EJERK is deprecated and should be removed."
 #elif defined(XY_TRAVEL_SPEED)
   #error "XY_TRAVEL_SPEED is now XY_PROBE_FEEDRATE."
 #elif defined(XY_PROBE_SPEED)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -828,8 +828,6 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 
   #if ENABLED(DIRECT_STEPPING)
     #error "DIRECT_STEPPING is incompatible with LIN_ADVANCE. (Extrusion is controlled externally by the Step Daemon.)"
-  #elif NONE(HAS_JUNCTION_DEVIATION, ALLOW_LOW_EJERK) && defined(DEFAULT_EJERK)
-    static_assert(DEFAULT_EJERK >= 10, "It is strongly recommended to set DEFAULT_EJERK >= 10 when using LIN_ADVANCE. Enable ALLOW_LOW_EJERK to bypass this alert (e.g., for direct drive).");
   #endif
 #endif
 


### PR DESCRIPTION
### Description

- Remove "`DEFAULT_EJERK` with `LIN_ADVANCE`" check added in eba0ae4 to "fix" a single user's misconfiguration.
- Deprecate `ALLOW_LOW_EJERK` flag I added in #23054 to get around the sanity check.

We don't sanity check other axis' jerk values & <10 is a perfectly valid `DEFAULT_EJERK` value with `LIN_ADVANCE` and adding a flag to enable lower values doesn't make sense, especially with all the direct drive hotends that exist today.

### Benefits

Removes unnecessary config flag. Users should be able to easily set `DEFAULT_EJERK` to whatever value that need to without enabling another flag.

### Related Issues

- eba0ae4
- #20649
- #23054