### PR TITLE
🔧 Default to English language on MKS H43

### DIFF
--- a/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.cpp
@@ -69,7 +69,7 @@ void MKS_reset_settings() {
     { 20, 20 }, { 20, 20 },
     { X_CENTER, Y_CENTER }
   };
-  mks_language_index = MKS_SimpleChinese;
+  mks_language_index = MKS_English;
   COPY(mks_corner_offsets, init_dgus_level_offsets);
   mks_park_pos.set(20, 20, 10);
   mks_min_extrusion_temp = 0;


### PR DESCRIPTION
### Description

Set default language to English on the MKS H43 TFT since it's a better default.

### Requirements

MKS H43 TFT (`#define DGUS_LCD_UI MKS`)

### Benefits

Display will default to English instead of Simplified Chinese

### Configurations

`#define DGUS_LCD_UI MKS`

### Related Issues

None.

I discovered this while getting my H43 working. It's a pretty TFT, but quite limited. A little bird told me that it may run @InsanityAutomation's DWIN firmware, so I will be trying that soon 😄 
