### PR TITLE
Simplify EMIT_CREALITY_422_WARNING

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -683,7 +683,7 @@
 
 #if ENABLED(EMIT_CREALITY_422_WARNING) && DISABLED(NO_CREALITY_422_DRIVER_WARNING)
   // Driver labels: A=TMC2208, B=TMC2209, C=HR4988, E=A4988, H=TMC2225, H8=HR4988
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (A or H: Use TMC2208_STANDALONE / B: Use TMC2209_STANDALONE / C, E, or H8: Use A4988). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (A/H: TMC2208_STANDALONE  B: TMC2209_STANDALONE  C/E/H8: A4988). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
 #if ENABLED(PRINTCOUNTER_SYNC)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -682,7 +682,8 @@
 #endif
 
 #if ENABLED(EMIT_CREALITY_422_WARNING) && DISABLED(NO_CREALITY_422_DRIVER_WARNING)
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988 (Use A4988), E=A4988, A=TMC2208 (Use TMC2208_STANDALONE), B=TMC2209 (Use TMC2209_STANDALONE), H=TMC2225 (Use TMC2208_STANDALONE), H8=HR4988 (Use A4988)). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
+  // Driver labels: A=TMC2208, B=TMC2209, C=HR4988, E=A4988, H=TMC2225, H8=HR4988
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (A or H: Use TMC2208_STANDALONE / B: Use TMC2209_STANDALONE / C, E, or H8: Use A4988). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
 #if ENABLED(PRINTCOUNTER_SYNC)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -682,7 +682,7 @@
 #endif
 
 #if ENABLED(EMIT_CREALITY_422_WARNING) && DISABLED(NO_CREALITY_422_DRIVER_WARNING)
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988 (A4988), E=A4988, A=TMC2208 (TMC2208_STANDALONE), B=TMC2209 (TMC2209_STANDALONE), H=TMC2225 (TMC2208_STANDALONE), H8=HR4988 (A4988)). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988 (Use A4988), E=A4988, A=TMC2208 (Use TMC2208_STANDALONE), B=TMC2209 (Use TMC2209_STANDALONE), H=TMC2225 (Use TMC2208_STANDALONE), H8=HR4988 (Use A4988)). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
 #if ENABLED(PRINTCOUNTER_SYNC)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -682,7 +682,7 @@
 #endif
 
 #if ENABLED(EMIT_CREALITY_422_WARNING) && DISABLED(NO_CREALITY_422_DRIVER_WARNING)
-  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988, E=A4988, A=TMC2208, B=TMC2209, H=TMC2225, H8=HR4988). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
+  #warning "Creality 4.2.2 boards come with a variety of stepper drivers. Check the board label (typically on SD Card module) and set the correct *_DRIVER_TYPE! (C=HR4988 (A4988), E=A4988, A=TMC2208 (TMC2208_STANDALONE), B=TMC2209 (TMC2209_STANDALONE), H=TMC2225 (TMC2208_STANDALONE), H8=HR4988 (A4988)). (Define NO_CREALITY_422_DRIVER_WARNING to suppress this warning.)"
 #endif
 
 #if ENABLED(PRINTCOUNTER_SYNC)


### PR DESCRIPTION
### Description

Add hints for `*_DRIVER_TYPE`s. h/t to @ellensp for the suggestion to simplify the warning further.

### Requirements

Creality 4.2.2 motherboard

### Benefits

Clearer hint for which `*_DRIVER_TYPE`s to define.

### Related Issues

I don't have a specific issue number, but I've seen this come up on Facebook/Discord/Reddit a lot.
