### PR TITLE
ignore warning sign-compare in pin_is_protected

### DIFF
--- a/Marlin/src/HAL/AVR/pinsDebug.h
+++ b/Marlin/src/HAL/AVR/pinsDebug.h
@@ -42,7 +42,7 @@
   #define digitalPinToTimer_DEBUG(p) digitalPinToTimer(p)
   #define digitalPinToBitMask_DEBUG(p) digitalPinToBitMask(p)
   #define digitalPinToPort_DEBUG(p) digitalPinToPort(p)
-  #define GET_PINMODE(pin) (*portModeRegister(pin) & digitalPinToBitMask_DEBUG(pin))
+  #define getValidPinMode(pin) (*portModeRegister(pin) & digitalPinToBitMask_DEBUG(pin))
 
 #elif AVR_ATmega2560_FAMILY_PLUS_70   // So we can access/display all the pins on boards using more than 70
 
@@ -50,32 +50,32 @@
   #define digitalPinToTimer_DEBUG(p) digitalPinToTimer_plus_70(p)
   #define digitalPinToBitMask_DEBUG(p) digitalPinToBitMask_plus_70(p)
   #define digitalPinToPort_DEBUG(p) digitalPinToPort_plus_70(p)
-  bool GET_PINMODE(int8_t pin) {return *portModeRegister(digitalPinToPort_DEBUG(pin)) & digitalPinToBitMask_DEBUG(pin); }
+  bool getValidPinMode(pin_t pin) {return *portModeRegister(digitalPinToPort_DEBUG(pin)) & digitalPinToBitMask_DEBUG(pin); }
 
 #else
 
   #define digitalPinToTimer_DEBUG(p) digitalPinToTimer(p)
   #define digitalPinToBitMask_DEBUG(p) digitalPinToBitMask(p)
   #define digitalPinToPort_DEBUG(p) digitalPinToPort(p)
-  bool GET_PINMODE(int8_t pin) {return *portModeRegister(digitalPinToPort_DEBUG(pin)) & digitalPinToBitMask_DEBUG(pin); }
-  #define GET_ARRAY_PIN(p) pgm_read_byte(&pin_array[p].pin)
+  bool getValidPinMode(pin_t pin) {return *portModeRegister(digitalPinToPort_DEBUG(pin)) & digitalPinToBitMask_DEBUG(pin); }
+  #define getPinByIndex(p) pgm_read_byte(&pin_array[p].pin)
 
 #endif
 
-#define VALID_PIN(pin) (pin >= 0 && pin < NUM_DIGITAL_PINS ? 1 : 0)
+#define isValidPin(pin) (pin >= 0 && pin < NUM_DIGITAL_PINS ? 1 : 0)
 #if AVR_ATmega1284_FAMILY
-  #define IS_ANALOG(P) WITHIN(P, analogInputToDigitalPin(7), analogInputToDigitalPin(0))
-  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int(IS_ANALOG(P) ? (P) - analogInputToDigitalPin(7) : -1)
+  #define isAnalogPin(P) WITHIN(P, analogInputToDigitalPin(7), analogInputToDigitalPin(0))
+  #define digitalPinToAnalogIndex(P) int(isAnalogPin(P) ? (P) - analogInputToDigitalPin(7) : -1)
 #else
   #define _ANALOG1(P) WITHIN(P, analogInputToDigitalPin(0), analogInputToDigitalPin(7))
   #define _ANALOG2(P) WITHIN(P, analogInputToDigitalPin(8), analogInputToDigitalPin(15))
-  #define IS_ANALOG(P) (_ANALOG1(P) || _ANALOG2(P))
-  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int(_ANALOG1(P) ? (P) - analogInputToDigitalPin(0) : _ANALOG2(P) ? (P) - analogInputToDigitalPin(8) + 8 : -1)
+  #define isAnalogPin(P) (_ANALOG1(P) || _ANALOG2(P))
+  #define digitalPinToAnalogIndex(P) int(_ANALOG1(P) ? (P) - analogInputToDigitalPin(0) : _ANALOG2(P) ? (P) - analogInputToDigitalPin(8) + 8 : -1)
 #endif
-#define GET_ARRAY_PIN(p) pgm_read_byte(&pin_array[p].pin)
+#define getPinByIndex(p) pgm_read_byte(&pin_array[p].pin)
 #define MULTI_NAME_PAD 26 // space needed to be pretty if not first name assigned to a pin
 
