### PR TITLE
Export M503 setting to file - serial redirect

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,3 +1,4 @@
+
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
@@ -4855,3 +4856,11 @@
 
 // Shrink the build for smaller boards by sacrificing some serial feedback
 //#define MARLIN_SMALL_BUILD
+
+#if ALL(HAS_MEDIA, HAS_MARLINUI_MENU)
+  //#define EXPORT_SETTINGS // Export memory settings to file M503.gc in SD card root for replay
+#endif
+
+#if ENABLED(EXPORT_SETTINGS)
+  #define SERIAL_2_FILE   // Dump serial output to file, needed for export settings
+#endif

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4858,7 +4858,7 @@
 //#define MARLIN_SMALL_BUILD
 
 #if ALL(HAS_MEDIA, HAS_MARLINUI_MENU)
-  //#define EXPORT_SETTINGS // Export memory settings to file M503.gc in SD card root for replay
+  #define EXPORT_SETTINGS // Export memory settings to file M503.gc in SD card root for replay
 #endif
 
 #if ENABLED(EXPORT_SETTINGS)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4857,7 +4857,7 @@
 // Shrink the build for smaller boards by sacrificing some serial feedback
 //#define MARLIN_SMALL_BUILD
 
-#if ALL(HAS_MEDIA, HAS_MARLINUI_MENU)
+#if ALL(HAS_MEDIA, HAS_MARLINUI_MENU) && DISABLED(SDCARD_READONLY)
   #define EXPORT_SETTINGS // Export memory settings to file M503.gc in SD card root for replay
 #endif
 

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -144,3 +144,29 @@ void print_xyze(LOGICAL_AXIS_ARGS_(const float) FSTR_P const prefix/*=nullptr*/,
   #endif
   if (suffix) SERIAL_ECHO(suffix); else SERIAL_EOL();
 }
+
+#if ENABLED(SERIAL_2_FILE)
+  #include <src/sd/SdFile.h>
+  #include <src/sd/cardreader.h>
+
+  MediaFile sr_dump_file;
+  size_t sr_write_res;
+
+  bool sr_file_open(const char * filename)
+  {
+    sr_write_res = 0;
+    MediaFile root = card.getroot();
+    return sr_dump_file.open(&root, filename, O_CREAT | O_WRITE | O_TRUNC);
+  }
+
+  void serial2file(uint8_t c)
+  {
+    if (sr_dump_file.isOpen() && sr_write_res != -1)
+      sr_write_res = sr_dump_file.write(c);
+  }
+
+  bool sr_file_close()
+  {
+    return sr_dump_file.close();
+  }
+#endif

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -250,6 +250,10 @@ inline void print_xyze(const xyze_pos_t &xyze, FSTR_P const prefix=nullptr, FSTR
   print_xyze(LOGICAL_AXIS_ELEM_LC_(xyze) prefix, suffix);
 }
 
+bool sr_file_open(const char * filename);
+bool sr_file_close();
+extern size_t sr_write_res;
+
 #define SERIAL_POS(SUFFIX,VAR) do { print_xyz(VAR, F("  " STRINGIFY(VAR) "="), F(" : " SUFFIX "\n")); }while(0)
 #define SERIAL_XYZ(PREFIX,V...) do { print_xyz(V, F(PREFIX)); }while(0)
 

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -200,6 +200,8 @@ struct RuntimeSerial : public SerialBase< RuntimeSerial<SerialT> >, public Seria
 #define _S_CLASS(N) class Serial##N##T,
 #define _S_NAME(N) Serial##N##T,
 
