### PR TITLE
Guard `time_spent_in/out_isr` with `MULTISTEPPING_LIMIT > 1`

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -374,10 +374,9 @@ class Stepper {
       static constexpr uint8_t steps_per_isr = 1; // Count of steps to perform per Stepper ISR call
     #else
       static uint8_t steps_per_isr;
-    #endif
-
-    #if DISABLED(OLD_ADAPTIVE_MULTISTEPPING)
-      static hal_timer_t time_spent_in_isr, time_spent_out_isr;
+      #if DISABLED(OLD_ADAPTIVE_MULTISTEPPING)
+        static hal_timer_t time_spent_in_isr, time_spent_out_isr;
+      #endif
     #endif
 
     #if ENABLED(ADAPTIVE_STEP_SMOOTHING)


### PR DESCRIPTION
### Description

Guard `time_spent_in_isr` and `time_spent_out_isr` with `MULTISTEPPING_LIMIT > 1` since the values are not actually used/useful in this case. The compiler doesn't do it for us especially since it won't optimize away even reads on any `volatile` variables.

### Benefits

Small speedup in max theoretically achievable stepping speed since there's less computation in the ISR. Example from LPC1769 with 80steps/mm: ~5400mm/s to ~6100mm/s (though note it was pre-optimized locally with `-flto` build option - for better inlining - and a spattering of `[[gnu::section(".ramcode")]]` to make sure the stepper ISR code was contained in microcontroller RAM).

Before, looking at the step/dir pins with a logic analyzer (at 16Mhz capture rate):
![guard-isr-ticks-before](https://github.com/MarlinFirmware/Marlin/assets/299015/590593d5-a263-499b-86d5-8fa57389a541)
After:
![guard-isr-ticks-after](https://github.com/MarlinFirmware/Marlin/assets/299015/4a692eae-d916-4cbe-a49e-cdae0caa932e)

