### PR TITLE
✨ MARLIN_SMALL_BUILD

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4527,3 +4527,6 @@
 
 // Report uncleaned reset reason from register r2 instead of MCUSR. Supported by Optiboot on AVR.
 //#define OPTIBOOT_RESET_REASON
+
+// Shrink the build for smaller boards by sacrificing some serial feedback
+//#define MARLIN_SMALL_BUILD

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -212,6 +212,8 @@ void FWRetract::M207() {
 }
 
 void FWRetract::M207_report() {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   SERIAL_ECHOLNPGM_P(
       PSTR("  M207 S"), LINEAR_UNIT(settings.retract_length)
     , PSTR(" W"), LINEAR_UNIT(settings.swap_retract_length)
@@ -237,6 +239,8 @@ void FWRetract::M208() {
 }
 
 void FWRetract::M208_report() {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   SERIAL_ECHOLNPGM(
       "  M208 S", LINEAR_UNIT(settings.retract_recover_extra)
     , " W", LINEAR_UNIT(settings.swap_retract_recover_extra)
@@ -258,6 +262,8 @@ void FWRetract::M208_report() {
   }
 
   void FWRetract::M209_report() {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     SERIAL_ECHOLNPGM("  M209 S", AS_DIGIT(autoretract_enabled));
   }
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -532,7 +532,7 @@ void GcodeSuite::G26() {
 
     if (bedtemp) {
       if (!WITHIN(bedtemp, 40, BED_MAX_TARGET)) {
-        SERIAL_ECHOLNPGM("?Specified bed temperature not plausible (40-", BED_MAX_TARGET, "C).");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified bed temperature not plausible (40-", BED_MAX_TARGET, "C)."));
         return;
       }
       g26.bed_temp = bedtemp;
@@ -543,7 +543,7 @@ void GcodeSuite::G26() {
   if (parser.seenval('L')) {
     g26.layer_height = parser.value_linear_units();
     if (!WITHIN(g26.layer_height, 0.0, 2.0)) {
-      SERIAL_ECHOLNPGM("?Specified layer height not plausible.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified layer height not plausible."));
       return;
     }
   }
@@ -552,12 +552,12 @@ void GcodeSuite::G26() {
     if (parser.has_value()) {
       g26.retraction_multiplier = parser.value_float();
       if (!WITHIN(g26.retraction_multiplier, 0.05, 15.0)) {
-        SERIAL_ECHOLNPGM("?Specified Retraction Multiplier not plausible.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified Retraction Multiplier not plausible."));
         return;
       }
     }
     else {
-      SERIAL_ECHOLNPGM("?Retraction Multiplier must be specified.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Retraction Multiplier must be specified."));
       return;
     }
   }
@@ -565,7 +565,7 @@ void GcodeSuite::G26() {
   if (parser.seenval('S')) {
     g26.nozzle = parser.value_float();
     if (!WITHIN(g26.nozzle, 0.1, 2.0)) {
-      SERIAL_ECHOLNPGM("?Specified nozzle size not plausible.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified nozzle size not plausible."));
       return;
     }
   }
@@ -575,7 +575,7 @@ void GcodeSuite::G26() {
       #if HAS_MARLINUI_MENU
         g26.prime_flag = -1;
       #else
-        SERIAL_ECHOLNPGM("?Prime length must be specified when not using an LCD.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Prime length must be specified when not using an LCD."));
         return;
       #endif
     }
@@ -583,7 +583,7 @@ void GcodeSuite::G26() {
       g26.prime_flag++;
       g26.prime_length = parser.value_linear_units();
       if (!WITHIN(g26.prime_length, 0.0, 25.0)) {
-        SERIAL_ECHOLNPGM("?Specified prime length not plausible.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified prime length not plausible."));
         return;
       }
     }
@@ -592,7 +592,7 @@ void GcodeSuite::G26() {
   if (parser.seenval('F')) {
     g26.filament_diameter = parser.value_linear_units();
     if (!WITHIN(g26.filament_diameter, 1.0, 4.0)) {
-      SERIAL_ECHOLNPGM("?Specified filament size not plausible.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified filament size not plausible."));
       return;
     }
   }
@@ -616,7 +616,7 @@ void GcodeSuite::G26() {
   // If any preset or temperature was specified
   if (noztemp) {
     if (!WITHIN(noztemp, 165, thermalManager.hotend_max_target(active_extruder))) {
-      SERIAL_ECHOLNPGM("?Specified nozzle temperature not plausible.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified nozzle temperature not plausible."));
       return;
     }
     g26.hotend_temp = noztemp;
@@ -637,12 +637,12 @@ void GcodeSuite::G26() {
     if (parser.seen('R'))
       g26_repeats = parser.has_value() ? parser.value_int() : GRID_MAX_POINTS + 1;
     else {
-      SERIAL_ECHOLNPGM("?(R)epeat must be specified when not using an LCD.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(R)epeat must be specified when not using an LCD."));
       return;
     }
   #endif
   if (g26_repeats < 1) {
-    SERIAL_ECHOLNPGM("?(R)epeat value not plausible; must be at least 1.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(R)epeat value not plausible; must be at least 1."));
     return;
   }
 
@@ -650,7 +650,7 @@ void GcodeSuite::G26() {
   g26.xy_pos.set(parser.seenval('X') ? RAW_X_POSITION(parser.value_linear_units()) : current_position.x,
                  parser.seenval('Y') ? RAW_Y_POSITION(parser.value_linear_units()) : current_position.y);
   if (!position_is_reachable(g26.xy_pos)) {
-    SERIAL_ECHOLNPGM("?Specified X,Y coordinate out of bounds.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Specified X,Y coordinate out of bounds."));
     return;
   }
 

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -64,7 +64,7 @@ void GcodeSuite::G35() {
 
   const uint8_t screw_thread = parser.byteval('S', TRAMMING_SCREW_THREAD);
   if (!WITHIN(screw_thread, 30, 51) || screw_thread % 10 > 1) {
-    SERIAL_ECHOLNPGM("?(S)crew thread must be 30, 31, 40, 41, 50, or 51.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(S)crew thread must be 30, 31, 40, 41, 50, or 51."));
     return;
   }
 

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -105,13 +105,12 @@ void GcodeSuite::M420() {
         const int16_t a = settings.calc_num_meshes();
 
         if (!a) {
-          SERIAL_ECHOLNPGM("?EEPROM storage not available.");
+          SERIAL_ECHOLNPGM(GCODE_ERR_MSG("EEPROM storage not available."));
           return;
         }
 
         if (!WITHIN(storage_slot, 0, a - 1)) {
-          SERIAL_ECHOLNPGM("?Invalid storage slot.");
-          SERIAL_ECHOLNPGM("?Use 0 to ", a - 1);
+          SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Invalid storage slot. Use 0 to ", a - 1));
           return;
         }
 
@@ -120,7 +119,7 @@ void GcodeSuite::M420() {
 
       #else
 
-        SERIAL_ECHOLNPGM("?EEPROM storage not available.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("EEPROM storage not available."));
         return;
 
       #endif
@@ -245,6 +244,8 @@ void GcodeSuite::M420() {
 }
 
 void GcodeSuite::M420_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(
     TERN(MESH_BED_LEVELING, "Mesh Bed Leveling", TERN(AUTO_BED_LEVELING_UBL, "Unified Bed Leveling", "Auto Bed Leveling"))
   ));

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -344,7 +344,7 @@ G29_TYPE GcodeSuite::G29() {
 
     abl.verbose_level = parser.intval('V');
     if (!WITHIN(abl.verbose_level, 0, 4)) {
-      SERIAL_ECHOLNPGM("?(V)erbose level implausible (0-4).");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(V)erbose level implausible (0-4)."));
       G29_RETURN(false, false);
     }
 
@@ -365,11 +365,11 @@ G29_TYPE GcodeSuite::G29() {
       if (parser.seenval('P')) abl.grid_points.x = abl.grid_points.y = parser.value_int();
 
       if (!WITHIN(abl.grid_points.x, 2, GRID_MAX_POINTS_X)) {
-        SERIAL_ECHOLNPGM("?Probe points (X) implausible (2-" STRINGIFY(GRID_MAX_POINTS_X) ").");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Probe points (X) implausible (2-" STRINGIFY(GRID_MAX_POINTS_X) ")."));
         G29_RETURN(false, false);
       }
       if (!WITHIN(abl.grid_points.y, 2, GRID_MAX_POINTS_Y)) {
-        SERIAL_ECHOLNPGM("?Probe points (Y) implausible (2-" STRINGIFY(GRID_MAX_POINTS_Y) ").");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Probe points (Y) implausible (2-" STRINGIFY(GRID_MAX_POINTS_Y) ")."));
         G29_RETURN(false, false);
       }
 
@@ -404,7 +404,7 @@ G29_TYPE GcodeSuite::G29() {
           DEBUG_ECHOLNPGM("G29 L", abl.probe_position_lf.x, " R", abl.probe_position_rb.x,
                              " F", abl.probe_position_lf.y, " B", abl.probe_position_rb.y);
         }
-        SERIAL_ECHOLNPGM("? (L,R,F,B) out of bounds.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG(" (L,R,F,B) out of bounds."));
         G29_RETURN(false, false);
       }
 

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -390,7 +390,7 @@ void GcodeSuite::G33() {
 
   const int8_t probe_points = parser.intval('P', DELTA_CALIBRATION_DEFAULT_POINTS);
   if (!WITHIN(probe_points, 0, 10)) {
-    SERIAL_ECHOLNPGM("?(P)oints implausible (0-10).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(P)oints implausible (0-10)."));
     return;
   }
 
@@ -409,19 +409,19 @@ void GcodeSuite::G33() {
 
   const float calibration_precision = parser.floatval('C', 0.0f);
   if (calibration_precision < 0) {
-    SERIAL_ECHOLNPGM("?(C)alibration precision implausible (>=0).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(C)alibration precision implausible (>=0)."));
     return;
   }
 
   const int8_t force_iterations = parser.intval('F', 0);
   if (!WITHIN(force_iterations, 0, 30)) {
-    SERIAL_ECHOLNPGM("?(F)orce iteration implausible (0-30).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(F)orce iteration implausible (0-30)."));
     return;
   }
 
   const int8_t verbose_level = parser.byteval('V', 1);
   if (!WITHIN(verbose_level, 0, 3)) {
-    SERIAL_ECHOLNPGM("?(V)erbose level implausible (0-3).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(V)erbose level implausible (0-3)."));
     return;
   }
 

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -110,19 +110,19 @@ void GcodeSuite::G34() {
 
       const int8_t z_auto_align_iterations = parser.intval('I', Z_STEPPER_ALIGN_ITERATIONS);
       if (!WITHIN(z_auto_align_iterations, 1, 30)) {
-        SERIAL_ECHOLNPGM("?(I)teration out of bounds (1-30).");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(I)teration out of bounds (1-30)."));
         break;
       }
 
       const float z_auto_align_accuracy = parser.floatval('T', Z_STEPPER_ALIGN_ACC);
       if (!WITHIN(z_auto_align_accuracy, 0.01f, 1.0f)) {
-        SERIAL_ECHOLNPGM("?(T)arget accuracy out of bounds (0.01-1.0).");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(T)arget accuracy out of bounds (0.01-1.0)."));
         break;
       }
 
       const float z_auto_align_amplification = TERN(HAS_Z_STEPPER_ALIGN_STEPPER_XY, Z_STEPPER_ALIGN_AMP, parser.floatval('A', Z_STEPPER_ALIGN_AMP));
       if (!WITHIN(ABS(z_auto_align_amplification), 0.5f, 2.0f)) {
-        SERIAL_ECHOLNPGM("?(A)mplification out of bounds (0.5-2.0).");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(A)mplification out of bounds (0.5-2.0)."));
         break;
       }
 
@@ -450,7 +450,7 @@ void GcodeSuite::M422() {
   const bool is_probe_point = parser.seen_test('S');
 
   if (TERN0(HAS_Z_STEPPER_ALIGN_STEPPER_XY, is_probe_point && parser.seen_test('W'))) {
-    SERIAL_ECHOLNPGM("?(S) and (W) may not be combined.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(S) and (W) may not be combined."));
     return;
   }
 
@@ -460,7 +460,7 @@ void GcodeSuite::M422() {
   );
 
   if (!is_probe_point && TERN1(HAS_Z_STEPPER_ALIGN_STEPPER_XY, !parser.seen_test('W'))) {
-    SERIAL_ECHOLNPGM("?(S)" TERN_(HAS_Z_STEPPER_ALIGN_STEPPER_XY, " or (W)") " is required.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(S)" TERN_(HAS_Z_STEPPER_ALIGN_STEPPER_XY, " or (W)") " is required."));
     return;
   }
 
@@ -490,11 +490,11 @@ void GcodeSuite::M422() {
 
   if (is_probe_point) {
     if (!probe.can_reach(pos.x, Y_CENTER)) {
-      SERIAL_ECHOLNPGM("?(X) out of bounds.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(X) out of bounds."));
       return;
     }
     if (!probe.can_reach(pos)) {
-      SERIAL_ECHOLNPGM("?(Y) out of bounds.");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(Y) out of bounds."));
       return;
     }
   }
@@ -503,6 +503,8 @@ void GcodeSuite::M422() {
 }
 
 void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_Z_AUTO_ALIGN));
   for (uint8_t i = 0; i < NUM_Z_STEPPERS; ++i) {
     report_echo_start(forReplay);

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -106,6 +106,8 @@ void GcodeSuite::M425() {
 }
 
 void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_BACKLASH_COMPENSATION));
   SERIAL_ECHOLNPGM_P(
     PSTR("  M425 F"), backlash.get_correction()

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -62,13 +62,13 @@ void GcodeSuite::M48() {
 
   const int8_t verbose_level = parser.byteval('V', 1);
   if (!WITHIN(verbose_level, 0, 4)) {
-    SERIAL_ECHOLNPGM("?(V)erbose level implausible (0-4).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(V)erbose level implausible (0-4)."));
     return;
   }
 
   const int8_t n_samples = parser.byteval('P', 10);
   if (!WITHIN(n_samples, 4, 50)) {
-    SERIAL_ECHOLNPGM("?Sample size not plausible (4-50).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Sample size not plausible (4-50)."));
     return;
   }
 
@@ -82,7 +82,7 @@ void GcodeSuite::M48() {
 
   if (!probe.can_reach(test_position)) {
     LCD_MESSAGE_MAX(MSG_M48_OUT_OF_BOUNDS);
-    SERIAL_ECHOLNPGM("? (X,Y) out of bounds.");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG(" (X,Y) out of bounds."));
     return;
   }
 
@@ -90,7 +90,7 @@ void GcodeSuite::M48() {
   bool seen_L = parser.seen('L');
   uint8_t n_legs = seen_L ? parser.value_byte() : 0;
   if (n_legs > 15) {
-    SERIAL_ECHOLNPGM("?Legs of movement implausible (0-15).");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Legs of movement implausible (0-15)."));
     return;
   }
   if (n_legs == 1) n_legs = 2;

--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -62,6 +62,8 @@
   }
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_DELTA_SETTINGS));
     SERIAL_ECHOLNPGM_P(
         PSTR("  M665 L"), LINEAR_UNIT(delta_diagonal_rod)
@@ -132,6 +134,8 @@
   }
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_SCARA_SETTINGS " (" STR_S_SEG_PER_SEC TERN_(HAS_SCARA_OFFSET, " " STR_SCARA_P_T_Z) ")"));
     SERIAL_ECHOLNPGM_P(
       PSTR("  M665 S"), segments_per_second
@@ -170,6 +174,8 @@
   }
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_POLARGRAPH_SETTINGS));
     SERIAL_ECHOLNPGM_P(
       PSTR("  M665 S"), LINEAR_UNIT(segments_per_second),
@@ -196,10 +202,11 @@
   }
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
     report_heading_etc(forReplay, F(STR_POLAR_SETTINGS));
     SERIAL_ECHOLNPGM_P(PSTR("  M665 S"), segments_per_second);
   }
 
