### PR TITLE
Configure AUTO_BED_LEVELING_BILINEAR grid size in runtime with G29 G<> M<>

### DIFF
--- a/Marlin/src/feature/bedlevel/abl/bbl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/bbl.cpp
@@ -120,16 +120,16 @@ void LevelingBilinear::extrapolate_unprobed_bed_level() {
   #ifdef HALF_IN_X
     constexpr uint8_t ctrx2 = 0, xend = GRID_MAX_POINTS_X - 1;
   #else
-    constexpr uint8_t ctrx1 = (GRID_MAX_CELLS_X) / 2, // left-of-center
-                      ctrx2 = (GRID_MAX_POINTS_X) / 2,  // right-of-center
+    uint8_t ctrx1 = (GRID_CELLS_X) / 2, // left-of-center
+                      ctrx2 = (GRID_POINTS_X) / 2,  // right-of-center
                       xend = ctrx1;
   #endif
 
   #ifdef HALF_IN_Y
     constexpr uint8_t ctry2 = 0, yend = GRID_MAX_POINTS_Y - 1;
   #else
-    constexpr uint8_t ctry1 = (GRID_MAX_CELLS_Y) / 2, // top-of-center
-                      ctry2 = (GRID_MAX_POINTS_Y) / 2,  // bottom-of-center
+    uint8_t ctry1 = (GRID_CELLS_Y) / 2, // top-of-center
+                      ctry2 = (GRID_POINTS_Y) / 2,  // bottom-of-center
                       yend = ctry1;
   #endif
 
@@ -156,7 +156,7 @@ void LevelingBilinear::extrapolate_unprobed_bed_level() {
 void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr*/) {
   // print internal grid(s) or just the one passed as a parameter
   SERIAL_ECHOLNPGM("Bilinear Leveling Grid:");
-  print_2d_array(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y, 3, _z_values ? *_z_values[0] : z_values[0]);
+  print_2d_array(GRID_POINTS_X, GRID_POINTS_Y, 3, _z_values ? *_z_values[0] : z_values[0]);
 
   #if ENABLED(ABL_BILINEAR_SUBDIVISION)
     if (!_z_values) {
@@ -168,16 +168,16 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
 
 #if ENABLED(ABL_BILINEAR_SUBDIVISION)
 
-  #define ABL_TEMP_POINTS_X (GRID_MAX_POINTS_X + 2)
-  #define ABL_TEMP_POINTS_Y (GRID_MAX_POINTS_Y + 2)
-  float LevelingBilinear::z_values_virt[ABL_GRID_POINTS_VIRT_X][ABL_GRID_POINTS_VIRT_Y];
+  #define ABL_TEMP_POINTS_X (GRID_POINTS_X + 2)
+  #define ABL_TEMP_POINTS_Y (GRID_POINTS_Y + 2)
+  float LevelingBilinear::z_values_virt[ABL_GRID_MAX_POINTS_VIRT_X][ABL_GRID_MAX_POINTS_VIRT_Y];
   xy_pos_t LevelingBilinear::grid_spacing_virt;
   xy_float_t LevelingBilinear::grid_factor_virt;
 
   #define LINEAR_EXTRAPOLATION(E, I) ((E) * 2 - (I))
   float LevelingBilinear::virt_coord(const uint8_t x, const uint8_t y) {
     uint8_t ep = 0, ip = 1;
-    if (x > (GRID_MAX_POINTS_X) + 1 || y > (GRID_MAX_POINTS_Y) + 1) {
+    if (x > (GRID_POINTS_X) + 1 || y > (GRID_POINTS_Y) + 1) {
       // The requested point requires extrapolating two points beyond the mesh.
       // These values are only requested for the edges of the mesh, which are always an actual mesh point,
       // and do not require interpolation. When interpolation is not needed, this "Mesh + 2" point is
@@ -187,8 +187,8 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
     }
     if (!x || x == ABL_TEMP_POINTS_X - 1) {
       if (x) {
-        ep = (GRID_MAX_POINTS_X) - 1;
-        ip = GRID_MAX_CELLS_X - 1;
+        ep = (GRID_POINTS_X) - 1;
+        ip = GRID_CELLS_X - 1;
       }
       if (WITHIN(y, 1, ABL_TEMP_POINTS_Y - 2))
         return LINEAR_EXTRAPOLATION(
@@ -203,8 +203,8 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
     }
     if (!y || y == ABL_TEMP_POINTS_Y - 1) {
       if (y) {
-        ep = (GRID_MAX_POINTS_Y) - 1;
-        ip = GRID_MAX_CELLS_Y - 1;
+        ep = (GRID_POINTS_Y) - 1;
+        ip = GRID_CELLS_Y - 1;
       }
       if (WITHIN(x, 1, ABL_TEMP_POINTS_X - 2))
         return LINEAR_EXTRAPOLATION(
@@ -243,11 +243,11 @@ void LevelingBilinear::print_leveling_grid(const bed_mesh_t* _z_values/*=nullptr
   void LevelingBilinear::subdivide_mesh() {
     grid_spacing_virt = grid_spacing / (BILINEAR_SUBDIVISIONS);
     grid_factor_virt = grid_spacing_virt.reciprocal();
-    for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; ++y)
-      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; ++x)
+    for (uint8_t y = 0; y < GRID_POINTS_Y; ++y)
+      for (uint8_t x = 0; x < GRID_POINTS_X; ++x)
         for (uint8_t ty = 0; ty < BILINEAR_SUBDIVISIONS; ++ty)
           for (uint8_t tx = 0; tx < BILINEAR_SUBDIVISIONS; ++tx) {
-            if ((ty && y == (GRID_MAX_POINTS_Y) - 1) || (tx && x == (GRID_MAX_POINTS_X) - 1))
+            if ((ty && y == (GRID_POINTS_Y) - 1) || (tx && x == (GRID_POINTS_X) - 1))
               continue;
             z_values_virt[x * (BILINEAR_SUBDIVISIONS) + tx][y * (BILINEAR_SUBDIVISIONS) + ty] =
               virt_2cmr(x + 1, y + 1, (float)tx / (BILINEAR_SUBDIVISIONS), (float)ty / (BILINEAR_SUBDIVISIONS));

--- a/Marlin/src/feature/bedlevel/abl/bbl.h
+++ b/Marlin/src/feature/bedlevel/abl/bbl.h
@@ -36,10 +36,13 @@ private:
   static void extrapolate_one_point(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);
 
   #if ENABLED(ABL_BILINEAR_SUBDIVISION)
-    #define ABL_GRID_POINTS_VIRT_X (GRID_MAX_CELLS_X * (BILINEAR_SUBDIVISIONS) + 1)
-    #define ABL_GRID_POINTS_VIRT_Y (GRID_MAX_CELLS_Y * (BILINEAR_SUBDIVISIONS) + 1)
+    #define ABL_GRID_MAX_POINTS_VIRT_X (GRID_MAX_CELLS_X * (BILINEAR_SUBDIVISIONS) + 1)
+    #define ABL_GRID_MAX_POINTS_VIRT_Y (GRID_MAX_CELLS_Y * (BILINEAR_SUBDIVISIONS) + 1)
 
-    static float z_values_virt[ABL_GRID_POINTS_VIRT_X][ABL_GRID_POINTS_VIRT_Y];
+    #define ABL_GRID_POINTS_VIRT_X (GRID_CELLS_X * (BILINEAR_SUBDIVISIONS) + 1)
+    #define ABL_GRID_POINTS_VIRT_Y (GRID_CELLS_Y * (BILINEAR_SUBDIVISIONS) + 1)
+
+    static float z_values_virt[ABL_GRID_MAX_POINTS_VIRT_X][ABL_GRID_MAX_POINTS_VIRT_Y];
     static xy_pos_t grid_spacing_virt;
     static xy_float_t grid_factor_virt;
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -287,8 +287,8 @@ typedef struct {
     p2.x = p1.x + dx;
     p2.y = p1.y + dy;
 
-    if (p2.x < 0 || p2.x >= (GRID_MAX_POINTS_X)) return;
-    if (p2.y < 0 || p2.y >= (GRID_MAX_POINTS_Y)) return;
+    if (p2.x < 0 || p2.x >= (GRID_POINTS_X)) return;
+    if (p2.y < 0 || p2.y >= (GRID_POINTS_Y)) return;
 
     if (circle_flags.marked(p1.x, p1.y) && circle_flags.marked(p2.x, p2.y)) {
       xyz_pos_t s, e;
@@ -632,7 +632,7 @@ void GcodeSuite::G26() {
   // Get repeat from 'R', otherwise do one full circuit
   grid_count_t g26_repeats;
   #if HAS_MARLINUI_MENU
-    g26_repeats = parser.intval('R', GRID_MAX_POINTS + 1);
+    g26_repeats = parser.intval('R', GRID_POINTS + 1);
   #else
     if (parser.seen('R'))
       g26_repeats = parser.has_value() ? parser.value_int() : GRID_MAX_POINTS + 1;
@@ -731,8 +731,8 @@ void GcodeSuite::G26() {
       // which is always drawn counter-clockwise.
       const xy_int8_t st = location;
       const bool f = st.y == 0,
-                 r = st.x >= (GRID_MAX_POINTS_X) - 1,
-                 b = st.y >= (GRID_MAX_POINTS_Y) - 1;
+                 r = st.x >= (GRID_POINTS_X) - 1,
+                 b = st.y >= (GRID_POINTS_Y) - 1;
 
       #if ENABLED(ARC_SUPPORT)
 

--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -40,7 +40,7 @@ void GcodeSuite::G42() {
     const bool hasJ = parser.seenval('J');
     const int8_t iy = hasJ ? parser.value_int() : 0;
 
-    if ((hasI && !WITHIN(ix, 0, GRID_MAX_POINTS_X - 1)) || (hasJ && !WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1))) {
+    if ((hasI && !WITHIN(ix, 0, GRID_POINTS_X - 1)) || (hasJ && !WITHIN(iy, 0, GRID_POINTS_Y - 1))) {
       SERIAL_ECHOLNPGM(STR_ERR_MESH_XY);
       return;
     }

--- a/Marlin/src/gcode/bedlevel/abl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/M421.cpp
@@ -52,10 +52,10 @@ void GcodeSuite::M421() {
              hasQ = !hasZ && parser.seenval('Q');
 
   if (hasZ || hasQ) {
-    if (WITHIN(ix, -1, GRID_MAX_POINTS_X - 1) && WITHIN(iy, -1, GRID_MAX_POINTS_Y - 1)) {
+    if (WITHIN(ix, -1, GRID_POINTS_X - 1) && WITHIN(iy, -1, GRID_POINTS_Y - 1)) {
       const float zval = parser.value_linear_units();
-      uint8_t sx = ix >= 0 ? ix : 0, ex = ix >= 0 ? ix : GRID_MAX_POINTS_X - 1,
-              sy = iy >= 0 ? iy : 0, ey = iy >= 0 ? iy : GRID_MAX_POINTS_Y - 1;
+      uint8_t sx = ix >= 0 ? ix : 0, ex = ix >= 0 ? ix : GRID_POINTS_X - 1,
+              sy = iy >= 0 ? iy : 0, ey = iy >= 0 ? iy : GRID_POINTS_Y - 1;
       for (uint8_t x = sx; x <= ex; ++x) {
         for (uint8_t y = sy; y <= ey; ++y) {
           bedlevel.z_values[x][y] = zval + (hasQ ? bedlevel.z_values[x][y] : 0);

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1565,7 +1565,8 @@
 
 #ifdef GRID_MAX_POINTS_X
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
-  #define GRID_LOOP(A,B) for (uint8_t A = 0; A < GRID_MAX_POINTS_X; ++A) for (uint8_t B = 0; B < GRID_MAX_POINTS_Y; ++B)
+  #define GRID_POINTS         ((GRID_POINTS_X) * (GRID_POINTS_Y))
+  #define GRID_LOOP(A,B) for (uint8_t A = 0; A < GRID_POINTS_X; ++A) for (uint8_t B = 0; B < GRID_POINTS_Y; ++B)
 #endif
 
 // Slim menu optimizations

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -412,6 +412,20 @@
 #ifdef GRID_MAX_POINTS_X
   #define GRID_MAX_CELLS_X (GRID_MAX_POINTS_X - 1)
   #define GRID_MAX_CELLS_Y (GRID_MAX_POINTS_Y - 1)
+
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    #define GRID_POINTS_X grid_points_x
+    #define GRID_POINTS_Y grid_points_y
+
+    #define GRID_CELLS_X (GRID_POINTS_X - 1)
+    #define GRID_CELLS_Y (GRID_POINTS_Y - 1)
+
+    extern uint8_t grid_points_x;
+    extern uint8_t grid_points_y;
+  #else
+    #define GRID_POINTS_X GRID_MAX_POINTS_X
+    #define GRID_POINTS_Y GRID_MAX_POINTS_Y
+  #endif
 #endif
 
 /**

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -355,15 +355,15 @@ private:
     void drawBedMesh(const int16_t selected=-1, const uint8_t gridline_width=1, const uint16_t padding_x=8, const uint16_t padding_y_top=40 + 53 - 7) {
       drawing_mesh = true;
       const uint16_t total_width_px = DWIN_WIDTH - padding_x - padding_x,
-                     cell_width_px  = total_width_px / (GRID_MAX_POINTS_X),
-                     cell_height_px = total_width_px / (GRID_MAX_POINTS_Y);
+                     cell_width_px  = total_width_px / (GRID_POINTS_X),
+                     cell_height_px = total_width_px / (GRID_POINTS_Y);
       const float v_max = abs(getMaxValue()), v_min = abs(getMinValue()), rmax = _MAX(v_min, v_max);
 
       // Clear background from previous selection and select new square
       dwinDrawRectangle(1, COLOR_BG_BLACK, _MAX(0, padding_x - gridline_width), _MAX(0, padding_y_top - gridline_width), padding_x + total_width_px, padding_y_top + total_width_px);
       if (selected >= 0) {
-        const auto selected_y = selected / (GRID_MAX_POINTS_X);
-        const auto selected_x = selected - (GRID_MAX_POINTS_X) * selected_y;
+        const auto selected_y = selected / (GRID_POINTS_X);
+        const auto selected_x = selected - (GRID_POINTS_X) * selected_y;
         const auto start_y_px = padding_y_top + selected_y * cell_height_px;
         const auto start_x_px = padding_x + selected_x * cell_width_px;
         dwinDrawRectangle(1, COLOR_WHITE, _MAX(0, start_x_px - gridline_width), _MAX(0, start_y_px - gridline_width), start_x_px + cell_width_px, start_y_px + cell_height_px);
@@ -373,7 +373,7 @@ private:
       GRID_LOOP(x, y) {
         const auto start_x_px = padding_x + x * cell_width_px;
         const auto end_x_px   = start_x_px + cell_width_px - 1 - gridline_width;
-        const auto start_y_px = padding_y_top + (GRID_MAX_POINTS_Y - y - 1) * cell_height_px;
+        const auto start_y_px = padding_y_top + (GRID_POINTS_Y - y - 1) * cell_height_px;
         const auto end_y_px   = start_y_px + cell_height_px - 1 - gridline_width;
         dwinDrawRectangle(1,                                          // RGB565 colors: http://www.barth-dev.de/online/rgb565-color-picker/
           isnan(bedlevel.z_values[x][y]) ? COLOR_GREY : (             // gray if undefined
@@ -395,12 +395,12 @@ private:
           }
           else {                          // has value
             MString<12> msg;
-            if (GRID_MAX_POINTS_X < 10)
+            if (GRID_POINTS_X < 10)
               msg.set(p_float_t(abs(bedlevel.z_values[x][y]), 2));
             else
               msg.setf(F("%02i"), uint16_t(abs(bedlevel.z_values[x][y] - int16_t(bedlevel.z_values[x][y])) * 100));
             const int8_t offset_x = cell_width_px / 2 - 3 * msg.length() - 2;
-            if (GRID_MAX_POINTS_X >= 10)
+            if (GRID_POINTS_X >= 10)
               dwinDrawString(false, font6x12, COLOR_WHITE, COLOR_BG_BLUE, start_x_px - 2 + offset_x, start_y_px + offset_y /*+ square / 2 - 6*/, F("."));
             dwinDrawString(false, font6x12, COLOR_WHITE, COLOR_BG_BLUE, start_x_px + 1 + offset_x, start_y_px + offset_y /*+ square / 2 - 6*/, msg);
           }
@@ -3530,7 +3530,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
               drawFloat(mesh_conf.mesh_x, row, 0, 1);
             }
             else
-              modifyValue(mesh_conf.mesh_x, 0, GRID_MAX_POINTS_X - 1, 1);
+              modifyValue(mesh_conf.mesh_x, 0, GRID_POINTS_X - 1, 1);
             break;
           case LEVELING_M_Y:
             if (draw) {
@@ -3544,8 +3544,8 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             if (draw)
               drawMenuItem(row, ICON_More, GET_TEXT_F(MSG_LEVEL_BED_NEXT_POINT));
             else {
-              if (mesh_conf.mesh_x != (GRID_MAX_POINTS_X - 1) || mesh_conf.mesh_y != (GRID_MAX_POINTS_Y - 1)) {
-                if ((mesh_conf.mesh_x == (GRID_MAX_POINTS_X - 1) && mesh_conf.mesh_y % 2 == 0) || (mesh_conf.mesh_x == 0 && mesh_conf.mesh_y % 2 == 1))
+              if (mesh_conf.mesh_x != (GRID_POINTS_X - 1) || mesh_conf.mesh_y != (GRID_MAX_POINTS_Y - 1)) {
+                if ((mesh_conf.mesh_x == (GRID_POINTS_X - 1) && mesh_conf.mesh_y % 2 == 0) || (mesh_conf.mesh_x == 0 && mesh_conf.mesh_y % 2 == 1))
                   mesh_conf.mesh_y++;
                 else if (mesh_conf.mesh_y % 2 == 0)
                   mesh_conf.mesh_x++;
@@ -3792,11 +3792,11 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
           case MMESH_OLD:
             uint8_t mesh_x, mesh_y;
             // 0,0 -> 1,0 -> 2,0 -> 2,1 -> 1,1 -> 0,1 -> 0,2 -> 1,2 -> 2,2
-            mesh_y = (gridpoint - 1) / (GRID_MAX_POINTS_Y);
-            mesh_x = (gridpoint - 1) % (GRID_MAX_POINTS_X);
+            mesh_y = (gridpoint - 1) / (GRID_POINTS_Y);
+            mesh_x = (gridpoint - 1) % (GRID_POINTS_X);
 
             if (mesh_y % 2 == 1)
-              mesh_x = (GRID_MAX_POINTS_X) - mesh_x - 1;
+              mesh_x = (GRID_POINTS_X) - mesh_x - 1;
 
             const float currval = bedlevel.z_values[mesh_x][mesh_y];
 

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -213,15 +213,15 @@ bool BedLevelTools::meshValidate() {
   void BedLevelTools::drawBedMesh(int16_t selected/*=-1*/, uint8_t gridline_width/*=1*/, uint16_t padding_x/*=8*/, uint16_t padding_y_top/*=(40 + 53 - 7)*/) {
     drawing_mesh = true;
     const uint16_t total_width_px = DWIN_WIDTH - padding_x - padding_x,
-                   cell_width_px  = total_width_px / (GRID_MAX_POINTS_X),
+                   cell_width_px  = total_width_px / (GRID_POINTS_X),
                    cell_height_px = total_width_px / (GRID_MAX_POINTS_Y);
     const float v_max = abs(getMaxValue()), v_min = abs(getMinValue()), rmax = _MAX(v_min, v_max);
 
     // Clear background from previous selection and select new square
     dwinDrawRectangle(1, COLOR_BG_BLACK, _MAX(0, padding_x - gridline_width), _MAX(0, padding_y_top - gridline_width), padding_x + total_width_px, padding_y_top + total_width_px);
     if (selected >= 0) {
-      const auto selected_y = selected / (GRID_MAX_POINTS_X);
-      const auto selected_x = selected - (GRID_MAX_POINTS_X) * selected_y;
+      const auto selected_y = selected / (GRID_POINTS_X);
+      const auto selected_x = selected - (GRID_POINTS_X) * selected_y;
       const auto start_y_px = padding_y_top + selected_y * cell_height_px;
       const auto start_x_px = padding_x + selected_x * cell_width_px;
       dwinDrawRectangle(1, COLOR_WHITE, _MAX(0, start_x_px - gridline_width), _MAX(0, start_y_px - gridline_width), start_x_px + cell_width_px, start_y_px + cell_height_px);
@@ -255,7 +255,7 @@ bool BedLevelTools::meshValidate() {
       }
       else {          // has value
         MString<12> msg;
-        constexpr bool is_wide = (GRID_MAX_POINTS_X) >= TERN(TJC_DISPLAY, 8, 10);
+        constexpr bool is_wide = (GRID_POINTS_X) >= TERN(TJC_DISPLAY, 8, 10);
         if (is_wide)
           msg.setf(F("%02i"), uint16_t(z * 100) % 100);
         else

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2115,7 +2115,7 @@ void autoHome() { queue.inject_P(G28_STR); }
     #if ANY(BABYSTEP_ZPROBE_OFFSET, JUST_BABYSTEP)
       babystep.accum = round(planner.settings.axis_steps_per_mm[Z_AXIS] * BABY_Z_VAR);
     #endif
-    setPFloatOnClick(PROBE_OFFSET_ZMIN, PROBE_OFFSET_ZMAX, 2, applyZOffset, liveZOffset);
+    setPFloatOnClick(Z_OFFSET_MIN, Z_OFFSET_MAX, 2, applyZOffset, liveZOffset);
   }
 
   void setMoveZto0() {
@@ -4027,8 +4027,8 @@ void drawMaxAccelMenu() {
     void applyEditMeshX() { bedLevelTools.mesh_x = menuData.value; }
     void applyEditMeshY() { bedLevelTools.mesh_y = menuData.value; }
     void resetMesh() { bedLevelTools.meshReset(); LCD_MESSAGE(MSG_MESH_RESET); }
-    void setEditMeshX() { hmiValue.select = 0; setIntOnClick(0, GRID_MAX_POINTS_X - 1, bedLevelTools.mesh_x, applyEditMeshX, liveEditMesh); }
-    void setEditMeshY() { hmiValue.select = 1; setIntOnClick(0, GRID_MAX_POINTS_Y - 1, bedLevelTools.mesh_y, applyEditMeshY, liveEditMesh); }
+    void setEditMeshX() { hmiValue.select = 0; setIntOnClick(0, GRID_POINTS_X - 1, bedLevelTools.mesh_x, applyEditMeshX, liveEditMesh); }
+    void setEditMeshY() { hmiValue.select = 1; setIntOnClick(0, GRID_POINTS_Y - 1, bedLevelTools.mesh_y, applyEditMeshY, liveEditMesh); }
     void setEditZValue() { setPFloatOnClick(Z_OFFSET_MIN, Z_OFFSET_MAX, 3); }
   #endif
 

--- a/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
@@ -116,7 +116,7 @@ void MeshViewer::draw(const bool withsave/*=false*/, const bool redraw/*=true*/)
     bedLevelTools.viewer_print_value = true;
     bedLevelTools.drawBedMesh(-1, 1, 8, 10 + TITLE_HEIGHT);
   #else
-    if (redraw) drawMesh(bedlevel.z_values, GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y);
+    if (redraw) drawMesh(bedlevel.z_values, GRID_POINTS_X, GRID_POINTS_Y);
     else DWINUI::drawBox(1, hmiData.colorBackground, { 89, 305, 99, 38 });
   #endif
   if (withsave) {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -240,10 +240,10 @@ void DGUSScreenHandler::meshUpdate(const int8_t xpos, const int8_t ypos) {
     return;
   }
 
-  uint8_t point = ypos * GRID_MAX_POINTS_X + xpos;
+  uint8_t point = ypos * GRID_POINTS_X + xpos;
   probing_icons[point < 16 ? 0 : 1] |= (1U << (point % 16));
 
-  if (xpos >= GRID_MAX_POINTS_X - 1 && ypos >= GRID_MAX_POINTS_Y - 1 && !ExtUI::getLevelingIsValid())
+  if (xpos >= GRID_POINTS_X - 1 && ypos >= GRID_POINTS_Y - 1 && !ExtUI::getLevelingIsValid())
     probing_icons[0] = probing_icons[1] = 0;
 
   triggerFullUpdate();

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.cpp
@@ -343,9 +343,9 @@ void DGUSTxHandler::ablGrid(DGUS_VP &vp) {
   xy_uint8_t point;
   int16_t fixed;
 
-  for (int16_t i = 0; i < DGUS_LEVEL_GRID_SIZE; i++) {
-    point.x = i % (GRID_MAX_POINTS_X);
-    point.y = i / (GRID_MAX_POINTS_X);
+  for (int16_t i = 0; i < GRID_POINTS_X * GRID_POINTS_Y; i++) {
+    point.x = i % (GRID_POINTS_X);
+    point.y = i / (GRID_POINTS_X);
     fixed = dgus.toFixedPoint<float, int16_t, 3>(ExtUI::getMeshPoint(point));
     data[i] = Swap16(fixed);
   }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_base.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/bed_mesh_base.cpp
@@ -27,8 +27,8 @@
 using namespace FTDI;
 
 void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t w, int16_t h, uint8_t opts, float autoscale_max, uint8_t highlightedTag, mesh_getter_ptr func, void *data) {
-  constexpr uint8_t rows = GRID_MAX_POINTS_Y;
-  constexpr uint8_t cols = GRID_MAX_POINTS_X;
+  uint8_t rows = GRID_POINTS_Y;
+  uint8_t cols = GRID_POINTS_X;
 
   #define VALUE(X,Y)  (func ? func(X,Y,data) : 0)
   #define ISVAL(X,Y)  (func ? !isnan(VALUE(X,Y)) : true)
@@ -84,17 +84,17 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
   // transforming the four corner points via the transformation equations and finding
   // the min and max for each axis.
 
-  constexpr float bounds[][3]  = {{TRANSFORM(0     , 0     , 0)},
-                                  {TRANSFORM(cols-1, 0     , 0)},
-                                  {TRANSFORM(0     , rows-1, 0)},
-                                  {TRANSFORM(cols-1, rows-1, 0)}};
+   float bounds[][3]  = {{TRANSFORM(0     , 0     , 0)},
+                        {TRANSFORM(cols-1, 0     , 0)},
+                        {TRANSFORM(0     , rows-1, 0)},
+                        {TRANSFORM(cols-1, rows-1, 0)}};
   #define APPLY(FUNC, AXIS) FUNC(FUNC(bounds[0][AXIS], bounds[1][AXIS]), FUNC(bounds[2][AXIS], bounds[3][AXIS]))
-  constexpr float grid_x       = APPLY(min,0);
-  constexpr float grid_y       = APPLY(min,1);
-  constexpr float grid_w       = APPLY(max,0) - grid_x;
-  constexpr float grid_h       = APPLY(max,1) - grid_y;
-  constexpr float grid_cx      = grid_x + grid_w/2;
-  constexpr float grid_cy      = grid_y + grid_h/2;
+   float grid_x       = APPLY(min,0);
+   float grid_y       = APPLY(min,1);
+   float grid_w       = APPLY(max,0) - grid_x;
+   float grid_h       = APPLY(max,1) - grid_y;
+   float grid_cx      = grid_x + grid_w/2;
+   float grid_cy      = grid_y + grid_h/2;
 
   // Figure out scale and offset such that the grid fits within the rectangle given by (x,y,w,h)
 
@@ -194,13 +194,13 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
 }
 
 uint8_t BedMeshBase::pointToTag(uint8_t x, uint8_t y) {
-  return x >= 0 && x < GRID_MAX_POINTS_X && y >= 0 && y < GRID_MAX_POINTS_Y ? y * (GRID_MAX_POINTS_X) + x + 10 : 0;
+  return x >= 0 && x < GRID_POINTS_X && y >= 0 && y < GRID_POINTS_Y ? y * (GRID_POINTS_X) + x + 10 : 0;
 }
 
 bool BedMeshBase::tagToPoint(uint8_t tag, xy_uint8_t &pt) {
   if (tag < 10) return false;
-  pt.x = (tag - 10) % (GRID_MAX_POINTS_X);
-  pt.y = (tag - 10) / (GRID_MAX_POINTS_X);
+  pt.x = (tag - 10) % (GRID_POINTS_X);
+  pt.y = (tag - 10) / (GRID_POINTS_X);
   return true;
 }
 

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
@@ -257,10 +257,10 @@ void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       rts.sendData(ExchangePageBase + 64, ExchangepageAddr);
   #if HAS_MESH
     uint8_t abl_probe_index = 0;
-    for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-      for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+    for (uint8_t outer = 0; outer < GRID_POINTS_Y; outer++)
+      for (uint8_t inner = 0; inner < GRID_POINTS_X; inner++) {
         const bool zig = outer & 1; // != ((PR_OUTER_END) & 1);
-        const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
+        const xy_uint8_t point = { uint8_t(zig ? (GRID_POINTS_X - 1) - inner : inner), outer };
         if (point.x == xpos && outer == ypos)
           rts.sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + (abl_probe_index * 2));
         ++abl_probe_index;
@@ -313,10 +313,10 @@ void onSettingsLoaded(const bool success) {
   #if HAS_MESH
     if (ExtUI::getLevelingIsValid()) {
       uint8_t abl_probe_index = 0;
-      for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-        for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+      for (uint8_t outer = 0; outer < GRID_POINTS_Y; outer++)
+        for (uint8_t inner = 0; inner < GRID_POINTS_X; inner++) {
           const bool zig = outer & 1;
-          const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
+          const xy_uint8_t point = { uint8_t(zig ? (GRID_POINTS_X - 1) - inner : inner), outer };
           rts.sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + (abl_probe_index * 2));
           ++abl_probe_index;
         }
@@ -373,10 +373,10 @@ void onLevelingDone() {
   #if HAS_MESH
     if (ExtUI::getLevelingIsValid()) {
       uint8_t abl_probe_index = 0;
-      for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-        for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+      for (uint8_t outer = 0; outer < GRID_POINTS_Y; outer++)
+        for (uint8_t inner = 0; inner < GRID_POINTS_X; inner++) {
           const bool zig = outer & 1;
-          const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
+          const xy_uint8_t point = { uint8_t(zig ? (GRID_POINTS_X - 1) - inner : inner), outer };
           rts.sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + abl_probe_index * 2);
           ++abl_probe_index;
         }

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_rts.cpp
@@ -1066,10 +1066,10 @@ void RTS::handleData() {
 
           if (ExtUI::getLevelingIsValid()) {
             uint8_t abl_probe_index = 0;
-            for (uint8_t outer = 0; outer < GRID_MAX_POINTS_Y; outer++)
-              for (uint8_t inner = 0; inner < GRID_MAX_POINTS_X; inner++) {
+            for (uint8_t outer = 0; outer < GRID_POINTS_Y; outer++)
+              for (uint8_t inner = 0; inner < GRID_POINTS_X; inner++) {
                 const bool zig = outer & 1;
-                const xy_uint8_t point = { uint8_t(zig ? (GRID_MAX_POINTS_X - 1) - inner : inner), outer };
+                const xy_uint8_t point = { uint8_t(zig ? (GRID_POINTS_X - 1) - inner : inner), outer };
                 sendData(ExtUI::getMeshPoint(point) * 1000, AutolevelVal + abl_probe_index * 2);
                 ++abl_probe_index;
               }
@@ -1627,9 +1627,9 @@ void RTS::handleData() {
 
     case AutolevelVal: {
       uint8_t meshPoint = (recdat.addr - AutolevelVal) / 2,
-              yPnt = meshPoint / (GRID_MAX_POINTS_X),
-              xPnt = meshPoint - yPnt * (GRID_MAX_POINTS_X);
-      if (yPnt % 2 != 0) xPnt = (GRID_MAX_POINTS_X) - 1 - xPnt; // zag row
+              yPnt = meshPoint / (GRID_POINTS_X),
+              xPnt = meshPoint - yPnt * (GRID_POINTS_X);
+      if (yPnt % 2 != 0) xPnt = (GRID_POINTS_X) - 1 - xPnt; // zag row
 
       float meshVal = float(recdat.data[0] - (recdat.data[0] >= 32768 ? 65536 : 0)) / 1000;
 

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -965,7 +965,7 @@ namespace ExtUI {
       bed_mesh_t& getMeshArray() { return bedlevel.z_values; }
       float getMeshPoint(const xy_uint8_t &pos) { return bedlevel.z_values[pos.x][pos.y]; }
       void setMeshPoint(const xy_uint8_t &pos, const_float_t zoff) {
-        if (WITHIN(pos.x, 0, (GRID_MAX_POINTS_X) - 1) && WITHIN(pos.y, 0, (GRID_MAX_POINTS_Y) - 1)) {
+        if (WITHIN(pos.x, 0, (GRID_POINTS_X) - 1) && WITHIN(pos.y, 0, (GRID_POINTS_Y) - 1)) {
           bedlevel.z_values[pos.x][pos.y] = zoff;
           TERN_(ABL_BILINEAR_SUBDIVISION, bedlevel.refresh_bed_level());
         }

--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -214,8 +214,8 @@
     static uint8_t xind, yind; // =0
     START_MENU();
     BACK_ITEM(MSG_BED_LEVELING);
-    EDIT_ITEM(uint8, MSG_MESH_X, &xind, 0, (GRID_MAX_POINTS_X) - 1);
-    EDIT_ITEM(uint8, MSG_MESH_Y, &yind, 0, (GRID_MAX_POINTS_Y) - 1);
+    EDIT_ITEM(uint8, MSG_MESH_X, &xind, 0, (GRID_POINTS_X) - 1);
+    EDIT_ITEM(uint8, MSG_MESH_Y, &yind, 0, (GRID_POINTS_Y) - 1);
     EDIT_ITEM_FAST(float43, MSG_MESH_EDIT_Z, &bedlevel.z_values[xind][yind], -(LCD_PROBE_Z_RANGE) * 0.5, (LCD_PROBE_Z_RANGE) * 0.5, refresh_planner);
     END_MENU();
   }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3783,8 +3783,8 @@ void MarlinSettings::reset() {
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
         if (leveling_is_valid()) {
-          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; ++py) {
-            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; ++px) {
+          for (uint8_t py = 0; py < GRID_POINTS_Y; ++py) {
+            for (uint8_t px = 0; px < GRID_POINTS_X; ++px) {
               CONFIG_ECHO_START();
               SERIAL_ECHOLN(F("  G29 W I"), px, F(" J"), py, FPSTR(SP_Z_STR), p_float_t(LINEAR_UNIT(bedlevel.z_values[px][py]), 5));
             }


### PR DESCRIPTION
### Description

This PR implements runtime configurable bilinear bed leveling (AUTO_BED_LEVELING_BILINEAR)  grid size with `G29 G<number X points> M<number X points>` command.  Defines GRID_MAX_POINTS_X and GRID_MAX_POINTS_Y were replaced with corresponding variables (besides arrays definitions).

### Benefits

It allows to probe specific bed region only, where is model is placed, thus reducing probing time. For instance in PrusaSlicer start gcode could have line like `G29 R{first_layer_print_max[0]} F{first_layer_print_min[1]} B{first_layer_print_max[1]} G{max(2,round(first_layer_print_max[0] / 50))} M{max(2,round((first_layer_print_max[1] - first_layer_print_min[1])/50))}` (I always probe left edge where priming line is extruded).

### N.B.

First commit includes tested core changes with configuration
```
#define BTT_TFT35_SPI_V1_0
#define TFT_COLOR_UI
#define TOUCH_SCREEN
```
Second commit includes other compiled, but not tested screens.
