### PR TITLE
Fan override and multiplier

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3895,12 +3895,14 @@
 //#define REPORT_FAN_CHANGE   // Report the new fan speed when changed by M106 (and others)
 
 /**
- * Add UI and gcode options to multiply fan speed and lock fan
- * at the current speed to override what is sent via M106. 
- * These are useful to fine tune fan speeds after while printing.
- * Not persisted in EEPROM. 
-*/
-// #define FAN_MULTIPLIER      
+ * Adds UI and G-code (M106) options to control fan speed while printing.
+ *
+ * - Lock Fan Speed: To prevent G-code commands (i.e., M106) from altering the current fan speed.
+ * - Fan Speed Multiplier: Multiplies the fan speed set by G-code commands by a specified factor for fine-tuning.
+ *
+ * Note: Settings are not saved in EEPROM and will reset after a power cycle.
+ */
+//#define FAN_MULTIPLIER
 
 /**
  * Auto-report temperatures with M155 S<seconds>

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3895,6 +3895,14 @@
 //#define REPORT_FAN_CHANGE   // Report the new fan speed when changed by M106 (and others)
 
 /**
+ * Add UI and gcode options to multiply fan speed and lock fan
+ * at the current speed to override what is sent via M106. 
+ * These are useful to fine tune fan speeds after while printing.
+ * Not persisted in EEPROM. 
+*/
+// #define FAN_MULTIPLIER      
+
+/**
  * Auto-report temperatures with M155 S<seconds>
  */
 #define AUTO_REPORT_TEMPERATURES

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -52,6 +52,7 @@
  *  P<index> Fan index, if more than one fan
  *  L        Lock fan
  *  U        Unlock fan
+ *  M<float> Fan speed multiplier between 0.1 and 10
  *
  * With EXTRA_FAN_SPEED enabled:
  *
