### PR TITLE
[2.1.x] 🩹 Fix missing HAS_DUAL_Y_STEPPERS define

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -456,6 +456,7 @@
 #endif
 #ifdef Y2_DRIVER_TYPE
   #define HAS_Y2_STEPPER 1
+  #define HAS_DUAL_Y_STEPPERS 1
 #endif
 
 /**


### PR DESCRIPTION
### Description

> [!IMPORTANT]  
> This is a `2.1.x`-specific patch for a missing `HAS_DUAL_Y_STEPPERS` define.

### Requirements

Marlin `2.1.x`

### Benefits

Marlin `2.1.x` will include this patch on the next release.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26801
