### PR TITLE
respect NO_MOTION_AFTER_HOMING and HOME_AFTER_DEACTIVATE with G38 and G30

### DIFF
--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -26,6 +26,7 @@
 
 #include "../gcode.h"
 #include "../../module/motion.h"
+#include "../../MalinCore.h"
 #include "../../module/probe.h"
 #include "../../feature/bedlevel/bedlevel.h"
 #include "../../lcd/marlinui.h"

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -50,6 +50,8 @@
  */
 void GcodeSuite::G30() {
 
+  if (!MOTION_CONDITIONS) return;
+  
   xy_pos_t old_pos = current_position,
            probepos = current_position;
 

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -26,7 +26,7 @@
 
 #include "../gcode.h"
 #include "../../module/motion.h"
-#include "../../MalinCore.h"
+#include "../../MarlinCore.h"
 #include "../../module/probe.h"
 #include "../../feature/bedlevel/bedlevel.h"
 #include "../../lcd/marlinui.h"

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -28,6 +28,7 @@
 
 #include "../../module/endstops.h"
 #include "../../module/motion.h"
+#include "../../MalinCore.h"
 #include "../../module/planner.h"
 #include "../../module/probe.h"
 

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -106,6 +106,8 @@ inline bool G38_run_probe() {
  */
 void GcodeSuite::G38(const int8_t subcode) {
 
+  if (!MOTION_CONDITIONS) return;
+
   // Get X Y Z E F
   get_destination_from_command();
 

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -28,7 +28,7 @@
 
 #include "../../module/endstops.h"
 #include "../../module/motion.h"
-#include "../../MalinCore.h"
+#include "../../MarlinCore.h"
 #include "../../module/planner.h"
 #include "../../module/probe.h"
 


### PR DESCRIPTION
### Description

Respect NO_MOTION_AFTER_HOMING and HOME_AFTER_DEACTIVATE with G38 and G30

### Requirements

Needs a Z probe

### Benefits

fix #27206

### Configurations

None

### Related Issues

#27206
