### PR TITLE
🎨 Add MKS TinyBee Silkscreen Labels

### DIFF
--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -35,7 +35,7 @@
 #endif
 
 #define BOARD_INFO_NAME      "MKS TinyBee"
-#define BOARD_WEBSITE_URL    "https://github.com/makerbase-mks"
+#define BOARD_WEBSITE_URL    "github.com/makerbase-mks/MKS-TinyBee"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
 // MAX_EXPANDER_BITS is defined for MKS TinyBee in HAL/ESP32/inc/Conditionals_adv.h
@@ -43,21 +43,22 @@
 //
 // Servos
 //
-#define SERVO0_PIN                             2
+#define SERVO0_PIN                             2  // 3D TOUCH
 
 //
 // Limit Switches
 //
-#define X_STOP_PIN                            33
-#define Y_STOP_PIN                            32
-#define Z_STOP_PIN                            22
-//#define FIL_RUNOUT_PIN                      35
-
+#define X_STOP_PIN                            33  // X
+#define Y_STOP_PIN                            32  // Y
+#define Z_STOP_PIN                            22  // Z
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                      35  // MT_DET
+#endif
 //
 // Probe enable
 //
 #if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
-  #define PROBE_ENABLE_PIN            SERVO0_PIN
+  #define PROBE_ENABLE_PIN            SERVO0_PIN  // 3D TOUCH
 #endif
 
 //
@@ -75,49 +76,44 @@
 //
 // Steppers
 //
-#define X_STEP_PIN                           129
+#define X_STEP_PIN                           129  // X
 #define X_DIR_PIN                            130
 #define X_ENABLE_PIN                         128
 
-#define Y_STEP_PIN                           132
+#define Y_STEP_PIN                           132  // Y
 #define Y_DIR_PIN                            133
 #define Y_ENABLE_PIN                         131
 
-#define Z_STEP_PIN                           135
+#define Z_STEP_PIN                           135  // Z1
 #define Z_DIR_PIN                            136
 #define Z_ENABLE_PIN                         134
 
-#define E0_STEP_PIN                          138
+#define E0_STEP_PIN                          138  // E0
 #define E0_DIR_PIN                           139
 #define E0_ENABLE_PIN                        137
 
-#define E1_STEP_PIN                          141
+#define E1_STEP_PIN                          141  // E1
 #define E1_DIR_PIN                           142
 #define E1_ENABLE_PIN                        140
-
-#define Z2_STEP_PIN                          141
-#define Z2_DIR_PIN                           142
-#define Z2_ENABLE_PIN                        140
 
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN                            36  // Analog Input
-#define TEMP_1_PIN                            34  // Analog Input, you need set R6=0Ω and R7=NC
-#define TEMP_BED_PIN                          39  // Analog Input
+#define TEMP_0_PIN                            36  // TH1 / Analog Input
+#define TEMP_1_PIN                            34  // TH2 / Analog Input, you need set R6=0Ω and R7=NC
+#define TEMP_BED_PIN                          39  // TB  / Analog Input
 
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                         145
-#define HEATER_1_PIN                         146
-#define FAN0_PIN                             147
-#define FAN1_PIN                             148
-#define HEATER_BED_PIN                       144
+#define HEATER_0_PIN                         145  // HE0
+#define HEATER_1_PIN                         146  // HE1
+#define FAN0_PIN                             147  // FAN1
+#define FAN1_PIN                             148  // FAN2
+#define HEATER_BED_PIN                       144  // H-BED
 
-//#define CONTROLLER_FAN_PIN                 148
-//#define E0_AUTO_FAN_PIN                    148  // need to update Configuration_adv.h @section extruder
-//#define E1_AUTO_FAN_PIN                    149  // need to update Configuration_adv.h @section extruder
+//#define CONTROLLER_FAN_PIN                 148  // FAN2
+//#define E0_AUTO_FAN_PIN                    148  // FAN2
 
 //
 // ADC Reference Voltage


### PR DESCRIPTION
### Description

- Add MKS TinyBee silkscreen labels based on the [TinyBee pins diagram](https://github.com/makerbase-mks/MKS-TinyBee/blob/main/hardware/MKS%20TinyBee%20V1.0_003/MKS%20TinyBee%20V1.0_003%20PIN.pdf)
- Some minor cleanup

### Related Issues

None. Found while helping someone in the Marlin Firmware group on Facebook.
