### PR TITLE
Fixed Backlash::get_applied_steps()

### DIFF
--- a/Marlin/src/feature/backlash.cpp
+++ b/Marlin/src/feature/backlash.cpp
@@ -171,13 +171,14 @@ int32_t Backlash::get_applied_steps(const AxisEnum axis) {
 
   const int32_t residual_error_axis = residual_error[axis];
 
-  // At startup it is assumed the last move was forward.
-  // So the applied steps will always be negative.
+  // At startup, when no steps are applied, it is assumed the last move was backwards.
+  // So the applied steps will always be zero (when moving backwards) or a positive
+  // number (when moving forwards).
 
-  if (forward) return -residual_error_axis;
+  if (!forward) return -residual_error_axis;
 
   const float f_corr = float(correction) / all_on;
-  const int32_t full_error_axis = -f_corr * distance_mm[axis] * planner.settings.axis_steps_per_mm[axis];
+  const int32_t full_error_axis = f_corr * distance_mm[axis] * planner.settings.axis_steps_per_mm[axis];
   return full_error_axis - residual_error_axis;
 }
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

#25791 broke an assumption in `Backlash::get_applied_steps()` by changing the meaning of the initial state of `last_direction_bits`. This variable is initialised to zero, which used to mean that at startup the "previous" movements were assumed to be forwards. Consequently for the first time backlash was applied was on a backwards (i.e. -ve direction) movement. With the new semantics the initial state of `last_direction_bits` has the opposite meaning. So the first time backlash is applied now is for a forward movement. But `Backlash::get_applied_steps()` was not updated to reflect this change.

This PR returns the behaviour of `Backlash::get_applied_steps()` to what it was before #25791, i.e. it returns the actual number of steps that have been added for backlash compensation.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Enable backlash correction.

### Benefits

<!-- What does this PR fix or improve? -->

Incorrect information returned from `Backlash::get_applied_steps()` may cause bugs which are strange, subtle and difficult to trace. For example, `M114 D` will give different values for the "Stepper:" positions on a freshly booted machine depending on whether it loaded config from EEPROM or reset from hard coded defaults. i.e. flash a new firmware and you get one value but reboot and you get a different value.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

Enable `BACKLASH_COMPENSATION`.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
