### PR TITLE
✨ Add Dagoma D6 as found in DiscoUltimate v2 TMC

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -131,6 +131,7 @@
 #define BOARD_PXMALION_CORE_I3        1164  // Pxmalion Core I3
 #define BOARD_PANOWIN_CUTLASS         1165  // Panowin Cutlass (as found in the Panowin F1)
 #define BOARD_KODAMA_BARDO            1166  // Kodama Bardo V1.x (as found in the Kodama Trinus)
+#define BOARD_DAGOMA_D6               1167  // Dagoma D6
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -131,7 +131,7 @@
 #define BOARD_PXMALION_CORE_I3        1164  // Pxmalion Core I3
 #define BOARD_PANOWIN_CUTLASS         1165  // Panowin Cutlass (as found in the Panowin F1)
 #define BOARD_KODAMA_BARDO            1166  // Kodama Bardo V1.x (as found in the Kodama Trinus)
-#define BOARD_DAGOMA_D6               1167  // Dagoma D6
+#define BOARD_DAGOMA_D6               1167  // Dagoma D6 (as found in the Dagoma DiscoUltimate V2 TMC)
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -225,7 +225,7 @@
 #elif MB(DAGOMA_F5)
   #include "ramps/pins_DAGOMA_F5.h"                 // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_D6)
-  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:FYSETC_F6
+  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:mega2560ext
 #elif MB(FYSETC_F6_13)
   #include "ramps/pins_FYSETC_F6_13.h"              // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_14)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -225,7 +225,7 @@
 #elif MB(DAGOMA_F5)
   #include "ramps/pins_DAGOMA_F5.h"                 // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_D6)
-  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:mega2560
+  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_13)
   #include "ramps/pins_FYSETC_F6_13.h"              // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_14)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -224,6 +224,8 @@
   #include "ramps/pins_RAMPS_CREALITY.h"            // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_F5)
   #include "ramps/pins_DAGOMA_F5.h"                 // ATmega2560                           env:mega2560
+#elif MB(DAGOMA_D6)
+  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:mega2560
 #elif MB(FYSETC_F6_13)
   #include "ramps/pins_FYSETC_F6_13.h"              // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_14)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -225,7 +225,7 @@
 #elif MB(DAGOMA_F5)
   #include "ramps/pins_DAGOMA_F5.h"                 // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_D6)
-  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:mega2560ext
+  #include "ramps/pins_DAGOMA_D6.h"                 // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_13)
   #include "ramps/pins_FYSETC_F6_13.h"              // ATmega2560                           env:FYSETC_F6
 #elif MB(FYSETC_F6_14)

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -74,6 +74,34 @@
   #define Z_DIAG_PIN                          47
   #define E0_DIAG_PIN                         21
   #define E1_DIAG_PIN                         20
+
+    // Default TMC slave addresses
+  #ifdef X_SLAVE_ADDRESS
+    static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_DAGOMA_D6.");
+  #else
+    #define X_SLAVE_ADDRESS                    0
+  #endif
+  #ifdef Y_SLAVE_ADDRESS
+    static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_DAGOMA_D6.");
+  #else
+    #define Y_SLAVE_ADDRESS                    1
+  #endif
+  #ifdef Z_SLAVE_ADDRESS
+    static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_DAGOMA_D6.");
+  #else
+    #define Z_SLAVE_ADDRESS                    2
+  #endif
+  #ifdef E0_SLAVE_ADDRESS
+    static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_DAGOMA_D6.");
+  #else
+    #define E0_SLAVE_ADDRESS                   3
+  #endif
+  #ifdef E1_SLAVE_ADDRESS
+    static_assert(E1_SLAVE_ADDRESS == 3, "E1_SLAVE_ADDRESS must be 3 for BOARD_DAGOMA_D6.");
+  #else
+    #define E1_SLAVE_ADDRESS                   3
+  #endif
+
 #endif
 
 //

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Dagoma3D D6 supports only 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Dagoma3D D6 supports up to 2 hotends / E-steppers."
 #endif
 
 #define BOARD_INFO_NAME "Dagoma3D D6"

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -21,11 +21,19 @@
  */
 #pragma once
 
+#include "env_validate.h"
+
 #if HOTENDS > 2 || E_STEPPERS > 2
   #error "Dagoma3D D6 supports up to 2 hotends / E-steppers."
 #endif
 
 #define BOARD_INFO_NAME "Dagoma3D D6"
+
+#define X_DIAG_PIN                            43
+#define Y_DIAG_PIN                            41
+#define Z_DIAG_PIN                            47
+#define E0_DIAG_PIN                           21
+#define E1_DIAG_PIN                           20
 
 //
 // Endstops
@@ -46,7 +54,7 @@
   #define BOARD_ST7920_DELAY_3               250
 #endif
 
-#define KILL_PIN                            -1  // NC
+#define KILL_PIN                              -1  // NC
 
 #define LCD_CONTRAST_DEFAULT                 255
 
