### PR TITLE
Fix ESP32 laser M4 exception issue.

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2456,7 +2456,7 @@ hal_timer_t Stepper::block_phase_isr() {
        */
       if (cutter.cutter_mode == CUTTER_MODE_DYNAMIC
         && planner.laser_inline.status.isPowered                  // isPowered flag set on any parsed G1, G2, G3, or G5 move; cleared on any others.
-        && current_block                                          // ESP32 isr can call call block_phase_isr() more than once discarding the block!
+        && current_block                                          // Block may not be available if steps completed (see discard_current_block() above)
         ) {
         if (cutter.last_block_power != current_block->laser.power) {   // Prevent constant update without change
           cutter.apply_power(current_block->laser.power);

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2458,7 +2458,7 @@ hal_timer_t Stepper::block_phase_isr() {
         && planner.laser_inline.status.isPowered                  // isPowered flag set on any parsed G1, G2, G3, or G5 move; cleared on any others.
         && current_block                                          // ESP32 isr can call call block_phase_isr() more than once discarding the block!
         ) {
-        if (laser.last_block_power != current_block->laser.power) {   // Prevent constant update without change
+        if (cutter.last_block_power != current_block->laser.power) {   // Prevent constant update without change
           cutter.apply_power(current_block->laser.power);
           cutter.last_block_power = current_block->laser.power;
         }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2456,11 +2456,13 @@ hal_timer_t Stepper::block_phase_isr() {
        */
       if (cutter.cutter_mode == CUTTER_MODE_DYNAMIC
         && planner.laser_inline.status.isPowered                  // isPowered flag set on any parsed G1, G2, G3, or G5 move; cleared on any others.
-        && cutter.last_block_power != current_block->laser.power  // Prevent constant update without change
-      ) {
-        cutter.apply_power(current_block->laser.power);
-        cutter.last_block_power = current_block->laser.power;
-      }
+        && current_block                                          // ESP32 isr can call call block_phase_isr() more than once discarding the block!
+        ) {
+        if (laser.last_block_power != current_block->laser.power) {   // Prevent constant update without change
+          cutter.apply_power(current_block->laser.power);
+          cutter.last_block_power = current_block->laser.power;
+        }
+      }       
     #endif
   }
   else { // !current_block

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2457,12 +2457,11 @@ hal_timer_t Stepper::block_phase_isr() {
       if (cutter.cutter_mode == CUTTER_MODE_DYNAMIC
         && planner.laser_inline.status.isPowered                  // isPowered flag set on any parsed G1, G2, G3, or G5 move; cleared on any others.
         && current_block                                          // Block may not be available if steps completed (see discard_current_block() above)
-        ) {
-        if (cutter.last_block_power != current_block->laser.power) {   // Prevent constant update without change
-          cutter.apply_power(current_block->laser.power);
-          cutter.last_block_power = current_block->laser.power;
-        }
-      }       
+        && cutter.last_block_power != current_block->laser.power  // Only update if the power changed
+      ) {
+        cutter.apply_power(current_block->laser.power);
+        cutter.last_block_power = current_block->laser.power;
+      }
     #endif
   }
   else { // !current_block


### PR DESCRIPTION

### Description

On ESP32 expander based boards with a laser, an exception is thrown at the end of a move in dynamic mode (`M4 I`).  The LoadProhibited exception is caused by an attempted  access to `current_block` when the it has been discarded (null pointer).  This happens on the last step of a move if `Stepper::block_phase_isr()` gets called with no steps remaining to complete.  

```diff
  if (current_block) {
...
    if (step_events_completed >= step_event_count) {
...
      discard_current_block();
    }
    else {
...
    }
    
    if (cutter.cutter_mode == CUTTER_MODE_DYNAMIC
        && planner.laser_inline.status.isPowered                  // isPowered flag set on any parsed G1, G2, G3, or G5 move; cleared on any others.
-        && cutter.last_block_power !=current_block->laser.power  // Prevent constant update without change
      ) {
        cutter.apply_power(current_block->laser.power);
-        cutter.last_block_power = current_block->laser.power;
      }
...
  }  
``` 
  
### Requirements

Any ESP32 expander board  with a laser. 

https://github.com/MarlinFirmware/Marlin/issues/26873