### PR TITLE
🎨 Restore G33 display precision

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -634,7 +634,7 @@ void GcodeSuite::G33() {
           }
         SERIAL_EOL();
 
-        MString<20> msg(F("Calibration sd:"));
+        MString<21> msg(F("Calibration sd:"));
         if (zero_std_dev_min < 1)
           msg.appendf(F("0.%03i"), (int)LROUND(zero_std_dev_min * 1000.0f));
         else


### PR DESCRIPTION
### Description

`G33` display precision was reduced in https://github.com/MarlinFirmware/Marlin/pull/24390 by shortening the string (serial output remains three digits).

#26629 requested to restore the display precision back to three digits, so I restored the old value.

|Before|After|
|---|---|
|<img alt="Calibration sd:0.03" src="https://github.com/MarlinFirmware/Marlin/assets/13375512/e42c386a-e7b8-4881-b944-6024724f5263">|<img alt="Calibration sd:0.014" src="https://github.com/MarlinFirmware/Marlin/assets/13375512/ab58f2b9-9996-4332-9bdf-a53d4075b730">|

### Requirements

Delta kinematics with `DELTA_AUTO_CALIBRATION`

### Benefits

Deltas will display `G33` results with increased precision

### Configurations

Any delta config with `DELTA_AUTO_CALIBRATION`

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26629
