### PR TITLE
Fix access to undefined _MS3 pins in stepper.cpp

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -4118,22 +4118,22 @@ void Stepper::report_positions() {
           break;
       #endif
       #if HAS_I_MS_PINS
-        case  I_AXIS: WRITE(I_MS1_PIN, ms1); break
+        case  I_AXIS: WRITE(I_MS1_PIN, ms1); break;
       #endif
       #if HAS_J_MS_PINS
-        case  J_AXIS: WRITE(J_MS1_PIN, ms1); break
+        case  J_AXIS: WRITE(J_MS1_PIN, ms1); break;
       #endif
       #if HAS_K_MS_PINS
-        case  K_AXIS: WRITE(K_MS1_PIN, ms1); break
+        case  K_AXIS: WRITE(K_MS1_PIN, ms1); break;
       #endif
       #if HAS_U_MS_PINS
-        case  U_AXIS: WRITE(U_MS1_PIN, ms1); break
+        case  U_AXIS: WRITE(U_MS1_PIN, ms1); break;
       #endif
       #if HAS_V_MS_PINS
-        case  V_AXIS: WRITE(V_MS1_PIN, ms1); break
+        case  V_AXIS: WRITE(V_MS1_PIN, ms1); break;
       #endif
       #if HAS_W_MS_PINS
-        case  W_AXIS: WRITE(W_MS1_PIN, ms1); break
+        case  W_AXIS: WRITE(W_MS1_PIN, ms1); break;
       #endif
       #if HAS_E0_MS_PINS
         case  E_AXIS: WRITE(E0_MS1_PIN, ms1); break;
@@ -4198,22 +4198,22 @@ void Stepper::report_positions() {
           break;
       #endif
       #if HAS_I_MS_PINS
-        case  I_AXIS: WRITE(I_MS2_PIN, ms2); break
+        case  I_AXIS: WRITE(I_MS2_PIN, ms2); break;
       #endif
       #if HAS_J_MS_PINS
-        case  J_AXIS: WRITE(J_MS2_PIN, ms2); break
+        case  J_AXIS: WRITE(J_MS2_PIN, ms2); break;
       #endif
       #if HAS_K_MS_PINS
-        case  K_AXIS: WRITE(K_MS2_PIN, ms2); break
+        case  K_AXIS: WRITE(K_MS2_PIN, ms2); break;
       #endif
       #if HAS_U_MS_PINS
-        case  U_AXIS: WRITE(U_MS2_PIN, ms2); break
+        case  U_AXIS: WRITE(U_MS2_PIN, ms2); break;
       #endif
       #if HAS_V_MS_PINS
-        case  V_AXIS: WRITE(V_MS2_PIN, ms2); break
+        case  V_AXIS: WRITE(V_MS2_PIN, ms2); break;
       #endif
       #if HAS_W_MS_PINS
-        case  W_AXIS: WRITE(W_MS2_PIN, ms2); break
+        case  W_AXIS: WRITE(W_MS2_PIN, ms2); break;
       #endif
       #if HAS_E0_MS_PINS
         case  E_AXIS: WRITE(E0_MS2_PIN, ms2); break;
@@ -4277,23 +4277,23 @@ void Stepper::report_positions() {
           #endif
           break;
       #endif
-      #if HAS_I_MS_PINS
-        case  I_AXIS: WRITE(I_MS3_PIN, ms3); break
+      #if HAS_I_MS_PINS && PIN_EXISTS(I_MS3)
+        case  I_AXIS: WRITE(I_MS3_PIN, ms3); break;
       #endif
-      #if HAS_J_MS_PINS
-        case  J_AXIS: WRITE(J_MS3_PIN, ms3); break
+      #if HAS_J_MS_PINS && PIN_EXISTS(J_MS3)
+        case  J_AXIS: WRITE(J_MS3_PIN, ms3); break;
       #endif
-      #if HAS_K_MS_PINS
-        case  K_AXIS: WRITE(K_MS3_PIN, ms3); break
+      #if HAS_K_MS_PINS && PIN_EXISTS(K_MS3)
+        case  K_AXIS: WRITE(K_MS3_PIN, ms3); break;
       #endif
-      #if HAS_U_MS_PINS
-        case  U_AXIS: WRITE(U_MS3_PIN, ms3); break
+      #if HAS_U_MS_PINS && PIN_EXISTS(U_MS3)
+        case  U_AXIS: WRITE(U_MS3_PIN, ms3); break;
       #endif
-      #if HAS_V_MS_PINS
-        case  V_AXIS: WRITE(V_MS3_PIN, ms3); break
+      #if HAS_V_MS_PINS && PIN_EXISTS(V_MS3)
+        case  V_AXIS: WRITE(V_MS3_PIN, ms3); break;
       #endif
-      #if HAS_W_MS_PINS
-        case  W_AXIS: WRITE(W_MS3_PIN, ms3); break
+      #if HAS_W_MS_PINS && PIN_EXISTS(W_MS3)
+        case  W_AXIS: WRITE(W_MS3_PIN, ms3); break;
       #endif
       #if HAS_E0_MS_PINS && PIN_EXISTS(E0_MS3)
         case  E_AXIS: WRITE(E0_MS3_PIN, ms3); break;


### PR DESCRIPTION
Fixes #26889.
Prevent switch cases in function Stepper::microstep_ms for axis I, J, K, U, V and W from accessing x_MS3_PIN in case if x_MS3_PIN is not defined. Add missing semicolon to break statements

### Requirements

none

### Benefits

Fixes #26889.

### Configurations

none but will add a separate Pull request for features and configurations actually using and requiring this fix.

### Related Issues

Fixes #26889.
