### PR TITLE
add special case for SIMULATED motherboard to mftest

### DIFF
--- a/buildroot/bin/mftest
+++ b/buildroot/bin/mftest
@@ -191,7 +191,11 @@ if ((AUTO_BUILD)); then
       echo "Detected \"$BDESC\" | $MB ($BNUM)."
       [[ $CHOICE > $ECOUNT ]] && { echo "Environment selection out of range." ; exit 1 ; }
     fi
-    TARGET="${ENVS[$CHOICE-1]}"
+    if [[ $MB == 'SIMULATED' ]]; then
+      TARGET="${ENVS[$CHOICE-2]}" # Skip the LINUX_NATIVE environment
+    else
+      TARGET="${ENVS[$CHOICE-1]}"
+    fi
     echo "Selected $TARGET"
   fi
 

--- a/buildroot/bin/mftest
+++ b/buildroot/bin/mftest
@@ -192,8 +192,8 @@ if ((AUTO_BUILD)); then
       [[ $CHOICE > $ECOUNT ]] && { echo "Environment selection out of range." ; exit 1 ; }
     fi
     TARGET="${ENVS[$CHOICE-1]}"
-    if [[ $MB == 'SIMULATED' && $TARGET == 'LINUX_NATIVE' ]]; then
-      TARGET="simulator_linux_release" # Skip the LINUX_NATIVE environment
+    if [[ $MB == 'SIMULATED' && $TARGET == 'linux_native' ]]; then
+      TARGET="simulator_linux_release" # Skip the linux_native environment
     fi
     echo "Selected $TARGET"
   fi

--- a/buildroot/bin/mftest
+++ b/buildroot/bin/mftest
@@ -191,10 +191,9 @@ if ((AUTO_BUILD)); then
       echo "Detected \"$BDESC\" | $MB ($BNUM)."
       [[ $CHOICE > $ECOUNT ]] && { echo "Environment selection out of range." ; exit 1 ; }
     fi
-    if [[ $MB == 'SIMULATED' ]]; then
-      TARGET="${ENVS[$CHOICE-2]}" # Skip the LINUX_NATIVE environment
-    else
-      TARGET="${ENVS[$CHOICE-1]}"
+    TARGET="${ENVS[$CHOICE-1]}"
+    if [[ $MB == 'SIMULATED' && $TARGET == 'LINUX_NATIVE' ]]; then
+      TARGET="simulator_linux_release" # Skip the LINUX_NATIVE environment
     fi
     echo "Selected $TARGET"
   fi


### PR DESCRIPTION
### Description

I attempted to run ./buildroot/bin/build_all_examples 
It failed on the broken examples as expected but it also failed on SIMULATED example config
The issues on linux is the build chooses the first build ENV: but in SIMULATED case it should skip the first env listed.

Added this exception to buildroot/bin/mftest so that build_all_examples can build the SIMULATED example.
 
### Requirements

use mftest on simulated board config

### Benefits

Builds as expected

### Related Issues

