### PR TITLE
🐛 Fix E3S1PRO DGUS builds

### DIFF
--- a/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSRxHandler.cpp
@@ -101,7 +101,7 @@ void DGUSRxHandler::retractLength(DGUS_VP &vp, void *data) {
 
 void DGUSRxHandler::setLanguage(DGUS_VP &vp, void *data) {
   DGUS_Data::Language language = (DGUS_Data::Language)Endianness::fromBE_P<uint16_t>(data);
-  ui_language = screen.config.language = language;
+  screen.config.language = language;
   screen.triggerEEPROMSave();
   screen.triggerFullUpdate();
 }


### PR DESCRIPTION
### Description

While building configs with Marlin's [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script, I found that E3S1PRO DGUS configs were now failing (https://github.com/MarlinFirmware/Configurations/issues/1068) and tracked it down to PR https://github.com/MarlinFirmware/Marlin/pull/26261.

Reverting the (unintentional?) change to `/dgus_e3s1pro/DGUSRxHandler.cpp` allows these configs to build again.

### Requirements

Any E3S1PRO DGUS-based config (`#define DGUS_LCD_UI E3S1PRO`)

### Benefits

Allows E3S1PRO DGUS-based configs to build again.

### Configurations

Any E3S1PRO DGUS config:
- [Creality/Ender-3 S1 Plus/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3%20S1%20Plus)
- [Creality/Ender-3 S1 Pro/](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3%20S1%20Pro)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26261
- https://github.com/MarlinFirmware/Configurations/issues/1068
