### PR TITLE
fix settings.cpp check for  ERR_EEPROM_NOPROM

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1823,7 +1823,7 @@ void MarlinSettings::postprocess() {
     EEPROM_Error eeprom_error = ERR_EEPROM_NOERR;
 
     const EEPROM_Error check = check_version();
-    if (check == ERR_EEPROM_VERSION) return eeprom_error;
+    if (check == ERR_EEPROM_NOPROM) return eeprom_error;
 
     uint16_t stored_crc;
 


### PR DESCRIPTION
### Description

Recent changes to `settings.cpp` in https://github.com/MarlinFirmware/Marlin/pull/27199 resulted in eeproms not being initialized, some ending up setting 0 for all settings

I believe this is the fix.

```DIFF
diff --git a/Marlin/src/module/settings.cpp b/Marlin/src/module/settings.cpp
index d4467b7687..a553d56745 100644
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1823,7 +1823,7 @@ void MarlinSettings::postprocess() {
     EEPROM_Error eeprom_error = ERR_EEPROM_NOERR;
 
     const EEPROM_Error check = check_version();
-    if (check == ERR_EEPROM_VERSION) return eeprom_error;
+    if (check == ERR_EEPROM_NOPROM) return eeprom_error;
 
     uint16_t stored_crc;
``` 

While [dbuezas](https://github.com/dbuezas) proposed a slight variant

```DIFF
diff --git a/Marlin/src/module/settings.cpp b/Marlin/src/module/settings.cpp
index d4467b7687..a553d56745 100644
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1823,7 +1823,7 @@ void MarlinSettings::postprocess() {
     EEPROM_Error eeprom_error = ERR_EEPROM_NOERR;
 
     const EEPROM_Error check = check_version();
-    if (check == ERR_EEPROM_VERSION) return eeprom_error;
+    if (check == ERR_EEPROM_NOPROM) return ERR_EEPROM_NOERR;
 
     uint16_t stored_crc;
``` 

This PR added my version for consideration

### Requirements

EEPROM

### Benefits

Works as expected

### Related Issues

- MarlinFirmware/Marlin/issues/27236
- https://github.com/MarlinFirmware/Marlin/issues/27253
- https://github.com/MarlinFirmware/Marlin/pull/27199#issuecomment-2217460127