### PR TITLE
🔧 Assert TMC slave addresses, minor pins cleanup

### DIFF
--- a/Marlin/src/pins/gd32f1/pins_SOVOL_V131.h
+++ b/Marlin/src/pins/gd32f1/pins_SOVOL_V131.h
@@ -62,6 +62,24 @@
   #define E0_SERIAL_TX_PIN                  PC14
   #define E0_SERIAL_RX_PIN                  PC14
 
+  // Default TMC slave addresses
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS                    3
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS                    3
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS                    3
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS                   3
+  #endif
+  static_assert(X_SLAVE_ADDRESS == 3, "X_SLAVE_ADDRESS must be 3 for BOARD_SOVOL_V131.");
+  static_assert(Y_SLAVE_ADDRESS == 3, "Y_SLAVE_ADDRESS must be 3 for BOARD_SOVOL_V131.");
+  static_assert(Z_SLAVE_ADDRESS == 3, "Z_SLAVE_ADDRESS must be 3 for BOARD_SOVOL_V131.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_SOVOL_V131.");
+
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE
     #define TMC_BAUD_RATE                  19200

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -569,9 +569,15 @@
 
 #if HAS_TMC_UART
   /**
-   * Address for the UART Configuration of the TMC2209. Override in Configuration files.
-   * To test TMC2209 Steppers enable TMC_DEBUG in Configuration_adv.h and test the M122 command with voltage on the steppers.
+   * TMC2208/TMC2209 stepper drivers
+   *  It seems to work perfectly fine on Software Serial, if an advanced user wants to test, you could use the SAMD51 Serial1 and Serial 2. Be careful with the Sercom configurations.
    */
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS                 0b00
   #endif
@@ -584,18 +590,15 @@
   #ifndef E0_SLAVE_ADDRESS
     #define E0_SLAVE_ADDRESS                0b11
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_BRICOLEMON_LITE_V1_0.");
 
-  /**
-   * TMC2208/TMC2209 stepper drivers
-   *  It seems to work perfectly fine on Software Serial, if an advanced user wants to test, you could use the SAMD51 Serial1 and Serial 2. Be careful with the Sercom configurations.
-   */
-  //#define X_HARDWARE_SERIAL  Serial1
-  //#define Y_HARDWARE_SERIAL  Serial1
-  //#define Z_HARDWARE_SERIAL  Serial1
-  //#define E0_HARDWARE_SERIAL Serial1
-
-  // This is the stable default value after testing, but, higher UART rates could be configured, remeber to test the Steppers with the M122 command to check if everything works.
-  #define TMC_BAUD_RATE 250000
+  // Reduce baud rate to improve software serial reliability
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200 // 250000
+  #endif
 
   //
   // Software serial

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -620,11 +620,19 @@
 #endif
 
 #if HAS_TMC_UART
-
   /**
-   * Address for the UART Configuration of the TMC2209. Override in Configuration files.
-   * To test TMC2209 Steppers enable TMC_DEBUG in Configuration_adv.h and test the M122 command with voltage on the steppers.
+   * TMC2208/TMC2209 stepper drivers
+   *  It seems to work perfectly fine on Software Serial, if an advanced user wants to test, you could use the SAMD51 Serial1 and Serial 2. Be careful with the Sercom configurations.
+   *  Steppers 1,2,3,4 (X,Y,Z,E0) are on the Serial1, Sercom (RX = 0, TX = 1), extra stepper 5 (E1 or any axis you want) is on Serial2, Sercom (RX = 17, TX = 16)
    */
+
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial2
+
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS                 0b00
   #endif
@@ -640,20 +648,16 @@
   #ifndef E1_SLAVE_ADDRESS
     #define E1_SLAVE_ADDRESS                0b00
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(E1_SLAVE_ADDRESS == 0b00, "E1_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_V1_0.");
 
