### PR TITLE
Fix and Improve Freeze Feature comment

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4262,7 +4262,7 @@
 /**
  * Instant freeze / unfreeze functionality
  * Potentially useful for rapid stop that allows being resumed. Halts stepper movement.
- * Note this does NOT pause spindles, lasers, fans, heaters or any other auxillary device.
+ * Note this does NOT pause spindles, lasers, fans, heaters or any other auxiliary device.
  * @section interface
  */
 //#define FREEZE_FEATURE

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4261,7 +4261,8 @@
 
 /**
  * Instant freeze / unfreeze functionality
- * Potentially useful for emergency stop that allows being resumed.
+ * Potentially useful for rapid stop that allows being resumed. Halts stepper movement.
+ * Note this does NOT pause spindles, lasers, fans, heaters or any other auxillary device.
  * @section interface
  */
 //#define FREEZE_FEATURE


### PR DESCRIPTION
As noted in issue #26510 the FREEZE_FEATURE does not stop lasers or spindles. This updates the comment to be clear that only stepper motion is stopped.

Removed the term "Emergency" as there is no safety rated emergency stop feature, and something only pausing motion has absolutely no place in an emergency process.