### PR TITLE
add onSetMinExtrusionTemp to anycubic_viper

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
@@ -154,6 +154,10 @@ namespace ExtUI {
     }
   #endif
 
+  #if ENABLED(PREVENT_COLD_EXTRUSION)
+    void onSetMinExtrusionTemp(const celsius_t) {}
+  #endif
+
   #if ENABLED(POWER_LOSS_RECOVERY)
     // Called when power-loss is enabled/disabled
     void onSetPowerLoss(const bool) { dgus.powerLoss(); }


### PR DESCRIPTION
### Description

 [convicte](https://github.com/convicte) noticed that anycubic_viper example config would not build 

producing this error:
 
```
Marlin\src\gcode\config/M302.cpp:54: undefined reference to `ExtUI::onSetMinExtrusionTemp(short)'
collect2.exe: error: ld returned 1 exit status

```
### Requirements

#define ANYCUBIC_LCD_VYPER

### Benefits

Now builds as expected.

### Configurations
Stock Anycubic Vyper configs https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/AnyCubic/Vyper

### Related Issues

<li>MarlinFirmware/Marlin/pull/26563