### PR TITLE
Sanity check: Z_CLEARANCE_FOR_HOMING must be below Z_MAX_POS

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1729,7 +1729,7 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
  * Make sure Z_CLEARANCE_FOR_HOMING is below Z_MAX_POS
  */
 #if HAS_Z_AXIS
-  static_assert(Z_MAX_POS >= Z_CLEARANCE_FOR_HOMING, "Z_CLEARANCE_FOR_HOMING must be smaller than or equal to Z_MAX_POS.");
+  static_assert(Z_CLEARANCE_FOR_HOMING <= Z_MAX_POS, "Z_CLEARANCE_FOR_HOMING must be smaller than or equal to Z_MAX_POS.");
 #endif
 
 // Check Safe Bed Leveling settings

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1725,6 +1725,13 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   static_assert(WITHIN(Z_SAFE_HOMING_Y_POINT, Y_MIN_POS, Y_MAX_POS), "Z_SAFE_HOMING_Y_POINT can't be reached by the nozzle.");
 #endif
 
+/**
+ * Make sure Z_CLEARANCE_FOR_HOMING is below Z_MAX_POS
+ */
+#if HAS_Z_AXIS
+  static_assert(Z_MAX_POS >= Z_CLEARANCE_FOR_HOMING, "Z_CLEARANCE_FOR_HOMING must be smaller than or equal to Z_MAX_POS.");
+#endif
+
 // Check Safe Bed Leveling settings
 #if HAS_SAFE_BED_LEVELING
   #if defined(SAFE_BED_LEVELING_START_Y) && !defined(SAFE_BED_LEVELING_START_X)


### PR DESCRIPTION
### Description

I wanted to set up a multi purpose CNC machine that homes to Z max and has machine position 0 at the top of the machine, so the bed surface is at a negative Z position. This seems typical for industrial machines. Reference: https://www.youtube.com/watch?v=Rd-h0YA9IzQ 

With this setup, G28 crashes the machine into the top end of the Z rail.

Reason: by default, Z_CLEARANCE_FOR_HOMING is undefined in Configuration.h and under the hood it is defined as

https://github.com/MarlinFirmware/Marlin/blob/0c3d1cf566c43d28bd99487c1352a7c019eecf32/Marlin/src/inc/Conditionals_post.h#L3221-L3227

In addition to the changes proposed here, I recommend to enable `Z_CLEARANCE_FOR_HOMING` explicitely in all example Configuration.h files. so users know that it is relevant for each machine and that they must respect the warning comments related to that option.


<del>I also found that with QUICK_HOMING, G28 did not set home positions correctly. It always set axes X and Y to position 0.</del>


### Requirements

None

### Benefits

- Sanity check against extreme combinations of `Z_CLEARANCE_FOR_HOMING` and `Z_MAX_POS`
<del>- QUICK_HOME now respects configured home positions</del>

### Configurations

[pr_26721_config.zip](https://github.com/MarlinFirmware/Marlin/files/14030858/pr_26721_config.zip)

### Related Issues

None