-#endif
+#endif // POLAR
 
 #endif // IS_KINEMATIC

--- a/Marlin/src/gcode/calibrate/M666.cpp
+++ b/Marlin/src/gcode/calibrate/M666.cpp
@@ -56,11 +56,13 @@
         }
       }
     }
-    if (is_err) SERIAL_ECHOLNPGM("?M666 offsets must be <= 0");
+    if (is_err) SERIAL_ECHOLNPGM(GCODE_ERR_MSG("M666 offsets must be <= 0"));
     if (!is_set) M666_report();
   }
 
   void GcodeSuite::M666_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_ENDSTOP_ADJUSTMENT));
     SERIAL_ECHOLNPGM_P(
         PSTR("  M666 X"), LINEAR_UNIT(delta_endstop_adj.a)
@@ -105,6 +107,8 @@
   }
 
   void GcodeSuite::M666_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_ENDSTOP_ADJUSTMENT));
     SERIAL_ECHOPGM("  M666");
     #if ENABLED(X_DUAL_ENDSTOPS)

--- a/Marlin/src/gcode/calibrate/M852.cpp
+++ b/Marlin/src/gcode/calibrate/M852.cpp
@@ -92,6 +92,8 @@ void GcodeSuite::M852() {
 }
 
 void GcodeSuite::M852_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_SKEW_FACTOR));
   SERIAL_ECHOPGM("  M852 I", p_float_t(planner.skew_factor.xy, 6));
   #if ENABLED(SKEW_CORRECTION_FOR_Z)

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -67,7 +67,7 @@
         if (WITHIN(lval, 0, VOLUMETRIC_EXTRUDER_LIMIT_MAX))
           planner.set_volumetric_extruder_limit(target_extruder, lval);
         else
