### PR TITLE
Fix minor RGB_LED Pin typos in pins_MKS_BASE_14.h

### DIFF
--- a/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
@@ -43,10 +43,10 @@
 #ifndef RGB_LED_R_PIN
   #define RGB_LED_R_PIN                       50
 #endif
-#ifndef RGB_LED_R_PIN
+#ifndef RGB_LED_G_PIN
   #define RGB_LED_G_PIN                       51
 #endif
-#ifndef RGB_LED_R_PIN
+#ifndef RGB_LED_B_PIN
   #define RGB_LED_B_PIN                       52
 #endif
 


### PR DESCRIPTION
### Description

While looking at something else I noticed two typo's in Marlin/src/pins/ramps/pins_MKS_BASE_14.h

Corrected the typos

### Requirements

MKS_BASE_14 + RGB_LED_G_PIN or RGB_LED_B_PIN

### Benefits

RGB_LED_G and RGB_LED_B work.
