### PR TITLE
Ender 2 Pro LCD_PINS_RS = PB15

### DIFF
--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -199,7 +199,7 @@
 #define EXP1_04_PIN                         PA3
 #define EXP1_05_PIN                         PB13
 #define EXP1_06_PIN                         PB14
-#define EXP1_07_PIN                         -1
+#define EXP1_07_PIN                         PB15
 #define EXP1_08_PIN                         PB12
 
 #if ENABLED(CR10_STOCKDISPLAY)                    // LCD used for C2

--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -31,8 +31,6 @@
   #error "Creality v2.4.S4 only supports one hotend and E-stepper"
 #endif
 
-//#define ENDER2_PRO_REV_QQQ
-
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "Creality v2.4.S4"
 #endif
@@ -186,14 +184,14 @@
 // LCD / Controller
 //
 
-/**         ------
- *   PC6   | 1  2 | PC7
- *   PA2   | 3  4 | PA3
- *   PB13    5  6 | PB14
- *  (PB15) | 7  8 | PB12
- *   GND   | 9 10 | 5V
- *          ------
- *           EXP1
+/**        ------
+ *   PC6  | 1  2 | PC7
+ *   PA2  | 3  4 | PA3
+ *   PB13   5  6 | PB14
+ *   PB15 | 7  8 | PB12
+ *   GND  | 9 10 | 5V
+ *         ------
+ *          EXP1
  */
 #define EXP1_01_PIN                         PC6
 #define EXP1_02_PIN                         PC7
@@ -201,11 +199,7 @@
 #define EXP1_04_PIN                         PA3
 #define EXP1_05_PIN                         PB13
 #define EXP1_06_PIN                         PB14
-#ifdef ENDER2_PRO_REV_QQQ
-  #define EXP1_07_PIN                       PB15
-#else
-  #define EXP1_07_PIN                       -1
-#endif
+#define EXP1_07_PIN                         PB15
 #define EXP1_08_PIN                         PB12
 
 #if ENABLED(CR10_STOCKDISPLAY)                    // LCD used for C2

--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -31,6 +31,8 @@
   #error "Creality v2.4.S4 only supports one hotend and E-stepper"
 #endif
 
+//#define ENDER2_PRO_REV_QQQ
+
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "Creality v2.4.S4"
 #endif
@@ -184,14 +186,14 @@
 // LCD / Controller
 //
 
-/**        ------
- *   PC6  | 1  2 | PC7
- *   PA2  | 3  4 | PA3
- *   PB13   5  6 | PB14
- *   N/C  | 7  8 | PB12
- *   GND  | 9 10 | 5V
- *         ------
- *          EXP1
+/**         ------
+ *   PC6   | 1  2 | PC7
+ *   PA2   | 3  4 | PA3
+ *   PB13    5  6 | PB14
+ *  (PB15) | 7  8 | PB12
+ *   GND   | 9 10 | 5V
+ *          ------
+ *           EXP1
  */
 #define EXP1_01_PIN                         PC6
 #define EXP1_02_PIN                         PC7
@@ -199,7 +201,11 @@
 #define EXP1_04_PIN                         PA3
 #define EXP1_05_PIN                         PB13
 #define EXP1_06_PIN                         PB14
-#define EXP1_07_PIN                         PB15
+#ifdef ENDER2_PRO_REV_QQQ
+  #define EXP1_07_PIN                       PB15
+#else
+  #define EXP1_07_PIN                       -1
+#endif
 #define EXP1_08_PIN                         PB12
 
 #if ENABLED(CR10_STOCKDISPLAY)                    // LCD used for C2


### PR DESCRIPTION
added missing LCD_PINS_RS for Ender 2 Pro BOARD_CREALITY_ENDER2P_V24S4 and set to PB15

I tested it on the Ender 2 Pro and the LCD is now working. Before, just de backlight of the LCD was turned on but no image.

### Description

This Pull Request defines the PB15 Pin, that is used as EXP_07 and then assigned to LCD_PINS_RS.
This is for the BOARD_CREALITY_ENDER2P_V24S4. The information was extracted from the Creality repository https://github.com/CrealityOfficial/Ender-2-Pro/tree/MCU_HDSC and tested on the Ender 2 Pro

### Requirements

- CR-10 LCD
- BOARD_CREALITY_ENDER2P_V24S4

### Benefits

This pull request makes the LCD of the Ender 2 Pro functional.

### Configurations

Default Config files of the Marlin Config repository for this board.
