### PR TITLE
✅Unit test improvements

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -99,7 +99,7 @@
   #warning "Warning! Don't use dummy thermistors (998/999) for final build!"
 #endif
 
-#if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT)
+#if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT, UNIT_TEST)
   #warning "Your Configuration provides no method to acquire user feedback!"
 #endif
 

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -32,6 +32,8 @@ extra_scripts    = ${common.extra_scripts}
 build_src_filter = ${env:linux_native.build_src_filter} +<tests>
 lib_deps         = throwtheswitch/Unity@^2.5.2
 test_build_src   = true
+build_unflags    = 
+build_flags      = ${env:linux_native.build_flags} -Werror
 
 #
 # Native Simulation

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -29,12 +29,13 @@
 
 static std::list<MarlinTest*> all_marlin_tests;
 
-MarlinTest::MarlinTest(const std::string _name, const void(*_test)(), const int _line)
-: name(_name), test(_test), line(_line) {
+MarlinTest::MarlinTest(const std::string _name, const void(*_test)(), const char *_file, const int _line)
+: name(_name), test(_test), file(_file), line(_line) {
   all_marlin_tests.push_back(this);
 }
 
 void MarlinTest::run() {
+  Unity.TestFile = file.c_str();
   UnityDefaultTestRun((UnityTestFunction)test, name.c_str(), line);
 }
 

--- a/test/unit_tests.h
+++ b/test/unit_tests.h
@@ -33,7 +33,7 @@
  */
 class MarlinTest {
 public:
-    MarlinTest(const std::string name, const void(*test)(), const int line);
+    MarlinTest(const std::string name, const void(*test)(), const char *_file, const int line);
     /**
      * Run the test via Unity
      */
@@ -45,6 +45,7 @@ public:
      */
     const std::string name;
     const void(*test)();
+    const std::string file;
     const int line;
 };
 
@@ -66,7 +67,7 @@ public:
 #define MARLIN_TEST(SUITE, NAME) \
     class _MARLIN_TEST_CLASS_NAME(SUITE, NAME) : public MarlinTest { \
     public: \
-        _MARLIN_TEST_CLASS_NAME(SUITE, NAME)() : MarlinTest(#NAME, (const void(*)())&TestBody, __LINE__) {} \
+        _MARLIN_TEST_CLASS_NAME(SUITE, NAME)() : MarlinTest(#SUITE "___" #NAME, (const void(*)())&TestBody, __FILE__, __LINE__) {} \
         static void TestBody(); \
     }; \
     const _MARLIN_TEST_CLASS_NAME(SUITE, NAME) _MARLIN_TEST_INSTANCE_NAME(SUITE, NAME); \


### PR DESCRIPTION
### Description

1. Enable warnings and treat them as errors, so that unit tests can protect against new warnings from PRs.
2. Adjust MarlinTest so that the actual test filename will be reported, instead of all tests being reported as "unit_tests.cpp".
3. Reformat test name to include the suite name, separated from the test name by `___`. This allows for some grouping of tests within a file.

Old Output:
`test/unit_tests.cpp:143: SString	[PASSED]`

New Output:
`Marlin/tests/types/test_types.cpp:143: types___SString  [PASSED]`

### Requirements

N/A

### Benefits

As unit testing is added for code, it will verify that it is warning-free, and no new warnings are introduced.

### Configurations

N/A

### Related Issues

N/A
