### PR TITLE
add ui_api.h include, fixes proui FILAMENT_RUNOUT_SENSOR issue

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -37,6 +37,7 @@
 
 #include "../../utf8.h"
 #include "../../marlinui.h"
+#include "../../extui/ui_api.h"
 #include "../../../MarlinCore.h"
 #include "../../../core/serial.h"
 #include "../../../core/macros.h"


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/pull/26563 Several ExtUI calls where added to Marlin/src/lcd/e3v2/proui/dwin.cpp 

In the current code the required extui/ui_api.h is only included if FILAMENT_RUNOUT_SENSOR is enabled
via an indirect route of #include "../../../feature/runout.h" which then #include "../lcd/extui/ui_api.h"

However the code now always requires ui_api.h
If #define FILAMENT_RUNOUT_SENSOR is disabled in the Configuration.h it results in numerous compile errors

```
Compiling .pio/build/STM32F103RE_creality/src/src/lcd/extui/ui_api.cpp.o
Marlin/src/lcd/e3v2/proui/dwin.cpp: In function 'void hmiSDCardUpdate()':
Marlin/src/lcd/e3v2/proui/dwin.cpp:1045:46: error: 'ExtUI' has not been declared
 1045 |     if (!DWIN_lcd_sd_status && sdPrinting()) ExtUI::stopPrint();  // Media removed while printing
      |                                              ^~~~~
Marlin/src/lcd/e3v2/proui/dwin.cpp: In function 'void onClickPauseOrStop()':
Marlin/src/lcd/e3v2/proui/dwin.cpp:1169:55: error: 'ExtUI' has not been declared
 1169 |     case PRINT_PAUSE_RESUME: if (hmiFlag.select_flag) ExtUI::pausePrint(); break; // Confirm pause
      |                                                       ^~~~~
Marlin/src/lcd/e3v2/proui/dwin.cpp:1170:47: error: 'ExtUI' has not been declared
 1170 |     case PRINT_STOP: if (hmiFlag.select_flag) ExtUI::stopPrint(); break; // Stop confirmed then abort print
      |                                               ^~~~~
Marlin/src/lcd/e3v2/proui/dwin.cpp: In function 'void hmiPrinting()':
Marlin/src/lcd/e3v2/proui/dwin.cpp:1204:11: error: 'ExtUI' has not been declared
 1204 |           ExtUI::resumePrint();
      |           ^~~~~
Marlin/src/lcd/e3v2/proui/dwin.cpp: At global scope:
Marlin/src/lcd/e3v2/proui/dwin.cpp:1854:15: error: 'ExtUI' has not been declared
 1854 | static_assert(ExtUI::eeprom_data_size >= sizeof(hmi_data_t), "Insufficient space in EEPROM for UI parameters");
      |               ^~~~~
*
```
### Requirements

PROUI

### Benefits

builds as expected

### Configurations

My example configs that trigger the error
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/14981208/Configuration.zip)

### Related Issues
<li>MarlinFirmware/Marlin/pull/26563</li>

https://github.com/MarlinFirmware/Marlin/pull/26917#issuecomment-2057138673
