### PR TITLE
🎨 Misc. SPI code cleanup

### DIFF
--- a/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
+++ b/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
@@ -120,7 +120,7 @@ void u8g_spiSend_sw_AVR_mode_3(uint8_t val) {
   U8G_ATOMIC_END();
 }
 
-#if ENABLED(FYSETC_MINI_12864)
+#if U8G_SPI_USE_MODE_3
   #define SPISEND_SW_AVR u8g_spiSend_sw_AVR_mode_3
 #else
   #define SPISEND_SW_AVR u8g_spiSend_sw_AVR_mode_0
@@ -143,9 +143,9 @@ uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ENABLED(FYSETC_MINI_12864)           // LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {                         //   SCK idle state needs to be set to the proper idle state before
-                                               //   the next chip select goes active
+      #if U8G_SPI_USE_MODE_3                                  // LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {                                        // SCK idle state needs to be set to the proper idle state before
+                                                              //  the next chip select goes active
           u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, 1);  // Set SCK to mode 3 idle state before CS goes active
           u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
         }

--- a/Marlin/src/HAL/DUE/inc/SanityCheck.h
+++ b/Marlin/src/HAL/DUE/inc/SanityCheck.h
@@ -68,16 +68,15 @@
  * Usually the hardware SPI pins are only available to the LCD. This makes the DUE hard SPI used at the same time
  * as the TMC2130 soft SPI the most common setup.
  */
-#define _IS_HW_SPI(P) (defined(TMC_SPI_##P) && (TMC_SPI_##P == SD_MOSI_PIN || TMC_SPI_##P == SD_MISO_PIN || TMC_SPI_##P == SD_SCK_PIN))
-
 #if HAS_MEDIA && HAS_DRIVER(TMC2130)
-  #if ENABLED(TMC_USE_SW_SPI)
-    #if DISABLED(SOFTWARE_SPI) && (_IS_HW_SPI(MOSI) || _IS_HW_SPI(MISO) || _IS_HW_SPI(SCK))
-      #error "DUE hardware SPI is required but is incompatible with TMC2130 software SPI. Either disable TMC_USE_SW_SPI or use separate pins for the two SPIs."
-    #endif
-  #elif ENABLED(SOFTWARE_SPI)
+  #define _IS_HW_SPI(P) (defined(TMC_SPI_##P) && (TMC_SPI_##P == SD_MOSI_PIN || TMC_SPI_##P == SD_MISO_PIN || TMC_SPI_##P == SD_SCK_PIN))
+  #if DISABLED(SOFTWARE_SPI) && ENABLED(TMC_USE_SW_SPI) && (_IS_HW_SPI(MOSI) || _IS_HW_SPI(MISO) || _IS_HW_SPI(SCK))
+    #error "DUE hardware SPI is required but is incompatible with TMC2130 software SPI. Either disable TMC_USE_SW_SPI or use separate pins for the two SPIs."
+  #endif
+  #if ENABLED(SOFTWARE_SPI) && DISABLED(TMC_USE_SW_SPI)
     #error "DUE software SPI is required but is incompatible with TMC2130 hardware SPI. Enable TMC_USE_SW_SPI to fix."
   #endif
+  #undef _IS_HW_SPI
 #endif
 
 #if ENABLED(FAST_PWM_FAN) || SPINDLE_LASER_FREQUENCY

--- a/Marlin/src/HAL/DUE/spi_pins.h
+++ b/Marlin/src/HAL/DUE/spi_pins.h
@@ -24,7 +24,7 @@
 /**
  * Define SPI Pins: SCK, MISO, MOSI, SS
  *
- * Available chip select pins for HW SPI are 4 10 52 77
+ * Available chip select pins for HW SPI are 4 10 52 77 87
  */
 #if SDSS == 4 || SDSS == 10 || SDSS == 52 || SDSS == 77 || SDSS == 87
   #if SDSS == 4

--- a/Marlin/src/HAL/DUE/u8g/u8g_com_HAL_DUE_sw_spi.cpp
+++ b/Marlin/src/HAL/DUE/u8g/u8g_com_HAL_DUE_sw_spi.cpp
@@ -66,7 +66,7 @@
 
 #include <U8glib-HAL.h>
 