-void PRINT_ARRAY_NAME(uint8_t x) {
+void printPinNameByIndex(uint8_t x) {
   PGM_P const name_mem_pointer = (PGM_P)pgm_read_ptr(&pin_array[x].name);
   for (uint8_t y = 0; y < MAX_NAME_LENGTH; ++y) {
     char temp_char = pgm_read_byte(name_mem_pointer + y);
@@ -88,7 +88,7 @@ void PRINT_ARRAY_NAME(uint8_t x) {
   }
 }
 
-#define GET_ARRAY_IS_DIGITAL(x)   pgm_read_byte(&pin_array[x].is_digital)
+#define getPinIsDigitalByIndex(x)   pgm_read_byte(&pin_array[x].is_digital)
 
 #if defined(__AVR_ATmega1284P__)  // 1284 IDE extensions set this to the number of
   #undef NUM_DIGITAL_PINS         // digital only pins while all other CPUs have it
@@ -276,7 +276,7 @@ void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - 
   if (TEST(*TMSK, TOIE)) err_prob_interrupt();
 }
 
-void pwm_details(uint8_t pin) {
+void printPinPWM(uint8_t pin) {
   switch (digitalPinToTimer_DEBUG(pin)) {
 
     #if ABTEST(0)
@@ -347,7 +347,7 @@ void pwm_details(uint8_t pin) {
   #else
     UNUSED(print_is_also_tied);
   #endif
-} // pwm_details
+} // printPinPWM
 
 #ifndef digitalRead_mod                   // Use Teensyduino's version of digitalRead - it doesn't disable the PWMs
   int digitalRead_mod(const pin_t pin) {  // same as digitalRead except the PWM stop section has been removed
@@ -356,7 +356,7 @@ void pwm_details(uint8_t pin) {
   }
 #endif
 
-void print_port(const pin_t pin) {   // print port number
+void printPinPort(const pin_t pin) {   // print port number
   #ifdef digitalPinToPort_DEBUG
     uint8_t x;
     SERIAL_ECHOPGM("  Port: ");
@@ -386,7 +386,7 @@ void print_port(const pin_t pin) {   // print port number
   #endif
 }
 
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
 
 #undef ABTEST

--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -127,7 +127,7 @@ typedef Servo hal_servo_t;
 #define HAL_ADC_RESOLUTION  10
 
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) ((p < 12U) ? (p) + 54U : -1)
+  #define analogInputToDigitalPin(p) pin_t((p < 12U) ? (p) + 54U : -1)
 #endif
 
 //

--- a/Marlin/src/HAL/DUE/pinsDebug.h
+++ b/Marlin/src/HAL/DUE/pinsDebug.h
@@ -71,7 +71,7 @@
 #define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
 #define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
-#define IS_ANALOG(P) WITHIN(P, char(analogInputToDigitalPin(0)), char(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
+#define IS_ANALOG(P) WITHIN(P, pin_t(analogInputToDigitalPin(0)), pin_t(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
 #define pwm_status(pin) (((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \
                         ((g_APinDescription[pin].ulPinAttribute & PIN_ATTR_PWM) == PIN_ATTR_PWM))
 #define MULTI_NAME_PAD 14 // space needed to be pretty if not first name assigned to a pin

--- a/Marlin/src/HAL/DUE/pinsDebug.h
+++ b/Marlin/src/HAL/DUE/pinsDebug.h
@@ -64,19 +64,19 @@
 #define NUMBER_PINS_TOTAL PINS_COUNT
 
 #define digitalRead_mod(p) extDigitalRead(p)  // AVR digitalRead disabled PWM before it read the pin
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%02d"), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
-#define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
-#define IS_ANALOG(P) WITHIN(P, pin_t(analogInputToDigitalPin(0)), pin_t(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%02d"), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define getPinIsDigitalByIndex(p) pin_array[p].is_digital
+#define isValidPin(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
+#define digitalPinToAnalogIndex(p) int(p - analogInputToDigitalPin(0))
+#define isAnalogPin(P) WITHIN(P, pin_t(analogInputToDigitalPin(0)), pin_t(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
 #define pwm_status(pin) (((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \
                         ((g_APinDescription[pin].ulPinAttribute & PIN_ATTR_PWM) == PIN_ATTR_PWM))
 #define MULTI_NAME_PAD 14 // space needed to be pretty if not first name assigned to a pin
 
-bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
+bool getValidPinMode(int8_t pin) {  // 1: output, 0: input
   volatile Pio* port = g_APinDescription[pin].pPort;
   uint32_t mask = g_APinDescription[pin].ulPin;
   uint8_t pin_status = g_pinStatus[pin] & 0xF;
@@ -85,14 +85,14 @@ bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
           || pwm_status(pin));
 }
 
-void pwm_details(int32_t pin) {
+void printPinPWM(int32_t pin) {
   if (pwm_status(pin)) {
     uint32_t chan = g_APinDescription[pin].ulPWMChannel;
     SERIAL_ECHOPGM("PWM = ", PWM_INTERFACE->PWM_CH_NUM[chan].PWM_CDTY);
   }
 }
 
-void print_port(const pin_t) {}
+void printPinPort(const pin_t) {}
 
 /**
  * DUE Board pin   |  PORT  | Label

--- a/Marlin/src/HAL/HC32/HAL.h
+++ b/Marlin/src/HAL/HC32/HAL.h
@@ -114,7 +114,7 @@
 // Misc. Functions
 //
 #ifndef analogInputToDigitalPin
-#define analogInputToDigitalPin(p) (p)
+#define analogInputToDigitalPin(p) pin_t(p)
 #endif
 
 #define CRITICAL_SECTION_START        \

--- a/Marlin/src/HAL/HC32/pinsDebug.h
+++ b/Marlin/src/HAL/HC32/pinsDebug.h
@@ -31,24 +31,24 @@
 
 #define NUM_DIGITAL_PINS BOARD_NR_GPIO_PINS
 #define NUMBER_PINS_TOTAL BOARD_NR_GPIO_PINS
-#define VALID_PIN(pin) IS_GPIO_PIN(pin)
+#define isValidPin(pin) IS_GPIO_PIN(pin)
 
 // Note: pin_array is defined in `Marlin/src/pins/pinsDebug.h`, and since this file is included
 // after it, it is available in this file as well.
-#define GET_ARRAY_PIN(p) pin_t(pin_array[p].pin)
+#define getPinByIndex(p) pin_t(pin_array[p].pin)
 #define digitalRead_mod(p) extDigitalRead(p)
-#define PRINT_PIN(p)                              \
+#define printPinNumber(p)                              \
   do {                                            \
     sprintf_P(buffer, PSTR("%3hd "), int16_t(p)); \
     SERIAL_ECHO(buffer);                          \
   } while (0)
-#define PRINT_PIN_ANALOG(p)                                               \
+#define printPinAnalog(p)                                               \
   do {                                                                    \
-    sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); \
+    sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); \
     SERIAL_ECHO(buffer);                                                  \
   } while (0)
-#define PRINT_PORT(p) print_port(p)
-#define PRINT_ARRAY_NAME(x)                                                          \
+#define PRINT_PORT(p) printPinPort(p)
+#define printPinNameByIndex(x)                                                          \
   do {                                                                               \
     sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); \
     SERIAL_ECHO(buffer);                                                             \
@@ -71,14 +71,14 @@
   #define M43_NEVER_TOUCH(Q) (IS_HOST_USART_PIN(Q) || IS_OSC_PIN(Q))
 #endif
 
-static pin_t DIGITAL_PIN_TO_ANALOG_PIN(pin_t pin) {
-  if (!VALID_PIN(pin)) return -1;
+static pin_t digitalPinToAnalogIndex(pin_t pin) {
+  if (!isValidPin(pin)) return -1;
   const int8_t adc_channel = int8_t(PIN_MAP[pin].adc_info.channel);
   return pin_t(adc_channel);
 }
 
-static bool IS_ANALOG(pin_t pin) {
-  if (!VALID_PIN(pin)) return false;
+static bool isAnalogPin(pin_t pin) {
+  if (!isValidPin(pin)) return false;
 
   if (PIN_MAP[pin].adc_info.channel != ADC_PIN_INVALID)
     return _GET_MODE(pin) == INPUT_ANALOG && !M43_NEVER_TOUCH(pin);
@@ -86,13 +86,13 @@ static bool IS_ANALOG(pin_t pin) {
   return false;
 }
 
-static bool GET_PINMODE(const pin_t pin) {
-  return VALID_PIN(pin) && !IS_INPUT(pin);
+static bool getValidPinMode(const pin_t pin) {
+  return isValidPin(pin) && !IS_INPUT(pin);
 }
 
-static bool GET_ARRAY_IS_DIGITAL(const int16_t array_pin) {
-  const pin_t pin = GET_ARRAY_PIN(array_pin);
-  return (!IS_ANALOG(pin));
+static bool getPinIsDigitalByIndex(const int16_t array_pin) {
+  const pin_t pin = getPinByIndex(array_pin);
+  return (!isAnalogPin(pin));
 }
 
 /**
@@ -117,7 +117,7 @@ bool pwm_status(const pin_t pin) {
   return timera_is_unit_initialized(unit) && timera_is_channel_active(unit, channel) && getPinMode(pin) == OUTPUT_PWM;
 }
 
-void pwm_details(const pin_t pin) {
+void printPinPWM(const pin_t pin) {
   // Get timer assignment for pin
   timera_config_t *unit;
   en_timera_channel_t channel;
@@ -161,7 +161,7 @@ void pwm_details(const pin_t pin) {
   }
 }
 
-void print_port(pin_t pin) {
+void printPinPort(pin_t pin) {
   const char port = 'A' + char(pin >> 4); // Pin div 16
   const int16_t gbit = PIN_MAP[pin].bit_pos;
   char buffer[8];

--- a/Marlin/src/HAL/LINUX/HAL.cpp
+++ b/Marlin/src/HAL/LINUX/HAL.cpp
@@ -52,7 +52,7 @@ uint8_t MarlinHAL::active_ch = 0;
 
 uint16_t MarlinHAL::adc_value() {
   const pin_t pin = analogInputToDigitalPin(active_ch);
-  if (!VALID_PIN(pin)) return 0;
+  if (!isValidPin(pin)) return 0;
   return uint16_t((Gpio::get(pin) >> 2) & 0x3FF); // return 10bit value as Marlin expects
 }
 

--- a/Marlin/src/HAL/LINUX/arduino.cpp
+++ b/Marlin/src/HAL/LINUX/arduino.cpp
@@ -49,28 +49,28 @@ extern "C" void delay(const int msec) {
 // IO functions
 // As defined by Arduino INPUT(0x0), OUTPUT(0x1), INPUT_PULLUP(0x2)
 void pinMode(const pin_t pin, const uint8_t mode) {
-  if (!VALID_PIN(pin)) return;
+  if (!isValidPin(pin)) return;
   Gpio::setMode(pin, mode);
 }
 
 void digitalWrite(pin_t pin, uint8_t pin_status) {
-  if (!VALID_PIN(pin)) return;
+  if (!isValidPin(pin)) return;
   Gpio::set(pin, pin_status);
 }
 
 bool digitalRead(pin_t pin) {
-  if (!VALID_PIN(pin)) return false;
+  if (!isValidPin(pin)) return false;
   return Gpio::get(pin);
 }
 
 void analogWrite(pin_t pin, int pwm_value) {  // 1 - 254: pwm_value, 0: LOW, 255: HIGH
-  if (!VALID_PIN(pin)) return;
+  if (!isValidPin(pin)) return;
   Gpio::set(pin, pwm_value);
 }
 
 uint16_t analogRead(pin_t adc_pin) {
-  if (!VALID_PIN(DIGITAL_PIN_TO_ANALOG_PIN(adc_pin))) return 0;
-  return Gpio::get(DIGITAL_PIN_TO_ANALOG_PIN(adc_pin));
+  if (!isValidPin(digitalPinToAnalogIndex(adc_pin))) return 0;
+  return Gpio::get(digitalPinToAnalogIndex(adc_pin));
 }
 
 char *dtostrf(double __val, signed char __width, unsigned char __prec, char *__s) {

--- a/Marlin/src/HAL/LINUX/include/pinmapping.h
+++ b/Marlin/src/HAL/LINUX/include/pinmapping.h
@@ -42,7 +42,7 @@ constexpr pin_t analogInputToDigitalPin(const int8_t p) {
 }
 
 // Get the analog index for a digital pin
-constexpr int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t p) {
+constexpr int8_t digitalPinToAnalogIndex(const pin_t p) {
   return (WITHIN(p, analog_offset, NUM_DIGITAL_PINS) ? p - analog_offset : P_NC);
 }
 
@@ -50,7 +50,7 @@ constexpr int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t p) {
 constexpr int16_t GET_PIN_MAP_INDEX(const pin_t pin) { return pin; }
 
 // Test whether the pin is valid
-constexpr bool VALID_PIN(const pin_t p) { return WITHIN(p, 0, NUM_DIGITAL_PINS); }
+constexpr bool isValidPin(const pin_t p) { return WITHIN(p, 0, NUM_DIGITAL_PINS); }
 
 // Test whether the pin is PWM
 constexpr bool PWM_PIN(const pin_t p) { return false; }

--- a/Marlin/src/HAL/LINUX/pinsDebug.h
+++ b/Marlin/src/HAL/LINUX/pinsDebug.h
@@ -29,20 +29,20 @@
  */
 
 #define NUMBER_PINS_TOTAL   NUM_DIGITAL_PINS
-#define IS_ANALOG(P)        (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
+#define isAnalogPin(P)        (digitalPinToAnalogIndex(P) >= 0 ? 1 : 0)
 #define digitalRead_mod(p)  digitalRead(p)
-#define GET_ARRAY_PIN(p)    pin_array[p].pin
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p)        do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p)    pin_array[p].pin
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p)        do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
 #define MULTI_NAME_PAD      16 // space needed to be pretty if not first name assigned to a pin
 
 // active ADC function/mode/code values for PINSEL registers
 constexpr int8_t ADC_pin_mode(pin_t pin) { return -1; }
 
