### PR TITLE
Allows RAMPS to auto assign HW SPI Pins for TMC

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -320,17 +320,29 @@
 #endif
 
 //
-// TMC software SPI
+// TMC SPI
 //
 #if HAS_TMC_SPI
-  #ifndef TMC_SPI_MOSI
-    #define TMC_SPI_MOSI                 AUX2_09
-  #endif
-  #ifndef TMC_SPI_MISO
-    #define TMC_SPI_MISO                 AUX2_07
-  #endif
-  #ifndef TMC_SPI_SCK
-    #define TMC_SPI_SCK                  AUX2_05
+  #if ENABLED(TMC_USE_SW_SPI)
+    #ifndef TMC_SPI_MOSI
+      #define TMC_SPI_MOSI                 AUX2_09
+    #endif
+    #ifndef TMC_SPI_MISO
+      #define TMC_SPI_MISO                 AUX2_07
+    #endif
+    #ifndef TMC_SPI_SCK
+      #define TMC_SPI_SCK                  AUX2_05
+    #endif
+  #else
+    #ifndef TMC_SPI_MOSI
+      #define TMC_SPI_MOSI                 AUX3_03
+    #endif
+    #ifndef TMC_SPI_MISO
+      #define TMC_SPI_MISO                 AUX3_04
+    #endif
+    #ifndef TMC_SPI_SCK
+      #define TMC_SPI_SCK                  AUX3_05
+    #endif
   #endif
 #endif
 

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -335,10 +335,10 @@
     #endif
   #else
     #ifndef TMC_SPI_MOSI
-      #define TMC_SPI_MOSI                 AUX3_03
+      #define TMC_SPI_MOSI                 AUX3_04
     #endif
     #ifndef TMC_SPI_MISO
-      #define TMC_SPI_MISO                 AUX3_04
+      #define TMC_SPI_MISO                 AUX3_03
     #endif
     #ifndef TMC_SPI_SCK
       #define TMC_SPI_SCK                  AUX3_05


### PR DESCRIPTION
Ramps pin definition assumes SW SPI for TMC drivers, even when TMC_USE_SW_SPI  is disabled. This checks if the user has hardware or software SPI on and selects the appropriate hardware SPI pins when SW SPI is disabled.