+void serial2file(uint8_t c);
+
 template < REPEAT(NUM_SERIAL, _S_CLASS) const uint8_t offset=0, const uint8_t step=1 >
 struct MultiSerial : public SerialBase< MultiSerial< REPEAT(NUM_SERIAL, _S_NAME) offset, step > > {
   typedef SerialBase< MultiSerial< REPEAT(NUM_SERIAL, _S_NAME) offset, step > > BaseClassT;
@@ -227,6 +229,9 @@ struct MultiSerial : public SerialBase< MultiSerial< REPEAT(NUM_SERIAL, _S_NAME)
     #define _S_WRITE(N) if (portMask.enabled(output[N])) serial##N.write(c);
     REPEAT(NUM_SERIAL, _S_WRITE);
     #undef _S_WRITE
+    #if ENABLED(SERIAL_2_FILE)
+      serial2file(c);
+    #endif
   }
   NO_INLINE void msgDone() {
     #define _S_DONE(N) if (portMask.enabled(output[N])) serial##N.msgDone();

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2799,6 +2799,8 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "Either disable SDCARD_READONLY or disable BINARY_FILE_TRANSFER."
   #elif ENABLED(SDCARD_EEPROM_EMULATION)
     #error "Either disable SDCARD_READONLY or disable SDCARD_EEPROM_EMULATION."
+  #elif ENABLED(EXPORT_SETTINGS)
+    #error "Either disable SDCARD_READONLY or disable EXPORT_SETTINGS."
   #endif
 #endif
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -411,6 +411,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_FILAMENT_LOAD                  = _UxGT("Load mm");
   LSTR MSG_ADVANCE_K                      = _UxGT("Advance K");
   LSTR MSG_ADVANCE_K_E                    = _UxGT("Advance K *");
+  LSTR MSG_EXPORT_SETTINGS                = _UxGT("Export Settings");
   LSTR MSG_INIT_EEPROM                    = _UxGT("Initialize EEPROM");
   LSTR MSG_MEDIA_UPDATE                   = MEDIA_TYPE_EN _UxGT(" Update");
   LSTR MSG_RESET_PRINTER                  = _UxGT("Reset Printer");

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -2021,8 +2021,8 @@ uint8_t expand_u8str_P(char * const outstr, PGM_P const ptpl, const int8_t ind, 
     }
   #endif
 #if ENABLED(EXPORT_SETTINGS)
-  void MarlinUI::export_settings() {
-    if (sr_file_open("M503.gc")) {
+  void MarlinUI::export_settings(const char* filename) {
+    if (sr_file_open(filename)) {
       settings.report(true);
       completion_feedback(sr_file_close() && sr_write_res != -1);
     } else

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -2020,6 +2020,16 @@ uint8_t expand_u8str_P(char * const outstr, PGM_P const ptpl, const int8_t ind, 
       zoffset_overlay(dir);
     }
   #endif
+#if ENABLED(EXPORT_SETTINGS)
+  void MarlinUI::export_settings() {
+    if (sr_file_open("M503.gc")) {
+      settings.report(true);
+      completion_feedback(sr_file_close() && sr_write_res != -1);
+    } else
+      completion_feedback(false);
+  }
+#endif
+
 
 #endif // HAS_MARLINUI_MENU
 

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -800,6 +800,10 @@ public:
     static void export_settings();
   #endif
 
+  #if ENABLED(EXPORT_SETTINGS)
+    static void export_settings(const char* filename);
+  #endif
+
   //
   // Special handling if a move is underway
   //

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -796,6 +796,10 @@ public:
     static void eeprom_alert(const EEPROM_Error) TERN_(EEPROM_AUTO_INIT, {});
   #endif
 
+  #if ENABLED(EXPORT_SETTINGS)
+    static void export_settings();
+  #endif
+
   //
   // Special handling if a move is underway
   //

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -818,6 +818,10 @@ void menu_advanced_settings() {
     );
   #endif
 
+  #if ENABLED(EXPORT_SETTINGS)
+    ACTION_ITEM(MSG_EXPORT_SETTINGS, ui.export_settings);
+  #endif
+
   END_MENU();
 }
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -819,7 +819,7 @@ void menu_advanced_settings() {
   #endif
 
   #if ENABLED(EXPORT_SETTINGS)
-    ACTION_ITEM(MSG_EXPORT_SETTINGS, ui.export_settings);
+    ACTION_ITEM(MSG_EXPORT_SETTINGS, []{ui.export_settings("M503.GC");});
   #endif
 
   END_MENU();


### PR DESCRIPTION
### Description

This PR adds menu item for redirection of M503 serial output to M503.gc file in the SD card root.

### Requirements

SD media and LCD screed. Build and tested with TFT35 display.

### Benefits

It allows to save and next load current memory settings. It could serve as backup, and especially useful when flash new Marlin build with changed settings structure, demanding initialization of EEPROM. After such initialization M503.gc file could be "printed" and previous settings is being loaded into the memory.

Serial redirect could also be used in future for saving logs to file.

Example of export file:

```
  G21 ; (mm)
  M149 C ; Units in Celsius
  M200 S0 D1.7500
  M92 X80.0000 Y80.0000 Z400.0000 E399.5100
  M203 X200.0000 Y200.0000 Z12.0000 E100.0000
  M201 X2000.0000 Y2000.0000 Z100.0000 E2500.0000
  M204 P4000.0000 R1200.0000 T4000.0000
  M205 B20000.0000 S0.0000 T0.0000 X12.0000 Y12.0000 Z0.4000 E10.0000
  M206 X0.0000 Y0.0000 Z0.0000
  M420 S0 Z30.0000 ; Leveling OFF
  M145 S0 H180.0000 B70.0000 F0
  M145 S1 H240.0000 B110.0000 F0
  M304 P82.5000 I8.0600 D563.1000
  M710 S255 I0 A1 D60 ; (100% 0%)
  M413 S0 B0 ; OFF
  M207 S3.0000 W13.0000 F1500.0000 Z0.0000
  M208 S0.0000 W0.0000 F1500.0000
  M851 X-19.9900 Y12.0100 Z-1.0500 ; (mm)
  M906 X800 Y800 Z600
  M906 T0 E500
  M569 S1 X Y Z
  M569 S1 T0 E
  M592 A0.0000 B0.0002 C1.0000
  M593 X F60.0000 D0.1500
  M593 Y F30.0000 D0.1500
  M86 B120 E0 S240 T180
  M900 K0.0000
  M603 L105.0000 U115.0000 ; (mm)
  M412 S0 D100.0000 ; Sensor OFF
  M306 E0 P40.00 C16.94 R0.2483 A0.0942 F0.1067 H0.0056


```

### Related Issues

- #15052