### PR TITLE
🩹 Add missing PIO upload protocol for AT90USB1286-based boards

### DIFF
--- a/buildroot/share/PlatformIO/boards/marlin_at90usb1286.json
+++ b/buildroot/share/PlatformIO/boards/marlin_at90usb1286.json
@@ -14,7 +14,7 @@
     "maximum_ram_size": 8192,
     "maximum_size": 122880,
     "require_upload_port": true,
-    "protocol": ""
+    "protocol": "teensy-gui"
   },
   "url": "https://github.com/MarlinFirmware/Marlin",
   "vendor": "various"


### PR DESCRIPTION
### Description

Silence / remove `Unknown upload protocol` warning while building for AT90USB1286-based motherboards.

### Requirements

Any supported AT90USB1286-based motherboard

### Benefits

Silence / remove `Unknown upload protocol` warning

### Configurations

[config/examples/Printrbot/Simple Metal RevD](https://github.com/MarlinFirmware/Configurations/tree/import-2.1.x/config/examples/Printrbot/Simple%20Metal%20RevD)

### Related Issues

None
