### PR TITLE
TESTING: make validate-pins on macOS vs. Linux

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -211,19 +211,19 @@
  *        ------                  ------
  *         EXP1                    EXP2
  */
-#define EXP1_01_PIN                         P1_31
-#define EXP1_02_PIN                         P1_30
-#define EXP1_03_PIN                         P0_18
-#define EXP1_04_PIN                         P0_16
-#define EXP1_05_PIN                         P0_15
+#define EXP1_01_PIN                        P1_31
+#define EXP1_02_PIN                        P1_30
+#define EXP1_03_PIN                        P0_18
+#define EXP1_04_PIN                        P0_16
+#define EXP1_05_PIN                        P0_15
 
-#define EXP2_01_PIN                         P0_08
-#define EXP2_02_PIN                         P0_07
-#define EXP2_03_PIN                         P3_25
-#define EXP2_04_PIN                         P0_28
-#define EXP2_05_PIN                         P3_26
-#define EXP2_06_PIN                         P0_09
-#define EXP2_07_PIN                         P0_27
+#define EXP2_01_PIN                        P0_08
+#define EXP2_02_PIN                        P0_07
+#define EXP2_03_PIN                        P3_25
+#define EXP2_04_PIN                        P0_28
+#define EXP2_05_PIN                        P3_26
+#define EXP2_06_PIN                        P0_09
+#define EXP2_07_PIN                        P0_27
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -325,23 +325,23 @@
 #if HAS_TMC_SPI
   #if ENABLED(TMC_USE_SW_SPI)
     #ifndef TMC_SPI_MOSI
-      #define TMC_SPI_MOSI                 AUX2_09
+      #define TMC_SPI_MOSI               AUX2_09
     #endif
     #ifndef TMC_SPI_MISO
-      #define TMC_SPI_MISO                 AUX2_07
+      #define TMC_SPI_MISO               AUX2_07
     #endif
     #ifndef TMC_SPI_SCK
-      #define TMC_SPI_SCK                  AUX2_05
+      #define TMC_SPI_SCK                AUX2_05
     #endif
   #else
     #ifndef TMC_SPI_MOSI
-      #define TMC_SPI_MOSI                 AUX3_04
+      #define TMC_SPI_MOSI               AUX3_04
     #endif
     #ifndef TMC_SPI_MISO
-      #define TMC_SPI_MISO                 AUX3_03
+      #define TMC_SPI_MISO               AUX3_03
     #endif
     #ifndef TMC_SPI_SCK
-      #define TMC_SPI_SCK                  AUX3_05
+      #define TMC_SPI_SCK                AUX3_05
     #endif
   #endif
 #endif

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -101,7 +101,7 @@
 #endif
 #if PIN_EXISTS(BEEPER) && (SERVO0_PIN == BEEPER_PIN || FIL_RUNOUT_PIN == BEEPER_PIN)
   #undef BEEPER_PIN
-  #define BEEPER_PIN -1
+  #define BEEPER_PIN                          -1
 #endif
 
 /**

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -108,7 +108,7 @@
   #endif
   #define E0_ENABLE_PIN                        4
 #else
-  #if !HAS_CUTTER && !ALL(HAS_WIRED_LCD, IS_NEWPANEL)  // Use IO Header
+  #if !HAS_CUTTER && !ALL(HAS_WIRED_LCD, IS_NEWPANEL) // Use IO Header
     #define CASE_LIGHT_PIN                     4  // Hardware PWM  - see if IO Header is available
   #endif
 #endif


### PR DESCRIPTION
### Description

`make validate-pins` appears to work differently between macOS & Linux and it formatted all the pins in this PR after the first run on my machine, so I'm opening a PR at the recommendation from @sjasonsmith to see if CI fails.

### Requirements

macOS

### Related Issues

- #26996