### PR TITLE
Fix slow UI when DISPLAY_SLEEP_MINUTES is used

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -377,7 +377,13 @@ void MarlinUI::draw_kill_screen() {
 void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
 #if HAS_DISPLAY_SLEEP
-  void MarlinUI::sleep_display(const bool sleep/*=true*/) { sleep ? u8g.sleepOn() : u8g.sleepOff(); }
+  void MarlinUI::sleep_display(const bool sleep/*=true*/) { 
+    static bool asleep = false;
+    if (asleep != sleep){
+      sleep ? u8g.sleepOn() : u8g.sleepOff(); 
+      asleep = sleep;
+    }
+  }
 #endif
 
 #if HAS_LCD_BRIGHTNESS


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
My LCD became noticeably slower when I enabled DISPLAY_SLEEP_MINUTES.
This is because `refresh_screen_timeout()` is called on each encoder action, which results in this chain of calls:
* `wake_display();`
* `sleep_display(false);`
* `sleep ? u8g.sleepOn() : u8g.sleepOff();`
And either u8g call results in sending extra data to the LCD.

This PR keeps track of the state of the display and omits calls to u8g unless necessary.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

u8g display.
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Performant LCD with sleep timeout
<!-- What does this PR fix or improve? -->

### Configurations

#define DISPLAY_SLEEP_MINUTES 2

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

Fixes #26467 