### PR TITLE
remove LCD_PINS_EN from LCD_I2C_PANELOLU2

### DIFF
--- a/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
+++ b/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
@@ -604,7 +604,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                        41
-      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
+++ b/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
@@ -604,7 +604,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                        41
-      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
+++ b/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
@@ -604,6 +604,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                        41
+      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -742,7 +742,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN               EXP2_08_PIN
-      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -742,6 +742,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN               EXP2_08_PIN
+      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -742,7 +742,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN               EXP2_08_PIN
-      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -430,7 +430,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS               EXP2_04_PIN
       //#define KILL_PIN                      41
-      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -430,6 +430,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS               EXP2_04_PIN
       //#define KILL_PIN                      41
+      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -430,7 +430,7 @@
       #define BTN_ENC                         32
       #define LCD_SDSS               EXP2_04_PIN
       //#define KILL_PIN                      41
-      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -361,7 +361,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -361,7 +361,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -361,6 +361,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
+      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -413,6 +413,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
+      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -413,7 +413,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -413,7 +413,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -308,7 +308,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -308,6 +308,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
+      //#undef LCD_PINS_EN                        // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_MINITRONICS20.h
+++ b/Marlin/src/pins/samd/pins_MINITRONICS20.h
@@ -308,7 +308,7 @@
       //#define BTN_ENC                       32
       //#define LCD_SDSS                    SDSS
       //#define KILL_PIN             EXP1_01_PIN
-      //#undef LCD_PINS_EN                        // not used, causes inaccurate pin conflict
+      //#undef LCD_PINS_EN                        // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_RAMPS_144.h
+++ b/Marlin/src/pins/samd/pins_RAMPS_144.h
@@ -564,6 +564,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                   AUX4_07
+      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_RAMPS_144.h
+++ b/Marlin/src/pins/samd/pins_RAMPS_144.h
@@ -564,7 +564,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                   AUX4_07
-      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/samd/pins_RAMPS_144.h
+++ b/Marlin/src/pins/samd/pins_RAMPS_144.h
@@ -564,7 +564,7 @@
       #define BTN_ENC                    AUX4_03
       #define LCD_SDSS                      SDSS
       #define KILL_PIN                   AUX4_07
-      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -263,7 +263,7 @@
     #else
       #define BTN_ENC                    AUX1_07
     #endif
-    #undef LCD_PINS_EN                            // not used, causes inaccurate pin conflict
+    #undef LCD_PINS_EN                            // not used, causes false pin conflict report
 
   #else // !LCD_FOR_MELZI && !ZONESTAR_LCD && !LCD_I2C_PANELOLU2
 

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -263,7 +263,7 @@
     #else
       #define BTN_ENC                    AUX1_07
     #endif
-    #undef LCD_PINS_EN                            // not used, casuses inaccurate pin conflict
+    #undef LCD_PINS_EN                            // not used, causes inaccurate pin conflict
 
   #else // !LCD_FOR_MELZI && !ZONESTAR_LCD && !LCD_I2C_PANELOLU2
 

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -263,6 +263,7 @@
     #else
       #define BTN_ENC                    AUX1_07
     #endif
+    #undef LCD_PINS_EN                            // not used, casuses inaccurate pin conflict
 
   #else // !LCD_FOR_MELZI && !ZONESTAR_LCD && !LCD_I2C_PANELOLU2
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D.h
@@ -161,7 +161,7 @@
       #define LCD_SDSS                      PD5   // 53
       #define SD_DETECT_PIN                 -1
       #define KILL_PIN                      PC9   // 41
-      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes false pin conflict report
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D.h
@@ -161,6 +161,7 @@
       #define LCD_SDSS                      PD5   // 53
       #define SD_DETECT_PIN                 -1
       #define KILL_PIN                      PC9   // 41
+      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D.h
@@ -161,7 +161,7 @@
       #define LCD_SDSS                      PD5   // 53
       #define SD_DETECT_PIN                 -1
       #define KILL_PIN                      PC9   // 41
-      #undef LCD_PINS_EN                          // not used, casuses inaccurate pin conflict
+      #undef LCD_PINS_EN                          // not used, causes inaccurate pin conflict
 
     #elif ENABLED(LCD_I2C_VIKI)
 

--- a/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
+++ b/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
@@ -160,7 +160,7 @@
     #define BTN_ENC                           41  // F3       JP2-4
 
     #define SDSS                              38  // F0       B-THERM connector - use SD card on Panelolu2
-    #undef LCD_PINS_EN                            // not used, causes inaccurate pin conflict
+    #undef LCD_PINS_EN                            // not used, causes false pin conflict report
 
   #else
 

--- a/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
+++ b/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
@@ -160,7 +160,7 @@
     #define BTN_ENC                           41  // F3       JP2-4
 
     #define SDSS                              38  // F0       B-THERM connector - use SD card on Panelolu2
-    #undef LCD_PINS_EN                            // not used, casuses inaccurate pin conflict
+    #undef LCD_PINS_EN                            // not used, causes inaccurate pin conflict
 
   #else
 

--- a/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
+++ b/Marlin/src/pins/teensy2/pins_PRINTRBOARD.h
@@ -160,6 +160,7 @@
     #define BTN_ENC                           41  // F3       JP2-4
 
     #define SDSS                              38  // F0       B-THERM connector - use SD card on Panelolu2
+    #undef LCD_PINS_EN                            // not used, casuses inaccurate pin conflict
 
   #else
 


### PR DESCRIPTION
### Description

LCD_I2C_PANELOLU2 on RAMPS type boards caused a false trigger of pin conflicts. When trying to use UART 2
LCD_PINS_EN is defined as pin 17 (RX2) but this pin is not used on this display

I have removed the LCD_PINS_EN defines from LCD_I2C_PANELOLU2 pin setup.

### Requirements

Eg only
RAMPS + LCD_I2C_PANELOLU2 + SERIAL_PORT_2 2

### Benefits

Works as expected

### Configurations

See 2.1.2.4 eg https://github.com/user-attachments/files/16255517/Config.zip

### Related Issues
<li>MarlinFirmware/Marlin/issues/27278