### PR TITLE
🔥 Drop BTT Manta XFER environments

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -564,15 +564,15 @@
 #elif MB(BTT_SKR_MINI_E3_V3_0)
   #include "stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h"    // STM32G0                              env:STM32G0B1RE_btt env:STM32G0B1RE_btt_xfer
 #elif MB(BTT_MANTA_M4P_V2_1)
-  #include "stm32g0/pins_BTT_MANTA_M4P_V2_1.h"      // STM32G0                              env:STM32G0B1RE_manta_btt env:STM32G0B1RE_manta_btt_xfer
+  #include "stm32g0/pins_BTT_MANTA_M4P_V2_1.h"      // STM32G0                              env:STM32G0B1RE_manta_btt
 #elif MB(BTT_MANTA_M5P_V1_0)
-  #include "stm32g0/pins_BTT_MANTA_M5P_V1_0.h"      // STM32G0                              env:STM32G0B1RE_manta_btt env:STM32G0B1RE_manta_btt_xfer
+  #include "stm32g0/pins_BTT_MANTA_M5P_V1_0.h"      // STM32G0                              env:STM32G0B1RE_manta_btt
 #elif MB(BTT_MANTA_E3_EZ_V1_0)
-  #include "stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h"    // STM32G0                              env:STM32G0B1RE_manta_btt env:STM32G0B1RE_manta_btt_xfer
+  #include "stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h"    // STM32G0                              env:STM32G0B1RE_manta_btt
 #elif MB(BTT_MANTA_M8P_V1_0)
-  #include "stm32g0/pins_BTT_MANTA_M8P_V1_0.h"      // STM32G0                              env:STM32G0B1VE_btt env:STM32G0B1VE_btt_xfer
+  #include "stm32g0/pins_BTT_MANTA_M8P_V1_0.h"      // STM32G0                              env:STM32G0B1VE_btt
 #elif MB(BTT_MANTA_M8P_V1_1)
-  #include "stm32g0/pins_BTT_MANTA_M8P_V1_1.h"      // STM32G0                              env:STM32G0B1VE_btt env:STM32G0B1VE_btt_xfer
+  #include "stm32g0/pins_BTT_MANTA_M8P_V1_1.h"      // STM32G0                              env:STM32G0B1VE_btt
 
 //
 // STM32 ARM Cortex-M3

--- a/ini/renamed.ini
+++ b/ini/renamed.ini
@@ -98,3 +98,9 @@ extends = renamed
 
 [env:STM32F446_tronxy]                ;=> TRONXY_CXY_446_V10
 extends = renamed
+
+[env:STM32G0B1RE_manta_btt_xfer]      ;=> STM32G0B1RE_manta_btt
+extends = renamed
+
+[env:STM32G0B1VE_btt_xfer]            ;=> STM32G0B1VE_btt
+extends = renamed

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -89,21 +89,6 @@ build_flags     = ${env:STM32G0B1RE_btt.build_flags}
                   -DPIN_SERIAL3_RX=PD_9 -DPIN_SERIAL3_TX=PD_8 -DENABLE_HWSERIAL3
 
 #
-# BigTreeTech Manta M4P V2.1 (STM32G0B0RET6 ARM Cortex-M0+)
-# BigTreeTech Manta E3 EZ V1.0 / Manta M5P V1.0 (STM32G0B1RET6 ARM Cortex-M0+)
-# Custom upload to SD via Marlin with Binary Protocol
-# Requires Marlin with BINARY_FILE_TRANSFER already installed on the target board.
-# If CUSTOM_FIRMWARE_UPLOAD is also installed, Marlin will reboot the board to install the firmware.
-# Currently CUSTOM_FIRMWARE_UPLOAD must also be enabled to use 'xfer' build envs.
-#
-[env:STM32G0B1RE_manta_btt_xfer]
-extends         = env:STM32G0B1RE_manta_btt
-build_flags     = ${env:STM32G0B1RE_manta_btt.build_flags} -DXFER_BUILD
-extra_scripts   = ${env:STM32G0B1RE_manta_btt.extra_scripts}
-                  pre:buildroot/share/scripts/upload.py
-upload_protocol = custom
-
-#
 # BigTreeTech Manta M8P V1.x (STM32G0B1VET6 ARM Cortex-M0+)
 #
 [env:STM32G0B1VE_btt]
@@ -123,14 +108,3 @@ build_flags                 = ${stm32_variant.build_flags}
                               -Wl,--no-warn-rwx-segment
 upload_protocol             = stlink
 debug_tool                  = stlink
-
-#
-# BigTreeTech Manta M8P V1.x (STM32G0B1VET6 ARM Cortex-M0+)
-# Custom upload to SD via Marlin with Binary Protocol
-#
-[env:STM32G0B1VE_btt_xfer]
-extends         = env:STM32G0B1VE_btt
-build_flags     = ${env:STM32G0B1VE_btt.build_flags} -DXFER_BUILD
-extra_scripts   = ${env:STM32G0B1VE_btt.extra_scripts}
-                  pre:buildroot/share/scripts/upload.py
-upload_protocol = custom


### PR DESCRIPTION
### Description

XFER environments don’t work on Manta boards because USB is connected to SoC/SBC (CM4/CB1/CB2), not the MCU.

### Requirements

BTT Manta E3 EZ, M4P, M5P, or M8P

### Benefits

Removes invalid PIO environments
