### PR TITLE
fix reading rle bmp data from pgm on avr

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -140,7 +140,7 @@ bool MarlinUI::detected() { return true; }
         uint8_t *dst = (uint8_t*)bmp;
 
         auto rle_nybble = [&](const uint16_t i) -> uint8_t {
-          const uint8_t b = bmp_rle[i / 2];
+          const uint8_t b = pgm_read_byte(&bmp_rle[i / 2]);
           return (i & 1 ? b & 0xF : b >> 4);
         };
 


### PR DESCRIPTION
### Description

COMPACT_CUSTOM_BOOTSCREEN does not work on 8 bit AVR machines
The data custom_start_bmp_rle is stored in PROGMEM, but it was being read out of standard memory,

![IMG_0290](https://github.com/MarlinFirmware/Marlin/assets/530024/e2d2770d-2b77-407f-a420-3c74aa482547)


Updated to use pgm_read_byte so it is read out of PROGMEM on AVR's

### Requirements

SHOW_CUSTOM_BOOTSCREEN with COMPACT_CUSTOM_BOOTSCREEN on a AVR controller
With a appropriately created _Bootscreen.h with custom_start_bmp_rle data.

### Benefits

Works as expected

### Related Issues
<li>MarlinFirmware/Marlin/pull/26419</li>

https://discord.com/channels/461605380783472640/491165528295997450/1212235657930350622
