### PR TITLE
Update motion.cpp - `do_z_clearance()`

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -723,9 +723,9 @@ void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*
    *  - Execute the move at the probing (or homing) feedrate
    */
   void do_z_clearance(const_float_t zclear, const bool with_probe/*=true*/, const bool lower_allowed/*=false*/) {
-    UNUSED(with_probe);
+    IF_DISABLED(HAS_BED_PROBE, UNUSED(with_probe);)
     float zdest = zclear;
-    TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest -= probe.offset.z);
+    TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest += probe.offset.z);
     NOMORE(zdest, Z_MAX_POS);
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("do_z_clearance(", zclear, " [", current_position.z, " to ", zdest, "], ", lower_allowed, ")");
     if ((!lower_allowed && zdest < current_position.z) || zdest == current_position.z) return;


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

The issue stems from when homing.

in **motion.cpp** `void do_z_clearance()`:
```diff
-   UNUSED(with_probe);
    float zdest = zclear;
-   TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest -= probe.offset.z);

+   IF_DISABLED(HAS_BED_PROBE, UNUSED(with_probe);)
    float zdest = zclear;
+   TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest += probe.offset.z);
```

We may be able to completely omit
`TERN_(HAS_BED_PROBE, if (with_probe && probe.offset.z < 0) zdest -= probe.offset.z);` instead.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
- If we omit the lines `with_probe`, we get a normal Home Z height (if set @ 5 or 10)
- If not, and just change the +/- logic, then we get 5 or 10 + Z Offset.
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/27294
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
