### PR TITLE
In PROUI rename MPCTEMP_START to MPC_STARTED as used in EXTUI

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1312,7 +1312,7 @@ void eachMomentUpdate() {
           TERN_(PIDTEMP, if (hmiValue.tempControl == PIDTEMP_START) { plot.update(thermalManager.wholeDegHotend(0)); })
           TERN_(PIDTEMPBED, if (hmiValue.tempControl == PIDTEMPBED_START) { plot.update(thermalManager.wholeDegBed()); })
           TERN_(PIDTEMPCHAMBER, if (hmiValue.tempControl == PIDTEMPCHAMBER_START) { plot.update(thermalManager.wholeDegChamber()); })
-          TERN_(MPCTEMP, if (hmiValue.tempControl == MPCTEMP_START) { plot.update(thermalManager.wholeDegHotend(0)); })
+          TERN_(MPCTEMP, if (hmiValue.tempControl == MPC_STARTED) { plot.update(thermalManager.wholeDegHotend(0)); })
           if (hmiFlag.abort_flag || hmiFlag.pause_flag || print_job_timer.isPaused()) {
             hmiReturnScreen();
           }
@@ -1567,7 +1567,7 @@ void dwinLevelingDone() {
     switch (hmiValue.tempControl) {
       default: return;
       #if ENABLED(MPC_AUTOTUNE)
-        case MPCTEMP_START:
+        case MPC_STARTED:
           DWINUI::drawCenteredString(hmiData.colorPopupTxt, 70, GET_TEXT_F(MSG_MPC_AUTOTUNE));
           DWINUI::drawString(hmiData.colorPopupTxt, gfrm.x, gfrm.y - DWINUI::fontHeight() - 4, F("MPC target:     Celsius"));
           DWINUI::drawCenteredString(hmiData.colorPopupTxt, 92, GET_TEXT_F(MSG_PID_FOR_NOZZLE));
@@ -1620,7 +1620,7 @@ void dwinLevelingDone() {
 
       switch (result) {
         #if ENABLED(MPCTEMP)
-          case MPCTEMP_START:
+          case MPC_STARTED:
         #elif ENABLED(PIDTEMP)
           case PIDTEMP_START:
         #endif
@@ -1656,7 +1656,7 @@ void dwinLevelingDone() {
 
     void drawHPlot() {
       TERN_(PIDTEMP, dwinDrawPlot(PIDTEMP_START));
-      TERN_(MPCTEMP, dwinDrawPlot(MPCTEMP_START));
+      TERN_(MPCTEMP, dwinDrawPlot(MPC_STARTED));
     }
     void drawBPlot() {
       TERN_(PIDTEMPBED, dwinDrawPlot(PIDTEMPBED_START));
@@ -1742,7 +1742,7 @@ void dwinLevelingDone() {
   void dwinMPCTuning(tempcontrol_t result) {
     hmiValue.tempControl = result;
     switch (result) {
-      case MPCTEMP_START:
+      case MPC_STARTED:
         hmiSaveProcessID(ID_MPCProcess);
         #if PROUI_TUNING_GRAPH
           dwinDrawPIDMPCPopup();

--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -90,7 +90,7 @@ enum processID : uint8_t {
       PID_TUNING_TIMEOUT,
     #endif
     #if ENABLED(MPC_AUTOTUNE)
-      MPCTEMP_START,
+      MPC_STARTED,
       MPC_TEMP_ERROR,
       MPC_INTERRUPTED,
     #endif

--- a/Marlin/src/lcd/e3v2/proui/proui_extui.cpp
+++ b/Marlin/src/lcd/e3v2/proui/proui_extui.cpp
@@ -222,7 +222,7 @@ namespace ExtUI {
     void onMPCTuning(const mpcresult_t rst) {
       // Called for temperature MPC tuning result
       switch (rst) {
-        case MPC_STARTED:     dwinMPCTuning(MPCTEMP_START);   break;
+        case MPC_STARTED:     dwinMPCTuning(MPC_STARTED);     break;
         case MPC_TEMP_ERROR:  dwinMPCTuning(MPC_TEMP_ERROR);  break;
         case MPC_INTERRUPTED: dwinMPCTuning(MPC_INTERRUPTED); break;
         case MPC_DONE:        dwinMPCTuning(AUTOTUNE_DONE);   break;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1195,7 +1195,7 @@ volatile bool Temperature::raw_temps_ready = false;
 
     // Determine ambient temperature.
     SERIAL_ECHOLNPGM(STR_MPC_COOLING_TO_AMBIENT);
-    TERN_(EXTENSIBLE_UI, ExtUI::onMPCTuning(ExtUI::mpcresult_t::MPCTEMP_START));
+    TERN_(EXTENSIBLE_UI, ExtUI::onMPCTuning(ExtUI::mpcresult_t::MPC_STARTED));
     TERN(DWIN_LCD_PROUI, LCD_ALERTMESSAGE(MSG_MPC_COOLING_TO_AMBIENT), LCD_MESSAGE(MSG_COOLING));
 
     if (tuner.measure_ambient_temp() != MPC_autotuner::MeasurementState::SUCCESS) return;


### PR DESCRIPTION
### Description

Compile error:
Marlin\src\module\temperature.cpp: error: 'MPCTEMP_START' is not a member of 'ExtUI::mpcresult_t'
1230 | TERN_(EXTENSIBLE_UI, ExtUI::onMPCTuning(ExtUI::mpcresult_t::MPCTEMP_START));

was modified for proui to use EXTUI, but proui uses  MPCTEMP_START while EXTUI uses MPC_STARTED

Renamed MPCTEMP_START to MPC_STARTED

### Requirements

MPCTEMP and EXTUI  user interface

### Benefits

Builds as expected

### Configurations

https://github.com/MarlinFirmware/Marlin/files/15076106/Configuration.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/26997