### PR TITLE
🩹 Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href="/LICENSE"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/marlinfirmware/marlin.svg"></a>
     <a href="https://github.com/MarlinFirmware/Marlin/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlin.svg"></a>
     <a href="https://github.com/MarlinFirmware/Marlin/releases"><img alt="Last Release Date" src="https://img.shields.io/github/release-date/MarlinFirmware/Marlin"></a>
-    <a href="https://github.com/MarlinFirmware/Marlin/actions"><img alt="CI Status" src="https://github.com/MarlinFirmware/Marlin/actions/workflows/test-builds.yml/badge.svg"></a>
+    <a href="https://github.com/MarlinFirmware/Marlin/actions/workflows/ci-build-tests.yml"><img alt="CI Status" src="https://github.com/MarlinFirmware/Marlin/actions/workflows/ci-build-tests.yml/badge.svg"></a>
     <a href="https://github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
     <br />
     <a href="https://fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>


### PR DESCRIPTION
### Description

`test-builds.yml` was renamed to `ci-build-tests.yml` in #26948, so the CI badge is now showing `CI - bugfix-2.0.x passing` (despite CI failing for that branch):

<img width="168" alt="image" src="https://github.com/MarlinFirmware/Marlin/assets/13375512/3941c2e2-8e53-42b9-ae7e-1b2685c834ce"> <br />

This PR points the badge to the renamed yml & directly links to the workflow:

<img width="168" alt="image" src="https://github.com/MarlinFirmware/Marlin/assets/13375512/12797d63-312b-4781-8c66-387da4d59474">

### Related Issues

- #26948