-          SERIAL_ECHOLNPGM("?L value out of range (0-" STRINGIFY(VOLUMETRIC_EXTRUDER_LIMIT_MAX) ").");
+          SERIAL_ECHOLNPGM(GCODE_ERR_MSG("L value out of range (0-" STRINGIFY(VOLUMETRIC_EXTRUDER_LIMIT_MAX) ")."));
       }
     #endif
 
@@ -75,6 +75,8 @@
   }
 
   void GcodeSuite::M200_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     if (!forReplay) {
       report_heading(forReplay, F(STR_FILAMENT_SETTINGS), false);
       if (!parser.volumetric_enabled) SERIAL_ECHOPGM(" (Disabled):");
@@ -142,6 +144,8 @@ void GcodeSuite::M201() {
 }
 
 void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_MAX_ACCELERATION));
   #if NUM_AXES
     SERIAL_ECHOPGM_P(
@@ -198,6 +202,8 @@ void GcodeSuite::M203() {
 }
 
 void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_MAX_FEEDRATES));
   #if NUM_AXES
     SERIAL_ECHOPGM_P(
@@ -255,6 +261,8 @@ void GcodeSuite::M204() {
 }
 
 void GcodeSuite::M204_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_ACCELERATION_P_R_T));
   SERIAL_ECHOLNPGM_P(
       PSTR("  M204 P"), LINEAR_UNIT(planner.settings.acceleration)
@@ -329,6 +337,8 @@ void GcodeSuite::M205() {
 }
 
 void GcodeSuite::M205_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(
     "Advanced (" M205_MIN_SEG_TIME_STR "<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>"
     TERN_(HAS_JUNCTION_DEVIATION, " J<junc_dev>")

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -164,6 +164,8 @@ void GcodeSuite::M217() {
 }
 
 void GcodeSuite::M217_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_TOOL_CHANGING));
 
   SERIAL_ECHOPGM("  M217");

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -63,6 +63,8 @@ void GcodeSuite::M218() {
 }
 
 void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_HOTEND_OFFSETS));
   for (uint8_t e = 1; e < HOTENDS; ++e) {
     report_echo_start(forReplay);

--- a/Marlin/src/gcode/config/M281.cpp
+++ b/Marlin/src/gcode/config/M281.cpp
@@ -55,6 +55,8 @@ void GcodeSuite::M281() {
 }
 
 void GcodeSuite::M281_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_SERVO_ANGLES));
   for (uint8_t i = 0; i < NUM_SERVOS; ++i) {
     switch (i) {

--- a/Marlin/src/gcode/config/M301.cpp
+++ b/Marlin/src/gcode/config/M301.cpp
@@ -78,6 +78,8 @@ void GcodeSuite::M301() {
 }
 
 void GcodeSuite::M301_report(const bool forReplay/*=true*/ E_OPTARG(const int8_t eindex/*=-1*/)) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_HOTEND_PID));
   IF_DISABLED(HAS_MULTI_EXTRUDER, constexpr int8_t eindex = -1);
   HOTEND_LOOP() {

--- a/Marlin/src/gcode/config/M304.cpp
+++ b/Marlin/src/gcode/config/M304.cpp
@@ -42,6 +42,8 @@ void GcodeSuite::M304() {
 }
 
 void GcodeSuite::M304_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_BED_PID));
   SERIAL_ECHOLNPGM("  M304"
       " P", thermalManager.temp_bed.pid.p()

--- a/Marlin/src/gcode/config/M309.cpp
+++ b/Marlin/src/gcode/config/M309.cpp
@@ -42,6 +42,8 @@ void GcodeSuite::M309() {
 }
 
 void GcodeSuite::M309_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_CHAMBER_PID));
   SERIAL_ECHOLNPGM("  M309"
       " P", thermalManager.temp_chamber.pid.p()

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -96,6 +96,8 @@ void GcodeSuite::M92() {
 }
 
 void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_STEPS_PER_UNIT));
   #if NUM_AXES
     #define PRINT_EOL

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -40,6 +40,8 @@ void GcodeSuite::M211() {
 }
 
 void GcodeSuite::M211_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_SOFT_ENDSTOPS));
   SERIAL_ECHOPGM("  M211 S", AS_DIGIT(soft_endstop._enabled), " ; ");
   serialprintln_onoff(soft_endstop._enabled);

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -79,7 +79,7 @@ void GcodeSuite::M42() {
       #ifdef OUTPUT_OPEN_DRAIN
         case 5: pinMode(pin, OUTPUT_OPEN_DRAIN); break;
       #endif
-      default: SERIAL_ECHOLNPGM("Invalid Pin Mode"); return;
+      default: SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Invalid Pin Mode")); return;
     }
   }
 
