### PR TITLE
Use Av^2+Bv+C for Nonlinear extrusion polynomial.

### DIFF
--- a/Marlin/src/gcode/feature/nonlinear/M592.cpp
+++ b/Marlin/src/gcode/feature/nonlinear/M592.cpp
@@ -35,12 +35,12 @@ void GcodeSuite::M592_report(const bool forReplay/*=true*/) {
 
 /**
  * M592: Get or set nonlinear extrusion parameters
- *  A<factor>   Linear coefficient (default 0.0)
- *  B<factor>   Quadratic coefficient (default 0.0)
+ *  A<factor>   Quadratic coefficient (default 0.0)
+ *  B<factor>   Linear coefficient (default 0.0)
  *  C<factor>   Constant coefficient (default 1.0)
  *
  * Adjusts the amount of extrusion based on the instantaneous velocity of extrusion, as a multiplier.
- * The amount of extrusion is multiplied by max(C, C + A*v + B*v^2) where v is extruder velocity in mm/s.
+ * The amount of extrusion is multiplied by max(C, A*v^2 + B*v + C) where v is extruder velocity in mm/s.
  * Only adjusts forward extrusions, since those are the ones affected by backpressure.
  */
 void GcodeSuite::M592() {

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2234,7 +2234,7 @@ hal_timer_t Stepper::calc_timer_interval(uint32_t step_rate) {
 #if ENABLED(NONLINEAR_EXTRUSION)
   void Stepper::calc_nonlinear_e(uint32_t step_rate) {
     const uint32_t velocity = ne_scale * step_rate; // Scale step_rate first so all intermediate values stay in range of 8.24 fixed point math
-    int32_t vd = (((int64_t)ne_fix.A * velocity) >> 24) + (((((int64_t)ne_fix.B * velocity) >> 24) * velocity) >> 24);
+    int32_t vd =  (((((int64_t)ne_fix.A * velocity) >> 24) * velocity) >> 24) + (((int64_t)ne_fix.B * velocity) >> 24);
     NOLESS(vd, 0);
 
     advance_dividend.e = (uint64_t(ne_fix.C + vd) * ne_edividend) >> 24;


### PR DESCRIPTION
Following https://github.com/MarlinFirmware/Marlin/pull/26824#issuecomment-1968319450 use mathematically correct Av^2+Bv+C expression for Nonlinear extrusion polynomial.

In the case of merge [documentation ](https://github.com/MarlinFirmware/MarlinDocumentation/blob/master/_gcode/M592.md) should also be updated.