### PR TITLE
HC32: fix WDT reset when saving UBL mesh

### DIFF
--- a/Marlin/src/HAL/HC32/sysclock.cpp
+++ b/Marlin/src/HAL/HC32/sysclock.cpp
@@ -104,7 +104,7 @@ void core_hook_sysclock_init() {
       .enPclk0Div = ClkSysclkDiv1, // PCLK0 = 200 MHz (Timer6 (not used))
       .enPclk1Div = ClkSysclkDiv4, // PCLK1 = 50 MHz (USART, SPI, I2S, Timer0 (step+temp), TimerA (Servo))
       .enPclk2Div = ClkSysclkDiv4, // PCLK2 = 50 MHz (ADC)
-      .enPclk3Div = ClkSysclkDiv4, // PCLK3 = 50 MHz (I2C, WDT)
+      .enPclk3Div = ClkSysclkDiv8, // PCLK3 = 25 MHz (I2C, WDT)
       .enPclk4Div = ClkSysclkDiv2, // PCLK4 = 100 MHz (ADC ctl)
   };
   sysclock_set_clock_dividers(&sysClkConf);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

While setting up UBL, i found that the WDT would reset the printer when trying to save a the mesh.

After some debugging, i've found the auto-configuration function in the IWatchdog library to fail configuring when a 5s timeout, instead configuring a timeout after ~2s. 


to mitigate this issue, 2 changes were implemented:
1. lower the PCLK3 clock to 25MHz (in this PR)
2. update the auto-config function of the IWatchdog library (in https://github.com/shadow578/framework-arduino-hc32f46x/pull/26)

Either of these would be sufficient to fix the reset "symptom", but both are necessary to get the watchdog to behave as expected.


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Any HC32 based board

### Benefits

<!-- What does this PR fix or improve? -->

Fixes unexpected watchdog timeouts when saving UBL mesh data.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

N/A
