### PR TITLE
📝 Drop MPCTEMP's experimental tag

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -672,7 +672,7 @@
  * MPCTEMP : Predictive Model temperature control. (~1.8K without auto-tune)
  */
 #define PIDTEMP           // See the PID Tuning Guide at https://reprap.org/wiki/PID_Tuning
-//#define MPCTEMP         // ** EXPERIMENTAL ** See https://marlinfw.org/docs/features/model_predictive_control.html
+//#define MPCTEMP         // See https://marlinfw.org/docs/features/model_predictive_control.html
 
 #define PID_MAX  255      // Limit hotend current while PID is active (see PID_FUNCTIONAL_RANGE below); 255=full current
 #define PID_K1     0.95   // Smoothing factor within any PID loop


### PR DESCRIPTION
### Description

It's been a couple years now & `MPCTEMP` works *really* well. So well, I'd like to see it as the default at some point, but let's drop the "experimental" tag for now.

Shout out to @The-EG for pointing out that it's been two years already. _timeflies.gif_
