### PR TITLE
Replaced "authorship" by "based on" in ProUI

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -22,9 +22,6 @@
 
 /**
  * Bed Level Tools for Pro UI
- * Extended by: Miguel A. Risco-Castillo (MRISCOC)
- * Version: 3.2.0
- * Date: 2023/05/03
  *
  * Based on the original work of: Henri-J-Norden
  * https://github.com/Jyers/Marlin/pull/126

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
@@ -22,9 +22,6 @@
 
 /**
  * Bed Level Tools for Pro UI
- * Extended by: Miguel A. Risco-Castillo (MRISCOC)
- * Version: 3.2.0
- * Date: 2023/05/03
  *
  * Based on the original work of: Henri-J-Norden
  * https://github.com/Jyers/Marlin/pull/126

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -22,7 +22,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.25.3
  * Date: 2023/05/18
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.25.3
  * Date: 2023/05/18
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN general defines and data structs for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.12.2
  * Date: 2022/08/08
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin_lcd.cpp
@@ -22,7 +22,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.12.1
  * Date: 2023/01/22
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin_lcd.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_lcd.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.12.1
  * Date: 2023/01/22
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin_popup.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin_popup.cpp
@@ -22,7 +22,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.11.1
  * Date: 2022/02/28
  */

--- a/Marlin/src/lcd/e3v2/proui/dwin_popup.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_popup.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.11.1
  * Date: 2022/02/28
  */

--- a/Marlin/src/lcd/e3v2/proui/dwinui.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwinui.cpp
@@ -22,7 +22,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.21.1
  * Date: 2023/03/21
  */

--- a/Marlin/src/lcd/e3v2/proui/dwinui.h
+++ b/Marlin/src/lcd/e3v2/proui/dwinui.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN Enhanced implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 3.21.1
  * Date: 2023/03/21
  */

--- a/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
+++ b/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
@@ -22,7 +22,8 @@
 
 /**
  * DWIN Endstops diagnostic page for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 1.4.3
  * Date: 2023/05/10
  */

--- a/Marlin/src/lcd/e3v2/proui/endstop_diag.h
+++ b/Marlin/src/lcd/e3v2/proui/endstop_diag.h
@@ -23,7 +23,8 @@
 
 /**
  * DWIN End Stops diagnostic page for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 1.4.3
  * Date: 2023/05/10
  */

--- a/Marlin/src/lcd/e3v2/proui/lockscreen.cpp
+++ b/Marlin/src/lcd/e3v2/proui/lockscreen.cpp
@@ -22,7 +22,8 @@
 
 /**
  * Lock screen implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 2.3.2
  * Date: 2022/11/20
  */

--- a/Marlin/src/lcd/e3v2/proui/lockscreen.h
+++ b/Marlin/src/lcd/e3v2/proui/lockscreen.h
@@ -23,7 +23,8 @@
 
 /**
  * Lock screen implementation for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 2.3.2
  * Date: 2022/11/20
  */

--- a/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/proui/meshviewer.cpp
@@ -22,7 +22,8 @@
 
 /**
  * Mesh Viewer for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * version: 4.2.1
  * Date: 2023/05/05
  */

--- a/Marlin/src/lcd/e3v2/proui/meshviewer.h
+++ b/Marlin/src/lcd/e3v2/proui/meshviewer.h
@@ -23,7 +23,8 @@
 
 /**
  * Mesh Viewer for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * version: 4.2.1
  * Date: 2023/05/05
  */

--- a/Marlin/src/lcd/e3v2/proui/printstats.cpp
+++ b/Marlin/src/lcd/e3v2/proui/printstats.cpp
@@ -22,7 +22,8 @@
 
 /**
  * Print Stats page for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 1.4.0
  * Date: 2022/12/03
  */

--- a/Marlin/src/lcd/e3v2/proui/printstats.h
+++ b/Marlin/src/lcd/e3v2/proui/printstats.h
@@ -23,7 +23,8 @@
 
 /**
  * Print Stats page for PRO UI
- * Author: Miguel A. Risco-Castillo (MRISCOC)
+ * Based on the original work of: Miguel Risco-Castillo (MRISCOC)
+ * https://github.com/mriscoc/Ender3V2S1
  * Version: 1.4.0
  * Date: 2022/12/03
  */


### PR DESCRIPTION
### Description
Replaced "authorship" by "based on" to avoid confusions with recent changes in Marlin ProUI implementations.
No functional changes.