### PR TITLE
Disable nonlinear extrusion on unretract

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2458,11 +2458,7 @@ bool Planner::_populate_block(
   #if ENABLED(LIN_ADVANCE)
     bool use_advance_lead = false;
   #endif
-  if (true NUM_AXIS_GANG(
-      && !block->steps.a, && !block->steps.b, && !block->steps.c,
-      && !block->steps.i, && !block->steps.j, && !block->steps.k,
-      && !block->steps.u, && !block->steps.v, && !block->steps.w)
-  ) {                                                             // Is this a retract / recover move?
+  if (!ANY_AXIS_MOVES(block)) {                                   // Is this a retract / recover move?
     accel = CEIL(settings.retract_acceleration * steps_per_mm);   // Convert to: acceleration steps/sec^2
   }
   else {

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1123,4 +1123,10 @@ class Planner {
 
 #define PLANNER_XY_FEEDRATE() _MIN(planner.settings.max_feedrate_mm_s[X_AXIS], planner.settings.max_feedrate_mm_s[Y_AXIS])
 
+#define ANY_AXIS_MOVES(BLOCK)  \
+  (false NUM_AXIS_GANG(        \
+  || BLOCK->steps.a, || BLOCK->steps.b, || BLOCK->steps.c, \
+  || BLOCK->steps.i, || BLOCK->steps.j, || BLOCK->steps.k, \
+  || BLOCK->steps.u, || BLOCK->steps.v, || BLOCK->steps.w))
+
 extern Planner planner;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2739,7 +2739,11 @@ hal_timer_t Stepper::block_phase_isr() {
         ne_edividend = advance_dividend.e;
         const float scale = (float(ne_edividend) / advance_divisor) * planner.mm_per_step[E_AXIS_N(current_block->extruder)];
         ne_scale = (1L << 24) * scale;
-        if (current_block->direction_bits.e) {
+        if (current_block->direction_bits.e && 
+            (false NUM_AXIS_GANG(
+            || current_block->steps.a, || current_block->steps.b, || current_block->steps.c,
+            || current_block->steps.i, || current_block->steps.j, || current_block->steps.k,
+            || current_block->steps.u, || current_block->steps.v, || current_block->steps.w))) {
           ne_fix.A = (1L << 24) * ne.A;
           ne_fix.B = (1L << 24) * ne.B;
           ne_fix.C = (1L << 24) * ne.C;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2739,11 +2739,7 @@ hal_timer_t Stepper::block_phase_isr() {
         ne_edividend = advance_dividend.e;
         const float scale = (float(ne_edividend) / advance_divisor) * planner.mm_per_step[E_AXIS_N(current_block->extruder)];
         ne_scale = (1L << 24) * scale;
-        if (current_block->direction_bits.e && 
-            (false NUM_AXIS_GANG(
-            || current_block->steps.a, || current_block->steps.b, || current_block->steps.c,
-            || current_block->steps.i, || current_block->steps.j, || current_block->steps.k,
-            || current_block->steps.u, || current_block->steps.v, || current_block->steps.w))) {
+        if (current_block->direction_bits.e && ANY_AXIS_MOVES(current_block)) {
           ne_fix.A = (1L << 24) * ne.A;
           ne_fix.B = (1L << 24) * ne.B;
           ne_fix.C = (1L << 24) * ne.C;


### PR DESCRIPTION
Resolves #26808

Don't use nonlinear extraction on untertracts to prevent blobs at the line start, use only when any axis is moving.