### PR TITLE
Fix bed leveling issues

### DIFF
--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -63,7 +63,7 @@
      */
     void mesh_bed_leveling::line_to_destination(const_feedRate_t scaled_fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
       // Get current and destination cells for this line
-      xy_int8_t scel = cell_indexes(current_position), ecel = cell_indexes(destination);
+      xy_uint8_t scel = cell_indexes(current_position), ecel = cell_indexes(destination);
       NOMORE(scel.x, GRID_MAX_CELLS_X - 1);
       NOMORE(scel.y, GRID_MAX_CELLS_Y - 1);
       NOMORE(ecel.x, GRID_MAX_CELLS_X - 1);
@@ -80,7 +80,7 @@
 
       float normalized_dist;
       xyze_pos_t dest;
-      const int8_t gcx = _MAX(scel.x, ecel.x), gcy = _MAX(scel.y, ecel.y);
+      const uint8_t gcx = _MAX(scel.x, ecel.x), gcy = _MAX(scel.y, ecel.y);
 
       // Crosses on the X and not already split on this X?
       // The x_splits flags are insurance against rounding errors.

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -256,7 +256,7 @@
 
     icell += ineg;
 
-    while (cnt.x || cnt.y) {
+    while (cnt) {
 
       const float next_mesh_line_x = get_mesh_x(icell.x + iadd.x),
                   next_mesh_line_y = get_mesh_y(icell.y + iadd.y);

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -256,7 +256,7 @@
 
     icell += ineg;
 
-    while (cnt) {
+    while (cnt.x || cnt.y) {
 
       const float next_mesh_line_x = get_mesh_x(icell.x + iadd.x),
                   next_mesh_line_y = get_mesh_y(icell.y + iadd.y);


### PR DESCRIPTION
### Description

Two bugs

1) a while loop in line_to_destination_cartesian can loop forever.
Code has `while (cnt)`  but variable cnt is a structure with a X and a Y component. This while does not end.
~~Replaced with `while (cnt.x || cnt.y)~~ now addressed by https://github.com/MarlinFirmware/Marlin/pull/26936

2) After https://github.com/MarlinFirmware/Marlin/commit/ba08dcfb76804a912380603b3f69831ea0d1d6eb
MESH_BED_LEVELING with SEGMENT_LEVELED_MOVES disabled fails to build.
Updated variable types to be unsigned.

### Requirements

Bed leveling (UBL or MESH) with SEGMENT_LEVELED_MOVES disabled

### Benefits

Works as expected

### Related Issues
<li>MarlinFirmware/Marlin/issues/26816
<li>MarlinFirmware/Marlin/issues/26718