### PR TITLE
✅ Skip compile tests when editing unit tests

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -14,6 +14,8 @@ on:
     - config/**
     - data/**
     - docs/**
+    - test/**
+    - Marlin/tests/**
     - '**/*.md'
   push:
     branches:
@@ -23,6 +25,8 @@ on:
     - config/**
     - data/**
     - docs/**
+    - test/**
+    - Marlin/tests/**
     - '**/*.md'
 
 jobs:


### PR DESCRIPTION
### Description

There is no need to perform compilation tests when only unit tests have been edited.
Exlude paths related to unit testing.
