### PR TITLE
Conditional definition of SUICIDE_PIN for RAMPS_CREALITY

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -70,7 +70,9 @@
 #define EXP3_PIN                              11  // SERVO0_PIN
 #define EXP4_PIN                              12  // PS_ON_PIN
 
-#define SUICIDE_PIN                           12  // Used by CR2020 Industrial series
-#ifndef SUICIDE_PIN_STATE
-  #define SUICIDE_PIN_STATE                 HIGH
+#ifndef SUICIDE_PIN
+  #define SUICIDE_PIN                           12  // Used by CR2020 Industrial series
+  #ifndef SUICIDE_PIN_STATE
+    #define SUICIDE_PIN_STATE                 HIGH
+  #endif
 #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -73,6 +73,6 @@
 #ifndef SUICIDE_PIN
   #define SUICIDE_PIN                         12  // Used by CR2020 Industrial series
   #ifndef SUICIDE_PIN_STATE
-    #define SUICIDE_PIN_STATE                 HIGH
+    #define SUICIDE_PIN_STATE               HIGH
   #endif
 #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -71,7 +71,7 @@
 #define EXP4_PIN                              12  // PS_ON_PIN
 
 #ifndef SUICIDE_PIN
-  #define SUICIDE_PIN                           12  // Used by CR2020 Industrial series
+  #define SUICIDE_PIN                         12  // Used by CR2020 Industrial series
   #ifndef SUICIDE_PIN_STATE
     #define SUICIDE_PIN_STATE                 HIGH
   #endif


### PR DESCRIPTION


### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Allow custom definition of `SUICIDE_PIN` for `BOARD_RAMPS_CREALITY`.

The systematic definition of `SUICIDE_PIN`, activate `HAS_SUICIDE`. Since `suicide()` is conditionnaly prefered to `powerManager.power_off()`, I cannot control my PSU. (see `M80_M81.cpp`)

Now, I can now define `SUICIDE_PIN` to -1, to avoid `HAS_SUICIDE` definition and use `M81` to turn off my PSU. 

All details could be find in this bug report #27142


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

A controllable Power Supply or a relay

### Benefits

<!-- What does this PR fix or improve? -->

Allows the use of `PSU_CONTROL` with `BOARD_RAMPS_CREALITY`

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

[Configuration.zip](https://github.com/user-attachments/files/15523376/Configuration.zip)


### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

#27142 
