### PR TITLE
AnyCubic Vyper default name of firmware

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -177,6 +177,7 @@ board_upload.offset_address = 0x08010000
 extends                     = env:STM32F103RE_creality
 board_build.offset          = 0x8000
 board_upload.offset_address = 0x08008000
+board_build.rename          = main_board_{date}_{time}.bin
 
 #
 # Creality 256K (STM32F103RC)


### PR DESCRIPTION



### Description

The vyper board need a file name which begin with 'main_board_' so rename it with this format

### Requirements

Anycubic vyper board 

### Benefits

File can be directly copied on SD card without renaming to make the upgrade.

### Configurations

The one from example https://github.com/MarlinFirmware/Configurations/tree/import-2.1.x/config/examples/AnyCubic/Vyper
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

Seed comments here : https://github.com/MarlinFirmware/Marlin/pull/27158#issuecomment-2160789343