### PR TITLE
For a SKR Mini E3 V3.0 make UART 5 available on PD2 and PD3

### DIFF
--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -57,7 +57,7 @@ board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
 build_flags                 = ${stm32_variant.build_flags}
                               -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
-                              -DPIN_SERIAL5_TX=PD_3 -DPIN_SERIAL5_RX=PD_2
+                              -DPIN_SERIAL5_RX=PD_2 -DPIN_SERIAL5_TX=PD_3
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -57,6 +57,7 @@ board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
 build_flags                 = ${stm32_variant.build_flags}
                               -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
+                              -DPIN_SERIAL5_TX=PD_3 -DPIN_SERIAL5_RX=PD_2
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
                               -DSTEP_TIMER_IRQ_PRIO=0


### PR DESCRIPTION
### Description

A discord user tommat6117 wanted to connect octoprint via serial to their SKR Mini E3 V3.0 (not via USB)  
I'm guessing that they have a BTT TFT so the TFT serial port and the serial port on EXP1 are not available, leaving no documented options.

At first they wanted software serial on any of the IO pins (PD0,PD2,PD3,PD4,PD5)
I pointed out that software serial was a bad idea, and Marlin doesn't support software serial ports for standard gcode serial ports.

After a little digging I noticed that hardware UART 5 can be configured to be on PD2 (RX) and PD3 (TX) 

The current build environment sets up UART 5 pins as PD2 (RX)  and PC12 (TX), PC12 being the POWER_LOSS_PIN on  the PWR-DET plug.

Updated the build environment STM32G0B1RE_btt
with -DPIN_SERIAL5_RX=PD_2 -DPIN_SERIAL5_TX=PD_3
 
So now any user can use UART 5 on PD2, PD3 easily

### Requirements

A desire to use UART 5

### Benefits

UART 5 works "out of the box"

### Related Issues
https://discord.com/channels/461605380783472640/491165528295997450/1211624259332612126 