### PR TITLE
Fix firmware upload with Marlin Binary File Transfer

### DIFF
--- a/buildroot/share/scripts/upload.py
+++ b/buildroot/share/scripts/upload.py
@@ -157,14 +157,14 @@ def Upload(source, target, env):
     marlin_string_config_h_author = _GetMarlinEnv(MarlinEnv, 'STRING_CONFIG_H_AUTHOR')
 
     # Get firmware upload params
-    upload_firmware_source_name = env['PROGNAME'] + '.bin' if 'PROGNAME' in env else str(source[0])
+    upload_firmware_source_path = os.path.join(env["PROJECT_BUILD_DIR"], env["PIOENV"], f"{env['PROGNAME']}.bin") if 'PROGNAME' in env else str(source[0])
                                                     # Source firmware filename
     upload_speed = env['UPLOAD_SPEED'] if 'UPLOAD_SPEED' in env else 115200
                                                     # baud rate of serial connection
     upload_port = _GetUploadPort(env)               # Serial port to use
 
     # Set local upload params
-    upload_firmware_target_name = os.path.basename(upload_firmware_source_name)
+    upload_firmware_target_name = os.path.basename(upload_firmware_source_path)
                                                     # Target firmware filename
     upload_timeout = 1000                           # Communication timout, lossy/slow connections need higher values
     upload_blocksize = 512                          # Transfer block size. 512 = Autodetect
@@ -216,7 +216,7 @@ def Upload(source, target, env):
             print(f' LONG_FILENAME_WRITE_SUPPORT : {marlin_longname_write}')
             print(f' CUSTOM_FIRMWARE_UPLOAD      : {marlin_custom_firmware_upload}')
             print('---- Upload parameters ------------------------')
-            print(f' Source                      : {upload_firmware_source_name}')
+            print(f' Source                      : {upload_firmware_source_path}')
             print(f' Target                      : {upload_firmware_target_name}')
             print(f' Port                        : {upload_port} @ {upload_speed} baudrate')
             print(f' Timeout                     : {upload_timeout}')
@@ -271,14 +271,14 @@ def Upload(source, target, env):
         # WARNING! The serial port must be closed here because the serial transfer that follow needs it!
 
         # Upload firmware file
-        debugPrint(f"Copy '{upload_firmware_source_name}' --> '{upload_firmware_target_name}'")
+        debugPrint(f"Copy '{upload_firmware_source_path}' --> '{upload_firmware_target_name}'")
         protocol = MarlinBinaryProtocol.Protocol(upload_port, upload_speed, upload_blocksize, float(upload_error_ratio), int(upload_timeout))
         #echologger = MarlinBinaryProtocol.EchoProtocol(protocol)
         protocol.connect()
         # Mark the rollback (delete broken transfer) from this point on
         rollback = True
         filetransfer = MarlinBinaryProtocol.FileTransferProtocol(protocol)
-        transferOK = filetransfer.copy(upload_firmware_source_name, upload_firmware_target_name, upload_compression, upload_test)
+        transferOK = filetransfer.copy(upload_firmware_source_path, upload_firmware_target_name, upload_compression, upload_test)
         protocol.disconnect()
 
         # Notify upload completed


### PR DESCRIPTION
### Description

When attempting to use Marlin Binary File Transfer to update firmware over UBS a FileNotFoundError is thrown.
 
> Exception: [Errno 2] No such file or directory: 'firmware.bin', transfer aborted
> Rollback: trying to delete firmware 'firmware.bin'...
> Traceback (most recent call last):
>   File "C:\Users\Jordan\Documents\Arduino\Marlin-2.1.2.2\buildroot\share\scripts\upload.py", line 282, in Upload
>     transferOK = filetransfer.copy(upload_firmware_source_path, upload_firmware_target_name, upload_compression, upload_test)
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "C:\Users\Jordan\Documents\Arduino\Marlin-2.1.2.2\buildroot\share\scripts\MarlinBinaryProtocol.py", line 405, in copy
>     data = open(filename, "rb").read()
>            ^^^^^^^^^^^^^^^^^^^^
> FileNotFoundError: [Errno 2] No such file or directory: 'firmware.bin'

The fallback value of `upload_firmware_source_name` is a relative file path from the current working directory to the firmware. The string built using `env["PROGNAME"]` is just a filename and is not a valid path to the firmware. I have corrected the string built with `env["PROGNAME"]` to be an absolute path to the firmware, I have also changed the variable name `upload_firmware_source_name` to `upload_firmware_source_path` to reflect this.

```py
upload_firmware_source_path = os.path.join(env["PROJECT_BUILD_DIR"], env["PIOENV"], f"{env['PROGNAME']}.bin") if 'PROGNAME' in env else str(source[0])
```

### Requirements

Board: BigTreeTech SKR-mini-E3-V3.0
PlatformIO environment: STM32G0B1RE_btt_xfer
Marlin Features: BINARY_FILE_TRANSFER and CUSTOM_FIRMWARE_UPLOAD enabled

### Configurations

[Marlin-2.1.2.2.zip](https://github.com/MarlinFirmware/Marlin/files/14755714/Marlin-2.1.2.2.zip)
