### PR TITLE
Fix HOTEND_IDLE_TIMEOUT without a heated bed

### DIFF
--- a/Marlin/src/feature/hotend_idle.h
+++ b/Marlin/src/feature/hotend_idle.h
@@ -32,7 +32,9 @@ typedef struct {
     timeout       = HOTEND_IDLE_TIMEOUT_SEC;
     trigger       = HOTEND_IDLE_MIN_TRIGGER;
     nozzle_target = HOTEND_IDLE_NOZZLE_TARGET;
-    bed_target    = HOTEND_IDLE_BED_TARGET;
+    #if HAS_HEATED_BED
+      bed_target  = HOTEND_IDLE_BED_TARGET;
+    #endif
   }
 } hotend_idle_settings_t;
 

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -265,7 +265,9 @@ void menu_advanced_settings();
     EDIT_ITEM(int3, MSG_TIMEOUT, &c.timeout, 0, 999);
     EDIT_ITEM(int3, MSG_TEMPERATURE, &c.trigger, 0, thermalManager.hotend_max_target(0));
     EDIT_ITEM(int3, MSG_HOTEND_IDLE_NOZZLE_TARGET, &c.nozzle_target, 0, thermalManager.hotend_max_target(0));
-    EDIT_ITEM(int3, MSG_HOTEND_IDLE_BED_TARGET, &c.bed_target, 0, BED_MAX_TARGET);
+    #if HAS_HEATED_BED
+      EDIT_ITEM(int3, MSG_HOTEND_IDLE_BED_TARGET, &c.bed_target, 0, BED_MAX_TARGET);
+    #endif
 
     END_MENU();
   }


### PR DESCRIPTION
### Description

Fix `'bed_target' was not declared in this scope` error found after running the [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script.

### Requirements

`HOTEND_IDLE_TIMEOUT` without a heated bed.

### Benefits

Configs without a heated bed & `HOTEND_IDLE_TIMEOUT` enabled will now compile.

### Configurations

[Ultimaker/Ultimaker Original (1.5.7)/ ](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Ultimaker/Ultimaker%20Original%20(1.5.7))
