### PR TITLE
fix  Undef motor current PWM for unused axes

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3973,7 +3973,7 @@ void Stepper::report_positions() {
             #endif
             break;
           case 2:
-            #if HAS_MOTOR_CURRENT_PWM_E
+            #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
               _WRITE_CURRENT_PWM(E);
             #endif
             #if PIN_EXISTS(MOTOR_CURRENT_PWM_E0)
@@ -4036,7 +4036,7 @@ void Stepper::report_positions() {
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
           INIT_CURRENT_PWM(Z);
         #endif
-        #if HAS_MOTOR_CURRENT_PWM_E
+        #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
           INIT_CURRENT_PWM(E);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_E0)


### PR DESCRIPTION
### Description

Commit https://github.com/MarlinFirmware/Marlin/commit/08fe8a3076c21f881f151bc596e54ff24831bdea broke things

Two cases where the test was specifically for  MOTOR_CURRENT_PWM_E and not MOTOR_CURRENT_PWM_E0 or MOTOR_CURRENT_PWM_E1 was replaced with HAS_MOTOR_CURRENT_PWM_E which is set when any of those three pins exist.

Resulting in failing to build for several stock configurations

Marlin/src/module/stepper.cpp: In static member function 'static void Stepper::set_digipot_current(uint8_t, int16_t)':
Marlin/src/module/stepper.cpp:3939:62: error: 'MOTOR_CURRENT_PWM_E_PIN' was not declared in this scope
         #define WRITE_CURRENT_PWM(P) hal.set_pwm_duty(pin_t(MOTOR_CURRENT_PWM## P ##_PIN), 255L * current / (MOTOR_CURRENT_PWM_RANGE))

### Requirements

MOTOR_CURRENT_PWM_E0, but no MOTOR_CURRENT_PWM_E, such as Marlin/src/pins/sam/pins_ARCHIM1.h
### Benefits

It builds again

### Configurations
https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/UltiMachine/Archim1