@@ -69,13 +77,7 @@
   #define E1_SERIAL_RX_PIN                    12
   #define E1_SERIAL_TX_PIN                    12
 
-  #define X_DIAG_PIN                          43
-  #define Y_DIAG_PIN                          41
-  #define Z_DIAG_PIN                          47
-  #define E0_DIAG_PIN                         21
-  #define E1_DIAG_PIN                         20
-
-    // Default TMC slave addresses
+  // Default TMC slave addresses
   #ifdef X_SLAVE_ADDRESS
     static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_DAGOMA_D6.");
   #else

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -27,6 +27,9 @@
 
 #define BOARD_INFO_NAME "Dagoma3D D6"
 
+//
+// Trinamic Stallguard pins
+//
 #define X_DIAG_PIN                            43
 #define Y_DIAG_PIN                            41
 #define Z_DIAG_PIN                            47
@@ -40,16 +43,27 @@
 #define Y_STOP_PIN                             3
 #define Z_STOP_PIN                            15
 
-#define FIL_RUNOUT_PIN                        39
-#if EXTRUDERS > 1
+//
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                      39
+#endif
+#if EXTRUDERS > 1 && !defined(FIL_RUNOUT2_PIN)
   #define FIL_RUNOUT2_PIN                     14
 #endif
 
 // Alter timing for graphical display
 #if IS_U8GLIB_ST7920
-  #define BOARD_ST7920_DELAY_1                 0
-  #define BOARD_ST7920_DELAY_2               250
-  #define BOARD_ST7920_DELAY_3               250
+  #ifndef BOARD_ST7920_DELAY_1
+    #define BOARD_ST7920_DELAY_1               0
+  #endif
+  #ifndef BOARD_ST7920_DELAY_2
+    #define BOARD_ST7920_DELAY_2             250
+  #endif
+  #ifndef BOARD_ST7920_DELAY_3
+    #define BOARD_ST7920_DELAY_3             250
+  #endif
 #endif
 
 #define KILL_PIN                              -1  // NC

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -21,8 +21,6 @@
  */
 #pragma once
 
-#include "env_validate.h"
-
 #if HOTENDS > 2 || E_STEPPERS > 2
   #error "Dagoma3D D6 supports up to 2 hotends / E-steppers."
 #endif

--- a/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_D6.h
@@ -1,0 +1,82 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "Dagoma3D D6 supports only 2 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_INFO_NAME "Dagoma3D D6"
+
+//
+// Endstops
+//
+#define X_STOP_PIN                             2
+#define Y_STOP_PIN                             3
+#define Z_STOP_PIN                            15
+
+#define FIL_RUNOUT_PIN                        39
+#if EXTRUDERS > 1
+  #define FIL_RUNOUT2_PIN                     14
+#endif
+
+// Alter timing for graphical display
+#if IS_U8GLIB_ST7920
+  #define BOARD_ST7920_DELAY_1                 0
+  #define BOARD_ST7920_DELAY_2               250
+  #define BOARD_ST7920_DELAY_3               250
+#endif
+
+#define KILL_PIN                            -1  // NC
+
+#define LCD_CONTRAST_DEFAULT                 255
+
+//
+// Sensorless homing DIAG pin is not directly connected to the MCU. Close
+// the jumper next to the limit switch socket when using sensorless homing.
+//
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   */
+  #define X_SERIAL_RX_PIN                     73
+  #define X_SERIAL_TX_PIN                     73
+  #define Y_SERIAL_RX_PIN                     73
+  #define Y_SERIAL_TX_PIN                     73
+  #define Z_SERIAL_RX_PIN                     73
+  #define Z_SERIAL_TX_PIN                     73
+  #define E0_SERIAL_RX_PIN                    73
+  #define E0_SERIAL_TX_PIN                    73
+  #define E1_SERIAL_RX_PIN                    12
+  #define E1_SERIAL_TX_PIN                    12
+
+  #define X_DIAG_PIN                          43
+  #define Y_DIAG_PIN                          41
+  #define Z_DIAG_PIN                          47
+  #define E0_DIAG_PIN                         21
+  #define E1_DIAG_PIN                         20
+#endif
+
+//
+// Import default RAMPS 1.4 pins
+//
+#include "pins_RAMPS.h"


### PR DESCRIPTION
### Description

Add the Dagoma3D D6 motherboard as used in their Disco Ultimate v2 TMC printer (and possibly other models).

![image](https://reprap.org/forum/thumbcache/537/54e/30a/481/a6b/f75/88f/514/674/a4f/d4_800x400.png)

### Requirements

Dagom3D D6 motherboard

### Benefits

Adds support for a new motherboard. 

### Configurations

Taken from the [Dagoma fork of Marlin DU_MC branch](https://github.com/dagoma3d/Marlin/blob/DU_MC/Marlin/Configuration.h) (where it is called FYSETC_DAGOMA_F5) and explicitly confirmed by Dagoma as being the D6 in response to a ticket I raised with them:

"the BOARD_FYSETC_DAGOMA_F5 is effectively the definition for the D6"

### Related Issues

No.