### PR TITLE
add missing comma in DEBUG_ECHOLNPGM when DEBUG_AVR_FAST_PWM is enabled

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -150,7 +150,7 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
       else {
         if (p == 32 || p == 128) continue;                    // Skip TIMER2 specific prescalers when not TIMER2
         const uint16_t rft = (F_CPU) / (p * f_desired);
-        DEBUG_ECHOLNPGM("(Not Timer 2) F_CPU=" STRINGIFY(F_CPU), " prescaler=", p, " f_desired=", f_desired);
+        DEBUG_ECHOLNPGM("(Not Timer 2) F_CPU=", STRINGIFY(F_CPU), " prescaler=", p, " f_desired=", f_desired);
         res_fast_temp = rft - 1;
         res_pc_temp = rft / 2;
       }


### PR DESCRIPTION
### Description

Was looking into a issue with PWM on AVR, enabled DEBUG_AVR_FAST_PWM but got the error

```
Compiling .pio/build/mega2560/src/src/HAL/AVR/fast_pwm.cpp.o
In file included from Marlin/src/HAL/AVR/../../inc/MarlinConfigPre.h:37:0,
                 from Marlin/src/HAL/AVR/../../inc/MarlinConfig.h:28,
                 from Marlin/src/HAL/AVR/fast_pwm.cpp:24:
Marlin/src/HAL/AVR/fast_pwm.cpp: In static member function 'static void MarlinHAL::set_pwm_frequency(pin_t, uint16_t)':
Marlin/src/HAL/AVR/fast_pwm.cpp:153:81: error: initializer fails to determine size of '__c'
         DEBUG_ECHOLNPGM("(Not Timer 2) F_CPU=" STRINGIFY(F_CPU), " prescaler=", p, " f_desired=", f_desired);

```
Tracked this down to a single missing comma

### Requirements

DEBUG_AVR_FAST_PWM

### Benefits

Builds as expected

