### PR TITLE
PSU control fixes

### DIFF
--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -112,9 +112,9 @@ void GcodeSuite::M81() {
     return;
   }
 
-  #if HAS_SUICIDE
-    suicide();
-  #elif ENABLED(PSU_CONTROL)
+  #if ENABLED(PSU_CONTROL)
     powerManager.power_off_soon();
+  #elif HAS_SUICIDE
+    suicide();
   #endif
 }

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -29,17 +29,57 @@
 
 #define BOARD_INFO_NAME "Creality3D RAMPS"
 
+//#define CR2020_INDUSTRIAL_SERIES                // Use layout specific to CR2020
+
+//
+// 4-pin expansion header
+//
+#define EXP1_PIN                              65  // A11 - Used by CR2020 Industrial series for case
+#define EXP2_PIN                              66  // A12
+#define EXP3_PIN                              11  // RAMPS: SERVO0_PIN
+#define EXP4_PIN                              12  // RAMPS: PS_ON_PIN
+
+//
+// Servos
+//
+#define SERVO1_PIN                            12
+
 //
 // Heaters / Fans
 //
 #define MOSFET_B_PIN                           7
 #define FAN0_PIN                               9
 
+//
+// Filament Runout Sensor
+//
 #define FIL_RUNOUT_PIN                         2
 #if NUM_RUNOUT_SENSORS >= 2
   #define FIL_RUNOUT2_PIN                     15  // Creality CR-X can use dual runout sensors
 #endif
 
+//
+// Misc. Functions
+//
+#ifdef CR2020_INDUSTRIAL_SERIES
+  #if ENABLED(PSU_CONTROL) && !defined(PS_ON_PIN)
+    #define PS_ON_PIN                         40  // Used by CR2020 Industrial series
+  #endif
+  #ifndef SUICIDE_PIN
+    #define SUICIDE_PIN                       12  // Used by CR2020 Industrial series
+  #endif
+  #ifndef SUICIDE_PIN_STATE
+    #define SUICIDE_PIN_STATE               HIGH
+  #endif
+#endif
+
+#if ENABLED(CASE_LIGHT_ENABLE) && !defined(CASE_LIGHT_PIN)
+  #define CASE_LIGHT_PIN                      65
+#endif
+
+//
+// SD Card
+//
 #ifndef SD_DETECT_PIN
   #if SD_CONNECTION_IS(ONBOARD)
     //#define HAS_ONBOARD_SD_DETECT               // If the SD_DETECT_PIN is wired up
@@ -49,30 +89,14 @@
   #endif
 #endif
 
-#ifndef PS_ON_PIN
-  #define PS_ON_PIN                           40  // Used by CR2020 Industrial series
-#endif
-
-#if ENABLED(CASE_LIGHT_ENABLE) && !defined(CASE_LIGHT_PIN)
-  #define CASE_LIGHT_PIN                      65
-#endif
-
-#define SERVO1_PIN                            12
-
+//
+// Based on RAMPS 1.4
+//
 #include "pins_RAMPS.h"
 
+//
+// LCD / Controller
+//
 #ifndef BEEPER_PIN
   #define BEEPER_PIN                          37  // Always define beeper pin so Play Tone works with ExtUI
-#endif
-
-#define EXP1_PIN                              65  // A11 - Used by CR2020 Industrial series for case
-#define EXP2_PIN                              66  // A12
-#define EXP3_PIN                              11  // SERVO0_PIN
-#define EXP4_PIN                              12  // PS_ON_PIN
-
-#ifndef SUICIDE_PIN
-  #define SUICIDE_PIN                         12  // Used by CR2020 Industrial series
-  #ifndef SUICIDE_PIN_STATE
-    #define SUICIDE_PIN_STATE               HIGH
-  #endif
 #endif


### PR DESCRIPTION
See #27142

- Assume RAMPS_CREALITY is not "CR2020 Industrial Series" by default. No PSU or auto-unalive pins.
- Change `M81` to power off with the PSU pin rather than the auto-unalive pin.