### PR TITLE
🔥 Drop BOARD_BIGTREE_SKR_V1_2 "renamed" reference

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -980,8 +980,6 @@
     #error "BOARD_BIQU_SKR_V1_1 is now BOARD_BTT_SKR_V1_1. Please update your configuration."
   #elif MB(BIGTREE_SKR_V1_1)
     #error "BOARD_BIGTREE_SKR_V1_1 is now BOARD_BTT_SKR_V1_1. Please update your configuration."
-  #elif MB(BIGTREE_SKR_V1_2)
-    #error "BOARD_BIGTREE_SKR_V1_2 is now BOARD_BTT_SKR_V1_2. Please update your configuration."
   #elif MB(BIGTREE_SKR_V1_3)
     #error "BOARD_BIGTREE_SKR_V1_3 is now BOARD_BTT_SKR_V1_3. Please update your configuration."
   #elif MB(BIGTREE_SKR_V1_4)


### PR DESCRIPTION
### Description

`BOARD_BIGTREE_SKR_V1_2`/`BOARD_BTT_SKR_V1_2` is not a real board & has never been in a tagged release / doesn't exist anywhere within Marlin currently.

Since this is missing all the usual code required for a "renamed" board, I can only assume it was added on accident.

### Related Issues

Found while parsing `boards.h` in every release to collect "supported since" data for https://github.com/MarlinFirmware/MarlinDocumentation/pull/566