### PR TITLE
fix _MAX warning in stepper.h

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -299,7 +299,7 @@ class Stepper {
     // and avoid the most unreasonably slow step rates.
     static constexpr uint32_t minimal_step_rate = (
       #ifdef CPU_32_BIT
-        _MAX((STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX, 1U) // 32-bit shouldn't go below 1
+        _MAX((uint32_t(STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX), 1U) // 32-bit shouldn't go below 1
       #else
         (F_CPU) / 500000U   // AVR shouldn't go below 32 (16MHz) or 40 (20MHz)
       #endif


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/26881 added a _MAX comparision between and int and a unsigned int

resulting in a warning that gets repeated a number of times 

```CPP
Marlin\src\module\../inc/../core/macros.h: In instantiation of 'constexpr decltype ((lhs + rhs)) _MAX(L, R) [with L = int; R = unsigned int; decltype ((lhs + rhs)) = unsigned int]':
Marlin\src\module\stepper.h:302:13:   required from here
Marlin\src\module\../inc/../core/macros.h:395:20: warning: comparison of integer expressions of different signedness: 'const int' and 'const unsigned int' [-Wsign-compare]
  395 |         return lhs > rhs ? lhs : rhs;
```

The line that triggers this is in stepper.h

`_MAX((STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX, 1U) // 32-bit shouldn't go below 1
`

since (STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX is never negative, tell the compiler this

```DIFF
diff --git a/Marlin/src/module/stepper.h b/Marlin/src/module/stepper.h
index 2a171bebd0..c24953c24e 100644
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -299,7 +299,7 @@ class Stepper {
     // and avoid the most unreasonably slow step rates.
     static constexpr uint32_t minimal_step_rate = (
       #ifdef CPU_32_BIT
-        _MAX((STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX, 1U) // 32-bit shouldn't go below 1
+        _MAX((uint32_t(STEPPER_TIMER_RATE) / HAL_TIMER_TYPE_MAX), 1U) // 32-bit shouldn't go below 1
       #else
         (F_CPU) / 500000U   // AVR shouldn't go below 32 (16MHz) or 40 (20MHz)
       #endif

```

This PR implements this 

### Requirements

Marlin with 26881

### Benefits

Users don't panic over trivial warnings.
 
### Configurations

https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Creality/Ender-3%20V2/CrealityV422/CrealityUI

### Related Issues

<li>MarlinFirmware/Marlin/issues/27271
