### PR TITLE
Fix serialEvent typo

### DIFF
--- a/Marlin/src/HAL/STM32/HardwareSerial.cpp
+++ b/Marlin/src/HAL/STM32/HardwareSerial.cpp
@@ -151,7 +151,7 @@
   #else
     HAL_HardwareSerial HSerial6(UART6);
   #endif
-  void serialEvent5() __attribute__((weak));
+  void serialEvent6() __attribute__((weak));
 #endif
 
 // Constructors ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description

Follow up to #26531 which is a follow up to #26328.

As pointed out in https://github.com/MarlinFirmware/Marlin/commit/c476e62a6f32bc4d197dc31a8587d53376505f4a#r138217905 by @Crazy-Charles, there is a duplicate `serialEvent5()` line when it should be `serialEvent6()`.

### Related Issues

- #26531
- #26328
- https://github.com/MarlinFirmware/Marlin/commit/c476e62a6f32bc4d197dc31a8587d53376505f4a#r138217905
