### PR TITLE
`set_axis_position()` potential unused

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -3153,6 +3153,14 @@ void Planner::set_machine_position_mm(const abce_pos_t &abce) {
   }
 }
 
+/**
+ * Set the machine positions in millimeters (soon) given the native position.
+ * Synchonized with the planner queue.
+ *
+ *   - Modifiers are applied for skew, leveling, retract, etc.
+ *   - Kinematics are applied to remap cartesian positions to stepper positions.
+ *   - The resulting stepper positions are synchronized at the end of the planner queue.
+ */
 void Planner::set_position_mm(const xyze_pos_t &xyze) {
   xyze_pos_t machine = xyze;
   TERN_(HAS_POSITION_MODIFIERS, apply_modifiers(machine, true));
@@ -3169,12 +3177,13 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
 #if HAS_EXTRUDERS
 
   /**
-   * Setters for planner position (also setting stepper position).
+   * Special setter for planner E position (also setting E stepper position).
    */
   void Planner::set_e_position_mm(const_float_t e) {
     const uint8_t axis_index = E_AXIS_N(active_extruder);
     TERN_(DISTINCT_E_FACTORS, last_extruder = active_extruder);
 
+    // Unapply the current retraction before (immediately) setting the planner position
     const float e_new = DIFF_TERN(FWRETRACT, e, fwretract.current_retract[active_extruder]);
     position.e = LROUND(settings.axis_steps_per_mm[axis_index] * e_new);
     TERN_(HAS_POSITION_FLOAT, position_float.e = e_new);
@@ -3186,9 +3195,11 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
       stepper.set_e_position(position.e);
   }
 
-#endif
+#endif // HAS_EXTRUDERS
 
-// Recalculate the steps/s^2 acceleration rates, based on the mm/s^2
+/**
+ * Recalculate steps/s^2 acceleration rates based on mm/s^2 acceleration rates
+ */
 void Planner::refresh_acceleration_rates() {
   uint32_t highest_rate = 1;
   LOOP_DISTINCT_AXES(i) {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -3183,7 +3183,7 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
     if (has_blocks_queued())
       buffer_sync_block(BLOCK_BIT_SYNC_POSITION);
     else
-      stepper.set_axis_position(E_AXIS, position.e);
+      stepper.set_e_axis_position(position.e);
   }
 
 #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -3183,7 +3183,7 @@ void Planner::set_position_mm(const xyze_pos_t &xyze) {
     if (has_blocks_queued())
       buffer_sync_block(BLOCK_BIT_SYNC_POSITION);
     else
-      stepper.set_e_axis_position(position.e);
+      stepper.set_e_position(position.e);
   }
 
 #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3361,40 +3361,40 @@ void Stepper::_set_position(const abce_long_t &spos) {
   #endif
 }
 
+// AVR requires guards to ensure any atomic memory operation greater than 8 bits
+#define ATOMIC_SECTION_START() const bool was_enabled = suspend()
+#define ATOMIC_SECTION_END() if (was_enabled) wake_up()
+#define ATOMIC_SECTION_START_AVR TERN_(__AVR__, ATOMIC_SECTION_START)
+#define ATOMIC_SECTION_END_AVR TERN_(__AVR__, ATOMIC_SECTION_END)
+
 /**
  * Get a stepper's position in steps.
  */
 int32_t Stepper::position(const AxisEnum axis) {
-  #ifdef __AVR__
-    // Protect the access to the position. Only required for AVR, as
-    //  any 32bit CPU offers atomic access to 32bit variables
-    const bool was_enabled = suspend();
-  #endif
-
+  ATOMIC_SECTION_START_AVR();
   const int32_t v = count_position[axis];
-
-  #ifdef __AVR__
-    // Reenable Stepper ISR
-    if (was_enabled) wake_up();
-  #endif
+  ATOMIC_SECTION_END_AVR();
   return v;
 }
 
-// Set the current position in steps
+/**
+ * Set all axis stepper positions in steps
+ */
 void Stepper::set_position(const xyze_long_t &spos) {
   planner.synchronize();
-  const bool was_enabled = suspend();
+  ATOMIC_SECTION_START();
   _set_position(spos);
-  if (was_enabled) wake_up();
+  ATOMIC_SECTION_END();
 }
 
+/**
+ * Set a single axis stepper position in steps
+ */
 void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
   planner.synchronize();
 
-  #ifdef __AVR__
-    // Protect the access to the position. Only required for AVR, as
-    //  any 32bit CPU offers atomic access to 32bit variables
-    const bool was_enabled = suspend();
+  #if ANY(__AVR__, INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z)
+    ATOMIC_SECTION_START();
   #endif
 
   count_position[a] = v;
@@ -3402,9 +3402,8 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
   TERN_(INPUT_SHAPING_Y, if (a == Y_AXIS) shaping_y.last_block_end_pos = v);
   TERN_(INPUT_SHAPING_Z, if (a == Z_AXIS) shaping_z.last_block_end_pos = v);
 
