### PR TITLE
🐛 Don't apply settings during validation

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1940,7 +1940,7 @@ void MarlinSettings::postprocess() {
         _FIELD_TEST(runout_sensor_enabled);
         EEPROM_READ(runout_sensor_enabled);
         #if HAS_FILAMENT_SENSOR
-          runout.enabled = runout_sensor_enabled < 0 ? FIL_RUNOUT_ENABLED_DEFAULT : runout_sensor_enabled;
+        if (!validating) runout.enabled = runout_sensor_enabled < 0 ? FIL_RUNOUT_ENABLED_DEFAULT : runout_sensor_enabled;
         #endif
 
         TERN_(HAS_FILAMENT_SENSOR, if (runout.enabled) runout.reset());
@@ -2121,7 +2121,7 @@ void MarlinSettings::postprocess() {
         #if ENABLED(PTC_HOTEND)
           EEPROM_READ(ptc.z_offsets_hotend);
         #endif
-        ptc.reset_index();
+        if (!validating) ptc.reset_index();
       #else
         // No placeholder data for this feature
       #endif
@@ -2681,11 +2681,13 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(backlash_smoothing_mm);
 
         #if ENABLED(BACKLASH_GCODE)
+        if (!validating) {
           LOOP_NUM_AXES(axis) backlash.set_distance_mm((AxisEnum)axis, backlash_distance_mm[axis]);
           backlash.set_correction_uint8(backlash_correction);
           #ifdef BACKLASH_SMOOTHING_MM
             backlash.set_smoothing_mm(backlash_smoothing_mm);
           #endif
+        }
         #endif
       }
       #endif // NUM_AXES
@@ -2787,7 +2789,7 @@ void MarlinSettings::postprocess() {
         uint8_t ui_language;
         EEPROM_READ(ui_language);
         if (ui_language >= NUM_LANGUAGES) ui_language = 0;
-        ui.set_language(ui_language);
+        if (!validating) ui.set_language(ui_language);
       }
       #endif
 
@@ -2813,8 +2815,10 @@ void MarlinSettings::postprocess() {
       {
         float _data[2];
         EEPROM_READ(_data);
-        stepper.set_shaping_frequency(X_AXIS, _data[0]);
-        stepper.set_shaping_damping_ratio(X_AXIS, _data[1]);
+        if (!validating) {
+          stepper.set_shaping_frequency(X_AXIS, _data[0]);
+          stepper.set_shaping_damping_ratio(X_AXIS, _data[1]);
+        }
       }
       #endif
 
@@ -2822,8 +2826,10 @@ void MarlinSettings::postprocess() {
       {
         float _data[2];
         EEPROM_READ(_data);
-        stepper.set_shaping_frequency(Y_AXIS, _data[0]);
-        stepper.set_shaping_damping_ratio(Y_AXIS, _data[1]);
+        if (!validating) {
+          stepper.set_shaping_frequency(Y_AXIS, _data[0]);
+          stepper.set_shaping_damping_ratio(Y_AXIS, _data[1]);
+        }
       }
       #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Several settings were being applied during the validation stage. In most cases this is benign, as it will be replaced in a subsequent step.

In the case of BACKLASH_COMPENSATION, the initial configuration with invalid data caused corruption of the Backlash::residual_error member. Do to the behavior of the backlash compensation mechanisms, this persists even beyond the loading or resetting of proper values, leading to undefined printer behavior and often physical crashes.

After identifying that issue the settings file was reviewed for other similar issues that needed to be fixed.

### Requirements

For the most drastic results, enable BACKLASH_COMPENSATION with BACKLASH_CORRECTION set to zero. On firmware boot this will often result in an overflowed residual_error member, resulting in doubled movements in one direction of one or more axis. The Z axis is where this is most often seen, since steps/mm is much higher on this axis.

### Benefits

Don't crash your printhead.

### Configurations

N/A

### Related Issues

N/A
