### PR TITLE
[WIP] Zero slowdown linear advance

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2322,7 +2322,7 @@
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with M900 L.
   //#define LA_DEBUG              // Print debug information to serial during operation. Disable for production use.
   //#define EXPERIMENTAL_I2S_LA   // Allow I2S_STEPPER_STREAM to be used with LA. Performance degrades as the LA step rate reaches ~20kHz.
-  //#define LA_ZERO_SLOWDOWN        // Removes motion acceleration limitation by allowing to gradual ramp up of nozzle pressure
+  //#define LA_ZERO_SLOWDOWN      // EXPERIMENTAL -- Removes motion acceleration limitation by allowing to gradual ramp up of nozzle pressure
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2322,6 +2322,7 @@
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with M900 L.
   //#define LA_DEBUG              // Print debug information to serial during operation. Disable for production use.
   //#define EXPERIMENTAL_I2S_LA   // Allow I2S_STEPPER_STREAM to be used with LA. Performance degrades as the LA step rate reaches ~20kHz.
+  //#define LA_ZERO_SLOWDOWN        // Removes motion acceleration limitation by allowing to gradual ramp up of nozzle pressure
 #endif
 
 /**

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -875,7 +875,6 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
       block->max_adv_steps = cruise_rate * comp;
       block->final_adv_steps = final_rate * comp;
       #if ENABLED(LA_ZERO_SLOWDOWN)
-        block->la_step_rate = 0;
         block->max_e_acc = (uint32_t)(float(planner.max_acceleration_steps_per_s2[E_AXIS + E_INDEX_N(extruder)]) * float(block->step_event_count) / float(block->steps[E_AXIS]) * (float(1UL << 24) / (STEPPER_TIMER_RATE)));
       #endif ENABLED(LIN_ADVANCE_ZERO_SLOWDOWN)
     }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -874,6 +874,8 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
       const float comp = extruder_advance_K[E_INDEX_N(block->extruder)] * block->steps.e / block->step_event_count;
       block->max_adv_steps = cruise_rate * comp;
       block->final_adv_steps = final_rate * comp;
+      block->la_step_rate = 0;
+      block->max_e_acc = (uint32_t)(float(planner.max_acceleration_steps_per_s2[E_AXIS + E_INDEX_N(extruder)]) * float(block->step_event_count) / float(block->steps[E_AXIS]) * (float(1UL << 24) / (STEPPER_TIMER_RATE)));
     }
   #endif
 
@@ -2411,7 +2413,9 @@ bool Planner::_populate_block(
           // Scale E acceleration so that it will be possible to jump to the advance speed.
           const uint32_t max_accel_steps_per_s2 = MAX_E_JERK(extruder) / (extruder_advance_K[E_INDEX_N(extruder)] * e_D_ratio) * steps_per_mm;
           if (accel > max_accel_steps_per_s2) {
-            accel = max_accel_steps_per_s2;
+            // Here, disabled acc limitation due to the jerk jump required to instantly get to la_advance_rate
+            // this new method doesn't even use e-jerk and allows taking multiple steps to build up nozzle pressure
+            // accel = max_accel_steps_per_s2;
             if (ENABLED(LA_DEBUG)) SERIAL_ECHOLNPGM("Acceleration limited.");
           }
         }

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -260,6 +260,8 @@ typedef struct PlannerBlock {
     uint8_t  la_scaling;                    // Scale ISR frequency down and step frequency up by 2 ^ la_scaling
     uint16_t max_adv_steps,                 // Max advance steps to get cruising speed pressure
              final_adv_steps;               // Advance steps for exit speed pressure
+    uint32_t la_step_rate;
+    uint32_t max_e_acc;      // Acceleration rate in (2^24 steps)/timer_ticks*s
   #endif
 
   uint32_t nominal_rate,                    // The nominal step rate for this block in step_events/sec

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -260,8 +260,10 @@ typedef struct PlannerBlock {
     uint8_t  la_scaling;                    // Scale ISR frequency down and step frequency up by 2 ^ la_scaling
     uint16_t max_adv_steps,                 // Max advance steps to get cruising speed pressure
              final_adv_steps;               // Advance steps for exit speed pressure
-    uint32_t la_step_rate;
-    uint32_t max_e_acc;      // Acceleration rate in (2^24 steps)/timer_ticks*s
+    #if ENABLED(LA_ZERO_SLOWDOWN)
+      uint32_t la_step_rate;                // Current linear advance rate
+      uint32_t max_e_acc;                   // Max E Acceleration rate in (2^24 steps)/timer_ticks*s
+    #endif
   #endif
 
   uint32_t nominal_rate,                    // The nominal step rate for this block in step_events/sec

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -261,7 +261,7 @@ typedef struct PlannerBlock {
     uint16_t max_adv_steps,                 // Max advance steps to get cruising speed pressure
              final_adv_steps;               // Advance steps for exit speed pressure
     #if ENABLED(LA_ZERO_SLOWDOWN)
-      uint32_t la_step_rate;                // Current linear advance rate
+      uint32_t current_la_step_rate;        // Current (gradually changing) linear advance rate
       uint32_t max_e_acc;                   // Max E Acceleration rate in (2^24 steps)/timer_ticks*s
     #endif
   #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2464,10 +2464,10 @@ hal_timer_t Stepper::block_phase_isr() {
             // const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
             // la_interval = calc_timer_interval((acc_step_rate + la_step_rate) >> current_block->la_scaling);
 
-            const uint32_t step_events_left_to_next = accelerate_before - step_events_completed;
+            const uint32_t step_events_left_until_ramp_down = accelerate_before - step_events_completed;
             const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
             
-            const bool is_ramping_up = step_events_left_to_next * max_e_accel >= current_block->la_step_rate + max_e_accel;
+            const bool is_ramping_up = step_events_left_until_ramp_down * max_e_accel >= current_block->la_step_rate;
             
             if (is_ramping_up){
               current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);
@@ -2539,11 +2539,11 @@ hal_timer_t Stepper::block_phase_isr() {
 
         #if ENABLED(LIN_ADVANCE)
           if (la_active) {
-            const uint32_t step_events_left_to_next = step_event_count - step_events_completed;
+            const uint32_t step_events_left_until_ramp_down = step_event_count - step_events_completed;
             const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
             
             // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
-            const bool is_ramping_up = step_events_left_to_next * max_e_accel >= current_block->la_step_rate  + max_e_accel;
+            const bool is_ramping_up = step_events_left_until_ramp_down * max_e_accel >= current_block->la_step_rate;
             
             if (is_ramping_up){
               current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2467,12 +2467,12 @@ hal_timer_t Stepper::block_phase_isr() {
             const uint32_t step_events_left_to_next = accelerate_before - step_events_completed;
             const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
             
-            const bool is_ramping_up = step_events_left_to_next * (max_e_accel + acc_step_rate) >= current_block->la_step_rate + (max_e_accel+acc_step_rate);
+            const bool is_ramping_up = step_events_left_to_next * max_e_accel >= current_block->la_step_rate + max_e_accel;
             
             if (is_ramping_up){
-              current_block->la_step_rate += min(max_e_accel-acc_step_rate, current_block->la_advance_rate - current_block->la_step_rate);
+              current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);
             } else {
-              current_block->la_step_rate -= min(max_e_accel+acc_step_rate, current_block->la_step_rate);
+              current_block->la_step_rate -= min(max_e_accel, current_block->la_step_rate);
             }
             uint32_t sum_rate = acc_step_rate + current_block->la_step_rate;
             la_interval = calc_timer_interval(sum_rate >> current_block->la_scaling);
@@ -2542,12 +2542,13 @@ hal_timer_t Stepper::block_phase_isr() {
             const uint32_t step_events_left_to_next = step_event_count - step_events_completed;
             const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
             
-            const bool is_ramping_up = step_events_left_to_next * (max_e_accel + step_rate) >= current_block->la_step_rate  + (max_e_accel + step_rate);
+            // TODO: respect max e accel by also considering the acceleration from the increased xy velocity
+            const bool is_ramping_up = step_events_left_to_next * max_e_accel >= current_block->la_step_rate  + max_e_accel;
             
             if (is_ramping_up){
-              current_block->la_step_rate += min(max_e_accel-step_rate, current_block->la_advance_rate - current_block->la_step_rate);
+              current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);
             } else {
-              current_block->la_step_rate -= min(max_e_accel+step_rate, current_block->la_step_rate);
+              current_block->la_step_rate -= min(max_e_accel, current_block->la_step_rate);
             }
 
             if (current_block->la_step_rate == step_rate) {
@@ -2885,7 +2886,7 @@ hal_timer_t Stepper::block_phase_isr() {
           // la_interval = calc_timer_interval((current_block->initial_rate + la_step_rate) >> current_block->la_scaling);
 
           const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc);           
-          current_block->la_step_rate = min(max_e_accel - acc_step_rate, current_block->la_advance_rate);
+          current_block->la_step_rate = min(max_e_accel, current_block->la_advance_rate);
           uint32_t sum_rate = acc_step_rate + current_block->la_step_rate;
           la_interval = calc_timer_interval(sum_rate >> current_block->la_scaling);
         }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2608,7 +2608,8 @@ hal_timer_t Stepper::block_phase_isr() {
             if (la_active) {
               la_interval = calc_timer_interval(current_block->nominal_rate >> current_block->la_scaling);
               if (current_block->la_step_rate) {
-                SERIAL_ECHOLNPGM("non zero la_step_rate during crusing.", current_block->la_step_rate);
+                if (ENABLED(LA_DEBUG)) SERIAL_ECHOLNPGM("warniing: non zero la_step_rate during cruising.", current_block->la_step_rate);
+                // TODO: fix this. Maybe ramp down needs a bit longer?
                 current_block->la_step_rate = 0; // should be zero already
               }
             }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2464,14 +2464,14 @@ hal_timer_t Stepper::block_phase_isr() {
               const uint32_t step_events_left_in_phase = accelerate_before - step_events_completed;
               const uint32_t max_delta_v =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
               // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
-              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->la_step_rate;
+              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->current_la_step_rate;
               
               if (is_ramping_up){
-                current_block->la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->la_step_rate);
+                current_block->current_la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->current_la_step_rate);
               } else {
-                current_block->la_step_rate -= _MIN(max_delta_v, current_block->la_step_rate);
+                current_block->current_la_step_rate -= _MIN(max_delta_v, current_block->current_la_step_rate);
               }
-              const uint32_t la_step_rate = current_block->la_step_rate;
+              const uint32_t la_step_rate = current_block->current_la_step_rate;
             #else
               const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
             #endif
@@ -2543,13 +2543,13 @@ hal_timer_t Stepper::block_phase_isr() {
               const uint32_t step_events_left_in_phase = step_event_count - step_events_completed;
               const uint32_t max_delta_v =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
               // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
-              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->la_step_rate;
+              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->current_la_step_rate;
               if (is_ramping_up){
-                current_block->la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->la_step_rate);
+                current_block->current_la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->current_la_step_rate);
               } else {
-                current_block->la_step_rate -= _MIN(max_delta_v, current_block->la_step_rate);
+                current_block->current_la_step_rate -= _MIN(max_delta_v, current_block->current_la_step_rate);
               }
-              const uint32_t la_step_rate = current_block->la_step_rate;
+              const uint32_t la_step_rate = current_block->current_la_step_rate;
             #else
               const uint32_t la_step_rate = la_advance_steps > current_block->final_adv_steps ? current_block->la_advance_rate : 0;
             #endif
@@ -2606,7 +2606,7 @@ hal_timer_t Stepper::block_phase_isr() {
             if (la_active) {
               la_interval = calc_timer_interval(current_block->nominal_rate >> current_block->la_scaling);
               #if ENABLED(LA_ZERO_SLOWDOWN)
-                current_block->la_step_rate = 0;
+                current_block->current_la_step_rate = 0;
               #endif
             }
           #endif
@@ -2880,9 +2880,9 @@ hal_timer_t Stepper::block_phase_isr() {
       #if ENABLED(LIN_ADVANCE)
         if (la_active) {
           #if ENABLED(LA_ZERO_SLOWDOWN)
-            // TODO: the block could have no deacceleration phase so it's not correct to blindly increase current_block->la_step_rate. 
+            // TODO: the block could start at cruise or deceleration phase so it's not correct to blindly increase current_block->current_la_step_rate. 
             // for now I'll leave the first step event without LA
-            current_block->la_step_rate = 0;
+            current_block->current_la_step_rate = 0;
             const uint32_t la_step_rate = 0;
           #else
             const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2461,14 +2461,15 @@ hal_timer_t Stepper::block_phase_isr() {
         #if ENABLED(LIN_ADVANCE)
           if (la_active) {
             #if ENABLED(LA_ZERO_SLOWDOWN)
-              const uint32_t step_events_left_until_ramp_down = accelerate_before - step_events_completed;
-              const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
+              const uint32_t step_events_left_in_phase = accelerate_before - step_events_completed;
+              const uint32_t max_delta_v =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
               // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
-              const bool is_ramping_up = step_events_left_until_ramp_down * max_e_accel >= current_block->la_step_rate;
+              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->la_step_rate;
+              
               if (is_ramping_up){
-                current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);
+                current_block->la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->la_step_rate);
               } else {
-                current_block->la_step_rate -= min(max_e_accel, current_block->la_step_rate);
+                current_block->la_step_rate -= _MIN(max_delta_v, current_block->la_step_rate);
               }
               const uint32_t la_step_rate = current_block->la_step_rate;
             #else
@@ -2539,14 +2540,14 @@ hal_timer_t Stepper::block_phase_isr() {
         #if ENABLED(LIN_ADVANCE)
           if (la_active) {
             #if ENABLED(LA_ZERO_SLOWDOWN)
-              const uint32_t step_events_left_until_ramp_down = step_event_count - step_events_completed;
-              const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
+              const uint32_t step_events_left_in_phase = step_event_count - step_events_completed;
+              const uint32_t max_delta_v =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
               // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
-              const bool is_ramping_up = step_events_left_until_ramp_down * max_e_accel >= current_block->la_step_rate;
+              const bool is_ramping_up = step_events_left_in_phase * max_delta_v >= current_block->la_step_rate;
               if (is_ramping_up){
-                current_block->la_step_rate += min(max_e_accel, current_block->la_advance_rate - current_block->la_step_rate);
+                current_block->la_step_rate += _MIN(max_delta_v, current_block->la_advance_rate - current_block->la_step_rate);
               } else {
-                current_block->la_step_rate -= min(max_e_accel, current_block->la_step_rate);
+                current_block->la_step_rate -= _MIN(max_delta_v, current_block->la_step_rate);
               }
               const uint32_t la_step_rate = current_block->la_step_rate;
             #else
@@ -2879,9 +2880,10 @@ hal_timer_t Stepper::block_phase_isr() {
       #if ENABLED(LIN_ADVANCE)
         if (la_active) {
           #if ENABLED(LA_ZERO_SLOWDOWN)
-            const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc);           
-            current_block->la_step_rate = min(max_e_accel, current_block->la_advance_rate);            
-            const uint32_t la_step_rate = current_block->la_step_rate;
+            // TODO: the block could have no deacceleration phase so it's not correct to blindly increase current_block->la_step_rate. 
+            // for now I'll leave the first step event without LA
+            current_block->la_step_rate = 0;
+            const uint32_t la_step_rate = 0;
           #else
             const uint32_t la_step_rate = la_advance_steps < current_block->max_adv_steps ? current_block->la_advance_rate : 0;
           #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2542,7 +2542,7 @@ hal_timer_t Stepper::block_phase_isr() {
             const uint32_t step_events_left_to_next = step_event_count - step_events_completed;
             const uint32_t max_e_accel =  STEP_MULTIPLY(interval, current_block->max_e_acc); 
             
-            // TODO: respect max e accel by also considering the acceleration from the increased xy velocity
+            // TODO: respect max e accel by also considering the acceleration from the step_rate delta between two timer steps
             const bool is_ramping_up = step_events_left_to_next * max_e_accel >= current_block->la_step_rate  + max_e_accel;
             
             if (is_ramping_up){


### PR DESCRIPTION
## Superseded by ------> https://github.com/MarlinFirmware/Marlin/pull/27352 <--------
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Linear advance currently limits acceleration by `k * xy_acceleraton * mm_of_extruder_per_mm_of_motion < e_jerk`. This is to instantly achieve the required nozzle pressure when an extruding movement begins/ends acceleration/deceleration.

This PR removes that limitation by allowing nozzle pressure to build up incrementally as demonstrated by this gsheets simulation:

<img width="833" alt="image" src="https://github.com/MarlinFirmware/Marlin/assets/777196/15e1ef22-fa54-4bf2-8e96-d417595cc104">

If the e-acceleration is set too small there will be some under-extrusion at the beginning and end of the acceleration phase, and over-extrusion at the beginning and end of deceleration phase of the trapezoidal acceleration profile.

I'm getting ~excellent~ **mediocre but workinig** results (with 5000mm/s2 movement acceleration and 3000mm/s2 extruder acceleration). ~Maybe even better than the current implementation, which I hypothesise is because the extruder acceleration slope makes extrusion behave more linearly~. **(too soon, there's a working better approach in the works)**

I don't have a bowden machine to test this, but those will see the most drastic print time improvements.
Accelerations are a lot faster than with classic LA, so you may need to reduce them a bit.

Another good sign is that now the time estimation in Orca Slicer is accurate, regardless of k factor.


## Computing slowdown of current approach

In my printer (direct drive extruder with a fairly long filament path of 14mm)
* line width = 0.4mm
* layer height = 0.2mm
* e_jerk = 5mm/s
* k = 0.1 

Results in
* `mm_of_extruder_per_mm_of_motion = (0.4mm * 0.2mm * 1mm) / (pi * (1.75 / 2)^2) = 0.0332`

Which applied to the equation above gives
* `0.1 * xy_acceleraton * 0.0332 < 5`
* `xy_acceleraton  < 5/0.0332/0.1`
* `xy_acceleraton  < 1506mm/s^2`

Find your own max acceleration (for the same layer height and line width) with `your_max_xy_acceleraton  = e_jerk/0.0332/k`

It doesn't matter if the movement axes max acceleration is configured to 10k, **linear advance will limit all extruding movements to `your_max_xy_acceleraton` (1500mm/s^2 in my case)**.

## Todos:

* [ ] Inline code documentation
* [x] A configuration_adv flag to switch between classic and zero slowdown LA
* [ ] Reduce computations done in the block_phase_isr (e.g precompute more)
* [ ] Reduce ram usage (e.g remove added value from the block)
* [ ] A lot of testing

## What I wish for

* Testing in 8 bit boards
* Testing in bowden extruders
* Confirmation that I'm not accidentally exceeding the max_e_acceleration
* Before and after pics :) 

## Left away for follow up PRs

* S_CURVE_ACCELERATION matching LA: Make la_rate adapt to the acceleration of each step event 
* Target the final la_rate to match the acceleration of the next block
* Smoothing out LA beyond the acceleration/deceleration phases and across contiguous blocks

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Faster printing, particularly in machines using large k values.

### Configurations

`#define LIN_ADVANCE`
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
