### PR TITLE
[2.1.x] 🩹 Fix missing MSG_ATTACH_SD_MEDIA define

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -567,6 +567,7 @@ namespace Language_en {
   #else
     LSTR MSG_ATTACH_MEDIA                 = _UxGT("Attach ") MEDIA_TYPE_EN;
   #endif
+  LSTR MSG_ATTACH_SD_MEDIA                = _UxGT("Attach SD Card");
   LSTR MSG_CHANGE_MEDIA                   = _UxGT("Change ") MEDIA_TYPE_EN;
   LSTR MSG_RELEASE_MEDIA                  = _UxGT("Release ") MEDIA_TYPE_EN;
   LSTR MSG_ZPROBE_OUT                     = _UxGT("Z Probe Past Bed");


### PR DESCRIPTION
### Description

> [!IMPORTANT]  
> This is a `2.1.x`-specific patch for a missing `MSG_ATTACH_SD_MEDIA` define.

### Requirements

Marlin `2.1.x`

### Benefits

Marlin `2.1.x` will include this patch on the next release.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26940
