### PR TITLE
Preliminary CR4NS200320C13 board (Ender-3 V3) support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -404,6 +404,9 @@
 #define BOARD_VOXELAB_AQUILA          5071  // Voxelab Aquila V1.0.0/V1.0.1 (GD32F103RC / N32G455RE / STM32F103RE)
 #define BOARD_SPRINGER_CONTROLLER     5072  // ORCA 3D SPRINGER Modular Controller (STM32F103VC)
 
+// Preliminary support for Creality Ender-3 V3 SE
+#define BOARD_CREALITY_CR4NS          5099  // Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
+
 //
 // ARM Cortex-M4F
 //

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -404,9 +404,6 @@
 #define BOARD_VOXELAB_AQUILA          5071  // Voxelab Aquila V1.0.0/V1.0.1 (GD32F103RC / N32G455RE / STM32F103RE)
 #define BOARD_SPRINGER_CONTROLLER     5072  // ORCA 3D SPRINGER Modular Controller (STM32F103VC)
 
-// Preliminary support for Creality Ender-3 V3 SE
-#define BOARD_CREALITY_CR4NS          5099  // Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
-
 //
 // ARM Cortex-M4F
 //
@@ -470,6 +467,11 @@
 #define BOARD_MELLOW_FLY_E3_V2        5249  // Mellow Fly E3 V2 (STM32F407VG)
 #define BOARD_FYSETC_CHEETAH_V30      5250  // FYSETC Cheetah V3.0 (STM32F446RC)
 #define BOARD_BLACKBEEZMINI_V1        5251  // BlackBeezMini V1 (STM32F401CCU6)
+
+//
+// Other ARM Cortex-M4
+//
+#define BOARD_CREALITY_CR4NS          5300  // Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
 
 //
 // ARM Cortex-M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -706,6 +706,8 @@
   #include "gd32f1/pins_VOXELAB_AQUILA.h"           // GD32F1, N32G4, STM32F1               env:GD32F103RC_voxelab_maple env:N32G455RE_voxelab_maple env:STM32F103RE_creality_maple env:STM32F103RE_creality
 #elif MB(SPRINGER_CONTROLLER)
   #include "stm32f1/pins_ORCA_3D_SPRINGER.h"        // STM32F1                              env:STM32F103VC_orca3d
+#elif MB(CREALITY_CR4NS)
+  #include "stm32f1/pins_CREALITY_CR4NS.h"          // STM32F1                              env:STM32F103RE_creality env:STM32F103RE_creality_maple
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
@@ -1,0 +1,136 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Creality CREALITY_CR4NS (GD32F303RET6) board pin assignments
+ * Sold as "Creality Ender-3 V3 SE CR4NS200320C13 Motherboard"
+ * Preliminary support for the Professional Firmwware
+ */
+
+#include "env_validate.h"
+
+#if HOTENDS > 1 || E_STEPPERS > 1
+  #error "CR4NS200320C13 only supports one hotend / E-stepper."
+#endif
+
+// Is E0_DRIVER_TYPE TMC2208_STANDALONE?
+// #if !AXIS_DRIVER_TYPE_X(TMC2208) || !AXIS_DRIVER_TYPE_Y(TMC2208) || !AXIS_DRIVER_TYPE_Z(TMC2208) || !AXIS_DRIVER_TYPE_E0(?)
+//   #error "This board has onboard TMC2208 drivers for X, Y, Z, and E0."
+// #endif
+
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME      "CR4NS200320C13"
+#endif
+#ifndef DEFAULT_MACHINE_NAME
+  #define DEFAULT_MACHINE_NAME "Ender-3 V3 SE"
+#endif
+#define BOARD_WEBSITE_URL      "www.creality.com"
+
+//
+// Servos
+//
+#ifndef SERVO0_PIN
+  #define SERVO0_PIN                        PC14
+#endif
+
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PC13   // BLTouch IN
+#endif
+
+//
+// Limit Switches
+//
+// #ifndef Z_STOP_PIN
+//   #define Z_STOP_PIN                        PA15
+// #endif
+
+//
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PC15   // "Pulled-high"
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_BED_PIN                      PB2   // HOT BED
+#define FAN1_PIN                            PC1   // extruder fan
+// #define FAN2_PIN                            PB1   // Controller fan FET
+
+//
+// Auto fans
+//
+// #ifndef CONTROLLER_FAN_PIN
+//   #define CONTROLLER_FAN_PIN                FAN2_PIN
+// #endif
+
+#if HAS_TMC_UART
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
+
+  // Software serial
+  #define X_SERIAL_TX_PIN                   PB12
+  #define X_SERIAL_RX_PIN                   X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PB13
+  #define Y_SERIAL_RX_PIN                   Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PB14
+  #define Z_SERIAL_RX_PIN                   Z_SERIAL_TX_PIN
+
+#endif // HAS_TMC_UART
+
+#if ANY(RET6_12864_LCD, HAS_DWIN_E3V2, IS_DWIN_MARLINUI)
+
+  /**
+   *    LCD PIN OUT
+   *        ------
+   *    NC | 1  2 | NC
+   *    RX | 3  4 | TX
+   *    EN   5  6 | BEEP
+   *     B | 7  8 | A
+   *   GND | 9 10 | +5V
+   *        ------
+   */
+  #define EXP3_01_PIN                       -1
+  #define EXP3_02_PIN                       -1
+  #define EXP3_03_PIN                       PA2
+  #define EXP3_04_PIN                       PA3
+  #define EXP3_05_PIN                       PB1
+  #define EXP3_06_PIN                       -1
+  #define EXP3_07_PIN                       PA12
+  #define EXP3_08_PIN                       PA11
+
+  #ifndef BEEPER_PIN
+    #define BEEPER_PIN               EXP1_06_PIN  // BEEP
+  #endif
+
+  #define BTN_ENC                    EXP1_05_PIN  // EN
+  #define BTN_EN1                    EXP1_08_PIN  // A
+  #define BTN_EN2                    EXP1_07_PIN  // B
+
+#endif
+
+
+#include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
@@ -54,7 +54,7 @@
 #endif
 
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PC13   // BLTouch IN
+  #define Z_MIN_PROBE_PIN                   PC13  // BLTouch IN
 #endif
 
 //
