### PR TITLE
update RGB565 color picker url

### DIFF
--- a/Marlin/src/lcd/dogm/u8g/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g/u8g_dev_tft_upscale_from_128x64.cpp
@@ -84,7 +84,7 @@ TFT_IO tftio;
 #define X_HI (UPSCALE(TFT_PIXEL_OFFSET_X, WIDTH) - 1)
 #define Y_HI (UPSCALE(TFT_PIXEL_OFFSET_Y, HEIGHT) - 1)
 
-// RGB565 color picker: https://embeddednotepad.com/page/rgb565-color-picker
+// RGB565 color picker: https://rgbcolorpicker.com/565
 // Hex code to color name: https://www.color-name.com/
 
 #define COLOR_BLACK       0x0000  // #000000

--- a/Marlin/src/lcd/tft/tft_color.h
+++ b/Marlin/src/lcd/tft/tft_color.h
@@ -30,7 +30,7 @@
 #define COLOR(color)          RGB(((color >> 16) & 0xFF), ((color >> 8) & 0xFF), (color & 0xFF))
 #define HALF(color)           RGB(RED(color) >> 1, GREEN(color) >> 1, BLUE(color) >> 1)
 
-// RGB565 color picker: https://embeddednotepad.com/page/rgb565-color-picker
+// RGB565 color picker: https://rgbcolorpicker.com/565
 // Hex code to color name: https://www.color-name.com/
 
 #define COLOR_BLACK           0x0000  // #000000


### PR DESCRIPTION
### Description

Mentioned in code twice is the URL https://embeddednotepad.com/page/rgb565-color-picker
This page no longer works

Updated the URL to a working RGB565 picker  https://rgbcolorpicker.com/565  

### Requirements

None

### Benefits

URL in comments works
