### PR TITLE
mount sdcard early for POWER_LOSS_RECOVERY

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1330,7 +1330,7 @@ void setup() {
     #endif
   #endif
 
-  #if ANY(SDCARD_EEPROM_EMULATION, POWER_LOSS_RECOVERY) && HAS_MEDIA
+  #if HAS_MEDIA && ANY(SDCARD_EEPROM_EMULATION, POWER_LOSS_RECOVERY)
     SETUP_RUN(card.mount());          // Mount media with settings before first_load
   #endif
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1330,7 +1330,7 @@ void setup() {
     #endif
   #endif
 
-  #if ALL(HAS_MEDIA, SDCARD_EEPROM_EMULATION)
+  #if ANY(SDCARD_EEPROM_EMULATION, POWER_LOSS_RECOVERY) && HAS_MEDIA
     SETUP_RUN(card.mount());          // Mount media with settings before first_load
   #endif
 


### PR DESCRIPTION
### Description

It was noticed in the simulator that enabling POWER_LOSS_RECOVERY caused it to crash https://github.com/MarlinFirmware/Marlin/issues/26541
An exception is generated on `int8_t fatType() const { return fatType_; }`
Examining the vol structure shows it has not yet been populated, so attempting to read  fatType_ causes an exception.
 
My solution is to mount the SDCARD earlier, there is already code for this for SDCARD_EEPROM_EMULATION
I updated the test to now also look for POWER_LOSS_RECOVERY to mount the sdcard early.

### Requirements

POWER_LOSS_RECOVERY

### Benefits

Simulator doesn't crash, and I presume POWER_LOSS_RECOVERY has a better chance of working as it should

### Related Issues
<li>MarlinFirmware/Marlin/issues/26541