### PR TITLE
Fix minor INPUT_SHAPING config bugs

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1204,14 +1204,14 @@
 //#define INPUT_SHAPING_Y
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y)
   #if ENABLED(INPUT_SHAPING_X)
-    #define SHAPING_FREQ_X  40.00f      // (Hz) The default dominant resonant frequency on the X axis.
-    #define SHAPING_ZETA_X   0.15f      // Damping ratio of the X axis (range: 0.0 = no damping to 1.0 = critical damping).
+    #define SHAPING_FREQ_X  40.0        // (Hz) The default dominant resonant frequency on the X axis.
+    #define SHAPING_ZETA_X   0.15       // Damping ratio of the X axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
   #if ENABLED(INPUT_SHAPING_Y)
-    #define SHAPING_FREQ_Y  40.00f      // (Hz) The default dominant resonant frequency on the Y axis.
-    #define SHAPING_ZETA_Y   0.15f      // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
+    #define SHAPING_FREQ_Y  40.0        // (Hz) The default dominant resonant frequency on the Y axis.
+    #define SHAPING_ZETA_Y   0.15       // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
-  //#define SHAPING_MIN_FREQ  20        // By default the minimum of the shaping frequencies. Override to affect SRAM usage.
+  //#define SHAPING_MIN_FREQ  20.0      // By default the minimum of the shaping frequencies. Override to affect SRAM usage.
   //#define SHAPING_MAX_STEPRATE 10000  // By default the maximum total step rate of the shaped axes. Override to affect SRAM usage.
   //#define SHAPING_MENU                // Add a menu to the LCD to set shaping parameters.
 #endif

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1211,7 +1211,7 @@
     #define SHAPING_FREQ_Y  40.0        // (Hz) The default dominant resonant frequency on the Y axis.
     #define SHAPING_ZETA_Y   0.15       // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
-  //#define SHAPING_MIN_FREQ  20.0      // By default the minimum of the shaping frequencies. Override to affect SRAM usage.
+  //#define SHAPING_MIN_FREQ  20.0      // (Hz) By default the minimum of the shaping frequencies. Override to affect SRAM usage.
   //#define SHAPING_MAX_STEPRATE 10000  // By default the maximum total step rate of the shaped axes. Override to affect SRAM usage.
   //#define SHAPING_MENU                // Add a menu to the LCD to set shaping parameters.
 #endif

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1204,12 +1204,12 @@
 //#define INPUT_SHAPING_Y
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y)
   #if ENABLED(INPUT_SHAPING_X)
-    #define SHAPING_FREQ_X  40          // (Hz) The default dominant resonant frequency on the X axis.
-    #define SHAPING_ZETA_X  0.15f       // Damping ratio of the X axis (range: 0.0 = no damping to 1.0 = critical damping).
+    #define SHAPING_FREQ_X  40.00f      // (Hz) The default dominant resonant frequency on the X axis.
+    #define SHAPING_ZETA_X   0.15f      // Damping ratio of the X axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
   #if ENABLED(INPUT_SHAPING_Y)
-    #define SHAPING_FREQ_Y  40          // (Hz) The default dominant resonant frequency on the Y axis.
-    #define SHAPING_ZETA_Y  0.15f       // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
+    #define SHAPING_FREQ_Y  40.00f      // (Hz) The default dominant resonant frequency on the Y axis.
+    #define SHAPING_ZETA_Y   0.15f      // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
   //#define SHAPING_MIN_FREQ  20        // By default the minimum of the shaping frequencies. Override to affect SRAM usage.
   //#define SHAPING_MAX_STEPRATE 10000  // By default the maximum total step rate of the shaped axes. Override to affect SRAM usage.

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4202,8 +4202,8 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
     TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) == 0 || (SHAPING_FREQ_X) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_X must be >= SHAPING_MIN_FREQ."));
     TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) == 0 || (SHAPING_FREQ_Y) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_Y must be >= SHAPING_MIN_FREQ."));
   #else
-    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) >= 0, "SHAPING_FREQ_X must be >= 0."));
-    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) >= 0, "SHAPING_FREQ_Y must be >= 0."));
+    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) > 0, "SHAPING_FREQ_X must be > 0 or SHAPING_MIN_FREQ must be set."));
+    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) > 0, "SHAPING_FREQ_Y must be > 0 or SHAPING_MIN_FREQ must be set."));
   #endif
   #ifdef __AVR__
     #if ENABLED(INPUT_SHAPING_X)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4199,8 +4199,6 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 
   #ifdef SHAPING_MIN_FREQ
     static_assert((SHAPING_MIN_FREQ) > 0, "SHAPING_MIN_FREQ must be > 0.");
