### PR TITLE
add ONBOARD_SDIO to pins_LONGER3D_LK.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -158,7 +158,8 @@
   #define LCD_BRIGHTNESS_DEFAULT TFT_BACKLIGHT_PWM
 #endif
 
-#if ENABLED(ONBOARD_SDIO)
+#if SD_CONNECTION_IS(ONBOARD)
+  #define ONBOARD_SDIO
   #define SD_SS_PIN                         -1    // else SDSS set to PA4 in M43 (spi_pins.h)
 #endif
 


### PR DESCRIPTION
### Description

It was noticed by @Wuerfelix that this motherboard has a sdio sdcard interface
https://github.com/MarlinFirmware/Marlin/issues/26491#issuecomment-2132170736

I confirmed the original pins file from Longer3D had this defines predecessor SDIO_SUPPORT
See https://github.com/LONGER3D/Marlin2.0-lgt/blob/support-LKxPro/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h#L181 

Updated pins_LONGER3D_LK to set ONBOARD_SDIO when SD_CONNECTION_IS set to ONBOARD

### Requirements

Motherboard BOARD_LONGER3D_LK  using onboard sdcard slot

### Benefits

Works as it should

### Related Issues
<li>MarlinFirmware/Marlin/issues/26491