### PR TITLE
fix text stacking in `BED_TRAMMING_USE_PROBE` menu when using `DWIN_MARLINUI`

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_tramming.cpp
@@ -183,7 +183,7 @@ static void _lcd_goto_next_corner() {
 
     uint8_t cy = TERN(TFT_COLOR_UI, 3, LCD_HEIGHT - 1), y = LCD_ROW_Y(cy);
 
-    // enable font background for DWIN
+    // Enable font background for DWIN
     TERN_(IS_DWIN_MARLINUI, dwin_font.solid = true);
 
     // Display # of good points found vs total needed

--- a/Marlin/src/lcd/menu/menu_bed_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_tramming.cpp
@@ -183,6 +183,9 @@ static void _lcd_goto_next_corner() {
 
     uint8_t cy = TERN(TFT_COLOR_UI, 3, LCD_HEIGHT - 1), y = LCD_ROW_Y(cy);
 
+    // enable font background for DWIN
+    TERN_(IS_DWIN_MARLINUI, dwin_font.solid = true);
+
     // Display # of good points found vs total needed
     if (PAGE_CONTAINS(y - (MENU_FONT_HEIGHT), y)) {
       SETCURSOR(TERN(TFT_COLOR_UI, 2, 0), cy);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

When using `BED_TRAMMING_USE_PROBE` with `DWIN_MARLINUI_*`, the 'Last Z' and 'Good Points' output gets re-drawn without clearing the previous text, causing the text to appear garbled.


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

DWIN Screen with MarlinUI (`DWIN_MARLINUI_PORTRAIT` or `DWIN_MARLINUI_LANDSCAPE`)

### Benefits

<!-- What does this PR fix or improve? -->

Makes the bed tramming menu usable on DWIN screens.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

N/A

### Attachments


| ![bed-tramming-menu-broken](https://github.com/MarlinFirmware/Marlin/assets/52449218/18ec6121-65fb-4619-aa11-9d4d10c0d996) | ![bed-tramming-menu-fixed](https://github.com/MarlinFirmware/Marlin/assets/52449218/360fbe2e-adb6-4279-9616-d264dd50bdf1) |
|-|-|
| Broken bed tramming menu on `DWIN_MARLINUI_PORTRAIT` | Bed tramming menu on `DWIN_MARLINUI_PORTRAIT` with this PR applied |


