### PR TITLE
check for old macros BOTH and EITHER

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -145,7 +145,6 @@ if pioutil.is_pio_build():
         for f in ("Configuration.h", "Configuration_adv.h"):
             if (p / f).is_file():
                 with open(p / f, 'r') as file:
-
                     if 'BOTH(' in open(p / f, 'r').read() or 'EITHER(' in open(p / f, 'r').read():
                         err = "ERROR: Old macro \"BOTH()\" or \"EITHER()\" found in your configuration files. Replace with \"ALL()\" and \"ANY()\" respectively and try again."
                         raise SystemExit(err)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -137,4 +137,17 @@ if pioutil.is_pio_build():
                         err = "ERROR: FILAMENT_RUNOUT_SCRIPT needs a %c parameter (e.g., \"M600 T%c\") when NUM_RUNOUT_SENSORS is > 1"
                         raise SystemExit(err)
 
+        #
+        # Check for old macros BOTH and EITHER in configuration file
+        #
+        epath = Path(env['PROJECT_DIR'])
+        p = Path(env['PROJECT_DIR'], "Marlin")
+        for f in ("Configuration.h", "Configuration_adv.h"):
+            if (p / f).is_file():
+                with open(p / f, 'r') as file:
+
+                    if 'BOTH(' in open(p / f, 'r').read() or 'EITHER(' in open(p / f, 'r').read():
+                        err = "ERROR: Old macro \"BOTH()\" or \"EITHER()\" found in your configuration files. Replace with \"ALL()\" and \"ANY()\" respectively and try again."
+                        raise SystemExit(err)
+
     sanity_check_target()

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -85,7 +85,7 @@ if pioutil.is_pio_build():
         #
         # Check for Config files in two common incorrect places
         #
-        for p in [ project_dir, project_dir / "config" ]:
+        for p in (project_dir, project_dir / "config"):
             for f in config_files:
                 if (p / f).is_file():
                     err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -156,6 +156,6 @@ if pioutil.is_pio_build():
                             file.write(modified_text)
 
         if conf_modified:
-            raise SystemExit('WARNING: Configuration files were updated. Build again to use the updated files.')
+            raise SystemExit('WARNING: Configuration files needed an update to remove incompatible items. Try the build again to use the updated files.')
 
     sanity_check_target()

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -78,12 +78,15 @@ if pioutil.is_pio_build():
                   ( build_env, motherboard, ", ".join([ e[4:] for e in board_envs if e.startswith("env:") ]) )
             raise SystemExit(err)
 
+        # Useful values
+        project_dir = Path(env['PROJECT_DIR'])
+        config_files = ("Configuration.h", "Configuration_adv.h")
+
         #
         # Check for Config files in two common incorrect places
         #
-        epath = Path(env['PROJECT_DIR'])
-        for p in [ epath, epath / "config" ]:
-            for f in ("Configuration.h", "Configuration_adv.h"):
+        for p in [ project_dir, project_dir / "config" ]:
+            for f in config_files:
                 if (p / f).is_file():
                     err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
                     raise SystemExit(err)
@@ -114,11 +117,11 @@ if pioutil.is_pio_build():
         # Check for old files indicating an entangled Marlin (mixing old and new code)
         #
         mixedin = []
-        p = Path(env['PROJECT_DIR'], "Marlin/src/lcd/dogm")
+        p = project_dir / "Marlin/src/lcd/dogm"
         for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
             if (p / f).is_file():
                 mixedin += [ f ]
-        p = Path(env['PROJECT_DIR'], "Marlin/src/feature/bedlevel/abl")
+        p = project_dir / "Marlin/src/feature/bedlevel/abl"
         for f in [ "abl.cpp", "abl.h" ]:
             if (p / f).is_file():
                 mixedin += [ f ]
@@ -138,14 +141,21 @@ if pioutil.is_pio_build():
                         raise SystemExit(err)
 
         #
-        # Check for old macros BOTH and EITHER in configuration file
+        # Update old macros BOTH and EITHER in configuration files
         #
-        p = Path(env['PROJECT_DIR'], "Marlin")
-        for f in ("Configuration.h", "Configuration_adv.h"):
-            if (p / f).is_file():
-                with open(p / f, 'r') as file:
-                    if 'BOTH(' in open(p / f, 'r').read() or 'EITHER(' in open(p / f, 'r').read():
-                        err = "ERROR: Old macro \"BOTH()\" or \"EITHER()\" found in your configuration files. Replace with \"ALL()\" and \"ANY()\" respectively and try again."
-                        raise SystemExit(err)
+        conf_modified = False
+        for f in config_files:
+            conf_path = project_dir / "Marlin" / f
+            if conf_path.is_file():
+                with open(conf_path, 'r') as file:
+                    text = file.read()
+                    modified_text = text.replace("BOTH(", "ALL(").replace("EITHER(", "ANY(")
+                    if text != modified_text:
+                        conf_modified = True
+                        with open(conf_path, 'w') as file:
+                            file.write(modified_text)
+
+        if conf_modified:
+            raise SystemExit('WARNING: Configuration files were updated. Build again to use the updated files.')
 
     sanity_check_target()

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -140,7 +140,6 @@ if pioutil.is_pio_build():
         #
         # Check for old macros BOTH and EITHER in configuration file
         #
-        epath = Path(env['PROJECT_DIR'])
         p = Path(env['PROJECT_DIR'], "Marlin")
         for f in ("Configuration.h", "Configuration_adv.h"):
             if (p / f).is_file():


### PR DESCRIPTION
### Description

Users are continuing to have issue with using old Configs, updating the version number but not updating these macros.

The Error missing binary operator before token "(" is not obvious to the causal user

Added a pre flight check that searches Configuration.h and Configuration_adv.h for  "BOTH(" and EITHER(" and errors with a much easier to understand error of the following:

`ERROR: Old macro "BOTH()" or "EITHER()" found in your configuration files. Replace with "ALL()" and "ANY()" respectively and try again.
`

NOTE: cannot just search for "BOTH" as there is a comment with that string in it.

Added at the request of @thisiskeithb 

### Requirements

BOTH( or EITHER( in Configuration.h or Configuration_adv.h

### Benefits

Less support requests