-#if ENABLED(FYSETC_MINI_12864)
+#if U8G_SPI_USE_MODE_3
   #define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_3
 #else
   #define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_0
@@ -96,15 +96,15 @@ uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ENABLED(FYSETC_MINI_12864)           // LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {                        //   SCK idle state needs to be set to the proper idle state before
-                                               //   the next chip select goes active
-          u8g_SetPILevel_DUE(u8g, U8G_PI_SCK, 1);  //set SCK to mode 3 idle state before CS goes active
+      #if U8G_SPI_USE_MODE_3                        // LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {                              // SCK idle state needs to be set to the proper idle state before
+                                                    //  the next chip select goes active
+          u8g_SetPILevel_DUE(u8g, U8G_PI_SCK, 1);   // Set SCK to mode 3 idle state before CS goes active
           u8g_SetPILevel_DUE(u8g, U8G_PI_CS, LOW);
         }
         else {
           u8g_SetPILevel_DUE(u8g, U8G_PI_CS, HIGH);
-          u8g_SetPILevel_DUE(u8g, U8G_PI_SCK, 0); //set SCK to mode 0 idle state after CS goes inactive
+          u8g_SetPILevel_DUE(u8g, U8G_PI_SCK, 0);   // Set SCK to mode 0 idle state after CS goes inactive
         }
       #else
         u8g_SetPILevel_DUE(u8g, U8G_PI_CS, !arg_val);

--- a/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
+++ b/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
@@ -82,7 +82,7 @@ static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, c
 }
 
 static void u8g_sw_spi_shift_out(uint8_t val) {
-  #if ANY(FYSETC_MINI_12864, MKS_MINI_12864)
+  #if U8G_SPI_USE_MODE_3
     swSpiTransfer_mode_3(val, SPI_speed);
   #else
     swSpiTransfer_mode_0(val, SPI_speed);
@@ -116,15 +116,15 @@ uint8_t u8g_com_HAL_HC32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, voi
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ANY(FYSETC_MINI_12864, MKS_MINI_12864) // This LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {                           // SCK idle state needs to be set to the proper idle state before
-                                                 // the next chip select goes active
-          WRITE(DOGLCD_SCK, HIGH);               // Set SCK to mode 3 idle state before CS goes active
+      #if U8G_SPI_USE_MODE_3        // This LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {              // SCK idle state needs to be set to the proper idle state before
+                                    //  the next chip select goes active
+          WRITE(DOGLCD_SCK, HIGH);  // Set SCK to mode 3 idle state before CS goes active
           WRITE(DOGLCD_CS, LOW);
         }
         else {
           WRITE(DOGLCD_CS, HIGH);
-          WRITE(DOGLCD_SCK, LOW);  // Set SCK to mode 0 idle state after CS goes inactive
+          WRITE(DOGLCD_SCK, LOW);   // Set SCK to mode 0 idle state after CS goes inactive
         }
       #else
         WRITE(DOGLCD_CS, !arg_val);

--- a/Marlin/src/HAL/LINUX/spi_pins.h
+++ b/Marlin/src/HAL/LINUX/spi_pins.h
@@ -28,12 +28,6 @@
                         // spiBeginTransaction.
 #endif
 
-// Onboard SD
-//#define SD_SCK_PIN     P0_07
-//#define SD_MISO_PIN    P0_08
-//#define SD_MOSI_PIN    P0_09
-//#define SD_SS_PIN      P0_06
-
 // External SD
 #ifndef SD_SCK_PIN
   #define SD_SCK_PIN        50

--- a/Marlin/src/HAL/LPC1768/spi_pins.h
+++ b/Marlin/src/HAL/LPC1768/spi_pins.h
@@ -28,12 +28,13 @@
                         // spiBeginTransaction.
 #endif
 
-/** onboard SD card */
-//#define SD_SCK_PIN        P0_07
-//#define SD_MISO_PIN       P0_08
-//#define SD_MOSI_PIN       P0_09
-//#define SD_SS_PIN         P0_06
-/** external */
+// Onboard SD
+//#define SD_SCK_PIN     P0_07
+//#define SD_MISO_PIN    P0_08
+//#define SD_MOSI_PIN    P0_09
+//#define SD_SS_PIN      P0_06
+
+// External SD
 #ifndef SD_SCK_PIN
   #define SD_SCK_PIN        P0_15
 #endif

