### PR TITLE
🩹 Fix Nextion cstr/fstr typo

### DIFF
--- a/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
@@ -61,7 +61,7 @@ namespace ExtUI {
     UNUSED(icon); UNUSED(fBtn);
   }
   void onUserConfirmRequired(const int icon, FSTR_P const fstr, FSTR_P const fBtn) {
-    onUserConfirmRequired(cstr);
+    onUserConfirmRequired(fstr);
     UNUSED(icon); UNUSED(fBtn);
   }
 


### PR DESCRIPTION
### Description

While running the [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script, I found that our [Nextion TFT-based config](https://github.com/MarlinFirmware/Configurations/tree/import-2.1.x/config/examples/Nextion) would not build:

<details><summary>details:</summary>
<p>

```prolog
Marlin/src/lcd/extui/nextion/nextion_extui.cpp: In function 'void ExtUI::onUserConfirmRequired(int, FSTR_P, FSTR_P)':
Marlin/src/lcd/extui/nextion/nextion_extui.cpp:64:27: error: 'cstr' was not declared in this scope
     onUserConfirmRequired(cstr);
                           ^~~~
Marlin/src/lcd/extui/nextion/nextion_extui.cpp:64:27: note: suggested alternative: 'fstr'
     onUserConfirmRequired(cstr);
                           ^~~~
                           fstr
*** [.pio/build/mega2560/src/src/lcd/extui/nextion/nextion_extui.cpp.o] Error 1
============================================================== [FAILED] Took 10.56 seconds ==============================================================

Environment    Status    Duration
-------------  --------  ------------
mega2560       FAILED    00:00:10.557
========================================================= 1 failed, 0 succeeded in 00:00:10.557 =========================================================
Failed
```

</p>
</details>

This appears to be an obvious typo & now matches the other extui changes made in #26539

### Requirements

Any config with `NEXTION_TFT`.

### Benefits

`NEXTION_TFT`-based configs will build.

### Configurations

[config/examples/Nextion](https://github.com/MarlinFirmware/Configurations/tree/import-2.1.x/config/examples/Nextion)

### Related Issues

- #26539
- https://github.com/MarlinFirmware/Configurations/issues/1052
