### PR TITLE
STM32 UID followup

### DIFF
--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -93,7 +93,7 @@ void GcodeSuite::M115() {
     #else
       uint16_t * const UID = (uint16_t*)UID_BASE;
       SERIAL_ECHO(
-        F("CEDE2A2F-"), hex_word(UID[0]), "-", hex_word(UID[1]), "-", hex_word(UID[2]), "-",
+        F("CEDE2A2F-"), hex_word(UID[0]), C('-'), hex_word(UID[1]), C('-'), hex_word(UID[2]), C('-'),
         hex_word(UID[3]), hex_word(UID[4]), hex_word(UID[5])
       );
     #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -93,7 +93,7 @@ void GcodeSuite::M115() {
     #else
       uint16_t * const UID = (uint16_t*)UID_BASE;
       SERIAL_ECHO(
-        F("CEDE2A2F-"), hex_word(UID[0]), '-', hex_word(UID[1]), '-', hex_word(UID[2]), '-',
+        F("CEDE2A2F-"), hex_word(UID[0]), "-", hex_word(UID[1]), "-", hex_word(UID[2]), "-",
         hex_word(UID[3]), hex_word(UID[4]), hex_word(UID[5])
       );
     #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -35,7 +35,7 @@
   #include "../../feature/caselight.h"
 #endif
 
-#if !defined(MACHINE_UUID) && HAS_STM32_UID
+#if !defined(MACHINE_UUID) && ENABLED(HAS_STM32_UID)
   #include "../../libs/hex_print.h"
 #endif
 
@@ -72,7 +72,7 @@ void GcodeSuite::M115() {
     #if NUM_AXES != XYZ
       " AXIS_COUNT:" STRINGIFY(NUM_AXES)
     #endif
-    #if defined(MACHINE_UUID) || HAS_STM32_UID
+    #if defined(MACHINE_UUID) || ENABLED(HAS_STM32_UID)
       " UUID:"
     #endif
     #ifdef MACHINE_UUID
@@ -80,7 +80,7 @@ void GcodeSuite::M115() {
     #endif
   );
 
-  #if !defined(MACHINE_UUID) && HAS_STM32_UID
+  #if !defined(MACHINE_UUID) && ENABLED(HAS_STM32_UID)
     /**
      * STM32-based devices have a 96-bit CPU device serial number.
      * Used by LumenPnP / OpenPNP to keep track of unique hardware/configurations.

--- a/Marlin/src/libs/hex_print.h
+++ b/Marlin/src/libs/hex_print.h
@@ -35,8 +35,8 @@ char* _hex_word(const uint16_t w);
 char* hex_address(const void * const w);
 char* _hex_long(const uintptr_t l);
 
-template<typename T> char* hex_word(T w) { return hex_word((uint16_t)w); }
-template<typename T> char* hex_long(T w) { return hex_long((uint32_t)w); }
+template<typename T> char* hex_word(T w) { return _hex_word((uint16_t)w); }
+template<typename T> char* hex_long(T w) { return _hex_long((uint32_t)w); }
 
 void print_hex_nybble(const uint8_t n);
 void print_hex_byte(const uint8_t b);

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV3.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV3.h
@@ -45,11 +45,6 @@
 // I2C MCP3426 (16-Bit, 240SPS, dual-channel ADC)
 #define HAS_MCP3426_ADC
 
-// Opulo Lumen uses the CPU serial number
-#ifdef STM32F4
-  #define HAS_STM32_UID                        1
-#endif
-
 //
 // Servos
 //

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
@@ -45,11 +45,6 @@
 // I2C MCP3426 (16-Bit, 240SPS, dual-channel ADC)
 #define HAS_MCP3426_ADC
 
-// Opulo Lumen uses the CPU serial number
-#ifdef STM32F4
-  #define HAS_STM32_UID                        1
-#endif
-
 //
 // Servos
 //

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -111,7 +111,7 @@ extends           = stm32_variant
 board             = marlin_opulo_lumen_rev3
 build_flags       = ${stm32_variant.build_flags}
   -DARDUINO_BLACK_F407VE
-  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS -DHAS_STM32_UID
 extra_scripts     = ${stm32_variant.extra_scripts}
 
 #
@@ -122,7 +122,7 @@ extends           = stm32_variant
 board             = marlin_opulo_lumen_rev4
 build_flags       = ${stm32_variant.build_flags}
   -DARDUINO_BLACK_F407VE
-  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS -DHAS_STM32_UID
 extra_scripts     = ${stm32_variant.extra_scripts}
 
 #


### PR DESCRIPTION
### Description

After PR 26715 I did some testing and found that HAS_STM32_UID crashes the simulator on M115 (I simulated register reads, so that was not the cause)
I then tested on a stm32f103re and it also crashed the controller on M115

Log of testing in a creality v4 controller

```
> FIRMWARE_NAME:Marlin bugfix-2.1.x (Jan 25 2024 03:43:32) SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:Ender-3 V2 EXTRUDER_COUNT:1 UUID:
>  Watchdog Reset

```
The reboot is being called by a infinite loop

```CPP
template<typename T> char* hex_word(T w) { return hex_word((uint16_t)w); }
template<typename T> char* hex_long(T w) { return hex_long((uint32_t)w); }
```
This calls itself, until it crashes

updated to

```CPP
template<typename T> char* hex_word(T w) { return _hex_word((uint16_t)w); }
template<typename T> char* hex_long(T w) { return _hex_long((uint32_t)w); }
```

The code no longer crashes but is still not correct

After this fix this is the log

```
> FIRMWARE_NAME:Marlin bugfix-2.1.x (Jan 25 2024 03:35:48) SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:Ender-3 V2 EXTRUDER_COUNT:1 UUID:CEDE2A2F-570145570145570145570157015701
```
This is not the correct formatting of a UID. 45 is being printed instead of - characters

Issue is in 

```CPP
        F("CEDE2A2F-"), hex_word(UID[0]), '-', hex_word(UID[1]), '-', hex_word(UID[2]), '-',
        hex_word(UID[3]), hex_word(UID[4]), hex_word(UID[5])
```
updated to
```CPP
        F("CEDE2A2F-"), hex_word(UID[0]), "-", hex_word(UID[1]), "-", hex_word(UID[2]), "-",
        hex_word(UID[3]), hex_word(UID[4]), hex_word(UID[5])
```

And finally the output is correct

```
> FIRMWARE_NAME:Marlin bugfix-2.1.x (Jan 25 2024 03:57:51) SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:Ender-3 V2 EXTRUDER_COUNT:1 UUID:CEDE2A2F-5701-5701-5701-570157015701
```
At this point Im presuming the stm32f103re doesn't have a real serial number, so we are just getting  5701 repeated.

### Requirements

STM32 board
Add   #define HAS_STM32_UID 1 to your Configuration.h

### Benefits

Works as expected

### Configurations

Creality V4 test [Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/14040351/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/26715
https://github.com/MarlinFirmware/Marlin/issues/26698
https://github.com/MarlinFirmware/Marlin/issues/26724