### PR TITLE
🚸 Add Input Shaping with I2S_STEPPER_STREAM warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -788,8 +788,13 @@
 /**
  * Input Shaping
  */
-#if HAS_ZV_SHAPING && ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
-  #warning "Input Shaping for CORE / MARKFORGED kinematic axes is still experimental."
+#if HAS_ZV_SHAPING
+  #if ANY(CORE_IS_XY, MARKFORGED_XY, MARKFORGED_YX)
+    #warning "Input Shaping for CORE / MARKFORGED kinematic axes is still experimental."
+  #endif
+  #if ENABLED(I2S_STEPPER_STREAM)
+    #warning "Input Shaping has not been tested with I2S_STEPPER_STREAM."
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
### Description

As the title states, add an Input Shaping with `I2S_STEPPER_STREAM` warning for ESP32-based motherboards like the MKS TinyBee.

The warning is a bit inaccurate since it's a [known issue](https://github.com/MarlinFirmware/Marlin/issues/25605) that these are incompatible (and it just came up again on Discord), but I wanted to match the existing `FT_MOTION` + `I2S_STEPPER_STREAM` warning:

https://github.com/MarlinFirmware/Marlin/blob/eb781afe7b01d510b58abc4f83b767ecc61d6b84/Marlin/src/inc/Warnings.cpp#L854-L859

I originally tried to sanity check this in https://github.com/MarlinFirmware/Marlin/pull/25632, but the PR got hijacked and turned into something else, so it was closed.

### Requirements

Any ESP32 motherboard like the MKS TinyBee with `I2S_STEPPER_STREAM` and `HAS_ZV_SHAPING` (`INPUT_SHAPING_X` / `INPUT_SHAPING_Y`)

### Benefits

Warn users that these settings may be incompatible (but we know they're not).

### Configurations

Any ESP32 motherboard like the MKS TinyBee with `I2S_STEPPER_STREAM` and `HAS_ZV_SHAPING` (`INPUT_SHAPING_X` / `INPUT_SHAPING_Y`)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/25605
- https://github.com/MarlinFirmware/Marlin/pull/25632