-    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) == 0 || (SHAPING_FREQ_X) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_X must be >= SHAPING_MIN_FREQ."));
-    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) == 0 || (SHAPING_FREQ_Y) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_Y must be >= SHAPING_MIN_FREQ."));
   #else
     TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) > 0, "SHAPING_FREQ_X must be > 0 or SHAPING_MIN_FREQ must be set."));
     TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) > 0, "SHAPING_FREQ_Y must be > 0 or SHAPING_MIN_FREQ must be set."));

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4199,9 +4199,11 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 
   #ifdef SHAPING_MIN_FREQ
     static_assert((SHAPING_MIN_FREQ) > 0, "SHAPING_MIN_FREQ must be > 0.");
+    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) == 0 || (SHAPING_FREQ_X) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_X must be >= SHAPING_MIN_FREQ."));
+    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) == 0 || (SHAPING_FREQ_Y) >= (SHAPING_MIN_FREQ), "SHAPING_FREQ_Y must be >= SHAPING_MIN_FREQ."));
   #else
-    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) > 0, "SHAPING_FREQ_X must be > 0 or SHAPING_MIN_FREQ must be set."));
-    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) > 0, "SHAPING_FREQ_Y must be > 0 or SHAPING_MIN_FREQ must be set."));
+    TERN_(INPUT_SHAPING_X, static_assert((SHAPING_FREQ_X) >= 0, "SHAPING_FREQ_X must be >= 0."));
+    TERN_(INPUT_SHAPING_Y, static_assert((SHAPING_FREQ_Y) >= 0, "SHAPING_FREQ_Y must be >= 0."));
   #endif
   #ifdef __AVR__
     #if ENABLED(INPUT_SHAPING_X)

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -159,10 +159,10 @@ constexpr ena_mask_t enable_overlap[] = {
   #endif
 
   #ifndef SHAPING_MIN_FREQ
-    #define SHAPING_MIN_FREQ _MIN(0x7FFFFFFFL OPTARG(INPUT_SHAPING_X, SHAPING_FREQ_X) OPTARG(INPUT_SHAPING_Y, SHAPING_FREQ_Y))
+    #define SHAPING_MIN_FREQ _MIN(__FLT_MAX__ OPTARG(INPUT_SHAPING_X, SHAPING_FREQ_X) OPTARG(INPUT_SHAPING_Y, SHAPING_FREQ_Y))
   #endif
-  constexpr uint16_t shaping_min_freq = SHAPING_MIN_FREQ,
-                     shaping_echoes = max_step_rate / shaping_min_freq / 2 + 3;
+  constexpr float shaping_min_freq = SHAPING_MIN_FREQ;
+  constexpr uint16_t shaping_echoes = FLOOR(max_step_rate / shaping_min_freq / 2) + 3;
 
   typedef hal_timer_t shaping_time_t;
   enum shaping_echo_t { ECHO_NONE = 0, ECHO_FWD = 1, ECHO_BWD = 2 };

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -159,7 +159,7 @@ constexpr ena_mask_t enable_overlap[] = {
   #endif
 
   #ifndef SHAPING_MIN_FREQ
-    #define SHAPING_MIN_FREQ _MIN(0x7FFFFFFFL OPTARG(INPUT_SHAPING_X, SHAPING_FREQ_X) OPTARG(INPUT_SHAPING_Y, SHAPING_FREQ_Y))
+    #define SHAPING_MIN_FREQ _MIN(0x7FFFFFFFL OPTARG(INPUT_SHAPING_X, _MAX(SHAPING_FREQ_X, 1)) OPTARG(INPUT_SHAPING_Y, _MAX(SHAPING_FREQ_Y, 1)))
   #endif
   constexpr uint16_t shaping_min_freq = SHAPING_MIN_FREQ,
                      shaping_echoes = max_step_rate / shaping_min_freq / 2 + 3;

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -159,7 +159,7 @@ constexpr ena_mask_t enable_overlap[] = {
   #endif
 
   #ifndef SHAPING_MIN_FREQ
-    #define SHAPING_MIN_FREQ _MIN(0x7FFFFFFFL OPTARG(INPUT_SHAPING_X, _MAX(SHAPING_FREQ_X, 1)) OPTARG(INPUT_SHAPING_Y, _MAX(SHAPING_FREQ_Y, 1)))
+    #define SHAPING_MIN_FREQ _MIN(0x7FFFFFFFL OPTARG(INPUT_SHAPING_X, SHAPING_FREQ_X) OPTARG(INPUT_SHAPING_Y, SHAPING_FREQ_Y))
   #endif
   constexpr uint16_t shaping_min_freq = SHAPING_MIN_FREQ,
                      shaping_echoes = max_step_rate / shaping_min_freq / 2 + 3;


### PR DESCRIPTION
### Description

1. `Stepper::set_shaping_frequency` takes freq as a float, so SHAPING_FREQ_X/Y should be defined in `Configuration_adv.h` as floats.

2. SHAPING_FREQ_X/Y can be zero to indicate disabled. SanityChecks need to reflect this.

### Requirements

No.

### Benefits

Improved configuration hints.

### Configurations

N/a

### Related Issues

None.