@@ -94,7 +94,7 @@ void GcodeSuite::M42() {
   #endif
 
   if (avoidWrite) {
-    SERIAL_ECHOLNPGM("?Cannot write to INPUT");
+    SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Cannot write to INPUT"));
     return;
   }
 

--- a/Marlin/src/gcode/control/M85.cpp
+++ b/Marlin/src/gcode/control/M85.cpp
@@ -32,11 +32,16 @@ void GcodeSuite::M85() {
     const millis_t ms = parser.value_millis_from_seconds();
     #if LASER_SAFETY_TIMEOUT_MS > 0
       if (ms && ms <= LASER_SAFETY_TIMEOUT_MS) {
-        SERIAL_ECHO_MSG("M85 timeout must be > ", MS_TO_SEC(LASER_SAFETY_TIMEOUT_MS + 999), " s for laser safety.");
+        SERIAL_ECHO_MSG(GCODE_ERR_MSG("M85 timeout must be > ", MS_TO_SEC(LASER_SAFETY_TIMEOUT_MS + 999), " s for laser safety."));
         return;
       }
     #endif
     max_inactive_time = ms;
+  }
+  else {
+    #if DISABLED(MARLIN_SMALL_BUILD)
+      SERIAL_ECHOLNPGM("Inactivity timeout ", MS_TO_SEC(max_inactive_time), " s.");
+    #endif
   }
 
 }

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -141,6 +141,8 @@ void GcodeSuite::M900() {
 }
 
 void GcodeSuite::M900_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_LINEAR_ADVANCE));
   #if DISTINCT_E < 2
     report_echo_start(forReplay);

