### PR TITLE
Fix missing temperature.h includes

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -39,6 +39,7 @@
 #include "../../../core/serial.h"
 #include "../../../module/stepper.h"
 #include "../../../module/probe.h"
+#include "../../../module/temperature.h"
 
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../../../feature/powerloss.h"

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -31,6 +31,7 @@
 #include "menu_item.h"
 
 #include "../../MarlinCore.h"
+#include "../../module/temperature.h"
 
 #if ENABLED(LCD_ENDSTOP_TEST)
   #include "../../module/endstops.h"


### PR DESCRIPTION
### Description

Follow up to https://github.com/MarlinFirmware/Marlin/commit/cb291e8d00a6c1ee0a778625e0170b6b7430a004

Fixes `'thermalManager' was not declared in this scope` errors found after running the [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script.

### Requirements

Any config that ends up using `thermalManager` object/methods.

### Benefits

Configs will now build.

### Configurations

- AnyCubic/Vyper/
- CTC/Bizer/
- Creality/Ender-4/
- FlashForge/Creator 2X/
- FlashForge/CreatorPro/
- Renkforce/RF100/
- Renkforce/RF100XL/
- Renkforce/RF100v2/
- Weistek/wt150/
- ...etc...

### Related Issues

- https://github.com/MarlinFirmware/Marlin/commit/cb291e8d00a6c1ee0a778625e0170b6b7430a004
