### PR TITLE
🩹 Fix Mini 12864 on BTT Kraken

### DIFF
--- a/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
@@ -516,6 +516,9 @@
       #define DOGLCD_CS              EXP1_03_PIN
       #define DOGLCD_A0              EXP1_04_PIN
       //#define LCD_BACKLIGHT_PIN           -1
+
+      #define FORCE_SOFT_SPI
+
       #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
       #if ANY(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
         #ifndef RGB_LED_R_PIN


### PR DESCRIPTION
### Description

`FORCE_SOFT_SPI` is required to get Mini 12864 displays working on the BTT Kraken, otherwise the display remains blank.

h/t to @ellensp for finding that missing define!

### Requirements

Any of the Mini 12864 LCDs on BTT Kraken

### Related Issues

- https://github.com/bigtreetech/BIGTREETECH-Kraken/issues/9
- https://github.com/MarlinFirmware/Marlin/pull/26565
