### PR TITLE
👷 Add "fail-fast: true" default strategy to build test CI

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: true
       matrix:
         test-platform:
 


### PR DESCRIPTION
### Description

Add `fail-fast: true` default strategy to build test CI so I don't have to look for this config option name/format when I want to make it `false` 😄 

Yes, CI tests can be run locally, but it takes ~1.5 hours on my machine to run through them all since they don't run in parallel like they do on GitHub.

### Benefits

It'll be easier to toggle this option while running CI tests in a PR and narrow in on failing tests.