### PR TITLE
Follow up to #26928 - whitespace, wording in pause.h

### DIFF
--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -57,9 +57,7 @@ enum PauseMessage : char {
 };
 
 #if M600_PURGE_MORE_RESUMABLE
-  /**
-   * Input methods can Purge More, Resume, or request input
-   */
+  // Input methods can Purge More, Resume, or request input
   enum PauseMenuResponse : char {
     PAUSE_RESPONSE_WAIT_FOR,
     PAUSE_RESPONSE_EXTRUDE_MORE,
@@ -109,7 +107,7 @@ void wait_for_confirmation(
 void resume_print(
   const_float_t   slow_load_length=0,                         // (mm) Slow Load Length for finishing move
   const_float_t   fast_load_length=0,                         // (mm) Fast Load Length for initial move
-  const_float_t   extrude_length=ADVANCED_PAUSE_PURGE_LENGTH, // (mm) Purge length
+  const_float_t   purge_length=ADVANCED_PAUSE_PURGE_LENGTH,   // (mm) Purge length
   const int8_t    max_beep_count=0,                           // Beep alert for attention
   const celsius_t targetTemp=0                                // (°C) A target temperature for the hotend
   DXC_PARAMS                                                  // Dual-X-Carriage extruder index
@@ -118,7 +116,7 @@ void resume_print(
 bool load_filament(
   const_float_t   slow_load_length=0,                         // (mm) Slow Load Length for finishing move
   const_float_t   fast_load_length=0,                         // (mm) Fast Load Length for initial move
-  const_float_t   extrude_length=0,                           // (mm) Purge length
+  const_float_t   purge_length=0,                             // (mm) Purge length
   const int8_t    max_beep_count=0,                           // Beep alert for attention
   const bool      show_lcd=false,                             // Set LCD status messages?
   const bool      pause_for_user=false,                       // Pause for user before returning?
@@ -139,4 +137,4 @@ bool unload_filament(
 
   constexpr uint8_t did_pause_print = 0;
 
-#endif // !ADVANCED_PAUSE_FEATURE
+#endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -137,4 +137,4 @@ bool unload_filament(
 
   constexpr uint8_t did_pause_print = 0;
 
-#endif // ADVANCED_PAUSE_FEATURE
+#endif // !ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -1169,7 +1169,7 @@ void MarlinUI::draw_status_screen() {
 
     lcd_moveto(LCD_WIDTH - 9, 2);
     lcd_put_lchar('S');
-    
+
 
   #endif // LCD_INFO_SCREEN_STYLE
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1668,7 +1668,7 @@ void MarlinUI::host_notify(const char * const cstr) {
         card.abortFilePrintSoon();
       else if (card.isMounted())
         card.closefile();
-      #endif
+    #endif
     #ifdef ACTION_ON_CANCEL
       hostui.cancel();
     #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Follow up to [Misc. changes from ProUI / ExtUI updates](#26928)
- remove whitespace **HD44780\marlinui_HD44780.cpp** + **marlinui.cpp**
- change wording in **pause.h** - `extrude_length` => `purge_length`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