-  #ifdef __AVR__
-    // Reenable Stepper ISR
-    if (was_enabled) wake_up();
+  #if ANY(__AVR__, INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z)
+    ATOMIC_SECTION_END();
   #endif
 }
 
@@ -3413,18 +3412,9 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
   void Stepper::set_e_position(const int32_t &v) {
     planner.synchronize();
 
-    #ifdef __AVR__
-      // Protect the access to the position. Only required for AVR, as
-      //  any 32bit CPU offers atomic access to 32bit variables
-      const bool was_enabled = suspend();
-    #endif
-
+    ATOMIC_SECTION_START_AVR();
     count_position.e = v;
-
-    #ifdef __AVR__
-      // Reenable Stepper ISR
-      if (was_enabled) wake_up();
-    #endif
+    ATOMIC_SECTION_END_AVR();
   }
 
 #endif // HAS_EXTRUDERS
@@ -3434,32 +3424,25 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
   void Stepper::ftMotion_syncPosition() {
     //planner.synchronize(); planner already synchronized in M493
 
-    #ifdef __AVR__
-      // Protect the access to the position. Only required for AVR, as
-      //  any 32bit CPU offers atomic access to 32bit variables
-      const bool was_enabled = suspend();
-    #endif
-
     // Update stepper positions from the planner
+    ATOMIC_SECTION_START_AVR();
     count_position = planner.position;
-
-    #ifdef __AVR__
-      // Reenable Stepper ISR
-      if (was_enabled) wake_up();
-    #endif
+    ATOMIC_SECTION_END_AVR();
   }
 
 #endif // FT_MOTION
 
