### PR TITLE
check for HAS_MULTI_HOTEND in Temperature::getHeaterPower

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1304,7 +1304,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
       case H_COOLER: return temp_cooler.soft_pwm_amount;
     #endif
     default:
-      return TERN0(HAS_HOTEND, temp_hotend[TERN0(HAS_MULTI_HOTEND, heater_id)].soft_pwm_amount);
+      return TERN0(HAS_HOTEND, temp_hotend[_MIN(heater_id, HOTENDS - 1)].soft_pwm_amount);
   }
 }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1303,8 +1303,10 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
     #if HAS_COOLER
       case H_COOLER: return temp_cooler.soft_pwm_amount;
     #endif
-    default:
-      return TERN0(HAS_HOTEND, temp_hotend[_MIN(heater_id, HOTENDS - 1)].soft_pwm_amount);
+    #if HAS_HOTEND
+      case 0 ... HOTENDS - 1: return temp_hotend[heater_id].soft_pwm_amount;
+    #endif
+    default: return 0;
   }
 }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1304,7 +1304,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
       case H_COOLER: return temp_cooler.soft_pwm_amount;
     #endif
     default:
-      return TERN0(HAS_HOTEND, temp_hotend[heater_id].soft_pwm_amount);
+      return TERN0(HAS_HOTEND, temp_hotend[TERN0(HAS_MULTI_HOTEND, heater_id)].soft_pwm_amount);
   }
 }
 


### PR DESCRIPTION
### Description

While p3p was updating the sim for multiple extruders and hotend he came across a bug in Marlin.
for full details. https://discord.com/channels/461605380783472640/491105471076368390/1234651377863753829

The issue is that Temperature::getHeaterPower does not know about single hotend options, so the array 
temp_hotend[heater_id]  goes out of bounds when there is only 1 hotend with multiple extruders.

This fix is just to limit the array to 0 when there is only the 1 hotend

Ie temp_hotend[TERN0(HAS_MULTI_HOTEND, heater_id)]

### Requirements

Multiple extruders with a single hotend.

### Benefits

Array is not over run.

