### PR TITLE
Allow touch screen fan edit for LASER_SYNCHRONOUS_M106_M107

### DIFF
--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -217,7 +217,7 @@ void Touch::touch(touch_control_t *control) {
       static uint8_t fan, fan_speed;
       fan = 0;
       fan_speed = thermalManager.fan_speed[fan];
-      MenuItem_percent::action(GET_TEXT_F(MSG_FIRST_FAN_SPEED), &fan_speed, 0, 255, []{ thermalManager.set_fan_speed(fan, fan_speed); });
+      MenuItem_percent::action(GET_TEXT_F(MSG_FIRST_FAN_SPEED), &fan_speed, 0, 255, []{ thermalManager.set_fan_speed(fan, fan_speed); TERN_(LASER_SYNCHRONOUS_M106_M107, planner.buffer_sync_block(BLOCK_BIT_SYNC_FANS));});
       break;
     case FEEDRATE:
       ui.clear_lcd();


### PR DESCRIPTION
Currently touch screen fan edit doesn't work with LASER_SYNCHRONOUS_M106_M107 enabled. This PR adds call to `planner.buffer_sync_block` in this case.