### PR TITLE
✅ Unit test improvements

### DIFF
--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -7,5 +7,6 @@ if [[ $1 == '-d' || $1 == '--default' ]]; then
 else
   git checkout Marlin/Configuration.h 2>/dev/null
   git checkout Marlin/Configuration_adv.h 2>/dev/null
+  git checkout Marlin/config.ini 2>/dev/null
   git checkout Marlin/src/pins/*/pins_*.h 2>/dev/null
 fi


### PR DESCRIPTION
### Description

- Update restore_configs to also restore the config.ini modified by unit tests
- Enable running of a single configuration of unit tests, to speed up local development.
When `unit-test-single-local` is run without specifying a configuration, it will run only for the default configuration.
