### PR TITLE
update incorrect endif comment 

### DIFF
--- a/Marlin/src/HAL/shared/eeprom_if_spi.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_spi.cpp
@@ -81,4 +81,4 @@ void eeprom_write_byte(uint8_t *pos, uint8_t value) {
 }
 
 #endif // USE_SHARED_EEPROM
-#endif // I2C_EEPROM
+#endif // SPI_EEPROM


### PR DESCRIPTION
### Description

Fix an insignificant comment cut and paste error.

endif comment in Marlin/src/HAL/shared/eeprom_if_spi.cpp doesn't match the if, clearly copied from different file.  

### Requirements

Set Pedantic controls to 11

### Benefits

endif comment matches if
