### PR TITLE
remove  -DHAS_LIBBSD from windows

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -140,5 +140,4 @@ build_src_flags = ${simulator_common.build_src_flags} -fpermissive
 build_flags     = ${simulator_common.build_flags} ${simulator_common.debug_build_flags}
                   -IC:\\msys64\\mingw64\\include\\SDL2 -fno-stack-protector -Wl,-subsystem,windows
                   -ldl -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lopengl32 -lssp
-                  -DHAS_LIBBSD
 build_type      = debug


### PR DESCRIPTION
### Description

Verified by two people now, windows does not include strlcpy so should not have HAS_LIBBSD defined

### Requirements

Windows

### Benefits

Simulator builds on windows 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26661