### PR TITLE
fix preflight checks for HC32

### DIFF
--- a/Marlin/src/pins/hc32f4/env_validate.h
+++ b/Marlin/src/pins/hc32f4/env_validate.h
@@ -22,7 +22,7 @@
 #ifndef ENV_VALIDATE_H
 #define ENV_VALIDATE_H
 
-#ifndef ARDUINO_ARCH_HC32
+#if NOT_TARGET(ARDUINO_ARCH_HC32)
   #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
 #endif
 


### PR DESCRIPTION

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

minor change to `hc32f4/env_validate.h` to fix preflight check script.

updates the behaviour when building a HC32 mainboard with a incompatible build environment to be in-line with other platforms.


currently, selecting a HC32 mainboard in `Configuration.h` but selecting a incompatible build environment causes a build error:
```
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../pins/hc32f4/env_validate.h:26:4: error: #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
   #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
    ^~~~~
Error: Failed to parse Marlin features. See previous error messages.
```

with this PR, a error is created in marlin preflight checks instead, similar to other platforms:
```
Error: Build environment 'mega2560' is incompatible with BOARD_AQUILA_V101. Use one of these environments: HC32F460C_aquila_101
```


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

N/A

### Benefits

<!-- What does this PR fix or improve? -->

bring error message of HC32 in-line with other platforms

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

https://github.com/shadow578/framework-arduino-hc32f46x/issues/17 (in arduino core repo)
