### PR TITLE
Allow FAN1_PIN override for FET_ORDER_EFF

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -245,7 +245,9 @@
     #define HEATER_BED_PIN          MOSFET_C_PIN
   #endif
 #elif FET_ORDER_EFF                               // Hotend, Fan, Fan
-  #define FAN1_PIN                  MOSFET_C_PIN
+  #ifndef FAN1_PIN
+    #define FAN1_PIN                MOSFET_C_PIN
+  #endif
 #elif DISABLED(FET_ORDER_SF)                      // Not Spindle, Fan (i.e., "EFBF" or "EFBE")
   #ifndef HEATER_BED_PIN
     #define HEATER_BED_PIN          MOSFET_C_PIN


### PR DESCRIPTION
### Description

Fixes `FAN1_PIN` redefined warnings for delta/Anycubic/Kossel/ config.

<details><summary>delta/Anycubic/Kossel/ "FAN1_PIN" redefined:</summary>
<p>

```prolog
Getting configuration files from ./.pio/build-import-2.1.x/config/examples/delta/Anycubic/Kossel/
Building the firmware now...
/.platformio/penv/bin/pio

Auto Build...
Building environment mega2560 for board TRIGORILLA_14 (1136)...

In file included from Marlin/src/HAL/AVR/../../inc/../pins/ramps/pins_TRIGORILLA_14.h:184:0,
                 from Marlin/src/HAL/AVR/../../inc/../pins/pins.h:220,
                 from Marlin/src/HAL/AVR/../../inc/MarlinConfig.h:36,
                 from Marlin/src/HAL/AVR/HAL.cpp:24:
Marlin/src/HAL/AVR/../../inc/../pins/ramps/pins_RAMPS.h:248:0: warning: "FAN1_PIN" redefined
   #define FAN1_PIN                  MOSFET_C_PIN
 
In file included from Marlin/src/HAL/AVR/../../inc/../pins/pins.h:220:0,
                 from Marlin/src/HAL/AVR/../../inc/MarlinConfig.h:36,
                 from Marlin/src/HAL/AVR/HAL.cpp:24:
Marlin/src/HAL/AVR/../../inc/../pins/ramps/pins_TRIGORILLA_14.h:50:0: note: this is the location of the previous definition
 #define FAN1_PIN                               7  // FAN1
 
[snipped due to being too long for GitHub]
```
</p>
</details>

This could be a slippery slope of updating `pins_RAMPS.h` to allow overriding all pins, but I only made this small change for now.

### Requirements

`BOARD_TRIGORILLA_14` & `BOARD_TRIGORILLA_14_11`

### Benefits

Stop `FAN1_PIN` redefined warnings & correctly define `FAN1_PIN` for `BOARD_TRIGORILLA_14` & `BOARD_TRIGORILLA_14_11`.

### Configurations

[/examples/delta/Anycubic/Kossel/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/delta/Anycubic/Kossel)

### Related Issues

None. Found while building all our hosted configs.