--- a/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -132,7 +132,7 @@ uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t sck
 static uint8_t SPI_speed = 0;
 
 static void u8g_sw_spi_shift_out(uint8_t dataPin, uint8_t clockPin, uint8_t val) {
-  #if ANY(FYSETC_MINI_12864, MKS_MINI_12864)
+  #if U8G_SPI_USE_MODE_3
     swSpiTransfer_mode_3(val, SPI_speed, clockPin, -1, dataPin);
   #else
     swSpiTransfer_mode_0(val, SPI_speed, clockPin, -1, dataPin);
@@ -160,15 +160,15 @@ uint8_t u8g_com_HAL_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ANY(FYSETC_MINI_12864, MKS_MINI_12864)  // LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {                            //   SCK idle state needs to be set to the proper idle state before
-                                                  //   the next chip select goes active
-          u8g_SetPILevel(u8g, U8G_PI_SCK, 1);     // Set SCK to mode 3 idle state before CS goes active
+      #if U8G_SPI_USE_MODE_3                    // LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {                          // SCK idle state needs to be set to the proper idle state before
+                                                //  the next chip select goes active
+          u8g_SetPILevel(u8g, U8G_PI_SCK, 1);   // Set SCK to mode 3 idle state before CS goes active
           u8g_SetPILevel(u8g, U8G_PI_CS, LOW);
         }
         else {
           u8g_SetPILevel(u8g, U8G_PI_CS, HIGH);
-          u8g_SetPILevel(u8g, U8G_PI_SCK, 0);  // Set SCK to mode 0 idle state after CS goes inactive
+          u8g_SetPILevel(u8g, U8G_PI_SCK, 0);   // Set SCK to mode 0 idle state after CS goes inactive
         }
       #else
         u8g_SetPILevel(u8g, U8G_PI_CS, !arg_val);

--- a/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
@@ -131,7 +131,7 @@ static uint8_t swSpiInit(const uint8_t spi_speed, const uint8_t clk_pin, const u
 }
 
 static void u8g_sw_spi_shift_out(uint8_t dataPin, uint8_t clockPin, uint8_t val) {
-  #if ANY(FYSETC_MINI_12864, MKS_MINI_12864)
+  #if U8G_SPI_USE_MODE_3
     swSpiTransfer_mode_3(val, SPI_speed, clockPin, -1, dataPin);
   #else
     swSpiTransfer_mode_0(val, SPI_speed, clockPin, -1, dataPin);
@@ -159,15 +159,15 @@ uint8_t u8g_com_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_pt
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ANY(FYSETC_MINI_12864, MKS_MINI_12864)  // LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {                            //   SCK idle state needs to be set to the proper idle state before
-                                                  //   the next chip select goes active
-          u8g_SetPILevel(u8g, U8G_PI_SCK, 1);     // Set SCK to mode 3 idle state before CS goes active
+      #if U8G_SPI_USE_MODE_3                    // LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {                          // SCK idle state needs to be set to the proper idle state before
+                                                //  the next chip select goes active
+          u8g_SetPILevel(u8g, U8G_PI_SCK, 1);   // Set SCK to mode 3 idle state before CS goes active
           u8g_SetPILevel(u8g, U8G_PI_CS, LOW);
         }
         else {
           u8g_SetPILevel(u8g, U8G_PI_CS, HIGH);
-          u8g_SetPILevel(u8g, U8G_PI_SCK, 0);  // Set SCK to mode 0 idle state after CS goes inactive
+          u8g_SetPILevel(u8g, U8G_PI_SCK, 0);   // Set SCK to mode 0 idle state after CS goes inactive
         }
       #else
         u8g_SetPILevel(u8g, U8G_PI_CS, !arg_val);

