### PR TITLE
Fix IDEX X2 Direction

### DIFF
--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -954,6 +954,12 @@
   #define HAS_MOTOR_CURRENT_I2C 1
 #endif
 
+#if ENABLED(DUAL_X_CARRIAGE)
+  #ifndef INVERT_X2_DIR
+    #define INVERT_X2_DIR INVERT_X_DIR
+  #endif
+#endif
+
 // X2 but not IDEX => Dual Synchronized X Steppers
 #if defined(X2_DRIVER_TYPE) && DISABLED(DUAL_X_CARRIAGE)
   #define HAS_SYNCED_X_STEPPERS 1

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1837,6 +1837,8 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "DUAL_X_CARRIAGE requires X2_HOME_POS, X2_MIN_POS, and X2_MAX_POS."
   #elif X_HOME_TO_MAX
     #error "DUAL_X_CARRIAGE requires X_HOME_DIR -1."
+  #elif (X2_HOME_POS <= X1_MAX_POS) || (X2_MAX_POS < X1_MAX_POS)
+    #error "DUAL_X_CARRIAGE will crash if X1 can meet or exceed X2 travel."
   #endif
 #endif
 


### PR DESCRIPTION
With IDEX enabled and INVERT_X_DIR set to true, X2 moved the wrong direction. The direction write macro now relies on INVERT_X2_DIR to be set independently from X. This checks if the value is not set, and defines it to match X1 if not.

Also added a sanity check in order to prevent misconfiguration as noted in #26915 where X1 was configured to allow travel beyond the X2 park point.