### PR TITLE
🔧 Convert TMC addresses to decimal

### DIFF
--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -579,21 +579,21 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS                 0b00
+    #define X_SLAVE_ADDRESS                  0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS                 0b01
+    #define Y_SLAVE_ADDRESS                  1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS                 0b10
+    #define Z_SLAVE_ADDRESS                  2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS                0b11
+    #define E0_SLAVE_ADDRESS                 3
   #endif
-  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_LITE_V1_0.");
-  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_BRICOLEMON_LITE_V1_0.");
-  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_BRICOLEMON_LITE_V1_0.");
-  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_BRICOLEMON_LITE_V1_0.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BRICOLEMON_LITE_V1_0.");
 
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -634,25 +634,25 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS                 0b00
+    #define X_SLAVE_ADDRESS                  0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS                 0b01
+    #define Y_SLAVE_ADDRESS                  1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS                 0b10
+    #define Z_SLAVE_ADDRESS                  2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS                0b11
+    #define E0_SLAVE_ADDRESS                 3
   #endif
   #ifndef E1_SLAVE_ADDRESS
-    #define E1_SLAVE_ADDRESS                0b00
+    #define E1_SLAVE_ADDRESS                 0
   #endif
-  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_V1_0.");
-  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_BRICOLEMON_V1_0.");
-  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_BRICOLEMON_V1_0.");
-  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_BRICOLEMON_V1_0.");
-  static_assert(E1_SLAVE_ADDRESS == 0b00, "E1_SLAVE_ADDRESS must be 0b00 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_BRICOLEMON_V1_0.");
+  static_assert(E1_SLAVE_ADDRESS == 0, "E1_SLAVE_ADDRESS must be 0 for BOARD_BRICOLEMON_V1_0.");
 
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -511,25 +511,25 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS                 0b00
+    #define X_SLAVE_ADDRESS                  0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS                 0b01
+    #define Y_SLAVE_ADDRESS                  1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS                 0b10
+    #define Z_SLAVE_ADDRESS                  2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS                0b11
+    #define E0_SLAVE_ADDRESS                 3
   #endif
   #ifndef E1_SLAVE_ADDRESS
-    #define E1_SLAVE_ADDRESS                0b00
+    #define E1_SLAVE_ADDRESS                 0
   #endif
-  static_assert(X_SLAVE_ADDRESS == 0b00, "X_SLAVE_ADDRESS must be 0b00 for BOARD_MINITRONICS20.");
-  static_assert(Y_SLAVE_ADDRESS == 0b01, "Y_SLAVE_ADDRESS must be 0b01 for BOARD_MINITRONICS20.");
-  static_assert(Z_SLAVE_ADDRESS == 0b10, "Z_SLAVE_ADDRESS must be 0b10 for BOARD_MINITRONICS20.");
-  static_assert(E0_SLAVE_ADDRESS == 0b11, "E0_SLAVE_ADDRESS must be 0b11 for BOARD_MINITRONICS20.");
-  static_assert(E1_SLAVE_ADDRESS == 0b00, "E1_SLAVE_ADDRESS must be 0b00 for BOARD_MINITRONICS20.");
+  static_assert(X_SLAVE_ADDRESS == 0, "X_SLAVE_ADDRESS must be 0 for BOARD_MINITRONICS20.");
+  static_assert(Y_SLAVE_ADDRESS == 1, "Y_SLAVE_ADDRESS must be 1 for BOARD_MINITRONICS20.");
+  static_assert(Z_SLAVE_ADDRESS == 2, "Z_SLAVE_ADDRESS must be 2 for BOARD_MINITRONICS20.");
+  static_assert(E0_SLAVE_ADDRESS == 3, "E0_SLAVE_ADDRESS must be 3 for BOARD_MINITRONICS20.");
+  static_assert(E1_SLAVE_ADDRESS == 0, "E1_SLAVE_ADDRESS must be 0 for BOARD_MINITRONICS20.");
 
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE

--- a/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
@@ -106,9 +106,9 @@
 
   // Default TMC slave addresses
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS               0b00
+    #define E0_SLAVE_ADDRESS                0
   #endif
-  static_assert(E0_SLAVE_ADDRESS == 0b00, "E0_SLAVE_ADDRESS must be 0b00 for BOARD_BTT_EBB42_V1_1.");
+  static_assert(E0_SLAVE_ADDRESS == 0, "E0_SLAVE_ADDRESS must be 0 for BOARD_BTT_EBB42_V1_1.");
 #endif
 
 //


### PR DESCRIPTION
### Description

Some pins files used binary numbers for TMC slave addresses. Convert these to decimal to be consistent for all boards.

All edits were performed using find/replace across files, to remove the chance of manual editing errors.