### PR TITLE
release debug pins on HC32 boards

### DIFF
--- a/Marlin/src/HAL/HC32/HAL.h
+++ b/Marlin/src/HAL/HC32/HAL.h
@@ -149,6 +149,25 @@
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
 
 //
+// Debug port disable
+// JTMS / SWDIO = PA13
+// JTCK / SWCLK = PA14
+// JTDI         = PA15
+// JTDO         = PB3
+// NJTRST       = PB4
+//
+#define DBG_SWCLK _BV(0)
+#define DBG_SWDIO _BV(1)
+#define DBG_TDO   _BV(2)
+#define DBG_TDI   _BV(3)
+#define DBG_TRST  _BV(4)
+#define DBG_ALL (DBG_SWCLK | DBG_SWDIO | DBG_TDO | DBG_TDI | DBG_TRST)
+
+#define JTAGSWD_RESET() PORT_DebugPortSetting(DBG_ALL, Enable);
+#define JTAG_DISABLE() PORT_DebugPortSetting(DBG_TDO | DBG_TDI | DBG_TRST, Disable);
+#define JTAGSWD_DISABLE() PORT_DebugPortSetting(DBG_ALL, Disable);
+
+//
 // MarlinHAL implementation
 //
 #include "MarlinHAL.h"

--- a/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
+++ b/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
@@ -45,10 +45,13 @@
 #endif
 
 //
-// Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
+// Release JTAG pins but keep SWD enabled
+// - PA15 (JTDI / USART2 RX)
+// - PB3 (JTDO / E0_DIR)
+// - PB4 (NJTRST / E0_STEP)
 //
 //#define DISABLE_DEBUG
-//#define DISABLE_JTAG
+#define DISABLE_JTAG
 
 //
 // EEPROM

--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -46,10 +46,13 @@
 #endif
 
 //
-// Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
+// Release JTAG pins but keep SWD enabled
+// - PA15 (JTDI / E0_DIR_PIN)
+// - PB3 (JTDO / E0_STEP_PIN)
+// - PB4 (NJTRST / E0_ENABLE_PIN)
 //
 //#define DISABLE_DEBUG
-//#define DISABLE_JTAG
+#define DISABLE_JTAG
 
 //
 // EEPROM


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

On ~some~ all currently supported HC32 boards, pins normally assigned to debugging functions are re-used for other functions.
The PR implements `DISABLE_DEBUG` and `DISABLE_JTAG` in the HC32 HAL and adds the corrosponding defined to the HC32 board files.

Currently, this doesn't cause issues since the bootloader releases these pins before booting into Marlin.
However, it's probably best to not rely on a side-effect of the bootloader, in case it changes with newer board revisions (or the user changes it).


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

HC32-Based Board

### Benefits

<!-- What does this PR fix or improve? -->

Removes reliance on side-effect of the bootloader

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

N/A


### Appendix

`PSPCR` register overview (set by `PORT_DebugPortSetting`)

| ![grafik](https://github.com/MarlinFirmware/Marlin/assets/52449218/72c74246-c5e6-4089-bac8-dfe59b055298) |
|-|
| Except from HC32F460 Reference Manual, Section 9.4.7 Special Control Register (PSPCR) |



Debug Port Pins assignments according to HC32F460 Datasheet

Pin | Debug Function
-|-
PA13 | JTMS / SWDIO
PA14 | JTCK / SWCLK
PA15 | JTDI
PB3 | JTDO
PB4 | NJTRST