### PR TITLE
🩹 Fix MCU check for STM32H7-based BTT Octopus Pro V1

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+// The Octopus Pro V1 has shipped with both STM32F4 and STM32H7 MCUs.
+// Ensure the correct env_validate.h file is included based on the build environment used.
 #if NOT_TARGET(STM32H7)
   #include "env_validate.h"
 #else

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -21,7 +21,11 @@
  */
 #pragma once
 
-#include "env_validate.h"
+#if NOT_TARGET(STM32H7)
+  #include "env_validate.h"
+#else
+  #include "../stm32h7/env_validate.h"
+#endif
 
 #define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 #define USES_DIAG_JUMPERS


### PR DESCRIPTION
### Description

Due to our use of [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) in the pins files, there needs to be an additional target check in `pins_BTT_OCTOPUS_V1_common.h` for the `env_validate.h` include since Octopus Pro V1 ships with both STM32F4 & STM32H7 MCUs.

_Note: I tried another method by removing the `env_validate.h` includes in both the Octopus board common files and defining them in individual pins files, but there are still nested pin includes that that end up failing due to mismatched MCUs._

### Requirements

STM32H7-based BTT Octopus Pro V1

### Benefits

STM32H7-based BTT Octopus Pro V1 configs will build

### Related Issues

- #26830