-  /**
-   * TMC2208/TMC2209 stepper drivers
-   *  It seems to work perfectly fine on Software Serial, if an advanced user wants to test, you could use the SAMD51 Serial1 and Serial 2. Be careful with the Sercom configurations.
-   *  Steppers 1,2,3,4 (X,Y,Z,E0) are on the Serial1, Sercom (RX = 0, TX = 1), extra stepper 5 (E1 or any axis you want) is on Serial2, Sercom (RX = 17, TX = 16)
-   */
-
-  //#define X_HARDWARE_SERIAL  Serial1
-  //#define Y_HARDWARE_SERIAL  Serial1
-  //#define Z_HARDWARE_SERIAL  Serial1
-  //#define E0_HARDWARE_SERIAL Serial1
-  //#define E1_HARDWARE_SERIAL Serial2
-
-  #define TMC_BAUD_RATE 250000
+  // Reduce baud rate to improve software serial reliability
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200 // 250000
+  #endif
 
   //
   // Software serial

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -497,11 +497,19 @@
 #define SD_DETECT_PIN                         22
 
 #if HAS_TMC_UART
-
   /**
-   * TMC2209 UART Address. Override in Configuration files.
-   * To test TMC2209 Steppers enable TMC_DEBUG and test M122 with voltage on the steppers.
+   * TMC2208/TMC2209 stepper drivers
+   * Seems to work fine with Software Serial. If you want to test, use SAMD51 Serial1 and Serial2. Be careful with the Sercom configurations.
+   * Steppers 1,2,3,4 (X,Y,Z,E0) are on Serial1, Sercom (RX=0, TX=1), extra stepper 5 (E1 or any axis you want) is on Serial2, Sercom (RX=17, TX=16)
    */
+
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial2
+
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS                 0b00
   #endif
@@ -517,20 +525,16 @@
   #ifndef E1_SLAVE_ADDRESS
     #define E1_SLAVE_ADDRESS                0b00
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_MINITRONICS20.");
+  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_MINITRONICS20.");
+  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_MINITRONICS20.");
+  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_MINITRONICS20.");
+  static_assert(E1_SLAVE_ADDRESS == 0b00, "E1_SLAVE_ADDRESS must be 0b00 for BOARD_MINITRONICS20.");
 
-  /**
-   * TMC2208/TMC2209 stepper drivers
-   * Seems to work fine with Software Serial. If you want to test, use SAMD51 Serial1 and Serial2. Be careful with the Sercom configurations.
-   * Steppers 1,2,3,4 (X,Y,Z,E0) are on Serial1, Sercom (RX=0, TX=1), extra stepper 5 (E1 or any axis you want) is on Serial2, Sercom (RX=17, TX=16)
-   */
-
-  //#define X_HARDWARE_SERIAL  Serial1
-  //#define Y_HARDWARE_SERIAL  Serial1
-  //#define Z_HARDWARE_SERIAL  Serial1
-  //#define E0_HARDWARE_SERIAL Serial1
-  //#define E1_HARDWARE_SERIAL Serial2
-
-  #define TMC_BAUD_RATE 250000
+  // Reduce baud rate to improve software serial reliability
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200 // 250000
+  #endif
 
   //
   // Software serial

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -25,8 +25,9 @@
  * BigTreeTech SKR CR-6 (STM32F103RET6) board pin assignments
  */
 
-#define DEFAULT_MACHINE_NAME "Creality3D"
+#define DEFAULT_MACHINE_NAME "Creality CR-6 SE"
 #define BOARD_INFO_NAME "BTT SKR CR-6"
+#define BOARD_WEBSITE_URL "github.com/bigtreetech/BIGTREETECH-SKR-CR6"
 
 #include "env_validate.h"
 
@@ -145,17 +146,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BTT_SKR_CR6.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_BTT_SKR_CR6.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_BTT_SKR_CR6.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BTT_SKR_CR6.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
@@ -24,6 +24,7 @@
 #include "pins_BTT_SKR_MINI_E3_common.h"
 
 #define BOARD_INFO_NAME "BTT SKR Mini E3 V1.0"
