### PR TITLE
🩹 Fix active extruder indicator

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -323,7 +323,7 @@ FORCE_INLINE void _draw_centered_temp(const celsius_t temp, const uint8_t tx, co
 
       } // PAGE_CONTAINS
 
-      #if HAS_MULTI_EXTRUDER && NONE(SLIM_LCD_MENUS, STATUS_HOTEND_NUMBERLESS)
+      #if HAS_MULTI_EXTRUDER && NONE(SLIM_LCD_MENUS, STATUS_HOTEND_NUMBERLESS, SINGLENOZZLE)
         if (active_extruder == heater_id)
           u8g.drawBitmapP(_MAX(0, STATUS_HOTEND_X(heater_id) - 6), STATUS_HEATERS_Y + 3, 1, 5, status_active_extruder_indicator_bmp);
       #endif

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -323,7 +323,7 @@ FORCE_INLINE void _draw_centered_temp(const celsius_t temp, const uint8_t tx, co
 
       } // PAGE_CONTAINS
 
-      #if HAS_MULTI_EXTRUDER && DISABLED(SLIM_LCD_MENUS)
+      #if HAS_MULTI_EXTRUDER && NONE(SLIM_LCD_MENUS, STATUS_HOTEND_NUMBERLESS)
         if (active_extruder == heater_id)
           u8g.drawBitmapP(_MAX(0, STATUS_HOTEND_X(heater_id) - 6), STATUS_HEATERS_Y + 3, 1, 5, status_active_extruder_indicator_bmp);
       #endif


### PR DESCRIPTION
### Description

Exclude `STATUS_HOTEND_NUMBERLESS` & `SINGLENOZZLE` for active extruder indicator feature.

### Requirements

Multi-extruder setup with a DOGM display

### Benefits

DOGM display-based configs with `STATUS_HOTEND_NUMBERLESS` or `SINGLENOZZLE` enabled will compile.

### Configurations

Any DOGM display-based config with `STATUS_HOTEND_NUMBERLESS` or `SINGLENOZZLE` or [config.zip](https://github.com/MarlinFirmware/Marlin/files/14470594/config.zip) + [pins.zip](https://github.com/MarlinFirmware/Marlin/files/14470612/Pins.zip) from #26833

### Related Issues

- #26893
- #26833
- #26152