--- a/Marlin/src/gcode/feature/controllerfan/M710.cpp
+++ b/Marlin/src/gcode/feature/controllerfan/M710.cpp
@@ -67,6 +67,8 @@ void GcodeSuite::M710() {
 }
 
 void GcodeSuite::M710_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_CONTROLLER_FAN));
   SERIAL_ECHOLNPGM("  M710"
     " S", int(controllerFan.settings.active_speed),

--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -126,6 +126,8 @@ void GcodeSuite::M907() {
 #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
 
   void GcodeSuite::M907_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_STEPPER_MOTOR_CURRENTS));
     #if HAS_MOTOR_CURRENT_PWM
       SERIAL_ECHOLNPGM_P(                                     // PWM-based has 3 values:

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -104,6 +104,8 @@ void say_shaping() {
 }
 
 void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_FT_MOTION));
   const ft_config_t &c = ftMotion.cfg;
   SERIAL_ECHOPGM("  M493 S", c.mode);

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -38,6 +38,8 @@
 void GcodeSuite::M207() { fwretract.M207(); }
 
 void GcodeSuite::M207_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_RETRACT_S_F_Z));
   fwretract.M207_report();
 }
@@ -53,6 +55,8 @@ void GcodeSuite::M207_report(const bool forReplay/*=true*/) {
 void GcodeSuite::M208() { fwretract.M208(); }
 
 void GcodeSuite::M208_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_RECOVER_S_F));
   fwretract.M208_report();
 }