@@ -61,18 +62,20 @@
  *           3-255 = Set the speed for use with T2
  */
 void GcodeSuite::M106() {
-  if (parser.seen('L')) {
-      thermalManager.lock_fan = true;
-    if (!parser.seenval('S')) return;
-  } if (parser.seen('U')) {
-     thermalManager.lock_fan = false;
-    return;
-  } else if (thermalManager.lock_fan) return;
-  
-  if (parser.seenval('M')) {
-    thermalManager.set_fan_multiplier(parser.value_float());
-    if (!parser.seenval('S')) return;
-  }
+  #if ENABLED(FAN_MULTIPLIER)
+    if (parser.seen('L')) {
+        thermalManager.lock_fan = true;
+      if (!parser.seenval('S')) return;
+    } if (parser.seen('U')) {
+      thermalManager.lock_fan = false;
+      return;
+    } else if (thermalManager.lock_fan) return;
+    
+    if (parser.seenval('M')) {
+      thermalManager.set_fan_multiplier(parser.value_float());
+      if (!parser.seenval('S')) return;
+    }
+  #endif
 
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
@@ -113,7 +116,10 @@ void GcodeSuite::M106() {
  * M107: Fan Off
  */
 void GcodeSuite::M107() {
-  if (thermalManager.lock_fan) return;
+  #if ENABLED(FAN_MULTIPLIER)
+    if (thermalManager.lock_fan) return;
+  #endif
+  
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -50,6 +50,8 @@
  *  I<index> Material Preset index (if material presets are defined)
  *  S<int>   Speed between 0-255
  *  P<index> Fan index, if more than one fan
+ *  L        Lock fan
+ *  U        Unlock fan
  *
  * With EXTRA_FAN_SPEED enabled:
  *
@@ -59,6 +61,19 @@
  *           3-255 = Set the speed for use with T2
  */
 void GcodeSuite::M106() {
+  if (parser.seen('L')) {
+      thermalManager.lock_fan = true;
+    if (!parser.seenval('S')) return;
+  } if (parser.seen('U')) {
+     thermalManager.lock_fan = false;
+    return;
+  } else if (thermalManager.lock_fan) return;
+  
+  if (parser.seenval('M')) {
+    thermalManager.set_fan_multiplier(parser.value_float());
+    if (!parser.seenval('S')) return;
+  }
+
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;
@@ -98,6 +113,7 @@ void GcodeSuite::M106() {
  * M107: Fan Off
  */
 void GcodeSuite::M107() {
+  if (thermalManager.lock_fan) return;
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2748,10 +2748,8 @@
   #ifndef FAN_MAX_PWM
     #define FAN_MAX_PWM 255
   #endif
-  #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255 && !defined(FAN_MULTIPLIER)
+  #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255
     #define CALC_FAN_SPEED(f) (f ?: FAN_OFF_PWM)
-  #elif defined(FAN_MULTIPLIER)
-    #define CALC_FAN_SPEED(f) (f ? map(thermalManager.compute_multiplied_fan(f), 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM) 
   #else
     #define CALC_FAN_SPEED(f) (f ? map(f, 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM)
   #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2748,8 +2748,10 @@
   #ifndef FAN_MAX_PWM
     #define FAN_MAX_PWM 255
   #endif
-  #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255
+  #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255 && !defined(FAN_MULTIPLIER)
     #define CALC_FAN_SPEED(f) (f ?: FAN_OFF_PWM)
+  #elif defined(FAN_MULTIPLIER)
+    #define CALC_FAN_SPEED(f) (f ? map(f * thermalManager.get_fan_multiplier(), 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM) 
   #else
     #define CALC_FAN_SPEED(f) (f ? map(f, 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM)
   #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2749,9 +2749,9 @@
     #define FAN_MAX_PWM 255
   #endif
   #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255 && !defined(FAN_MULTIPLIER)
-    #define CALC_FAN_SPEED(f) (f ?: FAN_OFF_PWM)
+    #define CALC_FAN_SPEED(f) (f ? f : FAN_OFF_PWM)
   #elif defined(FAN_MULTIPLIER)
-    #define CALC_FAN_SPEED(f) (f ? map(f * thermalManager.get_fan_multiplier(), 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM) 
+    #define CALC_FAN_SPEED(f) (f ? map(thermalManager.compute_multiplied_fan(f), 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM) 
   #else
     #define CALC_FAN_SPEED(f) (f ? map(f, 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM)
   #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2749,7 +2749,7 @@
     #define FAN_MAX_PWM 255
   #endif
   #if FAN_MIN_PWM == 0 && FAN_MAX_PWM == 255 && !defined(FAN_MULTIPLIER)
-    #define CALC_FAN_SPEED(f) (f ? f : FAN_OFF_PWM)
+    #define CALC_FAN_SPEED(f) (f ?: FAN_OFF_PWM)
   #elif defined(FAN_MULTIPLIER)
     #define CALC_FAN_SPEED(f) (f ? map(thermalManager.compute_multiplied_fan(f), 1, 255, FAN_MIN_PWM, FAN_MAX_PWM) : FAN_OFF_PWM) 
   #else

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -561,6 +561,9 @@ namespace LanguageNarrow_en {
   LSTR MSG_SINGLENOZZLE_UNRETRACT_SPEED   = _UxGT("Recover Speed");
   LSTR MSG_SINGLENOZZLE_FAN_SPEED         = _UxGT("Fan Speed");
   LSTR MSG_SINGLENOZZLE_FAN_TIME          = _UxGT("Fan Time");
+  LSTR MSG_LOCK_FAN                       = _UxGT("Lock Fan");
+  LSTR MSG_UNLOCK_FAN                     = _UxGT("Unlock Fan");
+  LSTR MSG_FAN_MULTIPLIER                 = _UxGT("Fan Multiplier");
   LSTR MSG_TOOL_MIGRATION_ON              = _UxGT("Auto ON");
   LSTR MSG_TOOL_MIGRATION_OFF             = _UxGT("Auto OFF");
   LSTR MSG_TOOL_MIGRATION                 = _UxGT("Tool Migration");

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -219,6 +219,14 @@ void menu_temperature() {
 
     #if FAN_IS_M106ABLE(0)
       _FAN_EDIT_ITEMS(0, FIRST_FAN_SPEED);
+      if (thermalManager.lock_fan) {
+        ACTION_ITEM(MSG_UNLOCK_FAN, []{ thermalManager.lock_fan = false; ui.refresh(); });
+      } else {
+        ACTION_ITEM(MSG_LOCK_FAN, []{ thermalManager.lock_fan = true; ui.refresh(); });
+      }
+      editable.decimal = thermalManager.get_fan_multiplier();
+      EDIT_ITEM_FAST(float31, MSG_FAN_MULTIPLIER, &editable.decimal, 0.0f, 9.9f, []{ thermalManager.set_fan_multiplier(editable.decimal); }, true);
+
     #endif
     #if FAN_IS_M106ABLE(1)
       FAN_EDIT_ITEMS(1);

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -219,14 +219,15 @@ void menu_temperature() {
 
     #if FAN_IS_M106ABLE(0)
       _FAN_EDIT_ITEMS(0, FIRST_FAN_SPEED);
-      if (thermalManager.lock_fan) {
-        ACTION_ITEM(MSG_UNLOCK_FAN, []{ thermalManager.lock_fan = false; ui.refresh(); });
-      } else {
-        ACTION_ITEM(MSG_LOCK_FAN, []{ thermalManager.lock_fan = true; ui.refresh(); });
-      }
-      editable.decimal = thermalManager.get_fan_multiplier();
-      EDIT_ITEM_FAST(float31, MSG_FAN_MULTIPLIER, &editable.decimal, 0.0f, 9.9f, []{ thermalManager.set_fan_multiplier(editable.decimal); }, true);
-
+      #if ENABLED(FAN_MULTIPLIER)
+        if (thermalManager.lock_fan) {
+          ACTION_ITEM(MSG_UNLOCK_FAN, []{ thermalManager.lock_fan = false; ui.refresh(); });
+        } else {
+          ACTION_ITEM(MSG_LOCK_FAN, []{ thermalManager.lock_fan = true; ui.refresh(); });
+        }
+        editable.decimal = thermalManager.get_fan_multiplier();
+        EDIT_ITEM_FAST(float31, MSG_FAN_MULTIPLIER, &editable.decimal, 0.0f, 9.9f, []{ thermalManager.set_fan_multiplier(editable.decimal); }, true);
+      #endif
     #endif
     #if FAN_IS_M106ABLE(1)
       FAN_EDIT_ITEMS(1);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1186,7 +1186,7 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
     #if ENABLED(FAN_SOFT_PWM)
       #define _FAN_SET(F) thermalManager.soft_pwm_amount_fan[F] = CALC_FAN_SPEED(fan_speed[F]);
     #else
-      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(fan_speed[F]));
+      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(constrain(fan_speed[F] * thermalManager.get_fan_multiplier(), 0, 255)));
     #endif
     #define FAN_SET(F) do{ kickstart_fan(fan_speed, ms, F); _FAN_SET(F); }while(0)
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1184,7 +1184,7 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
   void Planner::sync_fan_speeds(uint8_t (&fan_speed)[FAN_COUNT]) {
 
     #if defined(FAN_MULTIPLIER)
-      #define _CALC_FAN_SPEED(f) CALC_FAN_SPEED(thermalManager.compute_multiplied_fan(f)) 
+      #define _CALC_FAN_SPEED(f) CALC_FAN_SPEED(thermalManager.compute_multiplied_fan(f))
     #else
       #define _CALC_FAN_SPEED(f) CALC_FAN_SPEED(f)
     #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1183,10 +1183,16 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
 
   void Planner::sync_fan_speeds(uint8_t (&fan_speed)[FAN_COUNT]) {
 
-    #if ENABLED(FAN_SOFT_PWM)
-      #define _FAN_SET(F) thermalManager.soft_pwm_amount_fan[F] = CALC_FAN_SPEED(fan_speed[F]);
+    #if defined(FAN_MULTIPLIER)
+      #define _CALC_FAN_SPEED(f) CALC_FAN_SPEED(thermalManager.compute_multiplied_fan(f)) 
     #else
-      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(fan_speed[F]));
+      #define _CALC_FAN_SPEED(f) CALC_FAN_SPEED(f)
+    #endif
+    
+    #if ENABLED(FAN_SOFT_PWM)
+      #define _FAN_SET(F) thermalManager.soft_pwm_amount_fan[F] = _CALC_FAN_SPEED(fan_speed[F]);
+    #else
+      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), _CALC_FAN_SPEED(fan_speed[F]));
     #endif
     #define FAN_SET(F) do{ kickstart_fan(fan_speed, ms, F); _FAN_SET(F); }while(0)
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1186,7 +1186,7 @@ void Planner::recalculate(const_float_t safe_exit_speed_sqr) {
     #if ENABLED(FAN_SOFT_PWM)
       #define _FAN_SET(F) thermalManager.soft_pwm_amount_fan[F] = CALC_FAN_SPEED(fan_speed[F]);
     #else
-      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(constrain(fan_speed[F] * thermalManager.get_fan_multiplier(), 0, 255)));
+      #define _FAN_SET(F) hal.set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(fan_speed[F]));
     #endif
     #define FAN_SET(F) do{ kickstart_fan(fan_speed, ms, F); _FAN_SET(F); }while(0)
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -284,10 +284,12 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
  * public:
  */
 
+#if HAS_FAN
   void Temperature::set_fan_multiplier(float m){
     fan_multiplier = m;
     planner.sync_fan_speeds(fan_speed);
   }
+#endif
 
   float Temperature::get_fan_multiplier(){
     return fan_multiplier;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -289,11 +289,11 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
     fan_multiplier = m;
     planner.sync_fan_speeds(fan_speed);
   }
-#endif
 
   float Temperature::get_fan_multiplier(){
     return fan_multiplier;
   }
+#endif
 
 #if ENABLED(TEMP_TUNING_MAINTAIN_FAN)
   bool Temperature::adaptive_fan_slowing = true;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -290,6 +290,10 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
     planner.sync_fan_speeds(fan_speed);
   }
 
+  uint8_t Temperature::compute_multiplied_fan(uint8_t speed){
+    return constrain(speed * fan_multiplier, 1, 255);
+  }
+
   float Temperature::get_fan_multiplier(){
     return fan_multiplier;
   }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -284,7 +284,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
  * public:
  */
 
-#if HAS_FAN
+#if ALL(HAS_FAN, FAN_MULTIPLIER)
   void Temperature::set_fan_multiplier(float m){
     fan_multiplier = m;
     planner.sync_fan_speeds(fan_speed);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -291,7 +291,9 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
   }
 
   uint8_t Temperature::compute_multiplied_fan(uint8_t speed){
-    return constrain(speed * fan_multiplier, 1, 255);
+    if (!speed) return 0;
+    float new_speed = speed * fan_multiplier;
+    return constrain(new_speed, 1, 255);
   }
 
   float Temperature::get_fan_multiplier(){

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -284,6 +284,15 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
  * public:
  */
 
+  void Temperature::set_fan_multiplier(float m){
+    fan_multiplier = m;
+    planner.sync_fan_speeds(fan_speed);
+  }
+
+  float Temperature::get_fan_multiplier(){
+    return fan_multiplier;
+  }
+
 #if ENABLED(TEMP_TUNING_MAINTAIN_FAN)
   bool Temperature::adaptive_fan_slowing = true;
 #endif

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -597,6 +597,9 @@ typedef struct { raw_adc_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_
 class Temperature {
 
   public:
+    bool lock_fan;
+    void set_fan_multiplier(float m);
+    float get_fan_multiplier();
 
     #if HAS_HOTEND
       static hotend_info_t temp_hotend[HOTENDS];
@@ -1334,7 +1337,7 @@ class Temperature {
     #endif
 
   private:
-
+    float fan_multiplier = 1;
     // Reading raw temperatures and converting to Celsius when ready
     static volatile bool raw_temps_ready;
     static void update_raw_temperatures();

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -597,8 +597,8 @@ typedef struct { raw_adc_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_
 class Temperature {
 
   public:
-    bool lock_fan;
-    #if HAS_FAN
+    #if ALL(HAS_FAN, FAN_MULTIPLIER)
+      bool lock_fan;
       void set_fan_multiplier(float m);
       float get_fan_multiplier();
     #endif
@@ -1339,7 +1339,9 @@ class Temperature {
     #endif
 
   private:
-    float fan_multiplier = 1;
+    #if ENABLED(FAN_MULTIPLIER)
+      float fan_multiplier = 1;
+    #endif
     // Reading raw temperatures and converting to Celsius when ready
     static volatile bool raw_temps_ready;
     static void update_raw_temperatures();

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -598,8 +598,10 @@ class Temperature {
 
   public:
     bool lock_fan;
-    void set_fan_multiplier(float m);
-    float get_fan_multiplier();
+    #if HAS_FAN
+      void set_fan_multiplier(float m);
+      float get_fan_multiplier();
+    #endif
 
     #if HAS_HOTEND
       static hotend_info_t temp_hotend[HOTENDS];

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -600,6 +600,7 @@ class Temperature {
     #if ALL(HAS_FAN, FAN_MULTIPLIER)
       bool lock_fan;
       void set_fan_multiplier(float m);
+      uint8_t compute_multiplied_fan(uint8_t speed);
       float get_fan_multiplier();
     #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

I recently installed cpap style remote cooling, and found I often wished to reduce or force the fan speed mid print, independent of what gcode calls to M106 are done.

This PR adds:
* Fan Lock: inhibits setting the fan speed via gcode. Useful to override the slicer fan settings, particularly when using different speeds for overhangs, layer times, bridges, etc.
* Fan Multiplier: responds to gcode but multiplies by a factor (0 to 10) before applying. I find this very useful when trying new materials that require a lot more/less fan than my default preset, particularly tweaking it mid print.


~~Obviously the PR is still missing configuration.h options, but I'd like to get early feedback or save myself the hassle if the feature is not considered good to merge (I use it and find it useful myself)~~

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
Part cooling fan.

### Benefits

Avoid having to re-slice and restart a print when I find the current settings are not good mid-print.
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
