### PR TITLE
AnyCubic Vyper LCD improvements

### DIFF
--- a/Marlin/src/lcd/extui/anycubic/common_defs.h
+++ b/Marlin/src/lcd/extui/anycubic/common_defs.h
@@ -27,20 +27,18 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#define ACDEBUGLEVEL 0  //  0: off, 255: all levels enabled
+// Bit-masks for selective debug
+#define AC_INFO    1
+#define AC_ACTION  2
+#define AC_FILE    4
+#define AC_PANEL   8
+#define AC_MARLIN 16
+#define AC_SOME   32
+#define AC_ALL    64
+//#define ACDEBUGLEVEL AC_MARLIN  //  0: off, 255: all levels enabled
 
 #if ACDEBUGLEVEL
-  // Bit-masks for selective debug:
-  enum ACDebugMask : uint8_t {
-    AC_INFO   =  1,
-    AC_ACTION =  2,
-    AC_FILE   =  4,
-    AC_PANEL  =  8,
-    AC_MARLIN = 16,
-    AC_SOME   = 32,
-    AC_ALL    = 64
-  };
-  #define ACDEBUG(mask) ( ((mask) & ACDEBUGLEVEL) == mask )  // Debug flag macro
+  #define ACDEBUG(mask) ((mask) & ACDEBUGLEVEL)
 #else
   #define ACDEBUG(mask) false
 #endif

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -88,9 +88,11 @@ namespace Anycubic {
   int16_t DgusTFT::feedrate_back;
   lcd_info_t DgusTFT::lcd_info, DgusTFT::lcd_info_back;
   language_t DgusTFT::ui_language;
-  uint16_t page_index_saved;          // flags to keep from bombing the host display
-  uint8_t pop_up_index_saved;
-  uint32_t key_value_saved;
+
+  #if ACDEBUG(AC_MARLIN)
+    uint16_t page_index_saved;          // flags to keep from bombing the host display
+    uint32_t key_value_saved;
+  #endif
 
   void DEBUG_PRINT_PAUSED_STATE(const paused_state_t state, FSTR_P const msg=nullptr);
   void DEBUG_PRINT_PRINTER_STATE(const printer_state_t state, FSTR_P const msg=nullptr);
@@ -779,6 +781,18 @@ namespace Anycubic {
     #endif
   }
 
+  void DgusTFT::debugPage(int page/*=0*/) {
+    #if ACDEBUG(AC_ALL)
+      if (page == 0) page = page_index_now;
+      if (page_index_saved != page_index_now || key_value_saved != key_value) {
+        DEBUG_ECHOLNPGM("page", page, "  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
+        page_index_saved = page_index_now;
+        key_value_saved = key_value;
+      }
+    #endif
+    UNUSED(page);
+  }
+
   void DgusTFT::fakeChangePageOfTFT(const uint16_t page_index) {
     #if ACDEBUG(AC_MARLIN)
       if (page_index_saved != page_index_now)
@@ -1141,13 +1155,7 @@ namespace Anycubic {
   #endif
 
   void DgusTFT::page1() {
-    #if ACDEBUG(AC_ALL)
-      if (page_index_saved != page_index_now || key_value_saved != key_value) {
-        DEBUG_ECHOLNPGM("page1  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(1);
 
     switch (key_value) {
       case 0: break;
@@ -1190,13 +1198,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page2() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page2  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(2);
     char file_index = 0;
 
     switch (key_value) {
@@ -1326,13 +1328,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page3() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page3  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(3);
 
     static millis_t flash_time = 0;
     const millis_t ms = millis();
@@ -1410,13 +1406,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page4() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page4  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(4);
 
 
     switch (key_value) {
@@ -1483,13 +1473,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page5() {          // print settings
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page5  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(5);
     static bool z_change = false;
 
     switch (key_value) {
@@ -1616,13 +1600,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page6() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page6  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(6);
     switch (key_value) {
       case 0: break;
       case 1: break;
@@ -1630,13 +1608,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page7() { // tools
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page7  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(7);
     switch (key_value) {
       case 0: break;
 
@@ -1687,13 +1659,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page8() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page8  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(8);
     //static uint16_t movespeed = 50;
     static float move_dis = 1.0f;
 
@@ -1793,13 +1759,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page9() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page9  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(9);
 
     switch (key_value) {
       case 0: break;
@@ -1836,13 +1796,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page10() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page10  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(10);
 
     switch (key_value) {
       case 0: break;
@@ -1872,13 +1826,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page11() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page11  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(11);
     switch (key_value) {
       case 0: break;
 
@@ -1909,13 +1857,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page12() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page12  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(12);
     switch (key_value) {
       case 0: break;
       case 1:        // return
@@ -1925,13 +1867,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page13() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page13  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(13);
     switch (key_value) {
       case 0: break;
 
@@ -1944,13 +1880,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page14() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page14  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(14);
     switch (key_value) {
       case 0: break;
       case 1: break; // return
@@ -1961,13 +1891,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page15() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page15  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(15);
 
     switch (key_value) {
       case 0: break;
@@ -1998,13 +1922,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page16() {    // AUTO LEVELING
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page16  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(16);
     switch (key_value) {
       case 0: break;
       case 1:            // return
@@ -2030,13 +1948,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page17() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page17  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(17);
     float z_off;
     switch (key_value) {
       case 0: break;
@@ -2045,9 +1957,11 @@ namespace Anycubic {
         changePageOfTFT(PAGE_PreLEVEL);
         break;
 
-      case 2: {
-        setSoftEndstopState(false);
+      case 2: { // Babystep Z Offset -
         if (getZOffset_mm() <= -5) return;
+
+        setSoftEndstopState(false);
+
         z_off = getZOffset_mm() - 0.01f;
         setZOffset_mm(z_off);
 
@@ -2061,9 +1975,11 @@ namespace Anycubic {
         setSoftEndstopState(true);
       } break;
 
-      case 3: {
-        setSoftEndstopState(false);
+      case 3: { // Babystep Z Offset +
         if (getZOffset_mm() >= 5) return;
+
+        setSoftEndstopState(false);
+
         z_off = getZOffset_mm() + 0.01f;
         setZOffset_mm(z_off);
 
@@ -2097,13 +2013,7 @@ namespace Anycubic {
   #if HAS_HOTEND || HAS_HEATED_BED
 
     void DgusTFT::page18() {     // preheat
-      #if ACDEBUG(AC_ALL)
-        if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-          DEBUG_ECHOLNPGM("page18  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-          page_index_saved = page_index_now;
-          key_value_saved = key_value;
-        }
-      #endif
+    debugPage(18);
 
       switch (key_value) {
         case 0: break;
@@ -2139,13 +2049,7 @@ namespace Anycubic {
   #if HAS_EXTRUDERS
 
     void DgusTFT::page19() {       // Filament
-      #if ACDEBUG(AC_ALL)
-        if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-          DEBUG_ECHOLNPGM("page19  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-          page_index_saved = page_index_now;
-          key_value_saved = key_value;
-        }
-      #endif
+      debugPage(19);
       static char filament_status = 0;
       static millis_t flash_time  = 0;
       switch (key_value) {
@@ -2206,13 +2110,7 @@ namespace Anycubic {
   #endif // HAS_EXTRUDERS
 
   void DgusTFT::page20() {       // confirm
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page20  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(20);
 
     switch (key_value) {
       case 0: break;
@@ -2228,13 +2126,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page21() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page21  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(21);
 
     switch (key_value) {
       case 0: break;
@@ -2253,13 +2145,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page22() {       // print finish
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page22  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(22);
 
     switch (key_value) {
       case 0: break;
@@ -2279,13 +2165,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page23() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page23  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(23);
 
     switch (key_value) {
       case 0: break;
@@ -2300,13 +2180,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page24() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page24  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(24);
 
     switch (key_value) {
       case 0: break;
@@ -2321,13 +2195,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page25() {           // lack filament
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page25  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(25);
 
     switch (key_value) {
       case 0: break;
@@ -2353,13 +2221,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page26() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page26  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(26);
 
     switch (key_value) {
       case 0: break;
@@ -2374,13 +2236,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page27() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page27  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(27);
 
     switch (key_value) {
       case 0: break;
@@ -2413,13 +2269,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page28() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page28  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(28);
 
     switch (key_value) {
       case 0: break;
@@ -2434,13 +2284,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page29() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page29  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(29);
 
     switch (key_value) {
       case 0: break;
@@ -2460,13 +2304,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page30() {       // Auto heat filament
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page30  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(30);
 
     switch (key_value) {
       case 0: break;
@@ -2484,13 +2322,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page31() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page31  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(31);
 
     switch (key_value) {
       case 0: break;
@@ -2505,13 +2337,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page32() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page32  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(32);
 
     static millis_t flash_time = 0;
     const millis_t ms = millis();
@@ -2522,12 +2348,7 @@ namespace Anycubic {
   #if HAS_LEVELING
 
     void DgusTFT::page33() {
-      #if ACDEBUG(AC_ALL)
-        if (page_index_saved != page_index_now) {
-          DEBUG_ECHOLNPGM("page33  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-          page_index_saved = page_index_now;
-        }
-      #endif
+      debugPage(33);
 
       switch (key_value) {
         case 0: break;
@@ -2569,13 +2390,7 @@ namespace Anycubic {
     }
 
     void DgusTFT::page34() {
-      #if ACDEBUG(AC_ALL)
-        if ((page_index_saved != page_index_now) || (key_value_saved != key_value))  {
-          DEBUG_ECHOLNPGM("page34  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-          page_index_saved = page_index_now;
-          key_value_saved = key_value;
-        }
-      #endif
+      debugPage(34);
 
       #if HAS_HOTEND || HAS_HEATED_BED
         static millis_t flash_time = 0;
@@ -2596,13 +2411,7 @@ namespace Anycubic {
   #endif // HAS_LEVELING
 
   void DgusTFT::page115() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page115  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(115);
 
     switch (key_value) {
 
@@ -2629,13 +2438,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page117() {  // Page CHS Mute handler
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page117  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(117);
     switch (key_value) {
       case 0: break;
 
@@ -2666,37 +2469,17 @@ namespace Anycubic {
   }
 
   void DgusTFT::page124() {  // first time into page 124 the feedrate percent is not set
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page124  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-        //DEBUG_ECHOLNPGM("update feedrate percent");
-      }
-    #endif
+    debugPage(124);
     sendValueToTFT(uint16_t(getFeedrate_percent()), TXT_PRINT_SPEED_NOW);
   }
 
   void DgusTFT::page125() {  // first time into page 125 the feedrate percent is not set
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page125  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-        //DEBUG_ECHOLNPGM("update feedrate percent");
-      }
-    #endif
+    debugPage(125);
     sendValueToTFT(uint16_t(getFeedrate_percent()), TXT_PRINT_SPEED_NOW);
   }
 
   void DgusTFT::page170() {  // ENG Mute handler
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page170  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(170);
     switch (key_value) {
       case 0: break;
 
@@ -2729,12 +2512,7 @@ namespace Anycubic {
   #if ENABLED(POWER_LOSS_RECOVERY)
 
     void DgusTFT::page171() {  // CHS power outage resume handler
-      #if ACDEBUG(AC_ALL)
-        if (page_index_saved != page_index_now) {
-          DEBUG_ECHOLNPGM("page171  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-          page_index_saved = page_index_now;
-        }
-      #endif
+      debugPage(171);
       #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
         char filename[64] = { '\0' };
       #endif
@@ -2768,12 +2546,7 @@ namespace Anycubic {
     }
 
     void DgusTFT::page173() {  // ENG power outage resume handler
-      #if ACDEBUG(AC_ALL)
-        if (page_index_saved != page_index_now) {
-          DEBUG_ECHOLNPGM("page173  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-          page_index_saved = page_index_now;
-        }
-      #endif
+      debugPage(173);
       #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
         char filename[64] = { '\0' };
       #endif
@@ -2811,12 +2584,7 @@ namespace Anycubic {
   #if HAS_LEVELING
 
     void DgusTFT::page175() {     // CHS probe preheating handler
-      #if ACDEBUG(AC_ALL)
-        if (page_index_saved != page_index_now) {
-          DEBUG_ECHOLNPGM("page175  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-          page_index_saved = page_index_now;
-        }
-      #endif
+      debugPage(175);
 
       #if HAS_HOTEND || HAS_HEATED_BED
         static millis_t flash_time = 0;
@@ -2830,12 +2598,7 @@ namespace Anycubic {
     }
 
     void DgusTFT::page176() {     // ENG probe preheating handler
-      #if ACDEBUG(AC_ALL)
-        if (page_index_saved != page_index_now) {
-          DEBUG_ECHOLNPGM("page176  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-          page_index_saved = page_index_now;
-        }
-      #endif
+      debugPage(176);
 
       #if HAS_HOTEND || HAS_HEATED_BED
         static millis_t flash_time = 0;
@@ -2851,13 +2614,7 @@ namespace Anycubic {
   #endif // HAS_LEVELING
 
   void DgusTFT::page177_to_198() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page177_to_198  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage();
     switch (key_value) {
       case 1:       // return
         #if ACDEBUG(AC_MARLIN)
@@ -2895,6 +2652,7 @@ namespace Anycubic {
 
   #if 0
     void DgusTFT::page178_to_181_190_to_193() {  // temperature abnormal
+      debugPage();
       #if ACDEBUG(AC_ALL)
       if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
         DEBUG_ECHOLNPGM("page178_to_181_190_to_193  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
@@ -2925,13 +2683,7 @@ namespace Anycubic {
   #endif
 
   void DgusTFT::page199_to_200() {
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page199_to_200  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage();
     switch (key_value) {
       case 1:       // return
         #if ACDEBUG(AC_MARLIN)
@@ -2959,13 +2711,7 @@ namespace Anycubic {
   inline bool getProbeState() { return PROBE_TRIGGERED(); }
 
   void DgusTFT::page201() {  // probe precheck
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page201  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(201);
     static millis_t probe_check_time   = 0;
     static millis_t temperature_time   = 0;
     static uint8_t probe_check_counter = 0;
@@ -3021,13 +2767,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page202() {  // probe precheck ok
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page202  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(202);
 
     //static millis_t flash_time = 0;
     //static millis_t probe_check_counter = 0;
@@ -3041,13 +2781,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::page203() {    // probe precheck failed
-    #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page203  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-    #endif
+    debugPage(203);
     //static millis_t probe_check_counter = 0;
     //static uint8_t probe_state_last = 0;
 
@@ -3064,6 +2798,7 @@ namespace Anycubic {
 
   void DgusTFT::pop_up_manager() {
     #if ACDEBUG(AC_ALL)
+      static uint8_t pop_up_index_saved; // = 0
       if (pop_up_index_saved != pop_up_index) {
         DEBUG_ECHOLNPGM("pop_up_manager  pop_up_index: ", pop_up_index);
         pop_up_index_saved = pop_up_index;

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -989,7 +989,6 @@ namespace Anycubic {
     uint16_t control_index = 0;
     uint32_t control_value;
     uint16_t temp;
-    char str_buf[20];
 
     if (data_received) {
       data_received = false;
@@ -1035,7 +1034,7 @@ namespace Anycubic {
           control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
           const uint16_t feedrate = constrain(uint16_t(control_value), 40, 999);
           //feedrate_percentage=constrain(control_value,40,999);
-          sendTxtToTFT(MString<4>(feedrate), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<3>(feedrate), TXT_PRINT_SPEED);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_NOW);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_TARGET);
           setFeedrate_percent(feedrate);
@@ -1297,7 +1296,7 @@ namespace Anycubic {
 
             sendTxtToTFT(MString<17>(filenavigator.filelist.longFilename()), TXT_PRINT_NAME);
             sendTxtToTFT(ftostr72rj(getFeedrate_percent()), TXT_PRINT_SPEED);
-            sendTxtToTFT(MString<4>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
+            sendTxtToTFT(MString<3>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
             sendTimeToTFT(0, TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);
@@ -1341,7 +1340,6 @@ namespace Anycubic {
 
     static millis_t flash_time = 0;
     const millis_t ms = millis();
-    char str_buf[20];
 
     switch (key_value) {
       case 0: break;
@@ -1394,7 +1392,7 @@ namespace Anycubic {
       if (ifeedrate != 0)
         sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
       else
-        sendTxtToTFT(MString<4>(feedrate_back), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<3>(feedrate_back), TXT_PRINT_SPEED);
 
       #if ACDEBUG(AC_MARLIN)
         DEBUG_ECHOLNPGM("print speed: ", ifeedrate, " feedrate_back: ", feedrate_back);
@@ -1405,7 +1403,7 @@ namespace Anycubic {
     static uint8_t progress_last = 0;
     if (progress_last != getProgress_percent()) {
       progress_last = getProgress_percent();
-      sendTxtToTFT(MString<4>(progress_last), TXT_PRINT_PROGRESS);
+      sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
     }
 
     // Report Printing Time in minutes
@@ -1424,7 +1422,6 @@ namespace Anycubic {
       }
     #endif
 
-    char str_buf[20];
 
     switch (key_value) {
       case 0: break;
@@ -1473,14 +1470,14 @@ namespace Anycubic {
       if (ifeedrate != 0)
         sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
       else
-        sendTxtToTFT(MString<4>(feedrate_back), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<3>(feedrate_back), TXT_PRINT_SPEED);
       feedrate_back = ifeedrate;
     }
 
     static uint8_t progress_last = 0;
     if (progress_last != getProgress_percent()) {
       progress_last = getProgress_percent();
-      sendTxtToTFT(MString<4>(progress_last), TXT_PRINT_PROGRESS);
+      sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
     }
 
     // Report Printing Time in minutes
@@ -2765,8 +2762,8 @@ namespace Anycubic {
             sendTxtToTFT(recovery.info.sd_filename, TXT_OUTAGE_RECOVERY_FILE);
           #endif
 
-          sendTxtToTFT(MString<6>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
-          sendTxtToTFT(MString<4>(progress_last), TXT_PRINT_PROGRESS);
+          sendTxtToTFT(MString<5>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);              // show pause
           injectCommands(F("M355 S1\nM1000"));        // case light on, home and start recovery
@@ -2804,10 +2801,8 @@ namespace Anycubic {
             sendTxtToTFT(recovery.info.sd_filename, TXT_OUTAGE_RECOVERY_FILE);
           #endif
 
-          sendTxtToTFT(MString<6>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
-
-          sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
-          sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
+          sendTxtToTFT(MString<5>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<3>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);          // show pause
           injectCommands(F("M355 S1\nM1000"));    // case light on, home and start recovery

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -787,7 +787,7 @@ namespace Anycubic {
     changePageOfTFT(page_index, true);
   }
 
-  void DgusTFT::changePageOfTFTToAbout() {
+  void DgusTFT::showAboutPage() {
     sendTxtToTFT_P(getFirmwareName_str(), TXT_VERSION);
     changePageOfTFT(PAGE_ABOUT);
   }
@@ -1906,7 +1906,7 @@ namespace Anycubic {
         break;
 
       case 5:       // about
-        changePageOfTFTToAbout();
+        showAboutPage();
         break;
 
       case 6:
@@ -2666,7 +2666,7 @@ namespace Anycubic {
         break;
 
       case 5:       // about
-        changePageOfTFTToAbout();
+        showAboutPage();
         break;
 
       case 6:
@@ -2727,7 +2727,7 @@ namespace Anycubic {
         break;
 
       case 5:       // about
-        changePageOfTFTToAbout();
+        showAboutPage();
         break;
 
       case 6:

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1379,7 +1379,7 @@ namespace Anycubic {
     if (PENDING(ms, flash_time)) return;
     flash_time = ms + 1500;
 
-    const int16_t ifeedrate = int16_t(getFeedrate_percent());
+    const uint16_t ifeedrate = uint16_t(getFeedrate_percent());
     if (feedrate_back != ifeedrate) {
       if (ifeedrate != 0)
         sendTxtToTFT(MString<6>(ifeedrate), TXT_PRINT_SPEED);
@@ -1450,7 +1450,7 @@ namespace Anycubic {
     if (PENDING(ms, flash_time)) return;
     flash_time = ms + 1500;
 
-    const int16_t ifeedrate = int16_t(getFeedrate_percent());
+    const uint16_t ifeedrate = uint16_t(getFeedrate_percent());
     if (feedrate_back != ifeedrate) {
       if (ifeedrate != 0)
         sendTxtToTFT(MString<6>(ifeedrate), TXT_PRINT_SPEED);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -781,6 +781,14 @@ namespace Anycubic {
     changePageOfTFT(page_index, true);
   }
 
+  void DgusTFT::changePageOfTFTToAbout() {
+    char str_ver[32];
+    //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
+    sprintf(str_ver, MAIN_BOARD_FIRMWARE_VER);
+    sendTxtToTFT(str_ver, TXT_VERSION);
+    changePageOfTFT(PAGE_ABOUT);
+  }
+
   void DgusTFT::lcdAudioSet(const bool audio_on) {
     // On:  5A A5 07 82 00 80 5A 00 00 1A
     // Off: 5A A5 07 82 00 80 5A 00 00 12
@@ -1924,13 +1932,9 @@ namespace Anycubic {
         toggle_audio();
         break;
 
-      case 5: {      // about
-        char str_ver[32];
-        //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-        sprintf(str_ver, MAIN_BOARD_FIRMWARE_VER);
-        sendTxtToTFT(str_ver, TXT_VERSION);
-        changePageOfTFT(PAGE_ABOUT);
-      } break;
+      case 5:       // about
+        changePageOfTFTToAbout();
+        break;
 
       case 6:
         changePageOfTFT(PAGE_RECORD);
@@ -2696,11 +2700,7 @@ namespace Anycubic {
         break;
 
       case 5:       // about
-        char str_ver[32];
-        //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-        sprintf(str_ver, MAIN_BOARD_FIRMWARE_VER);
-        sendTxtToTFT(str_ver, TXT_VERSION);
-        changePageOfTFT(PAGE_ABOUT);
+        changePageOfTFTToAbout();
         break;
 
       case 6:
@@ -2761,11 +2761,7 @@ namespace Anycubic {
         break;
 
       case 5:       // about
-        char str_ver[32];
-        //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-        sprintf(str_ver, MAIN_BOARD_FIRMWARE_VER);
-        sendTxtToTFT(str_ver, TXT_VERSION);
-        changePageOfTFT(PAGE_ABOUT);
+        changePageOfTFTToAbout();
         break;
 
       case 6:

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1005,8 +1005,6 @@ namespace Anycubic {
             control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
             temp = constrain(uint16_t(control_value), 0, thermalManager.hotend_max_target(0));
             setTargetTemp_celsius(temp, E0);
-            //sprintf_P(str_buf, PSTR("%u/%u"), (uint16_t)thermalManager.degHotend(0), uint16_t(control_value));
-            //sendTxtToTFT(str_buf, TXT_PRINT_HOTEND);
           }
         #endif
 
@@ -1015,8 +1013,6 @@ namespace Anycubic {
             control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
             temp = constrain(uint16_t(control_value), 0, BED_MAX_TARGET);
             setTargetTemp_celsius(temp, BED);
-            //sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(thermalManager.degBed()), uint16_t(control_value));
-            //sendTxtToTFT(str_buf, TXT_PRINT_BED);
           }
         #endif
 
@@ -1455,7 +1451,6 @@ namespace Anycubic {
         sendValueToTFT((uint16_t)feedrate_back, TXT_ADJUST_SPEED);
         TERN_(HAS_FAN, sendValueToTFT(uint16_t(getActualFan_percent(FAN0)), TXT_FAN_SPEED_TARGET));
         sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 3, TXT_LEVEL_OFFSET);
-        //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
         requestValueFromTFT(TXT_ADJUST_SPEED);  // attempt to make feedrate visible on visit to this page
         break;
     }
@@ -1518,7 +1513,6 @@ namespace Anycubic {
           setZOffset_mm(z_off);
 
           sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-          //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
           //if (isAxisPositionKnown(Z)) {  // Move Z axis
           //  SERIAL_ECHOLNPGM("Z now:", getAxisPosition_mm(Z));
@@ -1556,7 +1550,6 @@ namespace Anycubic {
           setZOffset_mm(z_off);
 
           sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-          //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
           //int16_t steps = mmToWholeSteps(constrain(Zshift,-0.05,0.05), Z);
 
@@ -2027,7 +2020,6 @@ namespace Anycubic {
 
       case 3: {
         sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-        //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
         changePageOfTFT(PAGE_LEVEL_ADVANCE);
       } break;
 
@@ -2060,7 +2052,6 @@ namespace Anycubic {
         setZOffset_mm(z_off);
 
         sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-        //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
         if (isAxisPositionKnown(Z)) {
           const float currZpos = getAxisPosition_mm(Z);
@@ -2077,7 +2068,6 @@ namespace Anycubic {
         setZOffset_mm(z_off);
 
         sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-        //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
         if (isAxisPositionKnown(Z)) {          // Move Z axis
           const float currZpos = getAxisPosition_mm(Z);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -722,7 +722,8 @@ namespace Anycubic {
   }
 
   void DgusTFT::sendColorToTFT(const uint16_t color, const uint16_t address) {
-    uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(address >> 8), uint8_t(address & 0xFF), uint8_t(color >> 8), uint8_t(color & 0xFF) };
+    uint16_t color_address = address + 3;
+    uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(color_address >> 8), uint8_t(color_address & 0xFF), uint8_t(color >> 8), uint8_t(color & 0xFF) };
     for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -85,7 +85,7 @@ namespace Anycubic {
   uint32_t DgusTFT::key_value;
   uint8_t DgusTFT::lcd_txtbox_index;
   uint8_t DgusTFT::lcd_txtbox_page;
-  int16_t DgusTFT::feedrate_back;
+  uint16_t DgusTFT::feedrate_back;
   lcd_info_t DgusTFT::lcd_info, DgusTFT::lcd_info_back;
   language_t DgusTFT::ui_language;
 
@@ -731,8 +731,8 @@ namespace Anycubic {
     for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
   }
 
-  void DgusTFT::sendTimeToTFT(const uint16_t minutes, const uint16_t address) {
-    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), minutes / 60, minutes % 60), TXT_PRINT_TIME);
+  void DgusTFT::sendTimeToTFT(const uint32_t minutes, const uint16_t address) {
+    sendTxtToTFT(MString<20>().setf(PSTR("%3s H %3s M"), minutes / 60, minutes % 60), TXT_PRINT_TIME);
   }
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {
@@ -1044,7 +1044,7 @@ namespace Anycubic {
           control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
           const uint16_t feedrate = constrain(uint16_t(control_value), 40, 999);
           //feedrate_percentage=constrain(control_value,40,999);
-          sendTxtToTFT(MString<3>(feedrate), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<6>(feedrate), TXT_PRINT_SPEED);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_NOW);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_TARGET);
           setFeedrate_percent(feedrate);
@@ -1294,7 +1294,7 @@ namespace Anycubic {
 
             sendTxtToTFT(MString<17>(filenavigator.filelist.longFilename()), TXT_PRINT_NAME);
             sendTxtToTFT(ftostr72rj(getFeedrate_percent()), TXT_PRINT_SPEED);
-            sendTxtToTFT(MString<3>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
+            sendTxtToTFT(MString<6>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
             sendTimeToTFT(0, TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);
@@ -1384,7 +1384,7 @@ namespace Anycubic {
       if (ifeedrate != 0)
         sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
       else
-        sendTxtToTFT(MString<3>(feedrate_back), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<6>(feedrate_back), TXT_PRINT_SPEED);
 
       #if ACDEBUG(AC_MARLIN)
         DEBUG_ECHOLNPGM("print speed: ", ifeedrate, " feedrate_back: ", feedrate_back);
@@ -1395,7 +1395,7 @@ namespace Anycubic {
     static uint8_t progress_last = 0;
     if (progress_last != getProgress_percent()) {
       progress_last = getProgress_percent();
-      sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
+      sendTxtToTFT(MString<6>(progress_last), TXT_PRINT_PROGRESS);
     }
 
     // Report Printing Time in minutes
@@ -1455,14 +1455,14 @@ namespace Anycubic {
       if (ifeedrate != 0)
         sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
       else
-        sendTxtToTFT(MString<3>(feedrate_back), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<6>(feedrate_back), TXT_PRINT_SPEED);
       feedrate_back = ifeedrate;
     }
 
     static uint8_t progress_last = 0;
     if (progress_last != getProgress_percent()) {
       progress_last = getProgress_percent();
-      sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
+      sendTxtToTFT(MString<6>(progress_last), TXT_PRINT_PROGRESS);
     }
 
     // Report Printing Time in minutes
@@ -2530,8 +2530,8 @@ namespace Anycubic {
             sendTxtToTFT(recovery.info.sd_filename, TXT_OUTAGE_RECOVERY_FILE);
           #endif
 
-          sendTxtToTFT(MString<5>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
-          sendTxtToTFT(MString<3>(progress_last), TXT_PRINT_PROGRESS);
+          sendTxtToTFT(MString<6>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<6>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);              // show pause
           injectCommands(F("M355 S1\nM1000"));        // case light on, home and start recovery
@@ -2564,8 +2564,8 @@ namespace Anycubic {
             sendTxtToTFT(recovery.info.sd_filename, TXT_OUTAGE_RECOVERY_FILE);
           #endif
 
-          sendTxtToTFT(MString<5>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
-          sendTxtToTFT(MString<3>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
+          sendTxtToTFT(MString<6>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
+          sendTxtToTFT(MString<6>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);          // show pause
           injectCommands(F("M355 S1\nM1000"));    // case light on, home and start recovery

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1134,14 +1134,14 @@ namespace Anycubic {
   }
 
   #if HAS_HOTEND
-    void DgusTFT::send_temperature_hotend(const uint32_t addr) {
-      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(E0)), '/', uint16_t(getTargetTemp_celsius(E0))), addr);
+    void DgusTFT::send_temperature_hotend(const uint16_t address) {
+      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(E0)), '/', uint16_t(getTargetTemp_celsius(E0))), address);
     }
   #endif
 
   #if HAS_HEATED_BED
-    void DgusTFT::send_temperature_bed(const uint32_t addr) {
-      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(BED)), '/', uint16_t(getTargetTemp_celsius(BED))), addr);
+    void DgusTFT::send_temperature_bed(const uint16_t address) {
+      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(BED)), '/', uint16_t(getTargetTemp_celsius(BED))), address);
     }
   #endif
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -52,25 +52,6 @@
 
 namespace Anycubic {
 
-  const char MESSAGE_charu[]          = {0xB4, 0xE6, 0xB4, 0xA2, 0xBF, 0xA8, 0xD2, 0xD1, 0xB2, 0xE5, 0xC8, 0xEB, 0x00}; // '忙'垄驴篓脪脩虏氓脠毛
-  const char MESSAGE_bachu[]          = {0xB4, 0xE6, 0xB4, 0xA2, 0xBF, 0xA8, 0xD2, 0xD1, 0xB0, 0xCE, 0xB3, 0xF6, 0x00};
-  const char MESSAGE_wuka[]           = {0xCE, 0xDE, 0xB4, 0xE6, 0xB4, 0xA2, 0xBF, 0xA8, 0x00};
-  const char MESSAGE_lianji[]         = {0xC1, 0xAA, 0xBB, 0xFA, 0xD6, 0xD0, 0x00};
-  const char MESSAGE_tuoji[]          = {0xCD, 0xD1, 0xBB, 0xFA, 0xB4, 0xF2, 0xD3, 0xA1, 0xD6, 0xD0, 0x00};
-  const char MESSAGE_zanting[]        = {0xB4, 0xF2, 0xD3, 0xA1, 0xD4, 0xDD, 0xCD, 0xA3, 0xD6, 0xD0, 0x00};
-  const char MESSAGE_tingzhi[]        = {0xCD, 0xA3, 0xD6, 0xB9, 0xB4, 0xF2, 0xD3, 0xA1, 0x00};
-  const char MESSAGE_wancheng[]       = {0xCD, 0xEA, 0xB3, 0xC9, 0xB4, 0xF2, 0xD3, 0xA1, 0x00};
-  const char MESSAGE_hotend_heating[] = {0xB4, 0xF2, 0xD3, 0xA1, 0xCD, 0xB7, 0xD5, 0xFD, 0xD4, 0xDA, 0xBC, 0xD3, 0xC8, 0xC8, 0x00};
-  const char MESSAGE_hotend_over[]    = {0xB4, 0xF2, 0xD3, 0xA1, 0xCD, 0xB7, 0xBC, 0xD3, 0xC8, 0xC8, 0xCD, 0xEA, 0xB3, 0xC9, 0x00};
-  const char MESSAGE_bed_heating[]    = {0xC8, 0xC8, 0xB4, 0xB2, 0xD5, 0xFD, 0xD4, 0xDA, 0xBC, 0xD3, 0xC8, 0xC8, 0x00};
-  const char MESSAGE_bed_over[]       = {0xC8, 0xC8, 0xB4, 0xB2, 0xBC, 0xD3, 0xC8, 0xC8, 0xCD, 0xEA, 0xB3, 0xC9, 0x00};
-  const char MESSAGE_ready[]          = {0xD7, 0xBC, 0xB1, 0xB8, 0xBE, 0xCD, 0xD0, 0xF7, 0x00};
-  const char MESSAGE_cold[]           = {0xB4, 0xF2, 0xD3, 0xA1, 0xCD, 0xB7, 0xCE, 0xC2, 0xB6, 0xC8, 0xB9, 0xFD, 0xB5, 0xCD, 0x00};
-
-  const char *p_mesage[] = { MESSAGE_charu, MESSAGE_bachu, MESSAGE_wuka, MESSAGE_lianji, MESSAGE_tuoji, MESSAGE_zanting,
-                             MESSAGE_tingzhi, MESSAGE_wancheng, MESSAGE_hotend_heating, MESSAGE_hotend_over, MESSAGE_bed_heating,
-                             MESSAGE_bed_over, MESSAGE_ready, MESSAGE_cold };
-
   DgusTFT::p_fun fun_array[] = {
     DgusTFT::page1,  DgusTFT::page2,  DgusTFT::page3,  DgusTFT::page4,  DgusTFT::page5,  DgusTFT::page6,
     DgusTFT::page7,  DgusTFT::page8,  DgusTFT::page9,  DgusTFT::page10, DgusTFT::page11, DgusTFT::page12,
@@ -100,7 +81,6 @@ namespace Anycubic {
   uint8_t DgusTFT::data_buf[DATA_BUF_SIZE];
   uint8_t DgusTFT::data_index;
   uint16_t DgusTFT::page_index_now, DgusTFT::page_index_last, DgusTFT::page_index_last_2;
-  uint8_t DgusTFT::message_index;
   uint8_t DgusTFT::pop_up_index;
   uint32_t DgusTFT::key_value;
   uint8_t DgusTFT::lcd_txtbox_index;
@@ -121,7 +101,6 @@ namespace Anycubic {
 
   DgusTFT::DgusTFT() {
     data_buf[0] = '\0';
-    message_index = 100;
     pop_up_index = 100;
     page_index_now = page_index_last = page_index_last_2 = 1;
     lcd_txtbox_index = 0;
@@ -1109,24 +1088,6 @@ namespace Anycubic {
     }
   }
 
-  #if 0
-    {
-      // Break these up into logical blocks // as its easier to navigate than one huge switch case!
-      int8_t req = atoi(&panel_command[1]);
-
-      // Information requests A0 - A8 and A33
-      if (req <= 8 || req == 33) panelInfo(req);
-
-      // Simple Actions A9 - A28
-      else if (req <= 28) panelAction(req);
-
-      // Process Initiation
-      else if (req <= 34) panelProcess(req);
-
-      else tftSendLn();
-    }
-  #endif
-
   void DgusTFT::set_language(language_t language) {
     lcd_info.language = ui_language = lcd_info_back.language = language;
   }
@@ -1208,13 +1169,6 @@ namespace Anycubic {
         goto_system_page();
         break;
     }
-
-    #if 0
-      if (message_index < 30) {
-        sendTxtToTFT(p_mesage[message_index], TXT_MAIN_MESSAGE);
-        message_index = 30;
-      }
-    #endif
 
     #if HAS_HOTEND || HAS_HEATED_BED
       static millis_t flash_time = 0;
@@ -2474,7 +2428,6 @@ namespace Anycubic {
         if (isPrintingFromMedia()) {
           printer_state = AC_printer_stopping;
           stopPrint();
-          message_index = 6;
           changePageOfTFT(PAGE_MAIN);
         }
         else {

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -781,6 +781,14 @@ namespace Anycubic {
     #endif
   }
 
+  void DgusTFT::fakeChangePageOfTFT(const uint16_t page_index) {
+    #if ACDEBUG(AC_MARLIN)
+      if (page_index_saved != page_index_now)
+        DEBUG_ECHOLNPGM("fakeChangePageOfTFT: ", page_index);
+    #endif
+    changePageOfTFT(page_index, true);
+  }
+
   void DgusTFT::debugPage(int page/*=0*/) {
     #if ACDEBUG(AC_ALL)
       if (page == 0) page = page_index_now;
@@ -791,14 +799,6 @@ namespace Anycubic {
       }
     #endif
     UNUSED(page);
-  }
-
-  void DgusTFT::fakeChangePageOfTFT(const uint16_t page_index) {
-    #if ACDEBUG(AC_MARLIN)
-      if (page_index_saved != page_index_now)
-        DEBUG_ECHOLNPGM("fakeChangePageOfTFT: ", page_index);
-    #endif
-    changePageOfTFT(page_index, true);
   }
 
   void DgusTFT::showAboutPage() {

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -535,6 +535,11 @@ namespace Anycubic {
       static grid_count_t probe_cnt = 0;
     #endif
 
+    // Visible in main page
+    char str_buf[30];
+    strlcpy_P(str_buf, msg, sizeof(str_buf));
+    sendTxtToTFT(str_buf, TXT_MAIN_MESSAGE);
+
     // The only way to get printer status is to parse messages
     // Use the state to minimise the work we do here.
     switch (printer_state) {

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1293,7 +1293,7 @@ namespace Anycubic {
             printFile(filenavigator.filelist.shortFilename());
 
             sendTxtToTFT(MString<17>(filenavigator.filelist.longFilename()), TXT_PRINT_NAME);
-            sendTxtToTFT(ftostr72rj(getFeedrate_percent()), TXT_PRINT_SPEED);
+            sendTxtToTFT(MString<6>(uint16_t(getFeedrate_percent())), TXT_PRINT_SPEED);
             sendTxtToTFT(MString<6>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
             sendTimeToTFT(0, TXT_PRINT_TIME);
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -424,9 +424,8 @@ namespace Anycubic {
           else {
             printer_state = AC_printer_stopping;
 
-            // Get Printing Time in minutes
-            const uint32_t time = getProgress_seconds_elapsed() / 60;
-            sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_FINISH_TIME);
+            // Report Printing Time in minutes
+            sendTimeToTFT(getProgress_seconds_elapsed() / 60, TXT_FINISH_TIME);
             changePageOfTFT(PAGE_PRINT_FINISH);
             tftSendLn(AC_msg_print_complete);
             pop_up_index = 100;
@@ -728,6 +727,10 @@ namespace Anycubic {
     uint16_t color_address = address + 3;
     uint8_t data[] = { 0x5A, 0xA5, 0x05, 0x82, uint8_t(color_address >> 8), uint8_t(color_address & 0xFF), uint8_t(color >> 8), uint8_t(color & 0xFF) };
     for (uint8_t i = 0; i < COUNT(data); ++i) TFTSer.write(data[i]);
+  }
+
+  void DgusTFT::sendTimeToTFT(const uint16_t minutes, const uint16_t address) {
+    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
   }
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {
@@ -1132,18 +1135,14 @@ namespace Anycubic {
   }
 
   #if HAS_HOTEND
-    void DgusTFT::send_temperature_hotend(uint32_t addr) {
-      char str_buf[16];
-      sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(getActualTemp_celsius(E0)), uint16_t(getTargetTemp_celsius(E0)));
-      sendTxtToTFT(str_buf, addr);
+    void DgusTFT::send_temperature_hotend(const uint32_t addr) {
+      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(E0)), '/', uint16_t(getTargetTemp_celsius(E0))), addr);
     }
   #endif
 
   #if HAS_HEATED_BED
-    void DgusTFT::send_temperature_bed(uint32_t addr) {
-      char str_buf[16];
-      sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(getActualTemp_celsius(BED)), uint16_t(getTargetTemp_celsius(BED)));
-      sendTxtToTFT(str_buf, addr);
+    void DgusTFT::send_temperature_bed(const uint32_t addr) {
+      sendTxtToTFT(MString<16>(uint16_t(getActualTemp_celsius(BED)), '/', uint16_t(getTargetTemp_celsius(BED))), addr);
     }
   #endif
 
@@ -1309,8 +1308,7 @@ namespace Anycubic {
             sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
             sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
 
-            const uint32_t time = 0;
-            sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
+            sendTimeToTFT(0, TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);
           }
@@ -1422,9 +1420,8 @@ namespace Anycubic {
       progress_last = getProgress_percent();
     }
 
-    // Get Printing Time in minutes
-    const uint32_t time = getProgress_seconds_elapsed() / 60;
-    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
+    // Report Printing Time in minutes
+    sendTimeToTFT(getProgress_seconds_elapsed() / 60, TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
     TERN_(HAS_HEATED_BED, send_temperature_bed(TXT_PRINT_BED));
@@ -1500,9 +1497,8 @@ namespace Anycubic {
       progress_last = getProgress_percent();
     }
 
-    // Get Printing Time in minutes
-    const uint32_t time = getProgress_seconds_elapsed() / 60;
-    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
+    // Report Printing Time in minutes
+    sendTimeToTFT(getProgress_seconds_elapsed() / 60, TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
     TERN_(HAS_HEATED_BED, send_temperature_bed(TXT_PRINT_BED));
@@ -3133,9 +3129,8 @@ namespace Anycubic {
         break;
 
       case 24: {
-        // Get Printing Time in minutes
-        const uint32_t time = getProgress_seconds_elapsed() / 60;
-        sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_FINISH_TIME);
+        // Report Printing Time in minutes
+        sendTimeToTFT(getProgress_seconds_elapsed() / 60, TXT_FINISH_TIME);
         changePageOfTFT(PAGE_PRINT_FINISH);
         //tftSendLn(AC_msg_print_complete);   // no idea why this causes a compile error
         pop_up_index = 100;

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1382,7 +1382,7 @@ namespace Anycubic {
     const int16_t ifeedrate = int16_t(getFeedrate_percent());
     if (feedrate_back != ifeedrate) {
       if (ifeedrate != 0)
-        sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<6>(ifeedrate), TXT_PRINT_SPEED);
       else
         sendTxtToTFT(MString<6>(feedrate_back), TXT_PRINT_SPEED);
 
@@ -1453,7 +1453,7 @@ namespace Anycubic {
     const int16_t ifeedrate = int16_t(getFeedrate_percent());
     if (feedrate_back != ifeedrate) {
       if (ifeedrate != 0)
-        sendTxtToTFT(ftostr72rj(ifeedrate), TXT_PRINT_SPEED);
+        sendTxtToTFT(MString<6>(ifeedrate), TXT_PRINT_SPEED);
       else
         sendTxtToTFT(MString<6>(feedrate_back), TXT_PRINT_SPEED);
       feedrate_back = ifeedrate;

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -417,8 +417,8 @@ namespace Anycubic {
             // Get Printing Time
             uint32_t time = getProgress_seconds_elapsed() / 60;
             char str_buf[20];
-            sprintf(str_buf, "%s H ", utostr3(time / 60));
-            sprintf(str_buf + strlen(str_buf), "%s M", utostr3(time % 60));
+            sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
+            sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
             sendTxtToTFT(str_buf, TXT_FINISH_TIME);
             changePageOfTFT(PAGE_PRINT_FINISH);
             tftSendLn(AC_msg_print_complete);
@@ -536,9 +536,7 @@ namespace Anycubic {
     #endif
 
     // Visible in main page
-    char str_buf[30];
-    strlcpy_P(str_buf, msg, sizeof(str_buf));
-    sendTxtToTFT(str_buf, TXT_MAIN_MESSAGE);
+    sendTxtToTFT_P(msg, TXT_MAIN_MESSAGE);
 
     // The only way to get printer status is to parse messages
     // Use the state to minimise the work we do here.
@@ -787,10 +785,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::changePageOfTFTToAbout() {
-    char str_ver[32];
-    //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-    strlcpy_P(str_ver, getFirmwareName_str(), sizeof(str_ver));
-    sendTxtToTFT(str_ver, TXT_VERSION);
+    sendTxtToTFT_P(getFirmwareName_str(), TXT_VERSION);
     changePageOfTFT(PAGE_ABOUT);
   }
 
@@ -1007,7 +1002,7 @@ namespace Anycubic {
             control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
             temp = constrain(uint16_t(control_value), 0, thermalManager.hotend_max_target(0));
             setTargetTemp_celsius(temp, E0);
-            //sprintf(str_buf,"%u/%u", (uint16_t)thermalManager.degHotend(0), uint16_t(control_value));
+            //sprintf_P(str_buf, PSTR("%u/%u"), (uint16_t)thermalManager.degHotend(0), uint16_t(control_value));
             //sendTxtToTFT(str_buf, TXT_PRINT_HOTEND);
           }
         #endif
@@ -1017,7 +1012,7 @@ namespace Anycubic {
             control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
             temp = constrain(uint16_t(control_value), 0, BED_MAX_TARGET);
             setTargetTemp_celsius(temp, BED);
-            //sprintf(str_buf,"%u/%u", uint16_t(thermalManager.degBed()), uint16_t(control_value));
+            //sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(thermalManager.degBed()), uint16_t(control_value));
             //sendTxtToTFT(str_buf, TXT_PRINT_BED);
           }
         #endif
@@ -1036,7 +1031,7 @@ namespace Anycubic {
           control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
           const uint16_t feedrate = constrain(uint16_t(control_value), 40, 999);
           //feedrate_percentage=constrain(control_value,40,999);
-          sprintf(str_buf, "%u", feedrate);
+          sprintf_P(str_buf, PSTR("%u"), feedrate);
           sendTxtToTFT(str_buf, TXT_PRINT_SPEED);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_NOW);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_TARGET);
@@ -1133,7 +1128,7 @@ namespace Anycubic {
   #if HAS_HOTEND
     void DgusTFT::send_temperature_hotend(uint32_t addr) {
       char str_buf[16];
-      sprintf(str_buf, "%u/%u", uint16_t(getActualTemp_celsius(E0)), uint16_t(getTargetTemp_celsius(E0)));
+      sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(getActualTemp_celsius(E0)), uint16_t(getTargetTemp_celsius(E0)));
       sendTxtToTFT(str_buf, addr);
     }
   #endif
@@ -1141,7 +1136,7 @@ namespace Anycubic {
   #if HAS_HEATED_BED
     void DgusTFT::send_temperature_bed(uint32_t addr) {
       char str_buf[16];
-      sprintf(str_buf, "%u/%u", uint16_t(getActualTemp_celsius(BED)), uint16_t(getTargetTemp_celsius(BED)));
+      sprintf_P(str_buf, PSTR("%u/%u"), uint16_t(getActualTemp_celsius(BED)), uint16_t(getTargetTemp_celsius(BED)));
       sendTxtToTFT(str_buf, addr);
     }
   #endif
@@ -1260,8 +1255,8 @@ namespace Anycubic {
 
             TERN_(CASE_LIGHT_ENABLE, setCaseLightState(true));
 
-            char str_buf[20];
-            strlcpy_P(str_buf, filenavigator.filelist.longFilename(), 18);
+            char str_buf[18];
+            strlcpy_P(str_buf, filenavigator.filelist.longFilename(), sizeof(str_buf));
             sendTxtToTFT(str_buf, TXT_PRINT_NAME);
 
             #if ENABLED(POWER_LOSS_RECOVERY)
@@ -1302,15 +1297,15 @@ namespace Anycubic {
             strlcpy_P(str_buf, filenavigator.filelist.longFilename(), 18);
             sendTxtToTFT(str_buf, TXT_PRINT_NAME);
 
-            sprintf(str_buf, "%5.2f", getFeedrate_percent());
+            sprintf_P(str_buf, PSTR("%5.2f"), getFeedrate_percent());
             sendTxtToTFT(str_buf, TXT_PRINT_SPEED);
 
-            sprintf(str_buf, "%u", uint16_t(getProgress_percent()));
+            sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
             sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
 
             uint32_t time = 0;
-            sprintf(str_buf, "%s H ", utostr3(time / 60));
-            sprintf(str_buf + strlen(str_buf), "%s M", utostr3(time % 60));
+            sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
+            sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
             sendTxtToTFT(str_buf, TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);
@@ -1405,9 +1400,9 @@ namespace Anycubic {
 
     if (feedrate_back != getFeedrate_percent()) {
       if (getFeedrate_percent() != 0)
-        sprintf(str_buf, "%5.2f", getFeedrate_percent());
+        sprintf_P(str_buf, PSTR("%5.2f"), getFeedrate_percent());
       else
-        sprintf(str_buf, "%d", feedrate_back);
+        sprintf_P(str_buf, PSTR("%d"), feedrate_back);
 
       #if ACDEBUG(AC_MARLIN)
         DEBUG_ECHOLNPGM("print speed: ", str_buf);
@@ -1418,15 +1413,15 @@ namespace Anycubic {
     }
 
     if (progress_last != getProgress_percent()) {
-      sprintf(str_buf, "%u", getProgress_percent());
+      sprintf_P(str_buf, PSTR("%u"), getProgress_percent());
       sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
       progress_last = getProgress_percent();
     }
 
     // Get Printing Time
     uint32_t time = getProgress_seconds_elapsed() / 60;
-    sprintf(str_buf, "%s H ", utostr3(time / 60));
-    sprintf(str_buf + strlen(str_buf), "%s M", utostr3(time % 60));
+    sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
+    sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
     sendTxtToTFT(str_buf, TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
@@ -1491,23 +1486,23 @@ namespace Anycubic {
 
     if (feedrate_back != getFeedrate_percent()) {
       if (getFeedrate_percent() != 0)
-        sprintf(str_buf, "%5.2f", getFeedrate_percent());
+        sprintf_P(str_buf, PSTR("%5.2f"), getFeedrate_percent());
       else
-        sprintf(str_buf, "%d", feedrate_back);
+        sprintf_P(str_buf, PSTR("%d"), feedrate_back);
 
       sendTxtToTFT(str_buf, TXT_PRINT_SPEED);
       feedrate_back = getFeedrate_percent();
     }
 
     if (progress_last != getProgress_percent()) {
-      sprintf(str_buf, "%u", getProgress_percent());
+      sprintf_P(str_buf, PSTR("%u"), getProgress_percent());
       sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
       progress_last = getProgress_percent();
     }
 
-    uint32_t time = getProgress_seconds_elapsed() / 60;
-    sprintf(str_buf, "%s H ", utostr3(time / 60));
-    sprintf(str_buf + strlen(str_buf), "%s M", utostr3(time % 60));
+    const uint32_t time = getProgress_seconds_elapsed() / 60;
+    sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
+    sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
     sendTxtToTFT(str_buf, TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
@@ -2802,10 +2797,10 @@ namespace Anycubic {
           #endif
 
           char str_buf[20] = { '\0' };
-          sprintf(str_buf, "%u", uint16_t(getFeedrate_percent()));
+          sprintf_P(str_buf, PSTR("%u"), uint16_t(getFeedrate_percent()));
           sendTxtToTFT(str_buf, TXT_PRINT_SPEED);
 
-          sprintf(str_buf, "%u", uint16_t(getProgress_percent()));
+          sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
           sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);              // show pause
@@ -2845,10 +2840,10 @@ namespace Anycubic {
           #endif
 
           char str_buf[20] = { '\0' };
-          sprintf(str_buf, "%u", uint16_t(getFeedrate_percent()));
+          sprintf_P(str_buf, PSTR("%u"), uint16_t(getFeedrate_percent()));
           sendTxtToTFT(str_buf, TXT_PRINT_SPEED);
 
-          sprintf(str_buf, "%u", uint16_t(getProgress_percent()));
+          sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
           sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
 
           changePageOfTFT(PAGE_STATUS2);          // show pause
@@ -3154,8 +3149,8 @@ namespace Anycubic {
       case 24: { //
         uint32_t time = getProgress_seconds_elapsed() / 60;
         char str_buf[20];
-        sprintf(str_buf, "%s H ", utostr3(time / 60));
-        sprintf(str_buf + strlen(str_buf), "%s M", utostr3(time % 60));
+        sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
+        sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
         sendTxtToTFT(str_buf, TXT_FINISH_TIME);
         changePageOfTFT(PAGE_PRINT_FINISH);
         //tftSendLn(AC_msg_print_complete);   // no idea why this causes a compile error

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -414,12 +414,9 @@ namespace Anycubic {
           else {
             printer_state = AC_printer_stopping;
 
-            // Get Printing Time
-            uint32_t time = getProgress_seconds_elapsed() / 60;
-            char str_buf[20];
-            sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
-            sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
-            sendTxtToTFT(str_buf, TXT_FINISH_TIME);
+            // Get Printing Time in minutes
+            const uint32_t time = getProgress_seconds_elapsed() / 60;
+            sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_FINISH_TIME);
             changePageOfTFT(PAGE_PRINT_FINISH);
             tftSendLn(AC_msg_print_complete);
             pop_up_index = 100;
@@ -1303,10 +1300,8 @@ namespace Anycubic {
             sprintf_P(str_buf, PSTR("%u"), uint16_t(getProgress_percent()));
             sendTxtToTFT(str_buf, TXT_PRINT_PROGRESS);
 
-            uint32_t time = 0;
-            sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
-            sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
-            sendTxtToTFT(str_buf, TXT_PRINT_TIME);
+            const uint32_t time = 0;
+            sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);
           }
@@ -1418,11 +1413,9 @@ namespace Anycubic {
       progress_last = getProgress_percent();
     }
 
-    // Get Printing Time
-    uint32_t time = getProgress_seconds_elapsed() / 60;
-    sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
-    sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
-    sendTxtToTFT(str_buf, TXT_PRINT_TIME);
+    // Get Printing Time in minutes
+    const uint32_t time = getProgress_seconds_elapsed() / 60;
+    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
     TERN_(HAS_HEATED_BED, send_temperature_bed(TXT_PRINT_BED));
@@ -1500,10 +1493,9 @@ namespace Anycubic {
       progress_last = getProgress_percent();
     }
 
+    // Get Printing Time in minutes
     const uint32_t time = getProgress_seconds_elapsed() / 60;
-    sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
-    sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
-    sendTxtToTFT(str_buf, TXT_PRINT_TIME);
+    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
 
     TERN_(HAS_HOTEND, send_temperature_hotend(TXT_PRINT_HOTEND));
     TERN_(HAS_HEATED_BED, send_temperature_bed(TXT_PRINT_BED));
@@ -3146,7 +3138,8 @@ namespace Anycubic {
         pop_up_index = 100;
         break;
 
-      case 24: { //
+      case 24: {
+        // Get Printing Time in minutes
         const uint32_t time = getProgress_seconds_elapsed() / 60;
         sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_FINISH_TIME);
         changePageOfTFT(PAGE_PRINT_FINISH);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -3147,11 +3147,8 @@ namespace Anycubic {
         break;
 
       case 24: { //
-        uint32_t time = getProgress_seconds_elapsed() / 60;
-        char str_buf[20];
-        sprintf_P(str_buf, PSTR("%s H "), utostr3(time / 60));
-        sprintf_P(str_buf + strlen(str_buf), PSTR("%s M"), utostr3(time % 60));
-        sendTxtToTFT(str_buf, TXT_FINISH_TIME);
+        const uint32_t time = getProgress_seconds_elapsed() / 60;
+        sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_FINISH_TIME);
         changePageOfTFT(PAGE_PRINT_FINISH);
         //tftSendLn(AC_msg_print_complete);   // no idea why this causes a compile error
         pop_up_index = 100;

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1464,9 +1464,7 @@ namespace Anycubic {
         feedrate_back = getFeedrate_percent();
         sendValueToTFT((uint16_t)feedrate_back, TXT_ADJUST_SPEED);
         TERN_(HAS_FAN, sendValueToTFT(uint16_t(getActualFan_percent(FAN0)), TXT_FAN_SPEED_TARGET));
-        str_buf[0] = 0;
-        strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 3);
-        sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+        sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 3, TXT_LEVEL_OFFSET);
         //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
         requestValueFromTFT(TXT_ADJUST_SPEED);  // attempt to make feedrate visible on visit to this page
         break;
@@ -1531,10 +1529,7 @@ namespace Anycubic {
           z_off -= 0.05f;
           setZOffset_mm(z_off);
 
-          char str_buf[10];
-          str_buf[0] = 0;
-          strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 2);
-          sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+          sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
           //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
           //if (isAxisPositionKnown(Z)) {  // Move Z axis
@@ -1572,10 +1567,7 @@ namespace Anycubic {
           z_off += 0.05f;
           setZOffset_mm(z_off);
 
-          char str_buf[10];
-          str_buf[0] = '\0';
-          strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 2);
-          sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+          sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
           //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
           //int16_t steps = mmToWholeSteps(constrain(Zshift,-0.05,0.05), Z);
@@ -2045,10 +2037,7 @@ namespace Anycubic {
         break;
 
       case 3: {
-        char str_buf[10];
-        str_buf[0] = '\0';
-        strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 2);
-        sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+        sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
         //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
         changePageOfTFT(PAGE_LEVEL_ADVANCE);
       } break;
@@ -2081,9 +2070,7 @@ namespace Anycubic {
         z_off = getZOffset_mm() - 0.01f;
         setZOffset_mm(z_off);
 
-        char str_buf[10];
-        strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 2);
-        sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+        sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
         //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
         if (isAxisPositionKnown(Z)) {
@@ -2100,9 +2087,7 @@ namespace Anycubic {
         z_off = getZOffset_mm() + 0.01f;
         setZOffset_mm(z_off);
 
-        char str_buf[10];
-        strcat(str_buf, ftostr52sprj(getZOffset_mm()) + 2);
-        sendTxtToTFT(str_buf, TXT_LEVEL_OFFSET);
+        sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
         //sendTxtToTFT(ftostr52sprj(getZOffset_mm()), TXT_LEVEL_OFFSET);
 
         if (isAxisPositionKnown(Z)) {          // Move Z axis

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -1259,9 +1259,7 @@ namespace Anycubic {
 
             TERN_(CASE_LIGHT_ENABLE, setCaseLightState(true));
 
-            char str_buf[18];
-            strlcpy_P(str_buf, filenavigator.filelist.longFilename(), sizeof(str_buf));
-            sendTxtToTFT(str_buf, TXT_PRINT_NAME);
+            sendTxtToTFT(MString<17>(filenavigator.filelist.longFilename()), TXT_PRINT_NAME);
 
             #if ENABLED(POWER_LOSS_RECOVERY)
               if (printer_state == AC_printer_resuming_from_power_outage) {
@@ -1297,13 +1295,9 @@ namespace Anycubic {
             TERN_(CASE_LIGHT_ENABLE, setCaseLightState(true));
             printFile(filenavigator.filelist.shortFilename());
 
-            char str_buf[18];
-            strlcpy_P(str_buf, filenavigator.filelist.longFilename(), 18);
-            sendTxtToTFT(str_buf, TXT_PRINT_NAME);
-
+            sendTxtToTFT(MString<17>(filenavigator.filelist.longFilename()), TXT_PRINT_NAME);
             sendTxtToTFT(ftostr72rj(getFeedrate_percent()), TXT_PRINT_SPEED);
             sendTxtToTFT(MString<4>(uint16_t(getProgress_percent())), TXT_PRINT_PROGRESS);
-
             sendTimeToTFT(0, TXT_PRINT_TIME);
 
             changePageOfTFT(PAGE_STATUS2);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -732,7 +732,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::sendTimeToTFT(const uint32_t minutes, const uint16_t address) {
-    sendTxtToTFT(MString<20>().setf(PSTR("%3s H %3s M"), minutes / 60, minutes % 60), TXT_PRINT_TIME);
+    sendTxtToTFT(MString<20>().setf(PSTR("%3d H %3d M"), minutes / 60, minutes % 60), TXT_PRINT_TIME);
   }
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -784,7 +784,7 @@ namespace Anycubic {
   void DgusTFT::changePageOfTFTToAbout() {
     char str_ver[32];
     //sprintf(str_ver, "%04d-%02d-%02d %02d:%02d:%02d\n", BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR, BUILD_MIN, BUILD_SEC);
-    sprintf(str_ver, MAIN_BOARD_FIRMWARE_VER);
+    strlcpy_P(str_ver, getFirmwareName_str(), sizeof(str_ver));
     sendTxtToTFT(str_ver, TXT_VERSION);
     changePageOfTFT(PAGE_ABOUT);
   }

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -730,7 +730,7 @@ namespace Anycubic {
   }
 
   void DgusTFT::sendTimeToTFT(const uint16_t minutes, const uint16_t address) {
-    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), time / 60, time % 60), TXT_PRINT_TIME);
+    sendTxtToTFT(MString<20>.setf(PSTR("%3s H %3s M"), minutes / 60, minutes % 60), TXT_PRINT_TIME);
   }
 
   void DgusTFT::sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address) {

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -373,10 +373,10 @@ namespace Anycubic {
       static void store_changes();
 
       #if HAS_HOTEND
-        static void send_temperature_hotend(const uint32_t addr);
+        static void send_temperature_hotend(const uint16_t address);
       #endif
       #if HAS_HEATED_BED
-        static void send_temperature_bed(const uint32_t addr);
+        static void send_temperature_bed(const uint16_t address);
       #endif
 
       typedef void (*p_fun)();

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -122,29 +122,29 @@
 /****************** TXT **************************/
 
 // MAIN PAGE TXT
-#define TXT_MAIN_BED        0x2000
-#define TXT_MAIN_HOTEND     0x2030
-#define TXT_MAIN_MESSAGE    0x2060
+#define TXT_MAIN_BED            (0x2000+0*0x30)
+#define TXT_MAIN_HOTEND         (0x2000+1*0x30)
+#define TXT_MAIN_MESSAGE        (0x2000+2*0x30)
 
 // FILE TXT
-#define TXT_FILE_0          (0x2000+3*0x30)
-#define TXT_DESCRIPT_0      0x5000         // DESCRIBE ADDRESS
-#define TXT_FILE_1          (0x2000+4*0x30)
-#define TXT_DESCRIPT_1      0x5030
-#define TXT_FILE_2          (0x2000+5*0x30)
-#define TXT_DESCRIPT_2      0x5060
-#define TXT_FILE_3          (0x2000+6*0x30)
-#define TXT_DESCRIPT_3      0x5090
-#define TXT_FILE_4          (0x2000+7*0x30)
-#define TXT_DESCRIPT_4      0x50C0
+#define TXT_FILE_0              (0x2000+3*0x30)
+#define TXT_DESCRIPT_0          0x5000         // DESCRIBE ADDRESS
+#define TXT_FILE_1              (0x2000+4*0x30)
+#define TXT_DESCRIPT_1          0x5030
+#define TXT_FILE_2              (0x2000+5*0x30)
+#define TXT_DESCRIPT_2          0x5060
+#define TXT_FILE_3              (0x2000+6*0x30)
+#define TXT_DESCRIPT_3          0x5090
+#define TXT_FILE_4              (0x2000+7*0x30)
+#define TXT_DESCRIPT_4          0x50C0
 
 // PRINT TXT
-#define TXT_PRINT_NAME      0x2000+8*0x30
-#define TXT_PRINT_SPEED     0x2000+9*0x30
-#define TXT_PRINT_TIME      0x2000+10*0x30
-#define TXT_PRINT_PROGRESS  0x2000+11*0x30
-#define TXT_PRINT_HOTEND    0x2000+12*0x30
-#define TXT_PRINT_BED       0x2000+13*0x30
+#define TXT_PRINT_NAME          (0x2000+8*0x30)
+#define TXT_PRINT_SPEED         (0x2000+9*0x30)
+#define TXT_PRINT_TIME          (0x2000+10*0x30)
+#define TXT_PRINT_PROGRESS      (0x2000+11*0x30)
+#define TXT_PRINT_HOTEND        (0x2000+12*0x30)
+#define TXT_PRINT_BED           (0x2000+13*0x30)
 
 // PRINT ADJUST TXT
 
@@ -156,8 +156,8 @@
 
 #define TXT_BED_NOW             (0x2000+17*0x30)
 #define TXT_BED_TARGET          (0x2000+18*0x30)
-#define TXT_HOTEND_NOW           (0x2000+19*0x30)
-#define TXT_HOTEND_TARGET        (0x2000+20*0x30)
+#define TXT_HOTEND_NOW          (0x2000+19*0x30)
+#define TXT_HOTEND_TARGET       (0x2000+20*0x30)
 
 // SPEED SET TXT
 #define TXT_FAN_SPEED_NOW       (0x2000+21*0x30)
@@ -169,23 +169,23 @@
 #define TXT_ABOUT               (0x2000+25*0x30)
 
 // RECORT TXT
-#define TXT_RECORT_0             (0x2000+26*0x30)
-#define TXT_RECORT_1             (0x2000+27*0x30)
-#define TXT_RECORT_2             (0x2000+28*0x30)
-#define TXT_RECORT_3             (0x2000+29*0x30)
-#define TXT_RECORT_4             (0x2000+30*0x30)
-#define TXT_RECORT_5             (0x2000+31*0x30)
+#define TXT_RECORT_0            (0x2000+26*0x30)
+#define TXT_RECORT_1            (0x2000+27*0x30)
+#define TXT_RECORT_2            (0x2000+28*0x30)
+#define TXT_RECORT_3            (0x2000+29*0x30)
+#define TXT_RECORT_4            (0x2000+30*0x30)
+#define TXT_RECORT_5            (0x2000+31*0x30)
 
 // ADVANCE LEVEL TXT
-#define TXT_LEVEL_OFFSET             (0x2000+32*0x30)
+#define TXT_LEVEL_OFFSET        (0x2000+32*0x30)
 
 // FILAMENT TXT
-#define TXT_FILAMENT_TEMP        (0x2000+33*0x30)
+#define TXT_FILAMENT_TEMP       (0x2000+33*0x30)
 
-#define TXT_FINISH_TIME          (0x2000+34*0x30)
-#define TXT_VERSION              (0x2000+35*0x30)
-#define TXT_PREHEAT_HOTEND       (0x2000+36*0x30)
-#define TXT_PREHEAT_BED          (0x2000+37*0x30)
+#define TXT_FINISH_TIME         (0x2000+34*0x30)
+#define TXT_VERSION             (0x2000+35*0x30)
+#define TXT_PREHEAT_HOTEND      (0x2000+36*0x30)
+#define TXT_PREHEAT_BED         (0x2000+37*0x30)
 
 #define TXT_OUTAGE_RECOVERY_FILE 0x2180
 
@@ -473,7 +473,7 @@ namespace Anycubic {
       static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
       static void fakeChangePageOfTFT(const uint16_t page_index);
       static void lcdAudioSet(const bool audio_on);
-      static void changePageOfTFTToAbout();
+      static void showAboutPage();
 
     private:
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -341,7 +341,6 @@ namespace Anycubic {
     static uint8_t      data_buf[DATA_BUF_SIZE];
     static uint8_t      data_index;
     static uint16_t     page_index_last, page_index_last_2;
-    static uint8_t      message_index;
     static uint8_t      pop_up_index;
     static uint32_t     key_value;
     static uint8_t      lcd_txtbox_index;
@@ -457,9 +456,6 @@ namespace Anycubic {
       static void sendFileList(int8_t);
       static void selectFile();
       static void processPanelRequest();
-      static void panelInfo(uint8_t);
-      static void panelAction(uint8_t);
-      static void panelProcess(uint8_t);
 
       static void sendValueToTFT(const uint16_t value, const uint16_t address);
       static void requestValueFromTFT(const uint16_t address);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -29,8 +29,6 @@
 #include "../../../inc/MarlinConfigPre.h"
 #include "../ui_api.h"
 
-#define MAIN_BOARD_FIRMWARE_VER "V2.4.5"
-
 #define DATA_BUF_SIZE 64
 
 /****************** PAGE INDEX***********************/

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -343,7 +343,7 @@ namespace Anycubic {
     static uint32_t     key_value;
     static uint8_t      lcd_txtbox_index;
     static uint8_t      lcd_txtbox_page;
-    static int16_t      feedrate_back;
+    static uint16_t     feedrate_back;
     static language_t   ui_language;
 
     public:

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -373,10 +373,10 @@ namespace Anycubic {
       static void store_changes();
 
       #if HAS_HOTEND
-        static void send_temperature_hotend(uint32_t addr);
+        static void send_temperature_hotend(const uint32_t addr);
       #endif
       #if HAS_HEATED_BED
-        static void send_temperature_bed(uint32_t addr);
+        static void send_temperature_bed(const uint32_t addr);
       #endif
 
       typedef void (*p_fun)();
@@ -468,6 +468,7 @@ namespace Anycubic {
       }
 
       static void sendColorToTFT(const uint16_t color, const uint16_t address);
+      static void sendTimeToTFT(const uint32_t minutes, const uint16_t address);
       static void sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address);
       static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
       static void fakeChangePageOfTFT(const uint16_t page_index);

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -465,6 +465,7 @@ namespace Anycubic {
       static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
       static void fakeChangePageOfTFT(const uint16_t page_index);
       static void lcdAudioSet(const bool audio_on);
+      static void changePageOfTFTToAbout();
 
     private:
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -379,6 +379,9 @@ namespace Anycubic {
         static void send_temperature_bed(const uint16_t address);
       #endif
 
+      static void debugPage(int page=0);
+      static void fakeChangePageOfTFT(const uint16_t page_index);
+
       typedef void (*p_fun)();
       static void page1();
       static void page2();
@@ -471,7 +474,6 @@ namespace Anycubic {
       static void sendTimeToTFT(const uint32_t minutes, const uint16_t address);
       static void sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address);
       static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
-      static void fakeChangePageOfTFT(const uint16_t page_index);
       static void lcdAudioSet(const bool audio_on);
       static void showAboutPage();
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -379,8 +379,9 @@ namespace Anycubic {
         static void send_temperature_bed(const uint16_t address);
       #endif
 
-      static void debugPage(int page=0);
+      static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
       static void fakeChangePageOfTFT(const uint16_t page_index);
+      static void debugPage(int page=0);
 
       typedef void (*p_fun)();
       static void page1();
@@ -473,7 +474,6 @@ namespace Anycubic {
       static void sendColorToTFT(const uint16_t color, const uint16_t address);
       static void sendTimeToTFT(const uint32_t minutes, const uint16_t address);
       static void sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address);
-      static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);
       static void lcdAudioSet(const bool audio_on);
       static void showAboutPage();
 

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -457,7 +457,17 @@ namespace Anycubic {
 
       static void sendValueToTFT(const uint16_t value, const uint16_t address);
       static void requestValueFromTFT(const uint16_t address);
+
       static void sendTxtToTFT(const char *pdata, const uint16_t address);
+      static void sendTxtToTFT_P(PGM_P const pstr, const uint16_t address) {
+        char cstr[32];
+        strlcpy_P(cstr, pstr, sizeof(cstr));
+        sendTxtToTFT(cstr, address);
+      }
+      static void sendTxtToTFT(FSTR_P const fstr, const uint16_t address) {
+        sendTxtToTFT_P(FTOP(fstr), address);
+      }
+
       static void sendColorToTFT(const uint16_t color, const uint16_t address);
       static void sendReadNumOfTxtToTFT(const uint8_t number, const uint16_t address);
       static void changePageOfTFT(const uint16_t page_index, const bool no_send=false);


### PR DESCRIPTION
### Description

Various improvement for stock AnyCubic Vyper display.

### Requirements

This PR need a standard Anycubic Vyper. The screen must have stock DWIN_SET  firmware V2.4.5 (last from anycubic website _or include in Configuration repository_)

### Benefits

- ~~Make temperatures work on main page~~
  ~~Fix the same think that in PR #26261~~
- Fix the color change in file selection page
  The color was not changing when selecting a file and the filename was disappearing. 
- Show getFirmwareName_str() in  the About page 
   instead of  "V2.4.5" of original firmware it show the marlin version
- Use an empty field in original screen firmware to display message on main screen
  In the original screen there is a field of 30 character long in the middle top of the screen, I use it to show standard printer message
- ~~Fix the fact that the screen go black on reset (fix from #26261)~~
- ~~Add a tweak from #26261~~

~~I do not include set_brightness from #26261 because I do not see the need, the default brightness never change.~~
_I do not included fix from #26261_
I have put all in one PR but I can split it if necessary.

### Configurations

The configuration needed is the the one from example  https://github.com/MarlinFirmware/Configurations/tree/import-2.1.x/config/examples/AnyCubic/Vyper 

### Related Issues

~~This PR should replace #26261~~
