### PR TITLE
Correct Tare

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -61,7 +61,6 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine
@@ -1681,7 +1680,6 @@
 //#define PROBE_OFFSET_ZMAX  20   // (mm)
 
 // Enable the M48 repeatability test to test probe accuracy
-//#define Z_MIN_PROBE_REPEATABILITY_TEST
 
 // Before deploy/stow pause for user confirmation
 //#define PAUSE_BEFORE_DEPLOY_STOW
@@ -2102,7 +2100,6 @@
   /**
    * Enable the G26 Mesh Validation Pattern tool.
    */
-  //#define G26_MESH_VALIDATION
   #if ENABLED(G26_MESH_VALIDATION)
     #define MESH_TEST_NOZZLE_SIZE    0.4  // (mm) Diameter of primary nozzle.
     #define MESH_TEST_LAYER_HEIGHT   0.2  // (mm) Default layer height for G26.
@@ -2280,7 +2277,6 @@
 #endif
 
 // Homing speeds (linear=mm/min, rotational=°/min)
-#define HOMING_FEEDRATE_MM_M { (50*60), (50*60), (4*60) }
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -61,6 +61,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
+#define STRING_CONFIG_H_AUTHOR "(Gadgeteering Ltd)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine
@@ -115,7 +116,12 @@
 //#define BLUETOOTH
 
 // Name displayed in the LCD "Ready" message and Info menu
+<<<<<<< Updated upstream
 //#define CUSTOM_MACHINE_NAME "3D Printer"
+=======
+#define CUSTOM_MACHINE_NAME "Hictop Tare Z"    //Hictop
+#define PROBE_TARE
+>>>>>>> Stashed changes
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like https://www.uuidgenerator.net/version4
@@ -1383,7 +1389,11 @@
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
  *   (e.g., an inductive probe or a nozzle-based probe-switch.)
  */
+<<<<<<< Updated upstream
 //#define FIX_MOUNTED_PROBE
+=======
+//#define FIX_MOUNTED_PROBE // Loadcell instead
+>>>>>>> Stashed changes
 
 /**
  * Use the nozzle as the probe, as with a conductive
@@ -1617,12 +1627,29 @@
  * Useful for a strain gauge or piezo sensor that needs to factor out
  * elements such as cables pulling on the carriage.
  */
+<<<<<<< Updated upstream
 //#define PROBE_TARE
 #if ENABLED(PROBE_TARE)
   #define PROBE_TARE_TIME  200    // (ms) Time to hold tare pin
   #define PROBE_TARE_DELAY 200    // (ms) Delay after tare before
   #define PROBE_TARE_STATE HIGH   // State to write pin for tare
   //#define PROBE_TARE_PIN PA5    // Override default pin
+=======
+
+#if ENABLED(PROBE_TARE)
+  #define PROBE_TARE_ONLY_WHILE_INACTIVE
+  //#define XY_PROBE_FEEDRATE 8000 // Hitting the stops to hard will trigger the loadcell
+  #define PROBE_TARE_TIME  200    // (ms) Time to hold tare pin
+  #define PROBE_TARE_DELAY 200    // (ms) Delay after tare before
+  #define PROBE_TARE_STATE HIGH   // State to write pin for tare
+  #define PROBE_TARE_PIN 19    // Override default pin
+  #define DIOPROBE_TARE_PIN_RPORT 18
+  #define MESH_MIN_X 40
+  #define MESH_MAX_X 160
+  #define MESH_MIN_Y 40
+  #define MESH_MAX_Y 160
+
+>>>>>>> Stashed changes
   #if ENABLED(PROBE_ACTIVATION_SWITCH)
     //#define PROBE_TARE_ONLY_WHILE_INACTIVE  // Fail to tare/probe if PROBE_ACTIVATION_SWITCH is active
   #endif
@@ -1646,7 +1673,11 @@
  * A total of 2 does fast/slow probes with a weighted average.
  * A total of 3 or more adds more slow probes, taking the average.
  */
+<<<<<<< Updated upstream
 //#define MULTIPLE_PROBING 2
+=======
+#define MULTIPLE_PROBING 2
+>>>>>>> Stashed changes
 //#define EXTRA_PROBING    1
 
 /**
@@ -1680,6 +1711,7 @@
 //#define PROBE_OFFSET_ZMAX  20   // (mm)
 
 // Enable the M48 repeatability test to test probe accuracy
+#define Z_MIN_PROBE_REPEATABILITY_TEST
 
 // Before deploy/stow pause for user confirmation
 //#define PAUSE_BEFORE_DEPLOY_STOW
@@ -2100,6 +2132,7 @@
   /**
    * Enable the G26 Mesh Validation Pattern tool.
    */
+  #define G26_MESH_VALIDATION
   #if ENABLED(G26_MESH_VALIDATION)
     #define MESH_TEST_NOZZLE_SIZE    0.4  // (mm) Diameter of primary nozzle.
     #define MESH_TEST_LAYER_HEIGHT   0.2  // (mm) Default layer height for G26.
@@ -2277,6 +2310,7 @@
 #endif
 
 // Homing speeds (linear=mm/min, rotational=°/min)
+#define HOMING_FEEDRATE_MM_M { (50*60/2), (50*60/2), (4*60) }
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION



### Description

Improve some of the tare probe configuration parameters so that it can be used as a Z Homing Probe with a load cell on the nozzle


### Requirements

Arduino load cell [Arduino Code](https://github.com/Gadgeteering/3D_Sensor_Loadcell.git) or Piezo electric Nozzle sensor

### Benefits

Using this method of Z homing will provide a more accurate method of bed leveling 

### Configurations

To use the the tare probe `#define PROBE_TARE`  needs to be uncommented 

### Related Issues

The bed needs to be mechanically levelled a set tolerance when running G29 as there seems to be a limit when running mesh levelling  
