### PR TITLE
fix sprintf writing beyond ubl_lcd_gcode buffer

### DIFF
--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -144,7 +144,7 @@ void _lcd_ubl_custom_mesh() {
  * UBL Adjust Mesh Height Command
  */
 void _lcd_ubl_adjust_height_cmd() {
-  char ubl_lcd_gcode[13];
+  char ubl_lcd_gcode[14];
   const int ind = ubl_height_amount > 0 ? 6 : 7;
   strcpy_P(ubl_lcd_gcode, PSTR("G29P6C-"));
   sprintf_P(&ubl_lcd_gcode[ind], PSTR(".%i"), ABS(ubl_height_amount));


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

In `menu_ubl.cpp`'s `_lcd_ubl_adjust_height_cmd`, the `sprintf` call used for constructing the gcode command may write beyond the end of the `ubl_lcd_gcode`.
This is only the case when `abs(ubl_height_amount) >= 1000`, so it may not actually affect real-world scenarios.

Still, it's probably best to not ignore this, as it could cause memory corruption.


<details>
<summary>GCC Warning Message</summary>

```
In file included from /root/.platformio/packages/framework-arduino-hc32f46x/cores/arduino/Arduino.h:34,
                 from Marlin/src/lcd/menu/../../inc/../HAL/../HAL/HC32/../shared/Marduino.h:36,
                 from Marlin/src/lcd/menu/../../inc/../HAL/../HAL/HC32/HAL.h:34,
                 from Marlin/src/lcd/menu/../../inc/../HAL/HAL.h:30,
                 from Marlin/src/lcd/menu/../../inc/MarlinConfig.h:33,
                 from Marlin/src/lcd/menu/../marlinui.h:24,
                 from Marlin/src/lcd/menu/menu.h:24,
                 from Marlin/src/lcd/menu/menu_item.h:24,
                 from Marlin/src/lcd/menu/menu_ubl.cpp:31:
Marlin/src/lcd/menu/menu_ubl.cpp: In function 'void _lcd_ubl_adjust_height_cmd()':
Marlin/src/lcd/menu/menu_ubl.cpp:150:39: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
  150 |   sprintf_P(&ubl_lcd_gcode[ind], PSTR(".%i"), ABS(ubl_height_amount));
/root/.platformio/packages/framework-arduino-hc32f46x/cores/arduino/avr/pgmspace.h:99:44: note: in definition of macro 'sprintf_P'
   99 | #define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
      |                                            ^
Marlin/src/lcd/menu/menu_ubl.cpp:150:34: note: in expansion of macro 'PSTR'
  150 |   sprintf_P(&ubl_lcd_gcode[ind], PSTR(".%i"), ABS(ubl_height_amount));
      |                                  ^~~~
/root/.platformio/packages/framework-arduino-hc32f46x/cores/arduino/avr/pgmspace.h:99:37: note: 'sprintf' output between 3 and 8 bytes into a destination of size 7
   99 | #define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
      |                              ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
Marlin/src/lcd/menu/menu_ubl.cpp:150:3: note: in expansion of macro 'sprintf_P'
  150 |   sprintf_P(&ubl_lcd_gcode[ind], PSTR(".%i"), ABS(ubl_height_amount));
      |   ^~~~~~~~~
```
</details>




### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Found the issue & tested the fix on HC32 with `DWIN_MARLINUI_PORTRAIT` and `AUTO_BED_LEVELING_UBL`.

Since this issue is in the menu implementation, it should affect every marlinui screen when `AUTO_BED_LEVELING_UBL` is enabled.


### Benefits

<!-- What does this PR fix or improve? -->

Removes the compiler warning, potentially fixes hard-to-debug memory corruption issues.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

N/A
