### PR TITLE
add get_current_line_number as default action for gcode M110 without N parameter 

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -135,7 +135,7 @@
 #define STR_BUSY_PAUSED_FOR_USER            "busy: paused for user"
 #define STR_BUSY_PAUSED_FOR_INPUT           "busy: paused for input"
 #define STR_Z_MOVE_COMP                     "Z_move_comp"
-#define STR_LINE_NO                         "Line #: "
+#define STR_LINE_NO                         "Line: "
 #define STR_RESEND                          "Resend: "
 #define STR_UNKNOWN_COMMAND                 "Unknown command: \""
 #define STR_ACTIVE_EXTRUDER                 "Active Extruder: "

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -135,6 +135,7 @@
 #define STR_BUSY_PAUSED_FOR_USER            "busy: paused for user"
 #define STR_BUSY_PAUSED_FOR_INPUT           "busy: paused for input"
 #define STR_Z_MOVE_COMP                     "Z_move_comp"
+#define STR_LINE_NO                         "Line #: "
 #define STR_RESEND                          "Resend: "
 #define STR_UNKNOWN_COMMAND                 "Unknown command: \""
 #define STR_ACTIVE_EXTRUDER                 "Active Extruder: "

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -143,7 +143,7 @@
  *        R<temp> Wait for extruder current temp to reach target temp. ** Wait for heating or cooling. **
  *        If AUTOTEMP is enabled, S<mintemp> B<maxtemp> F<factor>. Exit autotemp by any M109 without F
  *
- * M110 - Set the current line number. (Used by host printing)
+ * M110 - Get or set the current line number. (Used by host printing)
  * M111 - Set debug flags: "M111 S<flagbits>". See flag bits defined in enum.h.
  * M112 - Full Shutdown.
  *

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -24,11 +24,12 @@
 #include "../queue.h" // for last_N
 
 /**
- * M110: Set Current Line Number
+ * M110: Get or set Current Line Number
  */
 void GcodeSuite::M110() {
 
   if (parser.seenval('N'))
     queue.set_current_line_number(parser.value_long());
-
+  else
+    SERIAL_ECHO_MSG("M110 N", queue.get_current_line_number());
 }

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -31,5 +31,5 @@ void GcodeSuite::M110() {
   if (parser.seenval('N'))
     queue.set_current_line_number(parser.value_long());
   else
-    SERIAL_ECHO_MSG("M110 N", queue.get_current_line_number());
+    SERIAL_ECHOLNPGM(STR_LINE_NO, queue.get_current_line_number());
 }

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -30,7 +30,7 @@
  *
  * Without parameters:
  *   Report the last-processed (not last-received or last-enqueued) command
- *   (A host could then potentially send an EP command to purge the queue then resume starting from LINE + 1.)
+ *   (To purge the queue and resume from this line, the host should use 'M999' instead.)
  */
 void GcodeSuite::M110() {
 

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -25,6 +25,12 @@
 
 /**
  * M110: Get or set Current Line Number
+ *
+ *   N<int>  Number to set as last-processed command
+ *
+ * Without parameters:
+ *   Report the last-processed (not last-received or last-enqueued) command
+ *   (A host could then potentially send an EP command to purge the queue then resume starting from LINE + 1.)
  */
 void GcodeSuite::M110() {
 

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -26,6 +26,7 @@
 /**
  * M110: Get or set Current Line Number
  *
+ * Parameters:
  *   N<int>  Number to set as last-processed command
  *
  * Without parameters:

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -212,6 +212,11 @@ public:
    */
   static void set_current_line_number(long n) { serial_state[ring_buffer.command_port().index].last_N = n; }
 
+  /**
+   * Get the current line number for the last received command
+   */
+  static long get_current_line_number() { return serial_state[ring_buffer.command_port().index].last_N; }
+
   #if ENABLED(BUFFER_MONITORING)
 
     private:


### PR DESCRIPTION
### Description

While looking around at how marlin handles gcode with line numbers and checksum I noticed there was no way to see the current line number.

M110 N#### sets the line number, but M110 on its own does nothing
This PR changes M110 on its own to emit the current line number

eg send: M110
receive: echo: M110 N0 

This adds a whole 6 bytes flash on Avr based machines, so I concluded that having a define to remove this new feature was probably not needed.

### Requirements

None

### Benefits

More constant gcode behavior (gcode without parameters tend to return the current settings for that gcode)  