@@ -68,6 +72,8 @@ void GcodeSuite::M208_report(const bool forReplay/*=true*/) {
   void GcodeSuite::M209() { fwretract.M209(); }
 
   void GcodeSuite::M209_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading_etc(forReplay, F(STR_AUTO_RETRACT_S));
     fwretract.M209_report();
   }

--- a/Marlin/src/gcode/feature/input_shaping/M593.cpp
+++ b/Marlin/src/gcode/feature/input_shaping/M593.cpp
@@ -28,6 +28,8 @@
 #include "../../../module/stepper.h"
 
 void GcodeSuite::M593_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F("Input Shaping"));
   #if ENABLED(INPUT_SHAPING_X)
     SERIAL_ECHOLNPGM("  M593 X"
@@ -78,7 +80,7 @@ void GcodeSuite::M593() {
       if (for_Y) stepper.set_shaping_frequency(Y_AXIS, freq);
     }
     else
-      SERIAL_ECHOLNPGM("?Frequency (F) must be greater than ", min_freq, " or 0 to disable");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Frequency (F) must be greater than ", min_freq, " or 0 to disable"));
   }
 }
 

--- a/Marlin/src/gcode/feature/network/M552-M554.cpp
+++ b/Marlin/src/gcode/feature/network/M552-M554.cpp
@@ -97,6 +97,7 @@ void GcodeSuite::M552() {
 }
 
 void GcodeSuite::M552_report() {
+  TERN_(MARLIN_SMALL_BUILD, return);
   ip_report(552, F("ip address"), Ethernet.linkStatus() == LinkON ? Ethernet.localIP() : ethernet.ip);
 }
 
@@ -111,6 +112,7 @@ void GcodeSuite::M553() {
 }
 
 void GcodeSuite::M553_report() {
+  TERN_(MARLIN_SMALL_BUILD, return);
   ip_report(553, F("subnet mask"), Ethernet.linkStatus() == LinkON ? Ethernet.subnetMask() : ethernet.subnet);
 }
 
@@ -125,6 +127,7 @@ void GcodeSuite::M554() {
 }
 
 void GcodeSuite::M554_report() {
+  TERN_(MARLIN_SMALL_BUILD, return);
   ip_report(554, F("gateway"), Ethernet.linkStatus() == LinkON ? Ethernet.gatewayIP() : ethernet.gateway);
 }
 

--- a/Marlin/src/gcode/feature/nonlinear/M592.cpp
+++ b/Marlin/src/gcode/feature/nonlinear/M592.cpp
@@ -28,6 +28,7 @@
 #include "../../../module/stepper.h"
 
 void GcodeSuite::M592_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
   report_heading(forReplay, F(STR_NONLINEAR_EXTRUSION));
   SERIAL_ECHOLNPGM("  M592 A", stepper.ne.A, " B", stepper.ne.B, " C", stepper.ne.C);
 }

--- a/Marlin/src/gcode/feature/pause/M603.cpp
+++ b/Marlin/src/gcode/feature/pause/M603.cpp
@@ -61,6 +61,8 @@ void GcodeSuite::M603() {
 }
 
 void GcodeSuite::M603_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_FILAMENT_LOAD_UNLOAD));
 
   #if EXTRUDERS == 1

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -64,6 +64,8 @@ void GcodeSuite::M413() {
 }
 
 void GcodeSuite::M413_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_POWER_LOSS_RECOVERY));
   SERIAL_ECHOPGM("  M413 S", AS_DIGIT(recovery.enabled)
     #if HAS_PLR_BED_THRESHOLD

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -67,6 +67,8 @@ void GcodeSuite::M412() {
 }
 
 void GcodeSuite::M412_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_FILAMENT_RUNOUT_SENSOR));
   SERIAL_ECHOPGM(
     "  M412 S", runout.enabled

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -155,6 +155,8 @@ void GcodeSuite::M569() {
 }
 
 void GcodeSuite::M569_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_DRIVER_STEPPING_MODE));
 
   auto say_M569 = [](const bool forReplay, FSTR_P const etc=nullptr, const bool eol=false) {

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -231,6 +231,8 @@ void GcodeSuite::M906() {
 }
 
 void GcodeSuite::M906_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_STEPPER_DRIVER_CURRENT));
 
   auto say_M906 = [](const bool forReplay) {

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -378,6 +378,8 @@
   }
 
   void GcodeSuite::M913_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading(forReplay, F(STR_HYBRID_THRESHOLD));
 
     auto say_M913 = [](const bool forReplay) {
@@ -565,6 +567,8 @@
   }
 
   void GcodeSuite::M914_report(const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     report_heading(forReplay, F(STR_STALLGUARD_THRESHOLD));
 
     auto say_M914 = [](const bool forReplay) {

--- a/Marlin/src/gcode/feature/trinamic/M919.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M919.cpp
@@ -64,7 +64,7 @@ void GcodeSuite::M919() {
     if (WITHIN(toff, 1, 15))
       DEBUG_ECHOLNPGM(".toff: ", toff);
     else {
-      SERIAL_ECHOLNPGM("?O out of range (1..15)");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("O out of range (1..15)"));
       err = true;
     }
   }
@@ -74,7 +74,7 @@ void GcodeSuite::M919() {
     if (WITHIN(hend, -3, 12))
       DEBUG_ECHOLNPGM(".hend: ", hend);
     else {
-      SERIAL_ECHOLNPGM("?P out of range (-3..12)");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("P out of range (-3..12)"));
       err = true;
     }
   }
