### PR TITLE
Fix NONE, ALL, EVAL macros to stop wrongly applying to same-named enums

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -197,8 +197,8 @@
 #define ENABLED(V...)       DO(ENA,&&,V)
 #define DISABLED(V...)      DO(DIS,&&,V)
 #define ANY(V...)          !DISABLED(V)
-#define ALL                 ENABLED
-#define NONE                DISABLED
+#define ALL(V...)           ENABLED(V)
+#define NONE(V...)          DISABLED(V)
 #define COUNT_ENABLED(V...) DO(ENA,+,V)
 #define MANY(V...)          (COUNT_ENABLED(V) > 1)
 
@@ -630,7 +630,7 @@
 #define DEFER4(M) M EMPTY EMPTY EMPTY EMPTY()()()()
 
 // Force define expansion
-#define EVAL           EVAL16
+#define EVAL(V...)     EVAL16(V)
 #define EVAL4096(V...) EVAL2048(EVAL2048(V))
 #define EVAL2048(V...) EVAL1024(EVAL1024(V))
 #define EVAL1024(V...) EVAL512(EVAL512(V))


### PR DESCRIPTION
### Description

Fix NONE, ALL, EVAL macros to stop wrongly applying to same-named enums

### Benefits

Fixes weird ODR warning when building with `-flto`. Prevents future confusing errors/warnings.
