### PR TITLE
Edit IS frequencies during printing.

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -700,7 +700,7 @@ void menu_advanced_settings() {
 
     // M593 - Acceleration items
     #if ENABLED(SHAPING_MENU)
-      if (!is_busy) SUBMENU(MSG_INPUT_SHAPING, menu_advanced_input_shaping);
+      SUBMENU(MSG_INPUT_SHAPING, menu_advanced_input_shaping);
     #endif
 
     #if ENABLED(CLASSIC_JERK)


### PR DESCRIPTION
Resolves  #26653 [FR] Allow input shaping tuning during print

I found editing IS frequencies extremely useful while tuning IS. I run gcode loop moving extruder/bed with frequency oscillating back and force within given range, and adjust IS until I get the most smooth result.