### PR TITLE
🔧 Add BIQU MicroProbe V2 pull-up warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -694,6 +694,10 @@
   #error "Z_SAFE_HOMING is recommended when homing with a probe. Enable Z_SAFE_HOMING or comment out this line to continue."
 #endif
 
+#if ENABLED(BIQU_MICROPROBE_V2) && NONE(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, NO_MICROPROBE_WARNING)
+  #warning "BIQU MicroProbe V2's detection signal requires a strong pull-up. Some processors have weak internal pull-up capabilities, so it is recommended to connect the MicroProbe SIGNAL and GND wires to Z-MIN / Z-STOP instead of the dedicated PROBE port. (Define NO_MICROPROBE_WARNING to suppress this warning.)"
+#endif
+
 //
 // Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
 //

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -695,7 +695,7 @@
 #endif
 
 #if ENABLED(BIQU_MICROPROBE_V2) && NONE(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, NO_MICROPROBE_WARNING)
-  #warning "BIQU MicroProbe V2's detection signal requires a strong pull-up. Some processors have weak internal pull-up capabilities, so it is recommended to connect the MicroProbe SIGNAL and GND wires to Z-MIN / Z-STOP instead of the dedicated PROBE port. (Define NO_MICROPROBE_WARNING to suppress this warning.)"
+  #warning "BIQU MicroProbe V2 detect signal requires a strong pull-up. Some processors have weak internal pull-up capabilities, so we recommended connecting MicroProbe SIGNAL / GND to Z-MIN / Z-STOP instead of the dedicated PROBE port. (Define NO_MICROPROBE_WARNING to suppress this warning.)"
 #endif
 
 //


### PR DESCRIPTION
### Description

As the warning states:

> BIQU MicroProbe V2's detection signal requires a strong pull-up. Some processors have weak internal pull-up capabilities, so it is recommended to connect the MicroProbe SIGNAL and GND wires to Z-MIN / Z-STOP instead of the dedicated PROBE port.

Pulled (and tweaked) text from the [MicroProbe manual](https://github.com/bigtreetech/MicroProbe/blob/master/MicroProbe%20V2%20User%20Manual_20240330.pdf).

_Note: This issue does not seem to be consistent, even when using the same type of motherboard across different builds, so it could be due to different V2 revisions/manufacturing._

### Requirements

BIQU MicroProbe-based config

### Benefits

Users will be alerted to potential issues when using the dedicated PROBE port instead of Z-MIN/Z-STOP ports with a MicroProbe.

### Related Issues

No related issue, but this has come up across several Discord servers & Facebook groups many times now.
