### PR TITLE
Reduce Kill Pin Wait

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -484,7 +484,6 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
     #endif
 
     static int killCount = 0;   // make the inactivity button a bit less responsive
-    const int killDelay = KILL_DELAY;
     if (kill_state())
       killCount++;
     else if (killCount > 0)
@@ -493,7 +492,7 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
     // Exceeded threshold and we can confirm that it was not accidental
     // KILL the machine
     // ----------------------------------------------------------------
-    if (killCount >= killDelay) {
+    if (killCount >= KILL_DELAY) {
       SERIAL_ERROR_START();
       SERIAL_ECHOPGM(STR_KILL_PRE);
       SERIAL_ECHOLNPGM(STR_KILL_BUTTON);

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -474,11 +474,17 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
 
   #if HAS_KILL
 
-    // Check if the kill button was pressed and wait just in case it was an accidental
-    // key kill key press
+    // Check if the kill button was pressed and wait to ensure the signal is not noise
+    // typically caused by poor insulation and grounding on LCD cables.
+    // Lower numbers here will increase response time and therefore safety rating.
+    // It is recommended to set this as low as possibe without false triggers.
     // -------------------------------------------------------------------------------
+    #ifndef KILL_DELAY
+      #define KILL_DELAY 250
+    #endif
+
     static int killCount = 0;   // make the inactivity button a bit less responsive
-    const int KILL_DELAY = 750;
+    const int killDelay = KILL_DELAY;
     if (kill_state())
       killCount++;
     else if (killCount > 0)
@@ -487,7 +493,7 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
     // Exceeded threshold and we can confirm that it was not accidental
     // KILL the machine
     // ----------------------------------------------------------------
-    if (killCount >= KILL_DELAY) {
+    if (killCount >= killDelay) {
       SERIAL_ERROR_START();
       SERIAL_ECHOPGM(STR_KILL_PRE);
       SERIAL_ECHOLNPGM(STR_KILL_BUTTON);


### PR DESCRIPTION
While working with @p3p on an issue in the simulator where we were triggering the kill pin, we noticed a very pronounced delay. In the case of the simulator linux HAL, the idle loop rate was 500hz and therefore this added significant dwell to the execution of the stop function. Looking at the code, we see the delay is called in cycles, not ms. This function cannot use the safe_delay calls as it is inside the manage inactivity function. The consensus in discussion on discord is that as a safety function, we should only be debouncing for signal noise, not accidental press. Most common actuation of a safety button is a rapid slap, not a press and hold.

Therefore we have 2 options. 1. Reduce the time to whats reasonable as a debounce or 2. Count ticks. For the moment, I opted for the simpler reduction and allowed an override for especially noisy systems. I updated the comment in order to point out explicitly that this should function as a debounce.