### PR TITLE
Fix M201 typos

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1270,11 +1270,11 @@
  * XY Frequency limit
  * Reduce resonance by limiting the frequency of small zigzag infill moves.
  * See https://hydraraptor.blogspot.com/2010/12/frequency-limit.html
- * Use M201 F<freq> G<min%> to change limits at runtime.
+ * Use M201 F<freq> S<min%> to change limits at runtime.
  */
 //#define XY_FREQUENCY_LIMIT      10 // (Hz) Maximum frequency of small zigzag infill moves. Set with M201 F<hertz>.
 #ifdef XY_FREQUENCY_LIMIT
-  #define XY_FREQUENCY_MIN_PERCENT 5 // (%) Minimum FR percentage to apply. Set with M201 G<min%>.
+  #define XY_FREQUENCY_MIN_PERCENT 5 // (%) Minimum FR percentage to apply. Set with M201 S<min%>.
 #endif
 
 //


### PR DESCRIPTION
### Description

Fix typos in comments in `Marlin/Configuration_adv.h`.

### Requirements

None. No code changes, only comment typos corrected.

See https://marlinfw.org/docs/gcode/M201.html and https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/Marlin/src/gcode/config/M200-M205.cpp#L124 for correct definitions in documentation and code.

### Benefits

Corrects the documentation for M201 S% (incorrectly shown as G%).

### Configurations

N/A

### Related Issues

- https://github.com/MarlinFirmware/Marlin/commit/41a469208afd14e3f804039291e0f2437b44aefc