### PR TITLE
Fan speed offset (In Work)  

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2722,6 +2722,21 @@
  */
 //#define EXTRA_FAN_SPEED
 
+/**
+ * Fan speed offset
+ * Adds a constant value to fan_speed, to increase/decrease  for the totality of your print.
+ * Can modify the fan speed permanently and proportionnaly , whatever the many fan speed changes
+ * Threshold must be used to target the normal fan speed with no effect, when full power or very low value.
+ *   'M106 C <%> : (-100/100) Set the additional speed
+ *   'M106 B <%> : (0/100) Min threshold of fan speed to be affected by(Any speed below this will not be modified)
+ *   'M106 D <%> : (0/100) Max threshold of fan speed addition  (If set on 70%, all higher fan speeds called will not be modified, like full power, will remains full power)
+ */
+//#define FAN_SPEED_OFFSET
+#if ENABLED(FAN_SPEED_OFFSET)
+  #define FAN_SPEED_OFFSET_MIN_THR   20 // '%'
+  #define FAN_SPEED_OFFSET_MAX_THR   70 // '%'
+#endif
+
 // @section gcode
 
 /**

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -47,6 +47,9 @@
 /**
  * M106: Set Fan Speed
  *
+ *  B<int>   Min threshold of constant addition
+ *  D<int>   Max threshold of constant addition
+ *  C<int>   Constant value for permanent modification during printing
  *  I<index> Material Preset index (if material presets are defined)
  *  S<int>   Speed between 0-255
  *  P<index> Fan index, if more than one fan
@@ -62,6 +65,14 @@ void GcodeSuite::M106() {
   const uint8_t pfan = parser.byteval('P', _ALT_P);
   if (pfan >= _CNT_P) return;
   if (FAN_IS_REDUNDANT(pfan)) return;
+
+  #if ENABLED(FAN_SPEED_OFFSET)
+    bool offsets_cfg = false;
+    if (parser.seenval('B')) {offsets_cfg = true; thermalManager.fan_speed_offset_thr_min[pfan] = (parser.value_ushort() *2.55f);}
+    if (parser.seenval('C')) {offsets_cfg = true; thermalManager.fan_speed_offset[pfan] = parser.value_ushort();}
+    if (parser.seenval('D')) {offsets_cfg = true; thermalManager.fan_speed_offset_thr_max[pfan] = (parser.value_ushort() *2.55f);}
+    if (offsets_cfg) return; // To skip M106 full power
+  #endif
 
   #if ENABLED(EXTRA_FAN_SPEED)
     const uint16_t t = parser.intval('T');
@@ -84,6 +95,15 @@ void GcodeSuite::M106() {
     speed = parser.value_ushort();
 
   TERN_(FOAMCUTTER_XYUV, speed *= 2.55f); // Get command in % of max heat
+
+  #if ENABLED(FAN_SPEED_OFFSET)
+    if ((speed > thermalManager.fan_speed_offset_thr_min[pfan])
+      && (speed < thermalManager.fan_speed_offset_thr_max[pfan])
+      && (thermalManager.fan_speed_offset_thr_min[pfan] < thermalManager.fan_speed_offset_thr_max[pfan])
+      && parser.seenval('S'))//Applied only on M106S.. (while printing, M106/M106A skipped)
+
+      speed += (thermalManager.fan_speed_offset[pfan] * 2.55f);
+  #endif
 
   // Set speed, with constraint
   thermalManager.set_fan_speed(pfan, speed);

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -338,6 +338,12 @@ namespace LanguageNarrow_en {
   LSTR MSG_STORED_FAN_N                   = _UxGT("Stored Fan ~");
   LSTR MSG_EXTRA_FAN_SPEED                = _UxGT("Extra Fan Speed");
   LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Extra Fan Speed ~");
+  LSTR MSG_OFFSET_FAN_SPEED               = _UxGT("Fan speed offs ~");
+  LSTR MSG_OFFSET_MIN_FAN_SPEED           = _UxGT("Fan offs min ~");
+  LSTR MSG_OFFSET_MAX_FAN_SPEED           = _UxGT("Fan offs max ~");
+  LSTR MSG_OFFSET_FAN_SPEED_N             = _UxGT("Fan speed offs ~");
+  LSTR MSG_OFFSET_MIN_FAN_SPEED_N         = _UxGT("Fan offs min ~");
+  LSTR MSG_OFFSET_MAX_FAN_SPEED_N         = _UxGT("Fan offs max ~");
   LSTR MSG_CONTROLLER_FAN                 = _UxGT("Controller Fan");
   LSTR MSG_CONTROLLER_FAN_IDLE_SPEED      = _UxGT("Idle Speed");
   LSTR MSG_CONTROLLER_FAN_AUTO_ON         = _UxGT("Auto Mode");

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -245,6 +245,12 @@ namespace LanguageNarrow_fr {
   LSTR MSG_STORED_FAN_N                   = _UxGT("Vit.  enreg.  ~");
   LSTR MSG_EXTRA_FAN_SPEED                = _UxGT("Extra ventil.  ");
   LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Extra ventil. ~");
+  LSTR MSG_OFFSET_FAN_SPEED               = _UxGT("Ventil. sup ~");
+  LSTR MSG_OFFSET_MIN_FAN_SPEED           = _UxGT("Seuil min ~");
+  LSTR MSG_OFFSET_MAX_FAN_SPEED           = _UxGT("Seuil max ~");
+  LSTR MSG_OFFSET_FAN_SPEED_N             = _UxGT("Ventil. sup ~");
+  LSTR MSG_OFFSET_MIN_FAN_SPEED_N         = _UxGT("Seuil min ~");
+  LSTR MSG_OFFSET_MAX_FAN_SPEED_N         = _UxGT("Seuil max ~");
 
   LSTR MSG_FLOW                           = _UxGT("Flux");
   LSTR MSG_FLOW_N                         = _UxGT("Flux ~");

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -578,18 +578,37 @@ class MenuItem_bool : public MenuEditItemBase {
     #define EDIT_EXTRA_FAN_SPEED(...)
   #endif
 
-  #if FAN_COUNT == 1
-    #define MSG_FIRST_FAN_SPEED       MSG_FAN_SPEED
-    #define MSG_EXTRA_FIRST_FAN_SPEED MSG_EXTRA_FAN_SPEED
+  #if ENABLED(FAN_SPEED_OFFSET)
+    #define EDIT_OFFSET_FAN_SPEED(V...)     EDIT_ITEM_FAST_N(V)
+    #define EDIT_OFFSET_MIN_FAN_SPEED(V...) EDIT_ITEM_FAST_N(V)
+    #define EDIT_OFFSET_MAX_FAN_SPEED(V...) EDIT_ITEM_FAST_N(V)
   #else
-    #define MSG_FIRST_FAN_SPEED       MSG_FAN_SPEED_N
-    #define MSG_EXTRA_FIRST_FAN_SPEED MSG_EXTRA_FAN_SPEED_N
+    #define EDIT_OFFSET_FAN_SPEED(...)
+    #define EDIT_OFFSET_MIN_FAN_SPEED(...)
+    #define EDIT_OFFSET_MAX_FAN_SPEED(...)
+  #endif
+
+  #if FAN_COUNT == 1
+    #define MSG_FIRST_FAN_SPEED             MSG_FAN_SPEED
+    #define MSG_EXTRA_FIRST_FAN_SPEED       MSG_EXTRA_FAN_SPEED
+    #define MSG_OFFSET_FIRST_FAN_SPEED      MSG_OFFSET_FAN_SPEED
+    #define MSG_OFFSET_MIN_FIRST_FAN_SPEED  MSG_OFFSET_MIN_FAN_SPEED
+    #define MSG_OFFSET_MAX_FIRST_FAN_SPEED  MSG_OFFSET_MAX_FAN_SPEED
+  #else
+    #define MSG_FIRST_FAN_SPEED             MSG_FAN_SPEED_N
+    #define MSG_EXTRA_FIRST_FAN_SPEED       MSG_EXTRA_FAN_SPEED_N
+    #define MSG_OFFSET_FIRST_FAN_SPEED      MSG_OFFSET_FAN_SPEED_N
+    #define MSG_OFFSET_MIN_FIRST_FAN_SPEED  MSG_OFFSET_MIN_FAN_SPEED_N
+    #define MSG_OFFSET_MAX_FIRST_FAN_SPEED  MSG_OFFSET_MAX_FAN_SPEED_N
   #endif
 
   #define _FAN_EDIT_ITEMS(F,L) do{ \
     editable.uint8 = thermalManager.fan_speed[F]; \
     EDIT_ITEM_FAST_N(percent, F, MSG_##L, &editable.uint8, 0, 255, on_fan_update); \
     EDIT_EXTRA_FAN_SPEED(percent, F, MSG_EXTRA_##L, &thermalManager.extra_fan_speed[F].speed, 3, 255); \
+    EDIT_OFFSET_FAN_SPEED(int3, F, MSG_OFFSET_##L, &thermalManager.fan_speed_offset[F], -100, 100); \
+    EDIT_OFFSET_MIN_FAN_SPEED(percent, F, MSG_OFFSET_MIN_##L, &thermalManager.fan_speed_offset_thr_min[F], 0, 255); \
+    EDIT_OFFSET_MAX_FAN_SPEED(percent, F, MSG_OFFSET_MAX_##L, &thermalManager.fan_speed_offset_thr_max[F], 0, 255); \
   }while(0)
 
   #if FAN_COUNT > 1

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -912,6 +912,12 @@ class Temperature {
         static void set_temp_fan_speed(const uint8_t fan, const uint16_t command_or_speed);
       #endif
 
+      #if ENABLED(FAN_SPEED_OFFSET)
+        int16_t fan_speed_offset[FAN_COUNT] = {0};
+        uint8_t fan_speed_offset_thr_min[FAN_COUNT] = {uint8_t(FAN_SPEED_OFFSET_MIN_THR * 2.55f)};
+        uint8_t fan_speed_offset_thr_max[FAN_COUNT] = {uint8_t(FAN_SPEED_OFFSET_MAX_THR * 2.55f)};
+      #endif
+
       #if ANY(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
         void set_fans_paused(const bool p);
       #endif


### PR DESCRIPTION
Add an offset to fan_speed. 
When printing is started, the fan_speed cannot be modified, each special feature of the object will change the fan speed and always resume it to the slicer value.
Now it's possible !  
Threshold min and max help targetting the 'normal fan speed ', full power or any special speed are ignored.
Each time M106 Sxxx appears , the offset is applyed. Perfect to increase or decrease fan speed during all the printing process.
For Devs:
This code, need  better translation, if you have time for it.
Thanks to help