### PR TITLE
🐛 Fix Flags<N> data storage width

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -159,7 +159,7 @@ template <class L, class R> struct IF<true, L, R> { typedef L type; };
 // General Flags for some number of states
 template<size_t N>
 struct Flags {
-  typedef uvalue_t(N) flagbits_t;
+  typedef bits_t(N) flagbits_t;
   typedef struct { bool b0:1, b1:1, b2:1, b3:1, b4:1, b5:1, b6:1, b7:1; } N8;
   typedef struct { bool b0:1, b1:1, b2:1, b3:1, b4:1, b5:1, b6:1, b7:1, b8:1, b9:1, b10:1, b11:1, b12:1, b13:1, b14:1, b15:1; } N16;
   typedef struct { bool b0:1,  b1:1,  b2:1,  b3:1,  b4:1,  b5:1,  b6:1,  b7:1,  b8:1,  b9:1, b10:1, b11:1, b12:1, b13:1, b14:1, b15:1,

--- a/Marlin/tests/core/test_types.cpp
+++ b/Marlin/tests/core/test_types.cpp
@@ -484,26 +484,23 @@ MARLIN_TEST(types, Flags_16) {
 
   flags.set(0, true);
   flags.set(15, true);
-  // BUG: The storage can only contain 8 bits!
-  // TEST_ASSERT_EQUAL(32769, flags.b);
-  TEST_ASSERT_EQUAL(1, flags.b);
+  TEST_ASSERT_EQUAL(32769, flags.b);
 
   flags.clear(0);
-  TEST_ASSERT_EQUAL(0, flags.b);
+  TEST_ASSERT_EQUAL(32768, flags.b);
 
   flags.reset();
   flags.set(7, true);
   flags.set(15, true);
   TEST_ASSERT_EQUAL(true, flags.test(7));
-  // BUG: This can't store a value above bit 7 right now
-  TEST_ASSERT_EQUAL(false, flags.test(15));
+  TEST_ASSERT_EQUAL(false, flags.test(8));
+  TEST_ASSERT_EQUAL(true, flags.test(15));
 
   TEST_ASSERT_EQUAL(true, flags[7]);
-  // BUG: This can't store a value above bit 7 right now
-  TEST_ASSERT_EQUAL(false, flags[15]);
+  TEST_ASSERT_EQUAL(false, flags[8]);
+  TEST_ASSERT_EQUAL(true, flags[15]);
 
-  // BUG: This size should be 2, but is incorrectly 1
-  TEST_ASSERT_EQUAL(1, flags.size());
+  TEST_ASSERT_EQUAL(2, flags.size());
 }
 
 MARLIN_TEST(types, Flags_32) {
@@ -514,9 +511,7 @@ MARLIN_TEST(types, Flags_32) {
 
   flags.set(0, true);
   flags.set(31, true);
-  // BUG: The storage can only contain 8 bits!
-  //TEST_ASSERT_EQUAL(2147483649, flags.b);
-  TEST_ASSERT_EQUAL(1, flags.b);
+  TEST_ASSERT_EQUAL(2147483649, flags.b);
 
   flags.clear(0);
   flags.clear(31);
@@ -525,22 +520,16 @@ MARLIN_TEST(types, Flags_32) {
   flags.set(0, true);
   flags.set(31, true);
   TEST_ASSERT_EQUAL(true, flags.test(0));
-  // BUG: This can't store a value above bit 7 right now
-  TEST_ASSERT_EQUAL(false, flags.test(31));
-  // TEST_ASSERT_EQUAL(true, flags.test(31));
+  TEST_ASSERT_EQUAL(true, flags.test(31));
   TEST_ASSERT_EQUAL(false, flags.test(1));
   TEST_ASSERT_EQUAL(false, flags.test(30));
 
   TEST_ASSERT_EQUAL(true, flags[0]);
-  // BUG: This can't store a value above bit 7 right now
-  TEST_ASSERT_EQUAL(false, flags[31]);
-  // TEST_ASSERT_EQUAL(true, flags[31]);
+  TEST_ASSERT_EQUAL(true, flags[31]);
   TEST_ASSERT_EQUAL(false, flags[1]);
   TEST_ASSERT_EQUAL(false, flags[30]);
 
-  // BUG: This size should be 4, but is incorrectly 1
-  TEST_ASSERT_EQUAL(1, flags.size());
-  // TEST_ASSERT_EQUAL(4, flags.size());
+  TEST_ASSERT_EQUAL(4, flags.size());
 }
 
 MARLIN_TEST(types, AxisFlags_const_as_bools) {

--- a/Marlin/tests/core/test_types.cpp
+++ b/Marlin/tests/core/test_types.cpp
@@ -71,7 +71,7 @@ MARLIN_TEST(types, XYval_magnitude) {
 
 MARLIN_TEST(types, XYval_small_large) {
   XYval<int> xy;
-  
+
   xy.set(3, 4);
   TEST_ASSERT_EQUAL(3, xy.small());
   TEST_ASSERT_EQUAL(4, xy.large());
@@ -187,7 +187,7 @@ MARLIN_TEST(types, XYZval_magnitude) {
 
 MARLIN_TEST(types, XYZval_small_large) {
   XYZval<int> xyz;
-  
+
   xyz.set(3, 4, 5);
   TEST_ASSERT_EQUAL(3, xyz.small());
   TEST_ASSERT_EQUAL(5, xyz.large());
@@ -325,7 +325,7 @@ MARLIN_TEST(types, XYZEval_magnitude) {
 
 MARLIN_TEST(types, XYZEval_small_large) {
   XYZEval<int> xyze;
-  
+
   xyze.set(3, 4, 5, 6);
   TEST_ASSERT_EQUAL(3, xyze.small());
   TEST_ASSERT_EQUAL(6, xyze.large());


### PR DESCRIPTION
### Description

Previously added unit tests identified that the storage for the Flags<N> type was always 8 bits, even if many more flags than this were requested.

This was due to the incorrect use of `uvalue_t` instead of `bits_t` when defining `flagbits_t`.

This PR fixes the underlying root cause, and adjusts the unit tests to verify the intended edges cases for the class.

The actual impact of this bug was probably limited to uncommon machines with more than 8 axis. I believe that this could have caused some Axis to not move, when using every available axis in Marlin.