### PR TITLE
fix STM32_UID string corruption

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -763,7 +763,7 @@
         SERIAL_CHAR('\t');
         st.printLabel();
         SERIAL_CHAR('\t');
-        print_hex_long(drv_status, ':');
+        print_hex_long(drv_status, ':', true);
         if (drv_status == 0xFFFFFFFF || drv_status == 0) SERIAL_ECHOPGM("\t Bad response!");
         SERIAL_EOL();
         break;

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -88,13 +88,13 @@ void GcodeSuite::M115() {
      * This code should work on all STM32-based boards.
      */
     #if ENABLED(STM32_UID_SHORT_FORM)
-      uint32_t * const UID = (uint32_t*)UID_BASE;
+      const uint32_t * const UID = (uint32_t*)UID_BASE;
       for (uint8_t i = 0; i < 3; i++) print_hex_long(UID[i]);
     #else
-      uint16_t * const UID = (uint16_t*)UID_BASE;       // Little-endian!
+      const uint16_t * const UID = (uint16_t*)UID_BASE; // Little-endian!
       SERIAL_ECHO(F("CEDE2A2F-"));
-      for (uint8_t i = 1; i < 7; i++) {
-        print_hex_word((i % 2) ? UID[i] : UID[i - 2]);  // 1111-0000-3333-2222555544447777
+      for (uint8_t i = 1; i <= 6; i++) {
+        print_hex_word(UID[(i % 2) ? i : i - 2]);       // 1111-0000-3333-2222555544446666
         if (i <= 3) SERIAL_ECHO(C('-'));
       }
     #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -94,7 +94,7 @@ void GcodeSuite::M115() {
       const uint16_t * const UID = (uint16_t*)UID_BASE; // Little-endian!
       SERIAL_ECHO(F("CEDE2A2F-"));
       for (uint8_t i = 1; i <= 6; i++) {
-        print_hex_word(UID[(i % 2) ? i : i - 2]);       // 1111-0000-3333-2222555544446666
+        print_hex_word(UID[(i % 2) ? i : i - 2]);       // 1111-0000-3333-222255554444
         if (i <= 3) SERIAL_ECHO(C('-'));
       }
     #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -89,12 +89,12 @@ void GcodeSuite::M115() {
      */
     #if ENABLED(STM32_UID_SHORT_FORM)
       uint32_t * const UID = (uint32_t*)UID_BASE;
-      SERIAL_ECHO(hex_long(UID[0]), hex_long(UID[1]), hex_long(UID[2]));
+      SERIAL_ECHO(strdup(hex_long(UID[0])), strdup(hex_long(UID[1])), hex_long(UID[2]));
     #else
       uint16_t * const UID = (uint16_t*)UID_BASE;
       SERIAL_ECHO(
-        F("CEDE2A2F-"), hex_word(UID[0]), C('-'), hex_word(UID[1]), C('-'), hex_word(UID[2]), C('-'),
-        hex_word(UID[3]), hex_word(UID[4]), hex_word(UID[5])
+        F("CEDE2A2F-"), strdup(hex_word(UID[1])), C('-'), strdup(hex_word(UID[0])), C('-'), strdup(hex_word(UID[3])), C('-'),
+        strdup(hex_word(UID[2])), strdup(hex_word(UID[5])), hex_word(UID[4])
       );
     #endif
   #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -89,13 +89,14 @@ void GcodeSuite::M115() {
      */
     #if ENABLED(STM32_UID_SHORT_FORM)
       uint32_t * const UID = (uint32_t*)UID_BASE;
-      SERIAL_ECHO(strdup(hex_long(UID[0])), strdup(hex_long(UID[1])), hex_long(UID[2]));
+      for (uint8_t i = 0; i < 3; i++) print_hex_long(UID[i]);
     #else
       uint16_t * const UID = (uint16_t*)UID_BASE;
-      SERIAL_ECHO(
-        F("CEDE2A2F-"), strdup(hex_word(UID[1])), C('-'), strdup(hex_word(UID[0])), C('-'), strdup(hex_word(UID[3])), C('-'),
-        strdup(hex_word(UID[2])), strdup(hex_word(UID[5])), hex_word(UID[4])
-      );
+      SERIAL_ECHO(F("CEDE2A2F-"));
+      for (uint8_t i = 1; i < 7; i++) {
+        print_hex_word((i%2) ? UID[i] : UID[i-2]);
+        if (i == 1 || i == 2 || i == 3) SERIAL_ECHO(C('-'));
+      }
     #endif
   #endif
 

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -91,11 +91,11 @@ void GcodeSuite::M115() {
       uint32_t * const UID = (uint32_t*)UID_BASE;
       for (uint8_t i = 0; i < 3; i++) print_hex_long(UID[i]);
     #else
-      uint16_t * const UID = (uint16_t*)UID_BASE;
+      uint16_t * const UID = (uint16_t*)UID_BASE;       // Little-endian!
       SERIAL_ECHO(F("CEDE2A2F-"));
       for (uint8_t i = 1; i < 7; i++) {
-        print_hex_word((i%2) ? UID[i] : UID[i-2]);
-        if (i == 1 || i == 2 || i == 3) SERIAL_ECHO(C('-'));
+        print_hex_word((i % 2) ? UID[i] : UID[i - 2]);  // 1111-0000-3333-2222555544447777
+        if (i <= 3) SERIAL_ECHO(C('-'));
       }
     #endif
   #endif

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -54,10 +54,12 @@ char* _hex_word(const uint16_t w) {
 }
 
 char* _hex_long(const uintptr_t l) {
-  _hex[2] = hex_nybble(l >> 28);
-  _hex[3] = hex_nybble(l >> 24);
-  _hex[4] = hex_nybble(l >> 20);
-  _hex[5] = hex_nybble(l >> 16);
+  #if CPU_32_BIT
+    _hex[2] = hex_nybble(l >> 28);
+    _hex[3] = hex_nybble(l >> 24);
+    _hex[4] = hex_nybble(l >> 20);
+    _hex[5] = hex_nybble(l >> 16);
+  #endif
   __hex_word((uint16_t)(l & 0xFFFF));
   return &_hex[2];
 }

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -27,19 +27,19 @@
 #include "hex_print.h"
 #include "../core/serial.h"
 
-static char _hex[] = "0x00000000";
+static char _hex[] = "0x00000000"; // 0:adr32 2:long 4:adr16 6:word 8:byte
 
 inline void __hex_byte(const uint8_t b, const uint8_t o=8) {
   _hex[o + 0] = hex_nybble(b >> 4);
   _hex[o + 1] = hex_nybble(b);
 }
 inline void __hex_word(const uint16_t w, const uint8_t o=6) {
-  __hex_byte(w >> 2, o + 0);
-  __hex_byte(w >> 0, o + 2);
+  __hex_byte(w >> 8, o + 0);
+  __hex_byte(w     , o + 2);
 }
-inline void __hex_long(const uint16_t w) {
-  __hex_word(w >> 4, 2);
-  __hex_word(w >> 0, 6);
+inline void __hex_long(const uint32_t w) {
+  __hex_word(w >> 16, 2);
+  __hex_word(w      , 6);
 }
 
 char*  hex_byte(const uint8_t b)  { __hex_byte(b); return &_hex[8]; }
@@ -51,7 +51,7 @@ char* hex_address(const void * const a) {
     (void)_hex_long((uintptr_t)a);
     return _hex;
   #else
-    hex[4] = '0'; hex[5] = 'x';
+    _hex[4] = '0'; _hex[5] = 'x';
     (void)_hex_word((uintptr_t)a);
     return &_hex[4];
   #endif
@@ -59,7 +59,7 @@ char* hex_address(const void * const a) {
 
 void print_hex_nybble(const uint8_t n)       { SERIAL_CHAR(hex_nybble(n));  }
 void print_hex_byte(const uint8_t b)         { SERIAL_ECHO(hex_byte(b));    }
-void print_hex_word(const uint16_t w)        { SERIAL_ECHO(hex_word(w));    }
+void print_hex_word(const uint16_t w)        { SERIAL_ECHO(_hex_word(w));    }
 void print_hex_address(const void * const w) { SERIAL_ECHO(hex_address(w)); }
 
 void print_hex_long(const uint32_t w, const char delimiter/*='\0'*/, const bool prefix/*=false*/) {

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -27,43 +27,33 @@
 #include "hex_print.h"
 #include "../core/serial.h"
 
-#ifdef CPU_32_BIT
-  constexpr int byte_start = 4;
-  static char _hex[] = "0x00000000";
-#else
-  constexpr int byte_start = 0;
-  static char _hex[] = "0x0000";
-#endif
+static char _hex[] = "00000000";
+
+inline void __hex_byte(const uint8_t b, uint8_t o) {
+  _hex[o + 0] = hex_nybble(b >> 4);
+  _hex[o + 1] = hex_nybble(b);
+}
+inline void __hex_word(const uint16_t w, const uint8_t o=4) {
+  __hex_byte(w >> 8, o + 0);
+  __hex_byte(w >> 0, o + 2);
+}
+inline void __hex_long(const uint16_t w) {
+  __hex_byte(w >> 8, 0);
+  __hex_byte(w >> 0, 4);
+}
 
 char* hex_byte(const uint8_t b) {
-  _hex[byte_start + 4] = hex_nybble(b >> 4);
-  _hex[byte_start + 5] = hex_nybble(b);
-  return &_hex[byte_start + 4];
+  __hex_byte(b, 6);
+  return &_hex[6];
 }
-
-inline void __hex_word(const uint16_t w) {
-  _hex[byte_start + 2] = hex_nybble(w >> 12);
-  _hex[byte_start + 3] = hex_nybble(w >> 8);
-  _hex[byte_start + 4] = hex_nybble(w >> 4);
-  _hex[byte_start + 5] = hex_nybble(w);
-}
-
 char* _hex_word(const uint16_t w) {
-  __hex_word(w);
-  return &_hex[byte_start + 2];
+  __hex_word(w, 4);
+  return &_hex[4];
 }
-
-char* _hex_long(const uintptr_t l) {
-  #ifdef CPU_32_BIT
-    _hex[2] = hex_nybble(l >> 28);
-    _hex[3] = hex_nybble(l >> 24);
-    _hex[4] = hex_nybble(l >> 20);
-    _hex[5] = hex_nybble(l >> 16);
-  #endif
-  __hex_word((uint16_t)(l & 0xFFFF));
-  return &_hex[2];
+char* _hex_long(const uint32_t l) {
+  __hex_long(l);
+  return _hex;
 }
-
 char* hex_address(const void * const w) {
   #ifdef CPU_32_BIT
     (void)hex_long((uintptr_t)w);

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -78,8 +78,8 @@ void print_hex_byte(const uint8_t b)         { SERIAL_ECHO(hex_byte(b));    }
 void print_hex_word(const uint16_t w)        { SERIAL_ECHO(hex_word(w));    }
 void print_hex_address(const void * const w) { SERIAL_ECHO(hex_address(w)); }
 
-void print_hex_long(const uint32_t w, const char delimiter/*='\0'*/) {
-  SERIAL_ECHOPGM("0x");
+void print_hex_long(const uint32_t w, const char delimiter/*='\0'*/, const bool prefix/*=false*/) {
+  if (prefix) SERIAL_ECHOPGM("0x");
   for (int B = 24; B >= 8; B -= 8) {
     print_hex_byte(w >> B);
     if (delimiter) SERIAL_CHAR(delimiter);

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -54,7 +54,7 @@ char* _hex_word(const uint16_t w) {
 }
 
 char* _hex_long(const uintptr_t l) {
-  #if CPU_32_BIT
+  #ifdef CPU_32_BIT
     _hex[2] = hex_nybble(l >> 28);
     _hex[3] = hex_nybble(l >> 24);
     _hex[4] = hex_nybble(l >> 20);

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -27,40 +27,34 @@
 #include "hex_print.h"
 #include "../core/serial.h"
 
-static char _hex[] = "00000000";
+static char _hex[] = "0x00000000";
 
-inline void __hex_byte(const uint8_t b, uint8_t o) {
+inline void __hex_byte(const uint8_t b, const uint8_t o=8) {
   _hex[o + 0] = hex_nybble(b >> 4);
   _hex[o + 1] = hex_nybble(b);
 }
-inline void __hex_word(const uint16_t w, const uint8_t o=4) {
-  __hex_byte(w >> 8, o + 0);
+inline void __hex_word(const uint16_t w, const uint8_t o=6) {
+  __hex_byte(w >> 2, o + 0);
   __hex_byte(w >> 0, o + 2);
 }
 inline void __hex_long(const uint16_t w) {
-  __hex_byte(w >> 8, 0);
-  __hex_byte(w >> 0, 4);
+  __hex_word(w >> 4, 2);
+  __hex_word(w >> 0, 6);
 }
 
-char* hex_byte(const uint8_t b) {
-  __hex_byte(b, 6);
-  return &_hex[6];
-}
-char* _hex_word(const uint16_t w) {
-  __hex_word(w, 4);
-  return &_hex[4];
-}
-char* _hex_long(const uint32_t l) {
-  __hex_long(l);
-  return _hex;
-}
-char* hex_address(const void * const w) {
+char*  hex_byte(const uint8_t b)  { __hex_byte(b); return &_hex[8]; }
+char* _hex_word(const uint16_t w) { __hex_word(w); return &_hex[6]; }
+char* _hex_long(const uint32_t l) { __hex_long(l); return &_hex[2]; }
+
+char* hex_address(const void * const a) {
   #ifdef CPU_32_BIT
-    (void)hex_long((uintptr_t)w);
+    (void)_hex_long((uintptr_t)a);
+    return _hex;
   #else
-    (void)hex_word((uintptr_t)w);
+    hex[4] = '0'; hex[5] = 'x';
+    (void)_hex_word((uintptr_t)a);
+    return &_hex[4];
   #endif
-  return _hex;
 }
 
 void print_hex_nybble(const uint8_t n)       { SERIAL_CHAR(hex_nybble(n));  }

--- a/Marlin/src/libs/hex_print.h
+++ b/Marlin/src/libs/hex_print.h
@@ -30,13 +30,14 @@
 constexpr char hex_nybble(const uint8_t n) {
   return (n & 0xF) + ((n & 0xF) < 10 ? '0' : 'A' - 10);
 }
-char* hex_byte(const uint8_t b);
 char* _hex_word(const uint16_t w);
-char* hex_address(const void * const w);
-char* _hex_long(const uintptr_t l);
+char* _hex_long(const uint32_t l);
 
+char* hex_byte(const uint8_t b);
 template<typename T> char* hex_word(T w) { return _hex_word((uint16_t)w); }
 template<typename T> char* hex_long(T w) { return _hex_long((uint32_t)w); }
+
+char* hex_address(const void * const w);
 
 void print_hex_nybble(const uint8_t n);
 void print_hex_byte(const uint8_t b);

--- a/Marlin/src/libs/hex_print.h
+++ b/Marlin/src/libs/hex_print.h
@@ -42,4 +42,4 @@ void print_hex_nybble(const uint8_t n);
 void print_hex_byte(const uint8_t b);
 void print_hex_word(const uint16_t w);
 void print_hex_address(const void * const w);
-void print_hex_long(const uint32_t w, const char delimiter='\0');
+void print_hex_long(const uint32_t w, const char delimiter='\0', const bool prefix=false);


### PR DESCRIPTION
### Description

The final UID generated from using STM32's internal Device electronic signature was being corrupted on printing it.

My test Board has a Device electronic signature of  0x004d0030 0x4646500a 0x20353631

Using STM32_UID_SHORT_FORM 

```
Marlin shows     UUID:203536312035363120353631       (20353631 repeated 3 times) 
but it should be UUID:004D00304646500A20353631 

```
Without STM32_UID_SHORT_FORM 

```
Marlin shows      UUID:CEDE2A2F-3631-3631-3631-363136313631        (3631 repeated 6 times) 
but it should be  UUID:CEDE2A2F-004D-0030-4646-500A20353631

```

The result of the next call of hex_word or hex_long replaces the previous calls result, so when all the results are printed, the last results are printed multiple times 

Went back to using simple loops to print each hex number in turn.  

### Requirements

A STM32 board with a Device electronic signature 

### Benefits

UID is displayed correctly

### Configurations

All you need is to add   #define HAS_STM32_UID 1 to your Config file

My test Configs for a BOARD_CREALITY_CR4NTXXC10

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/14074919/Configuration.zip)

### Related Issues

<ul>
<li>#26731</li>
<li>#26727</li>
<li>#26724</li>
<li>#26715</li>
<li>#26698</li>
</ul>