### PR TITLE
Fix M413 report output

### DIFF
--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -72,6 +72,7 @@ void GcodeSuite::M413_report(const bool forReplay/*=true*/) {
       , " B", recovery.bed_temp_threshold
     #endif
   );
+  SERIAL_ECHO(" ; ");
   serialprintln_onoff(recovery.enabled);
 }
 


### PR DESCRIPTION
Currently M413 report looks `M413 S1 B0ON`, this PR adds semicolon:

`M413 S1 B0 ; ON`