### PR TITLE
[TOP FEATURE]  Travel Leak compensation (In work , need all devs expertise and ideas)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2730,6 +2730,14 @@
 // @section gcode
 
 /**
+ * Firmware-based and LCD-controlled leak compensation
+ * Add quick extrusion before next extrusion commands
+ * To compensate lost material during travel on big machine for ex
+ *
+ */
+//#define LEAK_COMPENSATION
+
+/**
  * Firmware-based and LCD-controlled retract
  *
  * Add G10 / G11 commands for automatic firmware-based retract / recover.


### PR DESCRIPTION
@thinkyhead @thisiskeithb @ellensp @Bob-the-Kuhn @sjasonsmith  @Roxy-3D

Hi all !
Why ?  
When you have a big machine, any prints are stupid ! Tons of stupid travels , and impossible to solve this , because, all layers are made by features, and if we want to optimize we have more stupid printing (extern outlines first and more)
During all these tons of longs travel , the nozzle leaks and the restart is always a HOLE depending of the time of leaking/traveling ! The more the nozzle is strong the more it leaks , the more the hotend is big (supervolcano for ex ) , the more it leaks, and if you add  supervolcano + 1mm nozzle, it's like a foutain !

It's why i have this idea to make a compensation feature , that use the time of the travel movement , and make a quick recovery EXTRA extrusion before the restart.
Can be added to FW_RETRACTION or may be in stand alone

For the moment , this is just an idea !
NEED ALL HELP AS POSSIBLE

thks