### PR TITLE
[2.1.x] 🐛 Fix bool evalution of XYval and similar types

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -451,7 +451,7 @@ struct XYval {
   // Length reduced to one dimension
   FI constexpr T magnitude()    const { return (T)sqrtf(x*x + y*y); }
   // Pointer to the data as a simple array
-  FI operator T* ()                   { return pos; }
+  explicit FI operator T* ()          { return pos; }
   // If any element is true then it's true
   FI constexpr operator bool()  const { return x || y; }
   // Smallest element
@@ -601,7 +601,7 @@ struct XYZval {
   // Length reduced to one dimension
   FI constexpr T magnitude()    const { return (T)TERN(HAS_X_AXIS, sqrtf(NUM_AXIS_GANG(x*x, + y*y, + z*z, + i*i, + j*j, + k*k, + u*u, + v*v, + w*w)), 0); }
   // Pointer to the data as a simple array
-  FI operator T* ()                   { return pos; }
+  explicit FI operator T* ()          { return pos; }
   // If any element is true then it's true
   FI constexpr operator bool()  const { return 0 NUM_AXIS_GANG(|| x, || y, || z, || i, || j, || k, || u, || v, || w); }
   // Smallest element
@@ -749,7 +749,7 @@ struct XYZEval {
   // Length reduced to one dimension
   FI constexpr T magnitude()    const { return (T)sqrtf(LOGICAL_AXIS_GANG(+ e*e, + x*x, + y*y, + z*z, + i*i, + j*j, + k*k, + u*u, + v*v, + w*w)); }
   // Pointer to the data as a simple array
-  FI operator T* ()                   { return pos; }
+  explicit FI operator T* ()          { return pos; }
   // If any element is true then it's true
   FI constexpr operator bool()  const { return 0 LOGICAL_AXIS_GANG(|| e, || x, || y, || z, || i, || j, || k, || u, || v, || w); }
   // Smallest element


### PR DESCRIPTION
### Description

> [!IMPORTANT]  
> This is a `2.1.x`-specific patch for board lockup and bootloops with Input Shaping among other things. Originally submitted to `bugfix-2.1.x` by @sjasonsmith in https://github.com/MarlinFirmware/Marlin/pull/26936

And if you're asking why this didn't affect `bugfix-2.1.x`, it's because:

> The reason this specific bug behaviour does not occur in bugfix appears to be that the variable in question (`step_needed` in function `Stepper::shaping_isr()`) has changed type from `xy_bool_t` to `AxisFlags`.

_Originally posted by @tombrazier in https://github.com/MarlinFirmware/Marlin/issues/26811#issuecomment-2041060625_

---

Verified that board bootloops and lockups are gone on an SKR 1.4 with `INPUT_SHAPING_X` and `INPUT_SHAPING_Y` enabled.

### Requirements

Marlin `2.1.x`

### Benefits

Marlin `2.1.x` will include this patch on the next release.

### Related Issues

### Related Issues
- https://github.com/MarlinFirmware/Marlin/pull/26936 (Original Pull Request with fix)
- https://github.com/MarlinFirmware/Marlin/issues/26811
- https://github.com/MarlinFirmware/Marlin/issues/26870
- https://github.com/MarlinFirmware/Marlin/issues/26923
- https://github.com/MarlinFirmware/Marlin/issues/26961