### PR TITLE
🩹 Fix M907 E-axis check

### DIFF
--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -133,7 +133,7 @@ void GcodeSuite::M907() {
       SERIAL_ECHOLNPGM_P(                                     // PWM-based has 3 values:
           PSTR("  M907 X"), stepper.motor_current_setting[0]  // X, Y, (I, J, K, U, V, W)
         , SP_Z_STR,         stepper.motor_current_setting[1]  // Z
-        #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
+        #if HAS_EXTRUDERS && PIN_EXISTS(MOTOR_CURRENT_PWM_E)
           , SP_E_STR,       stepper.motor_current_setting[2]  // E
         #endif
       );


### PR DESCRIPTION
### Description

While running the [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script, I found that our [Mini Rambo-based CNC config](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/CNC/miniRambo) would not build:

<details><summary>details:</summary>
<p>

```prolog
In file included from Marlin/src/gcode/feature/digipot/../../../inc/MarlinConfigPre.h:37:0,
                 from Marlin/src/gcode/feature/digipot/../../../inc/MarlinConfig.h:28,
                 from Marlin/src/gcode/feature/digipot/M907-M910.cpp:23:
Marlin/src/gcode/feature/digipot/M907-M910.cpp: In static member function 'static void GcodeSuite::M907_report(bool)':
Marlin/src/gcode/feature/digipot/M907-M910.cpp:137:13: error: 'SP_E_STR' was not declared in this scope
           , SP_E_STR,       stepper.motor_current_setting[2]  // E
             ^

[snip]

*** [.pio/build/rambo/src/src/gcode/feature/digipot/M907-M910.cpp.o] Error 1
============================================================== [FAILED] Took 7.55 seconds ==============================================================
```
</p>
</details>

Since there's no extruder on this build/config, using `PIN_EXISTS(MOTOR_CURRENT_PWM_E)` is not enough and we need to also check for `HAS_EXTRUDERS`.

### Requirements

Mini Rambo board config without an extruder.

### Benefits

Mini Rambo board config without an extruder will build.

### Configurations

[Configurations/config/examples/CNC/miniRambo/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/CNC/miniRambo)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26892
- https://github.com/MarlinFirmware/Configurations/issues/1052
