### PR TITLE
🧑‍💻Improve make tests-all-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,13 @@ tests-single-local-docker:
 	$(CONTAINER_RT_BIN) run $(CONTAINER_RT_OPTS) $(CONTAINER_IMAGE) make tests-single-local TEST_TARGET=$(TEST_TARGET) VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) GIT_RESET_HARD=$(GIT_RESET_HARD) ONLY_TEST="$(ONLY_TEST)"
 
 tests-all-local:
-		export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
-			&& export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
-			&& for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
-					 echo "Running tests for $$TEST_TARGET" ; \
-					 run_tests . $$TEST_TARGET || exit 1 ; \
-					 sleep 5; \
-				 done
+	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
+		&& export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
+		&& for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
+					echo "Running tests for $$TEST_TARGET" ; \
+					run_tests . $$TEST_TARGET || exit 1 ; \
+					sleep 5; \
+				done
 
 tests-all-local-docker:
 	@if ! $(CONTAINER_RT_BIN) images -q $(CONTAINER_IMAGE) > /dev/null ; then $(MAKE) setup-local-docker ; fi

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ tests-single-local-docker:
 
 tests-all-local:
 	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
-		&& export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
-		&& for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
-					echo "Running tests for $$TEST_TARGET" ; \
-					run_tests . $$TEST_TARGET || exit 1 ; \
-					sleep 5; \
-				done
+	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
+	  && for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
+	    echo "Running tests for $$TEST_TARGET" ; \
+	    run_tests . $$TEST_TARGET || exit 1 ; \
+	    sleep 5; \
+	  done
 
 tests-all-local-docker:
 	@if ! $(CONTAINER_RT_BIN) images -q $(CONTAINER_IMAGE) > /dev/null ; then $(MAKE) setup-local-docker ; fi

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,10 @@ tests-single-local-docker:
 	$(CONTAINER_RT_BIN) run $(CONTAINER_RT_OPTS) $(CONTAINER_IMAGE) make tests-single-local TEST_TARGET=$(TEST_TARGET) VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) GIT_RESET_HARD=$(GIT_RESET_HARD) ONLY_TEST="$(ONLY_TEST)"
 
 tests-all-local:
+	@python -c "import yaml" 2>/dev/null || (echo 'pyyaml module is not installed. Install it with "python -m pip install pyyaml"' && exit 1)
 	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
 	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
-	  && for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
+	  && for TEST_TARGET in $$(python $(SCRIPTS_DIR)/get_test_targets.py) ; do \
 	    echo "Running tests for $$TEST_TARGET" ; \
 	    run_tests . $$TEST_TARGET || exit 1 ; \
 	    sleep 5; \

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,12 @@ tests-single-local-docker:
 	$(CONTAINER_RT_BIN) run $(CONTAINER_RT_OPTS) $(CONTAINER_IMAGE) make tests-single-local TEST_TARGET=$(TEST_TARGET) VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) GIT_RESET_HARD=$(GIT_RESET_HARD) ONLY_TEST="$(ONLY_TEST)"
 
 tests-all-local:
-	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
-	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
-	  && for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do echo "Running tests for $$TEST_TARGET" ; run_tests . $$TEST_TARGET ; done
+		export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
+			&& export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
+			&& for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
+					 echo "Running tests for $$TEST_TARGET" ; \
+					 run_tests . $$TEST_TARGET || exit 1 ; \
+				 done
 
 tests-all-local-docker:
 	@if ! $(CONTAINER_RT_BIN) images -q $(CONTAINER_IMAGE) > /dev/null ; then $(MAKE) setup-local-docker ; fi

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ tests-all-local:
 	export PATH="./buildroot/bin/:./buildroot/tests/:${PATH}" \
 	  && export VERBOSE_PLATFORMIO=$(VERBOSE_PLATFORMIO) \
 	  && for TEST_TARGET in $$(python $(SCRIPTS_DIR)/get_test_targets.py) ; do \
+	    if [ "$$TEST_TARGET" = "linux_native" ] && [ "$$(uname)" = "Darwin" ]; then \
+	      echo "Skipping tests for $$TEST_TARGET on macOS" ; \
+	      continue ; \
+	    fi ; \
 	    echo "Running tests for $$TEST_TARGET" ; \
 	    run_tests . $$TEST_TARGET || exit 1 ; \
 	    sleep 5; \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ tests-all-local:
 			&& for TEST_TARGET in $$($(SCRIPTS_DIR)/get_test_targets.py) ; do \
 					 echo "Running tests for $$TEST_TARGET" ; \
 					 run_tests . $$TEST_TARGET || exit 1 ; \
+					 sleep 5; \
 				 done
 
 tests-all-local-docker:

--- a/buildroot/share/scripts/get_test_targets.py
+++ b/buildroot/share/scripts/get_test_targets.py
@@ -5,7 +5,7 @@ Extract the builds used in Github CI, so that we can run them locally
 import yaml
 
 # Set the yaml file to parse
-yaml_file = '.github/workflows/test-builds.yml'
+yaml_file = '.github/workflows/ci-build-tests.yml'
 
 # Parse the yaml file, and load it into a dictionary (github_configuration)
 with open(yaml_file) as f:


### PR DESCRIPTION
### Description

This resolves several issues encountered when running `make tests-all-local`. These were found when operating inside Windows Subsystem for Linux, but likely impacted other development environments as well:

1. Tests continued after failing a TEST_TARGET. This made it difficult to notice when a failure occurred. By adding a test for status and an exit(1) call on failure, the test sequence now stops as soon as a failure occurs.

2. PlatformIO frequently failed to transition from one test target to the next, with errors indicating missing frameworks. This seems to be resolved by adding a 5 second delay when transitioning from one TEST_TARGET to the next.

3. Test the local Python to ensure `pyyaml` is available. If not, instruct user how to install it.
I chose not to install it automatically, since this is the user's default Python and not a virtual environment.

4. Fix broken file reference, and do not require Python files to be made executable to work.


### Requirements

- Linux-like development environment with `make` and other Marlin dependencies installed
- Execute `make tests-all-local` from the command line

### Benefits

Simplified running compilation tests locally to test changes outside of a PR.
