### PR TITLE
BigTreeTech GTR DIAG jumper/pin updates

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -681,7 +681,8 @@
 #if !USE_SENSORLESS
   #if ENABLED(USES_DIAG_JUMPERS) && DISABLED(DIAG_JUMPERS_REMOVED)
     #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled. (Define DIAG_JUMPERS_REMOVED to suppress this warning.)"
-  #elif ENABLED(USES_DIAG_PINS) && DISABLED(DIAG_PINS_REMOVED)
+  #endif
+  #if ENABLED(USES_DIAG_PINS) && DISABLED(DIAG_PINS_REMOVED)
     #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0) (Define DIAG_PINS_REMOVED to suppress this warning.)"
   #endif
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -31,7 +31,7 @@
 
 #define BOARD_INFO_NAME "BTT GTR V1.0"
 
-#define USES_DIAG_JUMPERS
+#define USES_DIAG_PINS                            // DIAG jumpers rendered useless due to a board design error
 #define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 #define M5_EXTENDER                               // The M5 extender is attached
 
@@ -106,6 +106,7 @@
 // Pins on the extender
 //
 #if ENABLED(M5_EXTENDER)
+  #define USES_DIAG_JUMPERS                       // DIAG jumpers work on M5 extender
   #ifndef X2_STOP_PIN
     #define X2_STOP_PIN                     PI4   // M5 M1_STOP
   #endif


### PR DESCRIPTION
### Description

Due to a board design error, DIAG pins are directly connected to endstop pins and render the DIAG jumpers useless (DIAG jumpers work fine on M5 extender board).

This also means that the DIAG pin & jumper warnings are no longer mutually exclusive, so I split them up.

### Requirements

BigTreeTech GTR

### Benefits

DIAG pin / jumper warnings will be correct for GTR.

### Related Issues

None. Found while helping someone on Discord and doing a deep dive into the GTR since I never really did much with it other than basic firmware flashing on my bench.