@@ -68,7 +68,7 @@
 // Filament Runout Sensor
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                    PC15   // "Pulled-high"
+  #define FIL_RUNOUT_PIN                    PC15  // "Pulled-high"
 #endif
 
 //
@@ -91,13 +91,13 @@
 
   // Software serial
   #define X_SERIAL_TX_PIN                   PB12
-  #define X_SERIAL_RX_PIN                   X_SERIAL_TX_PIN
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
 
   #define Y_SERIAL_TX_PIN                   PB13
-  #define Y_SERIAL_RX_PIN                   Y_SERIAL_TX_PIN
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
 
   #define Z_SERIAL_TX_PIN                   PB14
-  #define Z_SERIAL_RX_PIN                   Z_SERIAL_TX_PIN
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
 
 #endif // HAS_TMC_UART
 
@@ -131,6 +131,5 @@
   #define BTN_EN2                    EXP1_07_PIN  // B
 
 #endif
-
 
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_CR4NS.h
@@ -33,10 +33,10 @@
   #error "CR4NS200320C13 only supports one hotend / E-stepper."
 #endif
 
-// Is E0_DRIVER_TYPE TMC2208_STANDALONE?
-// #if !AXIS_DRIVER_TYPE_X(TMC2208) || !AXIS_DRIVER_TYPE_Y(TMC2208) || !AXIS_DRIVER_TYPE_Z(TMC2208) || !AXIS_DRIVER_TYPE_E0(?)
-//   #error "This board has onboard TMC2208 drivers for X, Y, Z, and E0."
-// #endif
+// Validate stepper driver selections.
+//#if !AXIS_DRIVER_TYPE_X(TMC2208) || !AXIS_DRIVER_TYPE_Y(TMC2208) || !AXIS_DRIVER_TYPE_Z(TMC2208) || !AXIS_DRIVER_TYPE_E0(TMC2208)
+//  #error "This board has onboard TMC2208 drivers for X, Y, Z, and E0."
+//#endif
 
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME      "CR4NS200320C13"
@@ -60,9 +60,9 @@
 //
 // Limit Switches
 //
-// #ifndef Z_STOP_PIN
-//   #define Z_STOP_PIN                        PA15
-// #endif
+//#ifndef Z_STOP_PIN
+//  #define Z_STOP_PIN                      PA15  // else PA7
+//#endif
 
 //
 // Filament Runout Sensor
@@ -76,14 +76,14 @@
 //
 #define HEATER_BED_PIN                      PB2   // HOT BED
 #define FAN1_PIN                            PC1   // extruder fan
-// #define FAN2_PIN                            PB1   // Controller fan FET
+//#define FAN2_PIN                          PB1   // Controller fan FET
 
 //
 // Auto fans
 //
-// #ifndef CONTROLLER_FAN_PIN
-//   #define CONTROLLER_FAN_PIN                FAN2_PIN
-// #endif
+//#ifndef CONTROLLER_FAN_PIN
+//  #define CONTROLLER_FAN_PIN          FAN2_PIN
+//#endif
 
 #if HAS_TMC_UART
   // Reduce baud rate to improve software serial reliability


### PR DESCRIPTION
Preliminary CR4NS200320C13 board support, as found in the Ender-3 V3 SE

Driver configuration and display pin-out must be verified, this board uses the [GD32F303 RET6](https://www.gigadevice.com/product/mcu/arm-cortex-m4/gd32f303ret6) SoC, it could be compatible with the STM32F103 as in other boards with the same SoC.

```cpp
  /**
   *    LCD PIN OUT
   *        ------
   *    NC | 1  2 | NC
   *    RX | 3  4 | TX
   *    EN   5  6 | BEEP
   *     B | 7  8 | A
   *   GND | 9 10 | +5V
   *        ------
   */

  #define EXP3_01_PIN                       -1
  #define EXP3_02_PIN                       -1
  #define EXP3_03_PIN                       PA2
  #define EXP3_04_PIN                       PA3
  #define EXP3_05_PIN                       PB1
  #define EXP3_06_PIN                       // To be verified
  #define EXP3_07_PIN                       PA12
  #define EXP3_08_PIN                       PA11

  #ifndef BEEPER_PIN
    #define BEEPER_PIN               EXP1_06_PIN  // BEEP
  #endif

  #define BTN_ENC                    EXP1_05_PIN  // EN
  #define BTN_EN1                    EXP1_08_PIN  // A
  #define BTN_EN2                    EXP1_07_PIN  // B
```

Seems that MS35774 driver is a clone of the TMC2208, **TMC_UART** configuration was found only for X, Y and Z drivers, so maybe E0 is working in TMC2208_STANDALONE mode.

Based on the disclosed board configuration, images and Creality's printer.cfg

![image](https://github.com/MarlinFirmware/Marlin/assets/2745567/4051f99c-d31c-4d0b-8678-21dc4e318f17)
Image from Ebay store