+#define BOARD_WEBSITE_URL "github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/tree/master/hardware/BIGTREETECH-SKR-mini-E3%20V1.0"
 
 /**
  * TMC220x stepper drivers
@@ -37,15 +38,19 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  2
+    #define Y_SLAVE_ADDRESS                    2
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  1
+    #define Z_SLAVE_ADDRESS                    1
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BTT_SKR_MINI_E3_V1_0.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_BTT_SKR_MINI_E3_V1_0.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_BTT_SKR_MINI_E3_V1_0.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BTT_SKR_MINI_E3_V1_0.");
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -95,17 +95,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  2
+    #define Y_SLAVE_ADDRESS                    2
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  1
+    #define Z_SLAVE_ADDRESS                    1
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_SKR_MINI_E3_V2_0.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_SKR_MINI_E3_V2_0.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_SKR_MINI_E3_V2_0.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_SKR_MINI_E3_V2_0.");
 #endif
 
 // Pins for documentation and sanity checks only.

--- a/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
@@ -135,6 +135,8 @@
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
+
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS                    2
   #endif
@@ -147,6 +149,10 @@
   #ifndef E0_SLAVE_ADDRESS
     #define E0_SLAVE_ADDRESS                   0
   #endif
+  static_assert(X_SLAVE_ADDRESS == 2, "X_SLAVE_ADDRESS must be 2 for BOARD_ERYONE_ERY32_MINI.");
+  static_assert(Y_SLAVE_ADDRESS == 3, "Y_SLAVE_ADDRESS must be 3 for BOARD_ERYONE_ERY32_MINI.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_ERYONE_ERY32_MINI.");
+  static_assert(E0_SLAVE_ADDRESS == 0, "E0_SLAVE_ADDRESS must be 0 for BOARD_ERYONE_ERY32_MINI.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -24,13 +24,13 @@
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME   "FYSETC AIO II"
-#define BOARD_WEBSITE_URL "fysetc.com"
+#define BOARD_WEBSITE_URL "github.com/FYSETC/FYSETC-AIO_II"
 
 #define BOARD_NO_NATIVE_USB
 #define RESET_STEPPERS_ON_MEDIA_INSERT
 #define DISABLE_JTAG
 
-#define pins_v2_20190128                          // new pins define
+#define PINS_V2_20190128                          // new pins define
 
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
@@ -55,7 +55,7 @@
 //
 // Filament runout
 //
-#ifdef pins_v2_20190128
+#ifdef PINS_V2_20190128
   #define FIL_RUNOUT_PIN                    PB15
 #else
   #define FIL_RUNOUT_PIN                    PB5
@@ -69,7 +69,7 @@
 #define X_ENABLE_PIN                        PA8
 
 #define Y_STEP_PIN                          PB2
-#ifdef pins_v2_20190128
+#ifdef PINS_V2_20190128
   #define Y_DIR_PIN                         PB3
 #else
   #define Y_DIR_PIN                         PB0
@@ -97,20 +97,22 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_FYSETC_AIO_II.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_FYSETC_AIO_II.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_FYSETC_AIO_II.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_FYSETC_AIO_II.");
 
-  // The 4xTMC2209 module doesn't have a serial multiplexer and
-  // needs to set *_SLAVE_ADDRESS in Configuration_adv.h for X,Y,Z,E0
   #if HAS_DRIVER(TMC2208)
     #define TMC_SERIAL_MULTIPLEXER
     #define SERIAL_MUL_PIN1                 PB13
@@ -162,7 +164,7 @@
   #if HAS_MARLINUI_U8GLIB
 
     #define DOGLCD_A0                       PA15
-    #ifdef pins_v2_20190128
+    #ifdef PINS_V2_20190128
       #define DOGLCD_CS                     PB5
     #else
       #define DOGLCD_CS                     PB7
@@ -183,7 +185,7 @@
     #define BTN_ENC                         PC12
   #endif
 
-  #ifdef pins_v2_20190128
+  #ifdef PINS_V2_20190128
     #define LCD_RESET_PIN                   PB4
     #ifndef RGB_LED_R_PIN
       #define RGB_LED_R_PIN                 PB0

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
@@ -23,10 +23,8 @@
 
 #include "env_validate.h"
 
-#define DEFAULT_MACHINE_NAME "3D Printer"
-
 #define BOARD_INFO_NAME   "FYSETC Cheetah"
-#define BOARD_WEBSITE_URL "fysetc.com"
+#define BOARD_WEBSITE_URL "github.com/FYSETC/FYSETC-Cheetah"
 
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
@@ -86,17 +84,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_FYSETC_CHEETAH.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_FYSETC_CHEETAH.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_FYSETC_CHEETAH.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_FYSETC_CHEETAH.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h
@@ -140,6 +140,10 @@
   #ifndef E0_SLAVE_ADDRESS
     #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BTT_SKR_MINI_E3_V3_0_1.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_BTT_SKR_MINI_E3_V3_0_1.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_BTT_SKR_MINI_E3_V3_0_1.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BTT_SKR_MINI_E3_V3_0_1.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTXXC10.h
@@ -153,18 +153,23 @@
   #define Z_HARDWARE_SERIAL  X_HARDWARE_SERIAL
   #define E0_HARDWARE_SERIAL X_HARDWARE_SERIAL
 
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS                   0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS                   1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS                   2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS                  3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_CREALITY_CR4NTXXC10.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_CREALITY_CR4NTXXC10.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_CREALITY_CR4NTXXC10.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_CREALITY_CR4NTXXC10.");
 
   // Software serial
 

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V20.h
@@ -23,10 +23,8 @@
 
 #include "env_validate.h"
 
-#define DEFAULT_MACHINE_NAME "3D Printer"
-
 #define BOARD_INFO_NAME   "FYSETC Cheetah V2.0"
-#define BOARD_WEBSITE_URL "fysetc.com"
+#define BOARD_WEBSITE_URL "github.com/FYSETC/FYSETC-Cheetah-v2"
 
 // USB Flash Drive support
 //#define HAS_OTG_USB_HOST_SUPPORT
@@ -94,17 +92,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  2
+    #define Y_SLAVE_ADDRESS                    2
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  1
+    #define Z_SLAVE_ADDRESS                    1
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_FYSETC_CHEETAH_V20.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_FYSETC_CHEETAH_V20.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_FYSETC_CHEETAH_V20.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_FYSETC_CHEETAH_V20.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V30.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V30.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME   "FYSETC Cheetah V3.0"
-#define BOARD_WEBSITE_URL "fysetc.com"
+#define BOARD_WEBSITE_URL "github.com/FYSETC/Cheetah_V3.0"
 
 // USB Flash Drive support
 //#define HAS_OTG_USB_HOST_SUPPORT
@@ -41,12 +41,12 @@
 //
 // Z Probe
 //
-//#if ENABLED(BLTOUCH)
-//  #error "You need to set jumper to 5V for BLTouch, then comment out this line to proceed."
-//  #define SERVO0_PIN                      PA0
-//#elif !defined(Z_MIN_PROBE_PIN)
-//  #define Z_MIN_PROBE_PIN                 PA0
-//#endif
+#if ENABLED(BLTOUCH)
+  #error "You need to set jumper to 5V for BLTouch, then comment out this line to proceed."
+  #define SERVO0_PIN                        PA0   // PROBE
+#elif !defined(Z_MIN_PROBE_PIN)
+  #define Z_MIN_PROBE_PIN                   PA0
+#endif
 
 //
 // Limit Switches
@@ -55,17 +55,10 @@
 #define Y_STOP_PIN                          PA3
 #define Z_STOP_PIN                          PC4
 
-#if 1
-#define TEST_IO1                            PA0   // PROBE
-#define TEST_IO2                            PA1   // FIL-D
-//#define TEST_IO3                          PA9
-//#define TEST_IO4                          PA10
-#endif
-
 //
 // Filament runout
 //
-//#define FIL_RUNOUT_PIN                    PA1
+#define FIL_RUNOUT_PIN                      PA1   // FIL-D
 
 //
 // Steppers
@@ -87,66 +80,61 @@
 #define E0_ENABLE_PIN                       PD2
 
 #if HAS_TMC_UART
- #if 1
-    #ifndef X_SERIAL_TX_PIN
-      #define X_SERIAL_TX_PIN               PB3
-    #endif
-    #ifndef X_SERIAL_RX_PIN
-      #define X_SERIAL_RX_PIN    X_SERIAL_TX_PIN
-    #endif
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial2
+  //#define Y_HARDWARE_SERIAL  Serial2
+  //#define Z_HARDWARE_SERIAL  Serial2
+  //#define E0_HARDWARE_SERIAL Serial2
 
-    #ifndef Y_SERIAL_TX_PIN
-      #define Y_SERIAL_TX_PIN               PB3
-    #endif
-    #ifndef Y_SERIAL_RX_PIN
-      #define Y_SERIAL_RX_PIN    Y_SERIAL_TX_PIN
-    #endif
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN                 PB3
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN      X_SERIAL_TX_PIN
+  #endif
 
-    #ifndef Z_SERIAL_TX_PIN
-      #define Z_SERIAL_TX_PIN               PB3
-    #endif
-    #ifndef Z_SERIAL_RX_PIN
-      #define Z_SERIAL_RX_PIN    Z_SERIAL_TX_PIN
-    #endif
-    #ifndef E0_SERIAL_TX_PIN
-      #define E0_SERIAL_TX_PIN              PB3
-    #endif
-    #ifndef E0_SERIAL_RX_PIN
-      #define E0_SERIAL_RX_PIN  E0_SERIAL_TX_PIN
-    #endif
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN                 PB3
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN      Y_SERIAL_TX_PIN
+  #endif
 
-    #ifndef X_SLAVE_ADDRESS
-      #define X_SLAVE_ADDRESS  0
-    #endif
-    #ifndef Y_SLAVE_ADDRESS
-      #define Y_SLAVE_ADDRESS  2
-    #endif
-    #ifndef Z_SLAVE_ADDRESS
-      #define Z_SLAVE_ADDRESS  1
-    #endif
-    #ifndef E0_SLAVE_ADDRESS
-      #define E0_SLAVE_ADDRESS 3
-    #endif
- #else
-  #define X_HARDWARE_SERIAL  Serial2
-  #define Y_HARDWARE_SERIAL  Serial2
-  #define Z_HARDWARE_SERIAL  Serial2
-  #define E0_HARDWARE_SERIAL Serial2
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN                 PB3
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN      Z_SERIAL_TX_PIN
+  #endif
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN                PB3
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN    E0_SERIAL_TX_PIN
+  #endif
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  2
+    #define Y_SLAVE_ADDRESS                    2
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  1
+    #define Z_SLAVE_ADDRESS                    1
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
- #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_FYSETC_CHEETAH_V30.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_FYSETC_CHEETAH_V30.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_FYSETC_CHEETAH_V30.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_FYSETC_CHEETAH_V30.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
@@ -134,17 +134,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_TH3D_EZBOARD_V2.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_TH3D_EZBOARD_V2.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_TH3D_EZBOARD_V2.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_TH3D_EZBOARD_V2.");
 
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE

--- a/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
@@ -34,6 +34,7 @@
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT EBB42 V1.1"
 #endif
+#define BOARD_WEBSITE_URL "github.com/bigtreetech/EBB/tree/master/EBB%20CAN%20V1.1%20(STM32G0B1)/EBB42%20CAN%20V1.1"
 
 //
 // EEPROM
@@ -105,8 +106,9 @@
 
   // Default TMC slave addresses
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 0b00
+    #define E0_SLAVE_ADDRESS               0b00
   #endif
+  static_assert(E0_SLAVE_ADDRESS == 0b00, "E0_SLAVE_ADDRESS must be 0b00 for BOARD_BTT_EBB42_V1_1.");
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -119,17 +119,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  2
+    #define Y_SLAVE_ADDRESS                    2
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  1
+    #define Z_SLAVE_ADDRESS                    1
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BTT_SKR_MINI_E3_V3_0.");
+  static_assert(Y_SLAVE_ADDRESS == 2, "Y_SLAVE_ADDRESS must be 2 for BOARD_BTT_SKR_MINI_E3_V3_0.");
+  static_assert(Z_SLAVE_ADDRESS == 1, "Z_SLAVE_ADDRESS must be 1 for BOARD_BTT_SKR_MINI_E3_V3_0.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BTT_SKR_MINI_E3_V3_0.");
 #endif
 
 //


### PR DESCRIPTION
### Description

Assert TMC slave addresses for boards with integrated TMC drivers at compile-time & some minor pins cleanup.

### Requirements

Any of the affected motherboards in this PR.

### Benefits

TMC slave addresses will be checked for validity at compile-time.

### Related Issues

None. Found while while helping someone on Discord who was following an incorrect tutorial.
