### PR TITLE
👷 Add Simulator CI test

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -43,6 +43,7 @@ jobs:
 
         # Native
         - linux_native
+        - simulator_linux_release
 
         # AVR
         - mega2560
@@ -181,6 +182,13 @@ jobs:
         pip install -U platformio
         pio upgrade --dev
         pio pkg update --global
+
+    - name: Install Simulator dependencies
+      run: |
+        sudo apt-get install build-essential
+        sudo apt-get install libsdl2-dev
+        sudo apt-get install libsdl2-net-dev
+        sudo apt-get install libglm-dev
 
     - name: Run ${{ matrix.test-platform }} Tests
       run: |

--- a/buildroot/tests/simulator_linux_release
+++ b/buildroot/tests/simulator_linux_release
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Build tests for Simulator on Linux
+#
+
+# exit on first failure
+set -e
+
+#
+# Build with the default configurations
+#
+use_example_configs Simulator
+exec_test $1 $2 "Simulator" "$3"
+
+# cleanup
+restore_configs


### PR DESCRIPTION
### Description

Add Simulator config for CI.

### Benefits

Catch potential build issues before PRs are merged.

### Configurations

[Default Simulator configs](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Simulator)
