### PR TITLE
[2.1.x] 🩹 Fix missing preheat_end_time define

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -595,7 +595,7 @@ volatile bool Temperature::raw_temps_ready = false;
 #endif
 
 #if MILLISECONDS_PREHEAT_TIME > 0
-  millis_t Temperature::preheat_end_ms_hotend[HOTENDS]; // = { 0 };
+  millis_t Temperature::preheat_end_time[HOTENDS] = { 0 };
 #endif
 #if HAS_HEATED_BED && PREHEAT_TIME_BED_MS > 0
   millis_t Temperature::preheat_end_ms_bed = 0;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -595,7 +595,7 @@ volatile bool Temperature::raw_temps_ready = false;
 #endif
 
 #if MILLISECONDS_PREHEAT_TIME > 0
-  millis_t Temperature::preheat_end_time[HOTENDS] = { 0 };
+  millis_t Temperature::preheat_end_ms_hotend[HOTENDS]; // = { 0 }
 #endif
 #if HAS_HEATED_BED && PREHEAT_TIME_BED_MS > 0
   millis_t Temperature::preheat_end_ms_bed = 0;
@@ -2442,7 +2442,7 @@ void Temperature::updateTemperaturesFromRawValues() {
       /**
       // DEBUG PREHEATING TIME
       SERIAL_ECHOLNPGM("\nExtruder = ", e, " Preheat On/Off = ", is_preheating(e));
-      const float test_is_preheating = (preheat_end_time[HOTEND_INDEX] - millis()) * 0.001f;
+      const float test_is_preheating = (preheat_end_ms_hotend[HOTEND_INDEX] - millis()) * 0.001f;
       if (test_is_preheating < 31) SERIAL_ECHOLNPGM("Extruder = ", e, " Preheat remaining time = ", test_is_preheating, "s", "\n");
       //*/
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -747,7 +747,7 @@ class Temperature {
     #endif
 
     #if MILLISECONDS_PREHEAT_TIME > 0
-      static millis_t preheat_end_time[HOTENDS];
+      static millis_t preheat_end_ms_hotend[HOTENDS];
     #endif
 
     #if HAS_FAN_LOGIC
@@ -909,13 +909,13 @@ class Temperature {
      */
     #if MILLISECONDS_PREHEAT_TIME > 0
       static bool is_preheating(const uint8_t E_NAME) {
-        return preheat_end_time[HOTEND_INDEX] && PENDING(millis(), preheat_end_time[HOTEND_INDEX]);
+        return preheat_end_ms_hotend[HOTEND_INDEX] && PENDING(millis(), preheat_end_ms_hotend[HOTEND_INDEX]);
       }
       static void start_preheat_time(const uint8_t E_NAME) {
-        preheat_end_time[HOTEND_INDEX] = millis() + MILLISECONDS_PREHEAT_TIME;
+        preheat_end_ms_hotend[HOTEND_INDEX] = millis() + MILLISECONDS_PREHEAT_TIME;
       }
       static void reset_preheat_time(const uint8_t E_NAME) {
-        preheat_end_time[HOTEND_INDEX] = 0;
+        preheat_end_ms_hotend[HOTEND_INDEX] = 0;
       }
     #else
       #define is_preheating(n) (false)


### PR DESCRIPTION
### Description

> [!IMPORTANT]  
> This is a `2.1.x`-specific patch for a missing `preheat_end_time` define.

### Requirements

Marlin `2.1.x`

### Benefits

Marlin `2.1.x` will include this patch on the next release.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26802
