### PR TITLE
🔨 DISABLE_ENCODER => NO_BACK_MENU_ITEM

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3415,7 +3415,9 @@
   #define BUTTON_DELAY_EDIT      50 // (ms) Button repeat delay for edit screens
   #define BUTTON_DELAY_MENU     250 // (ms) Button repeat delay for menus
 
-  //#define DISABLE_ENCODER         // Disable the click encoder, if any
+  #if ANY(TFT_CLASSIC_UI, TFT_COLOR_UI)
+    //#define REMOVE_BACK_MENU_ITEM // Remove "back" menu item
+  #endif
 
   #define TOUCH_SCREEN_CALIBRATION
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3416,7 +3416,7 @@
   #define BUTTON_DELAY_MENU     250 // (ms) Button repeat delay for menus
 
   #if ANY(TFT_CLASSIC_UI, TFT_COLOR_UI)
-    //#define REMOVE_BACK_MENU_ITEM // Remove "back" menu item
+    //#define NO_BACK_MENU_ITEM     // Don't display a top menu item to go back to the parent menu
   #endif
 
   #define TOUCH_SCREEN_CALIBRATION

--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -497,6 +497,8 @@
   #error "DIGIPOT_I2C is now DIGIPOT_MCP4451 (or DIGIPOT_MCP4018)."
 #elif defined(TOUCH_BUTTONS)
   #error "TOUCH_BUTTONS is now TOUCH_SCREEN."
+#elif defined(DISABLE_ENCODER)
+  #error "DISABLE_ENCODER is now REMOVE_BACK_MENU_ITEM."
 #elif defined(LCD_FULL_PIXEL_HEIGHT) || defined(LCD_FULL_PIXEL_WIDTH)
   #error "LCD_FULL_PIXEL_(WIDTH|HEIGHT) is deprecated and should be removed."
 #elif defined(FSMC_UPSCALE)

--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -498,7 +498,7 @@
 #elif defined(TOUCH_BUTTONS)
   #error "TOUCH_BUTTONS is now TOUCH_SCREEN."
 #elif defined(DISABLE_ENCODER)
-  #error "DISABLE_ENCODER is now REMOVE_BACK_MENU_ITEM."
+  #error "DISABLE_ENCODER is now NO_BACK_MENU_ITEM."
 #elif defined(LCD_FULL_PIXEL_HEIGHT) || defined(LCD_FULL_PIXEL_WIDTH)
   #error "LCD_FULL_PIXEL_(WIDTH|HEIGHT) is deprecated and should be removed."
 #elif defined(FSMC_UPSCALE)

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -426,7 +426,7 @@ class MenuItem_bool : public MenuEditItemBase {
 
 // Predefined menu item types //
 
-#if DISABLED(DISABLE_ENCODER)
+#if DISABLED(REMOVE_BACK_MENU_ITEM)
   #define BACK_ITEM_F(FLABEL)                            MENU_ITEM_F(back, FLABEL)
   #define BACK_ITEM(LABEL)                                 MENU_ITEM(back, LABEL)
 #else

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -426,7 +426,7 @@ class MenuItem_bool : public MenuEditItemBase {
 
 // Predefined menu item types //
 
-#if DISABLED(REMOVE_BACK_MENU_ITEM)
+#if DISABLED(NO_BACK_MENU_ITEM)
   #define BACK_ITEM_F(FLABEL)                            MENU_ITEM_F(back, FLABEL)
   #define BACK_ITEM(LABEL)                                 MENU_ITEM(back, LABEL)
 #else


### PR DESCRIPTION
### Description

Rename `DISABLE_ENCODER` flag to accurately reflect what it does.

cc: @EvilGremlin

### Requirements

`TFT_CLASSIC_UI` or `TFT_COLOR_UI` with `TOUCH_SCREEN`

### Benefits

Clearer flag name & description since it doesn't actually disable the encoder.