### PR TITLE
Fix missing #undef

### DIFF
--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -116,6 +116,7 @@ void menu_info_thermistors() {
   #if TEMP_SENSOR_1 != 0
     #define THERMISTOR_ID TEMP_SENSOR_1
     #include "../thermistornames.h"
+    #undef THERMISTOR_ID
     THERM_ITEMS(STR_E1, HEATER_1, WATCH_HOTENDS);
   #endif
 

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -163,9 +163,9 @@ void menu_info_thermistors() {
   #endif
 
   #if HAS_HEATED_BED
-    #undef THERMISTOR_ID
     #define THERMISTOR_ID TEMP_SENSOR_BED
     #include "../thermistornames.h"
+    #undef THERMISTOR_ID
     THERM_ITEMS("BED", BED, WATCH_BED);
   #endif
 

--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -104,6 +104,10 @@
   #define THERMISTOR_NAME "100k Dagoma NTC"
 #elif THERMISTOR_ID == 18
   #define THERMISTOR_NAME "ATC Semitec 204GT-2"
+#elif THERMISTOR_ID == 22
+  #define THERMISTOR_NAME "GTM32 Pro vB (hotend)"
+#elif THERMISTOR_ID == 23
+  #define THERMISTOR_NAME "GTM32 Pro vB (bed)"
 #elif THERMISTOR_ID == 60
   #define THERMISTOR_NAME "Makers Tool"
 #elif THERMISTOR_ID == 70
@@ -156,6 +160,8 @@
   #define THERMISTOR_NAME "Dyze / TL 4.7M"
 #elif THERMISTOR_ID == 67
   #define THERMISTOR_NAME "SliceEng 450°C"
+#elif THERMISTOR_ID == 68
+  #define THERMISTOR_NAME "PT-100 + Dyze amp"
 
 // Dummies for dev testing
 #elif THERMISTOR_ID == 998


### PR DESCRIPTION
### Description

Assuming that this bit of code should be just like the other ones, there is one missing and one misplaced `#undef` in the code here.

### Requirements

None

### Benefits

Fixes potential bug with thermistor types for printers with:

* with more than two hotends and different thermistors on hotends 2/3; or 
* with two hotends and a heated chamber; or 
* with a heated bed and a heated chamber.

### Configurations

n/a

### Related Issues

None found.