### PR TITLE
🐛 Fix YHCB2004 builds

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -12,7 +12,7 @@
 # The order of the features matters for source-filter resolution inside of common-dependencies.py.
 
 [features]
-YHCB2004                               = red-scorp/LiquidCrystal_AIP31068@^1.0.4, red-scorp/SoftSPIB@^1.1.1
+YHCB2004                               = LiquidCrystal_AIP31068=https://github.com/ellensp/LiquidCrystal_AIP31068/archive/3fc43b7.zip, red-scorp/SoftSPIB@^1.1.1
 HAS_TFT_LVGL_UI                        = lvgl=https://github.com/makerbase-mks/LVGL-6.1.1-MKS/archive/a3ebe98bc6.zip
                                          build_src_filter=+<src/lcd/extui/mks_ui>
                                          extra_scripts=download_mks_assets.py


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/commit/ec7ab5a277a0210e1349f9e8608c372e40fdb6e6 broke YHCB2004-based builds and @ellensp tracked down the appropriate fixes. While this fix has not been confirmed to work by @NoahJaehnert, YHCB2004-based configs now build again.

@ellensp is listed as a co-author, but changes are 100% theirs 😄 

### Requirements

Any YHCB2004-based build like our [Geeetech A10M YHCB2004_V4.1](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Geeetech/A10M/YHCB2004_V4.1) or [Geeetech A10PRO](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Geeetech/A10PRO) configs.

### Benefits

YHCB2004-based configs build again.

### Configurations

Any YHCB2004-based config: 

- [Geeetech A10M YHCB2004_V4.1](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Geeetech/A10M/YHCB2004_V4.1)
- [Geeetech A10PRO](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Geeetech/A10PRO)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26571