### PR TITLE
Remove Redundant '%' while drawing cutter power

### DIFF
--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -660,9 +660,6 @@ FORCE_INLINE void _draw_bed_status(const bool blink) {
       lcd_put_u8str(F("K"));
     #else
       lcd_put_u8str(cutter_power2str(cutter.unitPower));
-      #if CUTTER_UNIT_IS(PERCENT)
-        lcd_put_u8str(F("%"));
-      #endif
     #endif
 
     lcd_put_u8str(F(" "));


### PR DESCRIPTION
### Description

cutter_power2str (as macro from spindle_laser_types.h -> pcttostrpctrj) already returns a '%'-terminated string, no need to add one while rendering UI.

### Requirements

HAS_MARLINUI_HD44780
HAS_CUTTER
CUTTER_UNIT_IS(PERCENT)

### Benefits

Cosmetic Fix