--- a/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
@@ -89,7 +89,7 @@ static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, c
 }
 
 static void u8g_sw_spi_shift_out(uint8_t val) {
-  #if ENABLED(FYSETC_MINI_12864)
+  #if U8G_SPI_USE_MODE_3
     swSpiTransfer_mode_3(val, SPI_speed);
   #else
     swSpiTransfer_mode_0(val, SPI_speed);
@@ -123,15 +123,15 @@ uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:
-      #if ENABLED(FYSETC_MINI_12864) // This LCD SPI is running mode 3 while SD card is running mode 0
-        if (arg_val) {               // SCK idle state needs to be set to the proper idle state before
-                                     // the next chip select goes active
-          WRITE(DOGLCD_SCK, HIGH);   // Set SCK to mode 3 idle state before CS goes active
+      #if U8G_SPI_USE_MODE_3        // This LCD SPI is running mode 3 while SD card is running mode 0
+        if (arg_val) {              // SCK idle state needs to be set to the proper idle state before
+                                    //  the next chip select goes active
+          WRITE(DOGLCD_SCK, HIGH);  // Set SCK to mode 3 idle state before CS goes active
           WRITE(DOGLCD_CS, LOW);
         }
         else {
           WRITE(DOGLCD_CS, HIGH);
-          WRITE(DOGLCD_SCK, LOW);  // Set SCK to mode 0 idle state after CS goes inactive
+          WRITE(DOGLCD_SCK, LOW);   // Set SCK to mode 0 idle state after CS goes inactive
         }
       #else
         WRITE(DOGLCD_CS, !arg_val);

--- a/Marlin/src/HAL/STM32F1/u8g/LCD_defines.h
+++ b/Marlin/src/HAL/STM32F1/u8g/LCD_defines.h
@@ -25,7 +25,7 @@
  * STM32F1 (Maple) LCD-specific defines
  */
 
-uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr); // u8g_com_stm32duino_swspi.cpp
 uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);  // See U8glib-HAL
 
 #define U8G_COM_HAL_SW_SPI_FN     u8g_com_HAL_STM32F1_sw_spi_fn

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -815,6 +815,10 @@
 
 #endif
 
+#if ANY(FYSETC_MINI_12864, MKS_MINI_12864)
+  #define U8G_SPI_USE_MODE_3 1
+#endif
+
 // ST7920-based graphical displays
 #if ANY(IS_RRD_FG_SC, LCD_FOR_MELZI, SILVER_GATE_GLCD_CONTROLLER)
   #define DOGLCD

--- a/Marlin/src/sd/Sd2Card.h
+++ b/Marlin/src/sd/Sd2Card.h
@@ -78,7 +78,7 @@ uint8_t const SD_CARD_TYPE_SD1  = 1,        // Standard capacity V1 SD card
 /**
  * Define SOFTWARE_SPI to use bit-bang SPI
  */
-#if ANY(MEGA_SOFT_SPI, USE_SOFTWARE_SPI)
+#if ANY(MEGA_SOFT_SPI, SDFAT_USE_SOFTWARE_SPI)
   #define SOFTWARE_SPI
 #endif
 

--- a/Marlin/src/sd/SdFatConfig.h
+++ b/Marlin/src/sd/SdFatConfig.h
@@ -88,8 +88,8 @@
  */
 #define MEGA_SOFT_SPI 0
 
-// Set USE_SOFTWARE_SPI nonzero to ALWAYS use Software SPI.
-#define USE_SOFTWARE_SPI 0
+// Set SDFAT_USE_SOFTWARE_SPI nonzero to ALWAYS use Software SPI.
+#define SDFAT_USE_SOFTWARE_SPI 0
 
 /**
  * The __cxa_pure_virtual function is an error handler that is invoked when

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
@@ -33,7 +33,7 @@
   /**
    * Define SOFTWARE_SPI to use bit-bang SPI
    */
-  #if ANY(MEGA_SOFT_SPI, USE_SOFTWARE_SPI)
+  #if ANY(MEGA_SOFT_SPI, SDFAT_USE_SOFTWARE_SPI)
     #define SOFTWARE_SPI
   #endif
 


### PR DESCRIPTION
- Conditionally define `U8G_SPI_USE_MODE_3` for `*_MINI_12864` displays – for more generic HAL code. This makes AVR, DUE, and STM32F1 match up with HC32, LPC1768, and Native Sim. They previously used mode 3 only for `FYSETC_MINI_12864`, but not for `MKS_MINI_12864`.
- Rename `USE_SOFTWARE_SPI` to the less generic `SDFAT_USE_SOFTWARE_SPI`.
- Cosmetic cleanup of sanity checks, etc.