@@ -84,7 +84,7 @@ void GcodeSuite::M919() {
     if (WITHIN(hstrt, 1, 8))
       DEBUG_ECHOLNPGM(".hstrt: ", hstrt);
     else {
-      SERIAL_ECHOLNPGM("?S out of range (1..8)");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("S out of range (1..8)"));
       err = true;
     }
   }
@@ -118,7 +118,7 @@ void GcodeSuite::M919() {
     // Get the chopper timing for the specified axis and index
     switch (i) {
       default: // A specified axis isn't Trinamic
-        SERIAL_ECHOLNPGM("?Axis ", C(AXIS_CHAR(i)), " has no TMC drivers.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Axis ", C(AXIS_CHAR(i)), " has no TMC drivers."));
         break;
 
       #if AXIS_IS_TMC(X) || AXIS_IS_TMC(X2)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -341,6 +341,12 @@
   #define HAS_FAST_MOVES 1
 #endif
 
+#if ENABLED(MARLIN_SMALL_BUILD)
+  #define GCODE_ERR_MSG(V...) "?"
+#else
+  #define GCODE_ERR_MSG(V...) "?" V
+#endif
+
 enum AxisRelative : uint8_t {
   LOGICAL_AXIS_LIST(REL_E, REL_X, REL_Y, REL_Z, REL_I, REL_J, REL_K, REL_U, REL_V, REL_W)
   #if HAS_EXTRUDERS

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -48,6 +48,8 @@ void GcodeSuite::M206() {
 }
 
 void GcodeSuite::M206_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_HOME_OFFSET));
   SERIAL_ECHOLNPGM_P(
     #if IS_CARTESIAN

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -61,6 +61,8 @@ void GcodeSuite::M145() {
 }
 
 void GcodeSuite::M145_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F(STR_MATERIAL_HEATUP));
   for (uint8_t i = 0; i < PREHEAT_COUNT; ++i) {
     report_echo_start(forReplay);

--- a/Marlin/src/gcode/lcd/M250.cpp
+++ b/Marlin/src/gcode/lcd/M250.cpp
@@ -38,6 +38,7 @@ void GcodeSuite::M250() {
 }
 
 void GcodeSuite::M250_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
   report_heading_etc(forReplay, F(STR_LCD_CONTRAST));
   SERIAL_ECHOLNPGM("  M250 C", ui.contrast);
 }

--- a/Marlin/src/gcode/lcd/M255.cpp
+++ b/Marlin/src/gcode/lcd/M255.cpp
@@ -44,6 +44,7 @@ void GcodeSuite::M255() {
 }
 
 void GcodeSuite::M255_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
   report_heading_etc(forReplay, F(STR_DISPLAY_SLEEP));
   SERIAL_ECHOLNPGM("  M255 S",
     TERN(HAS_DISPLAY_SLEEP, ui.sleep_timeout_minutes, ui.backlight_timeout_minutes),

--- a/Marlin/src/gcode/lcd/M256.cpp
+++ b/Marlin/src/gcode/lcd/M256.cpp
@@ -37,6 +37,7 @@ void GcodeSuite::M256() {
 }
 
 void GcodeSuite::M256_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
   report_heading_etc(forReplay, F(STR_LCD_BRIGHTNESS));
   SERIAL_ECHOLNPGM("  M256 B", ui.brightness);
 }

--- a/Marlin/src/gcode/lcd/M414.cpp
+++ b/Marlin/src/gcode/lcd/M414.cpp
@@ -44,6 +44,7 @@ void GcodeSuite::M414() {
 }
 
 void GcodeSuite::M414_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
   report_heading_etc(forReplay, F(STR_UI_LANGUAGE));
   SERIAL_ECHOLNPGM("  M414 S", ui.language);
 }

--- a/Marlin/src/gcode/probe/M423.cpp
+++ b/Marlin/src/gcode/probe/M423.cpp
@@ -72,12 +72,12 @@ void GcodeSuite::M423() {
     do_report = false;
     const int8_t x = parser.value_int();
     if (!WITHIN(x, 0, XATC_MAX_POINTS - 1))
-      SERIAL_ECHOLNPGM("?(X) out of range (0..", XATC_MAX_POINTS - 1, ").");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(X) out of range (0..", XATC_MAX_POINTS - 1, ")."));
     else {
       if (parser.seenval('Z'))
         xatc.z_offset[x] = parser.value_linear_units();
       else
-        SERIAL_ECHOLNPGM("?(Z) required.");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("(Z) required."));
     }
   }
 
