### PR TITLE
Fix repeating Power Off Message

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -102,11 +102,11 @@ void Power::power_on() {
  * Processes any PSU_POWEROFF_GCODE and makes a PS_OFF_SOUND if enabled.
  */
 void Power::power_off() {
-  SERIAL_ECHOLNPGM(STR_POWEROFF);
-
   TERN_(HAS_SUICIDE, suicide());
 
   if (!psu_on) return;
+
+  SERIAL_ECHOLNPGM(STR_POWEROFF);
 
   #ifdef PSU_POWEROFF_GCODE
     gcode.process_subcommands_now(F(PSU_POWEROFF_GCODE));


### PR DESCRIPTION
When PSU control is enabled with a timeout, you get constant repeating power off messages in the terminal. This moves the message below the state check escape so the message only appears when an actual change occurs.