### PR TITLE
🧑‍💻 Fix RLE script for infille == outfile

### DIFF
--- a/buildroot/share/scripts/rle_compress_bitmap.py
+++ b/buildroot/share/scripts/rle_compress_bitmap.py
@@ -10,6 +10,8 @@ import sys,struct
 import re
 
 def addCompressedData(input_file, output_file):
+    input_lines = input_file.readlines()
+    input_file.close()
     ofile = open(output_file, 'wt')
 
     datatype = "uint8_t"
@@ -18,8 +20,7 @@ def addCompressedData(input_file, output_file):
     arrname = ''
 
     c_data_section = False ; c_skip_data = False ; c_footer = False
-    while True:
-        line = input_file.readline()
+    for line in input_lines:
         if not line: break
 
         if not c_footer:
@@ -55,8 +56,6 @@ def addCompressedData(input_file, output_file):
                 c_data_section = True
                 arrname = line.split('[')[0].split(' ')[-1]
                 print("Found data array", arrname)
-
-    input_file.close()
 
     #print("\nRaw Bitmap Data", raw_data)
 
@@ -190,11 +189,11 @@ if len(sys.argv) <= 2:
     print('Usage: rle_compress_bitmap.py INPUT_FILE OUTPUT_FILE')
     exit(1)
 
-output_cpp = sys.argv[2]
+output_h = sys.argv[2]
 inname = sys.argv[1].replace('//', '/')
 try:
-    input_cpp = open(inname)
+    input_h = open(inname)
     print("Processing", inname, "...")
-    addCompressedData(input_cpp, output_cpp)
+    addCompressedData(input_h, output_h)
 except OSError:
     print("Can't find input file", inname)


### PR DESCRIPTION
### Description

A well known user tried using this script using the following example command line 
```
rle_compress_bitmap.py _Bootscreen.h _Bootscreen.h 
```
Due to the script opening the output file before the input file was fully read, this results in the contents of the input file being lost.

Now I could have just added a simple check to make sure the input and output file names where different but that is not the thinkyhead way.   

So I updated the code to allow for the same input and output file name by reading the entire input file into a list and then closing it before opening the output file.  

I also renamed references to _cpp in variable names to _h, since the input file is a .h not a .cpp 

### Requirements

A desire to use rle_compress_bitmap.py without creating an additional file 

### Benefits

Script works as expected for this use case.

### Related Issues

<li>MarlinFirmware/Configurations/pull/1019</li>