### PR TITLE
Move cruise LASER_POWER_TRAP code to cruise block.

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2343,7 +2343,7 @@ hal_timer_t Stepper::block_phase_isr() {
             if (planner.laser_inline.status.isPowered && planner.laser_inline.status.isEnabled) {
               if (current_block->laser.trap_ramp_entry_incr > 0) {
                 cutter.apply_power(current_block->laser.trap_ramp_active_pwr);
-                current_block->laser.trap_ramp_active_pwr += current_block->laser.trap_ramp_entry_incr;
+                current_block->laser.trap_ramp_active_pwr += current_block->laser.trap_ramp_entry_incr * steps_per_isr;
               }
             }
             // Not a powered move.
@@ -2420,7 +2420,7 @@ hal_timer_t Stepper::block_phase_isr() {
           if (cutter.cutter_mode == CUTTER_MODE_CONTINUOUS) {
             if (planner.laser_inline.status.isPowered && planner.laser_inline.status.isEnabled) {
               if (current_block->laser.trap_ramp_exit_decr > 0) {
-                current_block->laser.trap_ramp_active_pwr -= current_block->laser.trap_ramp_exit_decr;
+                current_block->laser.trap_ramp_active_pwr -= current_block->laser.trap_ramp_exit_decr * steps_per_isr;
                 cutter.apply_power(current_block->laser.trap_ramp_active_pwr);
               }
               // Not a powered move.


### PR DESCRIPTION
Move cruise `LASER_POWER_TRAP` code into stepper cruise block. Small cleanup that fixes some potential issues:
- when `events_to_do` is not 1 (like if `MULTISTEPPING_LIMIT` is not 1) then the laser cruise update may not get run at all
- when we go straight from acceleration into deceleration then both the `LASER_POWER_TRAP` deceleration and cruise blocks run, which is not intentional

Only affects code using `LASER_POWER_TRAP`.

Lightly tested by hooking up a logic analyzer to the laser pwm pin. The ramp up/cruise/down look ok and quite similar as to before this change. Here's just an example of what I've looked at (snapshot of acceleration->cruise at 80% power):
![laser-before](https://github.com/MarlinFirmware/Marlin/assets/299015/c9a422b1-07cf-462c-a49f-faf0d5cb313b)

This change comes as a result of discussions on #27013 