### PR TITLE
Simplify endstops.h

### DIFF
--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -34,8 +34,8 @@
 #define _ES_ITEM(N) , N
 #define ES_ITEM(K,N) TERN(K,_ES_ITEM,_IF_1_ELSE)(N)
 
-#define _ESN_ITEM(K,A,M) ES_ITEM(K,ES_ENUM(A,M))
-#define ES_MINMAX(A) ES_ITEM(HAS_##A##_MIN_STATE, ES_ENUM(A,MIN)) ES_ITEM(HAS_##A##_MAX_STATE, ES_ENUM(A,MAX))
+#define ESN_ITEM(K,M) ES_ITEM(HAS_##K##_MIN_STATE,K##_ENDSTOP = TERN(M##_HOME_TO_MAX, K##_MAX, K##_MIN))
+#define ES_MINMAX(A) ES_ITEM(HAS_##A##_MIN_STATE,ES_ENUM(A,MIN)) ES_ITEM(HAS_##A##_MAX_STATE,ES_ENUM(A,MAX))
 
 #define HAS_CURRENT_HOME(N) ((N##_CURRENT_HOME > 0) && (N##_CURRENT_HOME != N##_CURRENT))
 
@@ -72,8 +72,8 @@ enum EndstopEnum : int8_t {
   ES_ITEM(HAS_CALIBRATION_STATE, CALIBRATION)
 
   // Bed Probe state is distinct or shared with Z_MIN (i.e., when the probe is the only Z endstop)
-  #if HAS_Z_PROBE_STATE && USE_Z_MIN_PROBE
-    , Z_MIN_PROBE
+  #if USE_Z_MIN_PROBE
+    ES_ITEM(HAS_Z_PROBE_STATE, Z_MIN_PROBE)
   #endif
 
   // The total number of distinct states
@@ -83,56 +83,29 @@ enum EndstopEnum : int8_t {
   #if HAS_Z_PROBE_STATE && !USE_Z_MIN_PROBE
     , Z_MIN_PROBE = Z_MIN
   #endif
-
-  #if HAS_X_STATE
-    , X_ENDSTOP = TERN(X_HOME_TO_MAX, X_MAX, X_MIN)
-  #endif
-  #if HAS_X2_STATE
-    , X2_ENDSTOP = TERN(X_HOME_TO_MAX, X2_MAX, X2_MIN)
-  #endif
-  #if HAS_Y_STATE
-    , Y_ENDSTOP = TERN(Y_HOME_TO_MAX, Y_MAX, Y_MIN)
-  #endif
-  #if HAS_Y2_STATE
-    , Y2_ENDSTOP = TERN(Y_HOME_TO_MAX, Y2_MAX, Y2_MIN)
-  #endif
+  ESN_ITEM(X, X)
+  ESN_ITEM(X2, X)
+  ESN_ITEM(Y, Y)
+  ESN_ITEM(Y2, Y)
   #if HOMING_Z_WITH_PROBE
     , Z_ENDSTOP = Z_MIN_PROBE // "Z" endstop alias when homing with the probe
   #elif HAS_Z_STATE
-    , Z_ENDSTOP = TERN(Z_HOME_TO_MAX, Z_MAX, Z_MIN)
+    ESN_ITEM(Z, Z)
   #endif
-  #if HAS_Z2_STATE
-    , Z2_ENDSTOP = TERN(Z_HOME_TO_MAX, Z2_MAX, Z2_MIN)
-  #endif
-  #if HAS_Z3_STATE
-    , Z3_ENDSTOP = TERN(Z_HOME_TO_MAX, Z3_MAX, Z3_MIN)
-  #endif
-  #if HAS_Z4_STATE
-    , Z4_ENDSTOP = TERN(Z_HOME_TO_MAX, Z4_MAX, Z4_MIN)
-  #endif
-  #if HAS_I_STATE
-    , I_ENDSTOP = TERN(I_HOME_TO_MAX, I_MAX, I_MIN)
-  #endif
-  #if HAS_J_STATE
-    , J_ENDSTOP = TERN(J_HOME_TO_MAX, J_MAX, J_MIN)
-  #endif
-  #if HAS_K_STATE
-    , K_ENDSTOP = TERN(K_HOME_TO_MAX, K_MAX, K_MIN)
-  #endif
-  #if HAS_U_STATE
-    , U_ENDSTOP = TERN(U_HOME_TO_MAX, U_MAX, U_MIN)
-  #endif
-  #if HAS_V_STATE
-    , V_ENDSTOP = TERN(V_HOME_TO_MAX, V_MAX, V_MIN)
-  #endif
-  #if HAS_W_STATE
-    , W_ENDSTOP = TERN(W_HOME_TO_MAX, W_MAX, W_MIN)
-  #endif
+  ESN_ITEM(Z2, Z)
+  ESN_ITEM(Z3, Z)
+  ESN_ITEM(Z4, Z)
+  ESN_ITEM(I, I)
+  ESN_ITEM(J, J)
+  ESN_ITEM(K, K)
+  ESN_ITEM(U, U)
+  ESN_ITEM(V, V)
+  ESN_ITEM(W, W)
 };
 
 #undef _ES_ITEM
 #undef ES_ITEM
-#undef _ESN_ITEM
+#undef ESN_ITEM
 #undef ES_MINMAX
 
 class Endstops {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
My attempt to utilize unused macro `_ESN_ITEM` and simplify `enum EndstopEnum`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
