### PR TITLE
update pins pins_CREALITY_ENDER2P_V24S4, solves issue 26903

### DIFF
--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -183,20 +183,20 @@
 
 /**        ------
  *   PC6  | 1  2 | PC7
- *   PA2  | 3  4 | PC1
+ *   PA2  | 3  4 | PA3
  *   PB13   5  6 | PB14
- *   PB15 | 7  8 | PB12
- *    GND | 9 10 | 5V
+ *   N/C  | 7  8 | PB12
+ *   GND  | 9 10 | 5V
  *         ------
  *          EXP1
  */
 #define EXP1_01_PIN                         PC6
 #define EXP1_02_PIN                         PC7
 #define EXP1_03_PIN                         PA2
-#define EXP1_04_PIN                         PC1
+#define EXP1_04_PIN                         PA3
 #define EXP1_05_PIN                         PB13
 #define EXP1_06_PIN                         PB14
-#define EXP1_07_PIN                         PB15
+#define EXP1_07_PIN                         -1
 #define EXP1_08_PIN                         PB12
 
 #if ENABLED(CR10_STOCKDISPLAY)                    // LCD used for C2


### PR DESCRIPTION
### Description

pins_CREALITY_ENDER2P_V24S4.h has errors and causes KILL pin to be falsely triggered. 

Updated to correct pin from information found online. https://gist.github.com/SteveGotthardt/33bdef27d1430f62b4fee5d723d0cde9

Has been tested and confirmed to work. 

### Requirements

Creality Ender 2 Pro motherboard CR-FDM-V2.4.S4.170

### Benefits

Correct Pins

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/26903