@@ -86,6 +86,8 @@ void GcodeSuite::M423() {
 }
 
 void GcodeSuite::M423_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F("X-Twist Correction"));
   SERIAL_ECHOLNPGM("  M423 A", xatc.start, " I", xatc.spacing);
   for (uint8_t x = 0; x < XATC_MAX_POINTS; ++x) {

--- a/Marlin/src/gcode/probe/M851.cpp
+++ b/Marlin/src/gcode/probe/M851.cpp
@@ -47,11 +47,11 @@ void GcodeSuite::M851() {
       if (WITHIN(x, PROBE_OFFSET_XMIN, PROBE_OFFSET_XMAX))
         offs.x = x;
       else {
-        SERIAL_ECHOLNPGM("?X out of range (", PROBE_OFFSET_XMIN, " to ", PROBE_OFFSET_XMAX, ")");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("X out of range (", PROBE_OFFSET_XMIN, " to ", PROBE_OFFSET_XMAX, ")"));
         ok = false;
       }
     #else
-      if (x) SERIAL_ECHOLNPGM("?X must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
+      if (x) SERIAL_ECHOLNPGM(GCODE_ERR_MSG("X must be 0 (NOZZLE_AS_PROBE).")); // ...but let 'ok' stay true
     #endif
   }
 
@@ -61,11 +61,11 @@ void GcodeSuite::M851() {
       if (WITHIN(y, PROBE_OFFSET_YMIN, PROBE_OFFSET_YMAX))
         offs.y = y;
       else {
-        SERIAL_ECHOLNPGM("?Y out of range (", PROBE_OFFSET_YMIN, " to ", PROBE_OFFSET_YMAX, ")");
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Y out of range (", PROBE_OFFSET_YMIN, " to ", PROBE_OFFSET_YMAX, ")"));
         ok = false;
       }
     #else
-      if (y) SERIAL_ECHOLNPGM("?Y must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
+      if (y) SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Y must be 0 (NOZZLE_AS_PROBE).")); // ...but let 'ok' stay true
     #endif
   }
 
@@ -74,7 +74,7 @@ void GcodeSuite::M851() {
     if (WITHIN(z, PROBE_OFFSET_ZMIN, PROBE_OFFSET_ZMAX))
       offs.z = z;
     else {
-      SERIAL_ECHOLNPGM("?Z out of range (", PROBE_OFFSET_ZMIN, " to ", PROBE_OFFSET_ZMAX, ")");
+      SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Z out of range (", PROBE_OFFSET_ZMIN, " to ", PROBE_OFFSET_ZMAX, ")"));
       ok = false;
     }
   }
@@ -84,6 +84,8 @@ void GcodeSuite::M851() {
 }
 
 void GcodeSuite::M851_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_Z_PROBE_OFFSET));
   SERIAL_ECHOPGM_P(
     #if HAS_PROBE_XY_OFFSET

--- a/Marlin/src/gcode/temp/M306.cpp
+++ b/Marlin/src/gcode/temp/M306.cpp
@@ -88,6 +88,8 @@ void GcodeSuite::M306() {
 }
 
 void GcodeSuite::M306_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading(forReplay, F("Model predictive control"));
   HOTEND_LOOP() {
     report_echo_start(forReplay);

--- a/Marlin/src/gcode/temp/M86-M87.cpp
+++ b/Marlin/src/gcode/temp/M86-M87.cpp
@@ -34,6 +34,8 @@
 #include "../../feature/hotend_idle.h"
 
 void GcodeSuite::M86_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   hotend_idle_settings_t &c = hotend_idle.cfg;
   report_heading(forReplay, F("Hotend Idle Timeout"));
   SERIAL_ECHOLNPGM("  M86"

--- a/Marlin/src/gcode/units/M149.cpp
+++ b/Marlin/src/gcode/units/M149.cpp
@@ -37,6 +37,8 @@ void GcodeSuite::M149() {
 }
 
 void GcodeSuite::M149_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   report_heading_etc(forReplay, F(STR_TEMPERATURE_UNITS));
   SERIAL_ECHOLN(F("  M149 "), C(parser.temp_units_code()), F(" ; Units in "), parser.temp_units_name());
 }

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -26,6 +26,12 @@
  * Conditionals set before pins.h and which depend on Configuration_adv.h.
  */
 
+#if ENABLED(MARLIN_SMALL_BUILD)
+  #undef EEPROM_CHITCHAT
+  #undef CAPABILITIES_REPORT
+  #define DISABLE_M503
+#endif
+
 #ifndef AXIS_RELATIVE_MODES
   #define AXIS_RELATIVE_MODES {}
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3957,7 +3957,7 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
  * Sanity Check for Slim LCD Menus and Probe Offset Wizard
  */
 #if ALL(SLIM_LCD_MENUS, PROBE_OFFSET_WIZARD)
-  #error "SLIM_LCD_MENUS disables \"Advanced Settings > Probe Offsets > PROBE_OFFSET_WIZARD.\""
+  #error "SLIM_LCD_MENUS disables 'Advanced Settings > Probe Offsets > PROBE_OFFSET_WIZARD.'"
 #endif
 
 /**

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2271,6 +2271,8 @@ void Temperature::task() {
   }
 
   void Temperature::M305_report(const uint8_t t_index, const bool forReplay/*=true*/) {
+    TERN_(MARLIN_SMALL_BUILD, return);
+
     gcode.report_heading_etc(forReplay, F(STR_USER_THERMISTORS));
     SERIAL_ECHOPGM("  M305 P", AS_DIGIT(t_index));
 


### PR DESCRIPTION
Option to shrink the build for smaller boards by sacrificing some serial feedback.

Particularly useful for flash-starved boards and custom applications that don't need detailed host or user interaction.