-// Signal endstops were triggered - This function can be called from
-// an ISR context  (Temperature, Stepper or limits ISR), so we must
-// be very careful here. If the interrupt being preempted was the
-// Stepper ISR (this CAN happen with the endstop limits ISR) then
-// when the stepper ISR resumes, we must be very sure that the movement
-// is properly canceled
+/**
+ * Record stepper positions and discard the rest of the current block
+ *
+ * WARNING! This function may be called from ISR context!
+ * If the Stepper ISR is preempted (e.g., by the endstop ISR) we
+ * must ensure the move is properly canceled before the ISR resumes.
+ */
 void Stepper::endstop_triggered(const AxisEnum axis) {
 
-  const bool was_enabled = suspend();
+  ATOMIC_SECTION_START();   // Suspend the Stepper ISR on all platforms
+
   endstops_trigsteps[axis] = (
     #if IS_CORE
       (axis == CORE_AXIS_2
@@ -3482,23 +3465,14 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
   // Discard the rest of the move if there is a current block
   quick_stop();
 
-  if (was_enabled) wake_up();
+  ATOMIC_SECTION_END();     // Suspend the Stepper ISR on all platforms
 }
 
+// Return the "triggered" position for an axis (that hit an endstop)
 int32_t Stepper::triggered_position(const AxisEnum axis) {
-  #ifdef __AVR__
-    // Protect the access to the position. Only required for AVR, as
-    //  any 32bit CPU offers atomic access to 32bit variables
-    const bool was_enabled = suspend();
-  #endif
-
+  ATOMIC_SECTION_START_AVR();
   const int32_t v = endstops_trigsteps[axis];
-
-  #ifdef __AVR__
-    // Reenable Stepper ISR
-    if (was_enabled) wake_up();
-  #endif
-
+  ATOMIC_SECTION_END_AVR();
   return v;
 }
 
@@ -3527,18 +3501,9 @@ void Stepper::report_a_position(const xyz_long_t &pos) {
 }
 
 void Stepper::report_positions() {
-
-  #ifdef __AVR__
-    // Protect the access to the position.
-    const bool was_enabled = suspend();
-  #endif
-
+  ATOMIC_SECTION_START_AVR();
   const xyz_long_t pos = count_position;
-
-  #ifdef __AVR__
-    if (was_enabled) wake_up();
-  #endif
-
+  ATOMIC_SECTION_END_AVR();
   report_a_position(pos);
 }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3364,8 +3364,8 @@ void Stepper::_set_position(const abce_long_t &spos) {
 // AVR requires guards to ensure any atomic memory operation greater than 8 bits
 #define ATOMIC_SECTION_START() const bool was_enabled = suspend()
 #define ATOMIC_SECTION_END() if (was_enabled) wake_up()
-#define ATOMIC_SECTION_START_AVR TERN_(__AVR__, ATOMIC_SECTION_START)
-#define ATOMIC_SECTION_END_AVR TERN_(__AVR__, ATOMIC_SECTION_END)
+#define ATOMIC_SECTION_START_AVR() TERN_(__AVR__, ATOMIC_SECTION_START())
+#define ATOMIC_SECTION_END_AVR() TERN_(__AVR__, ATOMIC_SECTION_END())
 
 /**
  * Get a stepper's position in steps.

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3388,7 +3388,7 @@ void Stepper::set_position(const xyze_long_t &spos) {
   if (was_enabled) wake_up();
 }
 
-void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
+void Stepper::set_e_axis_position(const int32_t &v) {
   planner.synchronize();
 
   #ifdef __AVR__
@@ -3397,10 +3397,7 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
     const bool was_enabled = suspend();
   #endif
 
-  count_position[a] = v;
-  TERN_(INPUT_SHAPING_X, if (a == X_AXIS) shaping_x.last_block_end_pos = v);
-  TERN_(INPUT_SHAPING_Y, if (a == Y_AXIS) shaping_y.last_block_end_pos = v);
-  TERN_(INPUT_SHAPING_Z, if (a == Z_AXIS) shaping_z.last_block_end_pos = v);
+  count_position[E_AXIS] = v;
 
   #ifdef __AVR__
     // Reenable Stepper ISR

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3364,16 +3364,16 @@ void Stepper::_set_position(const abce_long_t &spos) {
 // AVR requires guards to ensure any atomic memory operation greater than 8 bits
 #define ATOMIC_SECTION_START() const bool was_enabled = suspend()
 #define ATOMIC_SECTION_END() if (was_enabled) wake_up()
-#define ATOMIC_SECTION_START_AVR() TERN_(__AVR__, ATOMIC_SECTION_START())
-#define ATOMIC_SECTION_END_AVR() TERN_(__AVR__, ATOMIC_SECTION_END())
+#define AVR_ATOMIC_SECTION_START() TERN_(__AVR__, ATOMIC_SECTION_START())
+#define AVR_ATOMIC_SECTION_END() TERN_(__AVR__, ATOMIC_SECTION_END())
 
 /**
  * Get a stepper's position in steps.
  */
 int32_t Stepper::position(const AxisEnum axis) {
-  ATOMIC_SECTION_START_AVR();
+  AVR_ATOMIC_SECTION_START();
   const int32_t v = count_position[axis];
-  ATOMIC_SECTION_END_AVR();
+  AVR_ATOMIC_SECTION_END();
   return v;
 }
 
@@ -3412,9 +3412,9 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
   void Stepper::set_e_position(const int32_t &v) {
     planner.synchronize();
 
-    ATOMIC_SECTION_START_AVR();
+    AVR_ATOMIC_SECTION_START();
     count_position.e = v;
-    ATOMIC_SECTION_END_AVR();
+    AVR_ATOMIC_SECTION_END();
   }
 
 #endif // HAS_EXTRUDERS
@@ -3425,9 +3425,9 @@ void Stepper::set_axis_position(const AxisEnum a, const int32_t &v) {
     //planner.synchronize(); planner already synchronized in M493
 
     // Update stepper positions from the planner
-    ATOMIC_SECTION_START_AVR();
+    AVR_ATOMIC_SECTION_START();
     count_position = planner.position;
-    ATOMIC_SECTION_END_AVR();
+    AVR_ATOMIC_SECTION_END();
   }
 
 #endif // FT_MOTION
@@ -3470,9 +3470,9 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
 
 // Return the "triggered" position for an axis (that hit an endstop)
 int32_t Stepper::triggered_position(const AxisEnum axis) {
-  ATOMIC_SECTION_START_AVR();
+  AVR_ATOMIC_SECTION_START();
   const int32_t v = endstops_trigsteps[axis];
-  ATOMIC_SECTION_END_AVR();
+  AVR_ATOMIC_SECTION_END();
   return v;
 }
 
@@ -3501,9 +3501,9 @@ void Stepper::report_a_position(const xyz_long_t &pos) {
 }
 
 void Stepper::report_positions() {
-  ATOMIC_SECTION_START_AVR();
+  AVR_ATOMIC_SECTION_START();
   const xyz_long_t pos = count_position;
-  ATOMIC_SECTION_END_AVR();
+  AVR_ATOMIC_SECTION_END();
   report_a_position(pos);
 }
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -538,7 +538,7 @@ class Stepper {
 
     // Set the current position in steps
     static void set_position(const xyze_long_t &spos);
-    static void set_axis_position(const AxisEnum a, const int32_t &v);
+    static void set_e_axis_position(const int32_t &v);
 
     // Report the positions of the steppers, in steps
     static void report_a_position(const xyz_long_t &pos);

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -538,7 +538,12 @@ class Stepper {
 
     // Set the current position in steps
     static void set_position(const xyze_long_t &spos);
-    static void set_e_axis_position(const int32_t &v);
+    static void set_axis_position(const AxisEnum a, const int32_t &v);
+
+    #if HAS_EXTRUDERS
+      // Save a little when E is the only one used
+      static void set_e_position(const int32_t &v);
+    #endif
 
     // Report the positions of the steppers, in steps
     static void report_a_position(const xyz_long_t &pos);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
in **module/stepper.cpp**  
`Stepper::set_axis_position()` true intentions may be underutilized. it appears to be used only once in **planner.cpp** for only `E_AXIS`

So, I removed the call for other Axis' and renamed to `set_e_axis_position` to indicate its actual purpose.

I suppose this may get rid of the functions "future proofing", however, it is beyond me if this function has another use based on the original purpose.

For now, this change suites it for now.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Remove unused code.  
Better understanding of code.
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
