### PR TITLE
On LPC176x toggle pins using `LPC176x::gpio_toggle()`

### DIFF
--- a/Marlin/src/HAL/LPC1768/fastio.h
+++ b/Marlin/src/HAL/LPC1768/fastio.h
@@ -66,7 +66,7 @@
 #define _WRITE(IO,V)          WRITE_PIN(IO,V)
 
 /// toggle a pin
-#define _TOGGLE(IO)           _WRITE(IO, !READ(IO))
+#define _TOGGLE(IO)           LPC176x::gpio_toggle(IO)
 
 /// set pin as input
 #define _SET_INPUT(IO)        SET_DIR_INPUT(IO)


### PR DESCRIPTION
### Description

On LPC176x toggle pins using the framework-arduino-lpc176x `LPC176x::gpio_toggle()` function.

### Benefits

This method results in slightly more consistent gpio timing which is useful when using `EDGE_STEPPING`. This can be noticed on logic analyzer captures:

before
![toggle-before](https://github.com/MarlinFirmware/Marlin/assets/299015/f68f0df1-374a-471f-9e97-9d5b956845dd)

after
![toggle-after](https://github.com/MarlinFirmware/Marlin/assets/299015/b43dc891-0497-4f1d-9464-4d11b10e3b86)


### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
