### PR TITLE
Fix UTF-8 (Cyrillic) on DOGLCD

### DIFF
--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -114,7 +114,7 @@ lcd_uint_t expand_u8str_P(char * const outstr, PGM_P const ptpl, const int8_t in
  * Return the number of characters emitted
  */
 lcd_uint_t lcd_put_u8str_P(PGM_P const ptpl, const int8_t ind, const char *cstr/*=nullptr*/, FSTR_P const fstr/*=nullptr*/, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
-  char estr[maxlen + 2];
+  char estr[maxlen * LANG_CHARSIZE + 2];
   const lcd_uint_t outlen = expand_u8str_P(estr, ptpl, ind, cstr, fstr, maxlen);
   lcd_put_u8str_max(estr, maxlen * (MENU_FONT_WIDTH));
   return outlen;

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1637,8 +1637,7 @@ void prepare_line_to_destination() {
     SERIAL_ECHO_START();
     msg.echoln();
 
-    msg.setf(GET_TEXT_F(MSG_HOME_FIRST), need);
-    ui.set_status(msg);
+    ui.status_printf(0, GET_TEXT_F(MSG_HOME_FIRST), need);
     return true;
   }
 


### PR DESCRIPTION
In reference to #27097

This function always prints PGM strings so it had been modified to copy character bytes from flash in a loop. Apparently there are flaws, things broke. This reverts to the previous state before the fix was attempted. Maybe there is a simpler solution. We'll know after we do more playing around.