-int8_t get_pin_mode(const pin_t pin) { return VALID_PIN(pin) ? 0 : -1; }
+int8_t get_pin_mode(const pin_t pin) { return isValidPin(pin) ? 0 : -1; }
 
-bool GET_PINMODE(const pin_t pin) {
+bool getValidPinMode(const pin_t pin) {
   const int8_t pin_mode = get_pin_mode(pin);
   if (pin_mode == -1 || pin_mode == ADC_pin_mode(pin)) // Invalid pin or active analog pin
     return false;
@@ -50,11 +50,11 @@ bool GET_PINMODE(const pin_t pin) {
   return (Gpio::getMode(pin) != 0); // Input/output state
 }
 
-bool GET_ARRAY_IS_DIGITAL(const pin_t pin) {
-  return (!IS_ANALOG(pin) || get_pin_mode(pin) != ADC_pin_mode(pin));
+bool getPinIsDigitalByIndex(const pin_t pin) {
+  return (!isAnalogPin(pin) || get_pin_mode(pin) != ADC_pin_mode(pin));
 }
 
-void pwm_details(const pin_t pin) {}
+void printPinPWM(const pin_t pin) {}
 bool pwm_status(const pin_t) { return false; }
 
-void print_port(const pin_t) {}
+void printPinPort(const pin_t) {}

--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -137,12 +137,12 @@ extern DefaultSerial1 USBSerial;
 //
 
 // Test whether the pin is valid
-constexpr bool VALID_PIN(const pin_t pin) {
+constexpr bool isValidPin(const pin_t pin) {
   return LPC176x::pin_is_valid(pin);
 }
 
 // Get the analog index for a digital pin
-constexpr int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t pin) {
+constexpr int8_t digitalPinToAnalogIndex(const pin_t pin) {
   return (LPC176x::pin_is_valid(pin) && LPC176x::pin_has_adc(pin)) ? pin : -1;
 }
 

--- a/Marlin/src/HAL/LPC1768/pinsDebug.h
+++ b/Marlin/src/HAL/LPC1768/pinsDebug.h
@@ -29,12 +29,12 @@
  */
 
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
-#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
+#define isAnalogPin(P) (digitalPinToAnalogIndex(P) >= 0 ? 1 : 0)
 #define digitalRead_mod(p) extDigitalRead(p)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("P%d_%02d"), LPC176x::pin_port(p), LPC176x::pin_bit(p)); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR("_A%d     "), LPC176x::pin_get_adc_channel(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("P%d_%02d"), LPC176x::pin_port(p), LPC176x::pin_bit(p)); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR("_A%d     "), LPC176x::pin_get_adc_channel(pin)); SERIAL_ECHO(buffer); }while(0)
 #define MULTI_NAME_PAD 17 // space needed to be pretty if not first name assigned to a pin
 
 // pins that will cause hang/reset/disconnect in M43 Toggle and Watch utilities
@@ -42,15 +42,15 @@
   #define M43_NEVER_TOUCH(Q) ((Q) == P0_29 || (Q) == P0_30 || (Q) == P2_09)  // USB pins
 #endif
 
-bool GET_PINMODE(const pin_t pin) {
+bool getValidPinMode(const pin_t pin) {
   if (!LPC176x::pin_is_valid(pin) || LPC176x::pin_adc_enabled(pin)) // Invalid pin or active analog pin
     return false;
 
   return LPC176x::gpio_direction(pin);
 }
 
-#define GET_ARRAY_IS_DIGITAL(x) ((bool) pin_array[x].is_digital)
+#define getPinIsDigitalByIndex(x) ((bool) pin_array[x].is_digital)
 
-void print_port(const pin_t) {}
-void pwm_details(const pin_t) {}
+void printPinPort(const pin_t) {}
+void printPinPWM(const pin_t) {}
 bool pwm_status(const pin_t) { return false; }

--- a/Marlin/src/HAL/NATIVE_SIM/pinsDebug.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/pinsDebug.cpp
@@ -27,9 +27,9 @@
 
 int8_t ADC_pin_mode(pin_t pin) { return -1; }
 
-int8_t get_pin_mode(const pin_t pin) { return VALID_PIN(pin) ? 0 : -1; }
+int8_t get_pin_mode(const pin_t pin) { return isValidPin(pin) ? 0 : -1; }
 
-bool GET_PINMODE(const pin_t pin) {
+bool getValidPinMode(const pin_t pin) {
   const int8_t pin_mode = get_pin_mode(pin);
   if (pin_mode == -1 || pin_mode == ADC_pin_mode(pin)) // Invalid pin or active analog pin
     return false;
@@ -37,12 +37,12 @@ bool GET_PINMODE(const pin_t pin) {
   return (Gpio::getMode(pin) != 0); // Input/output state
 }
 
-bool GET_ARRAY_IS_DIGITAL(const pin_t pin) {
-  return !IS_ANALOG(pin) || get_pin_mode(pin) != ADC_pin_mode(pin);
+bool getPinIsDigitalByIndex(const pin_t pin) {
+  return !isAnalogPin(pin) || get_pin_mode(pin) != ADC_pin_mode(pin);
 }
 
-void print_port(const pin_t) {}
-void pwm_details(const pin_t) {}
+void printPinPort(const pin_t) {}
+void printPinPWM(const pin_t) {}
 bool pwm_status(const pin_t) { return false; }
 
 #endif

--- a/Marlin/src/HAL/NATIVE_SIM/pinsDebug.h
+++ b/Marlin/src/HAL/NATIVE_SIM/pinsDebug.h
@@ -30,19 +30,19 @@
  */
 
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
-#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
+#define isAnalogPin(P) (digitalPinToAnalogIndex(P) >= 0 ? 1 : 0)
 #define digitalRead_mod(p)  digitalRead(p)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
 #define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
 
 // Active ADC function/mode/code values for PINSEL registers
 int8_t ADC_pin_mode(pin_t pin);
 int8_t get_pin_mode(const pin_t pin);
-bool GET_PINMODE(const pin_t pin);
-bool GET_ARRAY_IS_DIGITAL(const pin_t pin);
-void print_port(const pin_t);
-void pwm_details(const pin_t);
+bool getValidPinMode(const pin_t pin);
+bool getPinIsDigitalByIndex(const pin_t pin);
+void printPinPort(const pin_t);
+void printPinPWM(const pin_t);
 bool pwm_status(const pin_t);

--- a/Marlin/src/HAL/SAMD21/fastio.h
+++ b/Marlin/src/HAL/SAMD21/fastio.h
@@ -152,7 +152,7 @@
                                  : ((P) == 14) ? ADC_INPUTCTRL_MUXPOS_PIN14 \
                                  : ADC_INPUTCTRL_MUXPOS_PIN15)
 
-#define digitalPinToAnalogInput(P) (WITHIN(P, 67, 74) ? (P) - 67 : WITHIN(P, 54, 61) ? 8 + (P) - 54 : WITHIN(P, 12, 13) ? 16 + (P) - 12 : P == 9 ? 18 : -1)
+#define digitalPinToAnalogIndex(P) (WITHIN(P, 67, 74) ? (P) - 67 : WITHIN(P, 54, 61) ? 8 + (P) - 54 : WITHIN(P, 12, 13) ? 16 + (P) - 12 : P == 9 ? 18 : -1)
 
 /**
  * pins

--- a/Marlin/src/HAL/SAMD21/pinsDebug.h
+++ b/Marlin/src/HAL/SAMD21/pinsDebug.h
@@ -30,14 +30,13 @@
 
 #define digitalRead_mod(p) extDigitalRead(p)
 #define PRINT_PORT(p) do{ SERIAL_ECHOPGM("  Port: "); sprintf_P(buffer, PSTR("%c%02ld"), 'A' + g_APinDescription[p].ulPort, g_APinDescription[p].ulPin); SERIAL_ECHO(buffer); }while (0)
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL)
-#define DIGITAL_PIN_TO_ANALOG_PIN(p) digitalPinToAnalogInput(p)
-#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P)!=-1)
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define getPinIsDigitalByIndex(p) pin_array[p].is_digital
+#define isValidPin(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL)
+#define isAnalogPin(P) (digitalPinToAnalogIndex(P)!=-1)
 #define pwm_status(pin) digitalPinHasPWM(pin)
 #define MULTI_NAME_PAD 27 // space needed to be pretty if not first name assigned to a pin
 
@@ -45,13 +44,13 @@
 // uses pin index
 #define M43_NEVER_TOUCH(Q) ((Q) >= 75)
 
-bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
+bool getValidPinMode(int8_t pin) {  // 1: output, 0: input
   const EPortType samdport = g_APinDescription[pin].ulPort;
   const uint32_t samdpin = g_APinDescription[pin].ulPin;
   return PORT->Group[samdport].DIR.reg & MASK(samdpin) || (PORT->Group[samdport].PINCFG[samdpin].reg & (PORT_PINCFG_INEN | PORT_PINCFG_PULLEN)) == PORT_PINCFG_PULLEN;
 }
 
-void pwm_details(int32_t pin) {
+void printPinPWM(int32_t pin) {
   if (pwm_status(pin)) {
     //uint32_t chan = g_APinDescription[pin].ulPWMChannel TODO when fast pwm is operative;
     //SERIAL_ECHOPGM("PWM = ", duty);

--- a/Marlin/src/HAL/SAMD51/fastio.h
+++ b/Marlin/src/HAL/SAMD51/fastio.h
@@ -174,7 +174,7 @@
                                    : (P == 17) ? PIN_TO_SAMD_PIN(13)  \
                                    : PIN_TO_SAMD_PIN(9))
 
-  #define digitalPinToAnalogInput(P) (WITHIN(P, 67, 74) ? (P) - 67 : WITHIN(P, 54, 61) ? 8 + (P) - 54 : WITHIN(P, 12, 13) ? 16 + (P) - 12 : P == 9 ? 18 : -1)
+  #define digitalPinToAnalogIndex(P) (WITHIN(P, 67, 74) ? (P) - 67 : WITHIN(P, 54, 61) ? 8 + (P) - 54 : WITHIN(P, 12, 13) ? 16 + (P) - 12 : P == 9 ? 18 : -1)
 
   /**
    * pins

--- a/Marlin/src/HAL/SAMD51/pinsDebug.h
+++ b/Marlin/src/HAL/SAMD51/pinsDebug.h
@@ -29,14 +29,13 @@
 
 #define digitalRead_mod(p) extDigitalRead(p)
 #define PRINT_PORT(p) do{ SERIAL_ECHOPGM("  Port: "); sprintf_P(buffer, PSTR("%c%02ld"), 'A' + g_APinDescription[p].ulPort, g_APinDescription[p].ulPin); SERIAL_ECHO(buffer); }while (0)
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
-#define DIGITAL_PIN_TO_ANALOG_PIN(p) digitalPinToAnalogInput(p)
-#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P)!=-1)
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%3d "), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define getPinIsDigitalByIndex(p) pin_array[p].is_digital
+#define isValidPin(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
+#define isAnalogPin(P) (digitalPinToAnalogIndex(P)!=-1)
 #define pwm_status(pin) digitalPinHasPWM(pin)
 #define MULTI_NAME_PAD 27 // space needed to be pretty if not first name assigned to a pin
 
@@ -44,13 +43,13 @@
 // uses pin index
 #define M43_NEVER_TOUCH(Q) ((Q) >= 75)
 
-bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
+bool getValidPinMode(int8_t pin) {  // 1: output, 0: input
   const EPortType samdport = g_APinDescription[pin].ulPort;
   const uint32_t samdpin = g_APinDescription[pin].ulPin;
   return PORT->Group[samdport].DIR.reg & MASK(samdpin) || (PORT->Group[samdport].PINCFG[samdpin].reg & (PORT_PINCFG_INEN | PORT_PINCFG_PULLEN)) == PORT_PINCFG_PULLEN;
 }
 
-void pwm_details(int32_t pin) {
+void printPinPWM(int32_t pin) {
   if (pwm_status(pin)) {
     //uint32_t chan = g_APinDescription[pin].ulPWMChannel TODO when fast pwm is operative;
     //SERIAL_ECHOPGM("PWM = ", duty);

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -129,7 +129,7 @@
  * TODO: review this to return 1 for pins that are not analog input
  */
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) (p)
+  #define analogInputToDigitalPin(p) pin_t(p)
 #endif
 
 //

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -115,16 +115,16 @@ const XrefInfo pin_xref[] PROGMEM = {
   #define NUM_ANALOG_LAST ((NUM_ANALOG_FIRST) + (NUM_ANALOG_INPUTS) - 1)
 #endif
 #define NUMBER_PINS_TOTAL ((NUM_DIGITAL_PINS) + TERN0(HAS_HIGH_ANALOG_PINS, NUM_ANALOG_INPUTS))
-#define VALID_PIN(P) (WITHIN(P, 0, (NUM_DIGITAL_PINS) - 1) || TERN0(HAS_HIGH_ANALOG_PINS, WITHIN(P, NUM_ANALOG_FIRST, NUM_ANALOG_LAST)))
+#define isValidPin(P) (WITHIN(P, 0, (NUM_DIGITAL_PINS) - 1) || TERN0(HAS_HIGH_ANALOG_PINS, WITHIN(P, NUM_ANALOG_FIRST, NUM_ANALOG_LAST)))
 #define digitalRead_mod(Ard_num) extDigitalRead(Ard_num)  // must use Arduino pin numbers when doing reads
-#define PRINT_PIN(Q)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
-#define DIGITAL_PIN_TO_ANALOG_PIN(ANUM) -1  // will report analog pin number in the print port routine
+#define printPinNumber(Q)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
+#define digitalPinToAnalogIndex(ANUM) -1  // will report analog pin number in the print port routine
 
 // x is a variable used to search pin_array
-#define GET_ARRAY_IS_DIGITAL(x) ((bool) pin_array[x].is_digital)
-#define GET_ARRAY_PIN(x) ((pin_t) pin_array[x].pin)
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define getPinIsDigitalByIndex(x) ((bool) pin_array[x].is_digital)
+#define getPinByIndex(x) ((pin_t) pin_array[x].pin)
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
 #define MULTI_NAME_PAD 33 // space needed to be pretty if not first name assigned to a pin
 
 //
@@ -164,7 +164,7 @@ uint8_t get_pin_mode(const pin_t Ard_num) {
   }
 }
 
-bool GET_PINMODE(const pin_t Ard_num) {
+bool getValidPinMode(const pin_t Ard_num) {
   const uint8_t pin_mode = get_pin_mode(Ard_num);
   return pin_mode == MODE_PIN_OUTPUT || pin_mode == MODE_PIN_ALT;  // assume all alt definitions are PWM
 }
@@ -173,11 +173,11 @@ int8_t digital_pin_to_analog_pin(const pin_t Ard_num) {
   if (WITHIN(Ard_num, NUM_ANALOG_FIRST, NUM_ANALOG_LAST))
     return Ard_num - NUM_ANALOG_FIRST;
 
-  const uint32_t ind = digitalPinToAnalogInput(Ard_num);
+  const uint32_t ind = digitalPinToAnalogIndex(Ard_num);
   return (ind < NUM_ANALOG_INPUTS) ? ind : -1;
 }
 
-bool IS_ANALOG(const pin_t Ard_num) {
+bool isAnalogPin(const pin_t Ard_num) {
   return get_pin_mode(Ard_num) == MODE_PIN_ANALOG;
 }
 
@@ -186,7 +186,7 @@ bool is_digital(const pin_t Ard_num) {
   return pin_mode == MODE_PIN_INPUT || pin_mode == MODE_PIN_OUTPUT;
 }
 
-void print_port(const pin_t Ard_num) {
+void printPinPort(const pin_t Ard_num) {
   char buffer[16];
   pin_t Index;
   for (Index = 0; Index < NUMBER_PINS_TOTAL; Index++)
@@ -226,7 +226,7 @@ bool pwm_status(const pin_t Ard_num) {
   return get_pin_mode(Ard_num) == MODE_PIN_ALT;
 }
 
-void pwm_details(const pin_t Ard_num) {
+void printPinPWM(const pin_t Ard_num) {
   #ifndef STM32F1xx
     if (pwm_status(Ard_num)) {
       uint32_t alt_all = 0;
@@ -285,4 +285,4 @@ void pwm_details(const pin_t Ard_num) {
   #else
     // TODO: F1 doesn't support changing pins function, so we need to check the function of the PIN and if it's enabled
   #endif
-} // pwm_details
+} // printPinPWM

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -158,7 +158,7 @@
  * TODO: review this to return 1 for pins that are not analog input
  */
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) (p)
+  #define analogInputToDigitalPin(p) pin_t(p)
 #endif
 
 #ifndef digitalPinHasPWM

--- a/Marlin/src/HAL/TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.h
@@ -98,7 +98,7 @@ uint32_t __get_PRIMASK(void); // CMSIS
 // ------------------------
 
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) ((p < 12U) ? (p) + 54U : -1)
+  #define analogInputToDigitalPin(p) pin_t((p < 12U) ? (p) + 54U : -1)
 #endif
 
 #define HAL_ADC_VREF_MV   3300

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -103,7 +103,7 @@ typedef int8_t pin_t;
 // ------------------------
 
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) ((p < 12U) ? (p) + 54U : -1)
+  #define analogInputToDigitalPin(p) pin_t((p < 12U) ? (p) + 54U : -1)
 #endif
 
 #define HAL_ADC_VREF_MV   3300

--- a/Marlin/src/HAL/TEENSY35_36/pinsDebug.h
+++ b/Marlin/src/HAL/TEENSY35_36/pinsDebug.h
@@ -53,9 +53,9 @@
   #define TPM1_CH1_PIN 17
 #endif
 
-#define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && (P) <= analogInputToDigitalPin(9)) || ((P) >= analogInputToDigitalPin(12) && (P) <= analogInputToDigitalPin(20))
+#define isAnalogPin(P) ((P) >= analogInputToDigitalPin(0) && (P) <= analogInputToDigitalPin(9)) || ((P) >= analogInputToDigitalPin(12) && (P) <= analogInputToDigitalPin(20))
 
-void print_analog_pin(char buffer[], int8_t pin) {
+void printAnalogPin(char buffer[], int8_t pin) {
   if (pin <= 23)      sprintf_P(buffer, PSTR("(A%2d)  "), int(pin - 14));
   else if (pin <= 39) sprintf_P(buffer, PSTR("(A%2d)  "), int(pin - 19));
 }
@@ -108,4 +108,4 @@ bool pwm_status(int8_t pin) {
   SERIAL_ECHOPGM("  ");
 }
 
-void pwm_details(uint8_t pin) { /* TODO */ }
+void printPinPWM(uint8_t pin) { /* TODO */ }

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -133,7 +133,7 @@ typedef int8_t pin_t;
 // ------------------------
 
 #ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) ((p < 12U) ? (p) + 54U : -1)
+  #define analogInputToDigitalPin(p) pin_t((p < 12U) ? (p) + 54U : -1)
 #endif
 
 #define HAL_ADC_VREF_MV   3300

--- a/Marlin/src/HAL/TEENSY40_41/pinsDebug.h
+++ b/Marlin/src/HAL/TEENSY40_41/pinsDebug.h
@@ -30,16 +30,17 @@
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
 
 #define digitalRead_mod(p) extDigitalRead(p)  // AVR digitalRead disabled PWM before it read the pin
-#define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("%02d"), p); SERIAL_ECHO(buffer); }while(0)
-#define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), DIGITAL_PIN_TO_ANALOG_PIN(pin)); SERIAL_ECHO(buffer); }while(0)
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define GET_ARRAY_IS_DIGITAL(p) pin_array[p].is_digital
-#define VALID_PIN(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
-#define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
-#define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && (P) <= analogInputToDigitalPin(13)) || ((P) >= analogInputToDigitalPin(14) && (P) <= analogInputToDigitalPin(17))
-#define GET_PINMODE(PIN) (VALID_PIN(pin) && IS_OUTPUT(pin))
+#define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
+#define printPinNumber(p) do{ sprintf_P(buffer, PSTR("%02d"), p); SERIAL_ECHO(buffer); }while(0)
+#define printPinAnalog(p) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(pin)); SERIAL_ECHO(buffer); }while(0)
+#define getPinByIndex(p) pin_array[p].pin
+#define getPinIsDigitalByIndex(p) pin_array[p].is_digital
+#define isValidPin(pin) (pin >= 0 && pin < int8_t(NUMBER_PINS_TOTAL))
+#define digitalPinToAnalogIndex(p) int(p - analogInputToDigitalPin(0))
+#define getValidPinMode(PIN) (isValidPin(pin) && IS_OUTPUT(pin))
 #define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
+
+#define isAnalogPin(P) (pin_t(P) >= analogInputToDigitalPin(0) && pin_t(P) <= analogInputToDigitalPin(13)) || (pin_t(P) >= analogInputToDigitalPin(14) && pin_t(P) <= analogInputToDigitalPin(17))
 
 struct pwm_pin_info_struct {
   uint8_t type;    // 0=no pwm, 1=flexpwm, 2=quad
@@ -118,7 +119,7 @@ const struct pwm_pin_info_struct pwm_pin_info[] = {
   #endif
 };
 
-void print_analog_pin(char buffer[], const pin_t pin) {
+void printAnalogPin(char buffer[], const pin_t pin) {
   if (pin <= 23)      sprintf_P(buffer, PSTR("(A%2d)  "), int(pin - 14));
   else if (pin <= 41) sprintf_P(buffer, PSTR("(A%2d)  "), int(pin - 24));
 }
@@ -149,6 +150,6 @@ bool pwm_status(const pin_t pin) {
   return (*(portConfigRegister(pin)) == info->muxval);
 }
 
-void pwm_details(const pin_t) { /* TODO */ }
+void printPinPWM(const pin_t) { /* TODO */ }
 
-void print_port(const pin_t) {}
+void printPinPort(const pin_t) {}

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -318,7 +318,7 @@ bool pin_is_protected(const pin_t pin) {
   for (uint8_t i = 0; i < COUNT(sensitive_dio); ++i)
     if (pin == pgm_read_pin(&sensitive_dio[i])) return true;
   for (uint8_t i = 0; i < COUNT(sensitive_aio); ++i)
-    if (pin == analogInputToDigitalPin(pgm_read_pin(&sensitive_dio[i]))) return true;
+    if (pin == analogInputToDigitalPin(pgm_read_pin(&sensitive_aio[i]))) return true;
   return false;
 }
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -311,6 +311,7 @@ bool wait_for_heatup = false;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
+#pragma GCC diagnostic ignored "-Wsign-compare"
 
 bool pin_is_protected(const pin_t pin) {
   #define pgm_read_pin(P) (sizeof(pin_t) == 2 ? (pin_t)pgm_read_word(P) : (pin_t)pgm_read_byte(P))

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -63,18 +63,18 @@ inline void toggle_pins() {
 
   for (uint8_t i = start; i <= end; ++i) {
     pin_t pin = GET_PIN_MAP_PIN_M43(i);
-    if (!VALID_PIN(pin)) continue;
+    if (!isValidPin(pin)) continue;
     if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) {
-      report_pin_state_extended(pin, ignore_protection, true, F("Untouched "));
+      printPinStateExt(pin, ignore_protection, true, F("Untouched "));
       SERIAL_EOL();
     }
     else {
       hal.watchdog_refresh();
-      report_pin_state_extended(pin, ignore_protection, true, F("Pulsing   "));
+      printPinStateExt(pin, ignore_protection, true, F("Pulsing   "));
       #ifdef __STM32F1__
         const auto prior_mode = _GET_MODE(i);
       #else
-        const bool prior_mode = GET_PINMODE(pin);
+        const bool prior_mode = getValidPinMode(pin);
       #endif
       #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == TEENSY_E2) {
@@ -326,14 +326,14 @@ void GcodeSuite::M43() {
     bool can_watch = false;
     for (uint8_t i = first_pin; i <= last_pin; ++i) {
       pin_t pin = GET_PIN_MAP_PIN_M43(i);
-      if (!VALID_PIN(pin)) continue;
+      if (!isValidPin(pin)) continue;
       if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
       can_watch = true;
       pinMode(pin, INPUT_PULLUP);
       delay(1);
       /*
-      if (IS_ANALOG(pin))
-        pin_state[pin - first_pin] = analogRead(DIGITAL_PIN_TO_ANALOG_PIN(pin)); // int16_t pin_state[...]
+      if (isAnalogPin(pin))
+        pin_state[pin - first_pin] = analogRead(digitalPinToAnalogIndex(pin)); // int16_t pin_state[...]
       else
       //*/
         pin_state[i - first_pin] = extDigitalRead(pin);
@@ -369,17 +369,17 @@ void GcodeSuite::M43() {
     for (;;) {
       for (uint8_t i = first_pin; i <= last_pin; ++i) {
         const pin_t pin = GET_PIN_MAP_PIN_M43(i);
-        if (!VALID_PIN(pin)) continue;
+        if (!isValidPin(pin)) continue;
         if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
         const byte val =
           /*
-          IS_ANALOG(pin)
-            ? analogRead(DIGITAL_PIN_TO_ANALOG_PIN(pin)) : // int16_t val
+          isAnalogPin(pin)
+            ? analogRead(digitalPinToAnalogIndex(pin)) : // int16_t val
             :
           //*/
             extDigitalRead(pin);
         if (val != pin_state[i - first_pin]) {
-          report_pin_state_extended(pin, ignore_protection, true);
+          printPinStateExt(pin, ignore_protection, true);
           pin_state[i - first_pin] = val;
         }
       }
@@ -398,7 +398,7 @@ void GcodeSuite::M43() {
     // Report current state of selected pin(s)
     for (uint8_t i = first_pin; i <= last_pin; ++i) {
       const pin_t pin = GET_PIN_MAP_PIN_M43(i);
-      if (VALID_PIN(pin)) report_pin_state_extended(pin, ignore_protection, true);
+      if (isValidPin(pin)) printPinStateExt(pin, ignore_protection, true);
     }
   }
 }

--- a/buildroot/share/PlatformIO/variants/MARLIN_ARCHIM/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_ARCHIM/variant.h
@@ -58,7 +58,7 @@ extern "C"{
 #define PINS_COUNT           79
 #define NUM_DIGITAL_PINS     66
 #define NUM_ANALOG_INPUTS    12
-#define analogInputToDigitalPin(p)  ((p < 12) ? (p) + 54 : -1)
+#define analogInputToDigitalPin(p)  pin_t((p < 12) ? (p) + 54 : -1)
 
 #define digitalPinToPort(P)        ( g_APinDescription[P].pPort )
 #define digitalPinToBitMask(P)     ( g_APinDescription[P].ulPin )

--- a/buildroot/share/PlatformIO/variants/MARLIN_MEGA_EXTENDED/pins_arduino.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_MEGA_EXTENDED/pins_arduino.h
@@ -27,7 +27,7 @@
 
 #define NUM_DIGITAL_PINS            86
 #define NUM_ANALOG_INPUTS           16
-#define analogInputToDigitalPin(p)  ((p < 16) ? (p) + 54 : -1)
+#define analogInputToDigitalPin(p)  pin_t((p < 16) ? (p) + 54 : -1)
 #define digitalPinHasPWM(p)         (((p) >= 2 && (p) <= 13) || ((p) >= 44 && (p)<= 46))
 
 #define PIN_SPI_SS    (53)


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/pull/27219  most 32bit boards give a compiler warning

```
Marlin/src/MarlinCore.cpp:320:13: warning: comparison of integer expressions of different signedness: 'const pin_t' {aka 'const long int'} and 'uint32_t' {aka 'long unsigned int'} [-Wsign-compare]
  320 |     if (pin == analogInputToDigitalPin(pgm_read_pin(&sensitive_dio[i]))) return true;

```

Since this function is already using #pragma GCC diagnostic ignored "-Wnarrowing"
I added #pragma GCC diagnostic ignored "-Wsign-compare"
To just silence the warning.

### Requirements

Any 32 bit controller

### Benefits

warning removed.

### Related Issues

<li>MarlinFirmware/Marlin/issues/27258