### PR TITLE
add -DGLM_ENABLE_EXPERIMENTAL flag to env:simulator_windows

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -153,4 +153,5 @@ build_src_flags = ${simulator_common.build_src_flags} -fpermissive
 build_flags     = ${simulator_common.build_flags} ${simulator_common.debug_build_flags}
                   -IC:\\msys64\\mingw64\\include\\SDL2 -fno-stack-protector -Wl,-subsystem,windows
                   -ldl -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lopengl32 -lssp
+                  -DGLM_ENABLE_EXPERIMENTAL
 build_type      = debug


### PR DESCRIPTION
### Description

The simulator under windows 11 doesn't build anymore

#error "GLM: GLM_GTX_euler_angles is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."

Added the required define into the environment

### Requirements

use BOARD_SIMULATED with env:simulator_windows

### Benefits

Builds as expected

### Configurations

https://github.com/MarlinFirmware/Marlin/files/15306344/Config.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/27091
