### PR TITLE
Revert "🔨 Rename BTT SKR V2.0 PIO envs (#27301)"

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -125,7 +125,7 @@ jobs:
         - REMRAM_V1
 
         # STM32H7
-        - BIGTREE_SKR_SE_BX
+        - BTT_SKR_SE_BX
         - STM32H743VI_btt
 
         # STM32F1 (Maple)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -757,9 +757,9 @@
 #elif MB(BTT_SKR_MINI_E3_V3_0_1)
   #include "stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h"  // STM32F4                              env:STM32F401RC_btt env:STM32F401RC_btt_xfer
 #elif MB(BTT_SKR_V2_0_REV_A)
-  #include "stm32f4/pins_BTT_SKR_V2_0_REV_A.h"      // STM32F4                              env:STM32F407VG_btt env:STM32F407VG_btt_USB env:STM32F407VG_btt_USB_debug
+  #include "stm32f4/pins_BTT_SKR_V2_0_REV_A.h"      // STM32F4                              env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug
 #elif MB(BTT_SKR_V2_0_REV_B)
-  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"      // STM32F4                              env:STM32F407VG_btt env:STM32F407VG_btt_USB env:STM32F407VG_btt_USB_debug env:STM32F429VG_btt env:STM32F429VG_btt_USB env:STM32F429VG_btt_USB_debug
+  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"      // STM32F4                              env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug env:BIGTREE_SKR_2_F429 env:BIGTREE_SKR_2_F429_USB env:BIGTREE_SKR_2_F429_USB_debug
 #elif MB(BTT_OCTOPUS_V1_0)
   #include "stm32f4/pins_BTT_OCTOPUS_V1_0.h"        // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive
 #elif MB(BTT_OCTOPUS_V1_1)
@@ -846,9 +846,9 @@
 #elif MB(NUCLEO_F767ZI)
   #include "stm32f7/pins_NUCLEO_F767ZI.h"           // STM32F7                              env:NUCLEO_F767ZI
 #elif MB(BTT_SKR_SE_BX_V2)
-  #include "stm32h7/pins_BTT_SKR_SE_BX_V2.h"        // STM32H7                              env:BIGTREE_SKR_SE_BX
+  #include "stm32h7/pins_BTT_SKR_SE_BX_V2.h"        // STM32H7                              env:BTT_SKR_SE_BX
 #elif MB(BTT_SKR_SE_BX_V3)
-  #include "stm32h7/pins_BTT_SKR_SE_BX_V3.h"        // STM32H7                              env:BIGTREE_SKR_SE_BX
+  #include "stm32h7/pins_BTT_SKR_SE_BX_V3.h"        // STM32H7                              env:BTT_SKR_SE_BX
 #elif MB(BTT_SKR_V3_0)
   #include "stm32h7/pins_BTT_SKR_V3_0.h"            // STM32H7                              env:STM32H743VI_btt env:STM32H723VG_btt
 #elif MB(BTT_SKR_V3_0_EZ)

--- a/buildroot/share/PlatformIO/debugging/launch.json
+++ b/buildroot/share/PlatformIO/debugging/launch.json
@@ -20,7 +20,7 @@
             "showDevDebugOutput": false,
             "configFiles": [ "interface/stlink.cfg", "target/stm32f4x.cfg" ],
             "device": "stlink",
-            "executable": "${workspaceRoot}/.pio/build/STM32F407VG_btt_USB_debug/firmware.elf",
+            "executable": "${workspaceRoot}/.pio/build/BIGTREE_SKR_2_USB_debug/firmware.elf",
             "openOCDLaunchCommands": [ "init", "reset init" ],
             "svdFile": "${env:HOME}/.platformio/platforms/ststm32@12.1.1/misc/svd/STM32F40x.svd",
         },

--- a/buildroot/tests/BTT_SKR_SE_BX
+++ b/buildroot/tests/BTT_SKR_SE_BX
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build tests for BIGTREE_SKR_SE_BX
+# Build tests for BTT_SKR_SE_BX
 #
 
 # exit on first failure

--- a/ini/renamed.ini
+++ b/ini/renamed.ini
@@ -104,24 +104,3 @@ extends = renamed
 
 [env:STM32G0B1VE_btt_xfer]            ;=> STM32G0B1VE_btt
 extends = renamed
-
-[env:BTT_SKR_SE_BX]                   ;=> BIGTREE_SKR_SE_BX
-extends = renamed
-
-[env:BIGTREE_SKR_2]                   ;=> STM32F407VG_btt
-extends = renamed
-
-[env:BIGTREE_SKR_2_USB]               ;=> STM32F407VG_btt_USB
-extends = renamed
-
-[env:BIGTREE_SKR_2_USB_debug]         ;=> STM32F407VG_btt_USB_debug
-extends = renamed
-
-[env:BIGTREE_SKR_2_F429]              ;=> STM32F429VG_btt
-extends = renamed
-
-[env:BIGTREE_SKR_2_F429_USB]          ;=> STM32F429VG_btt_USB
-extends = renamed
-
-[env:BIGTREE_SKR_2_F429_USB_debug]    ;=> STM32F429VG_btt_USB_debug
-extends = renamed

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -231,7 +231,7 @@ board             = marlin_BigTree_BTT002_VET6
 #
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
-[env:STM32F407VG_btt]
+[env:BIGTREE_SKR_2]
 extends                     = stm32_variant
 platform_packages           = ${stm_flash_drive.platform_packages}
 board                       = marlin_STM32F407VGT6_CCM
@@ -248,35 +248,35 @@ upload_protocol             = stlink
 #
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Media Share Support
 #
-[env:STM32F407VG_btt_USB]
-extends           = env:STM32F407VG_btt
-build_flags       = ${env:STM32F407VG_btt.build_flags} -DUSBD_USE_CDC_MSC
-build_unflags     = ${env:STM32F407VG_btt.build_unflags} -DUSBD_USE_CDC
+[env:BIGTREE_SKR_2_USB]
+extends           = env:BIGTREE_SKR_2
+build_flags       = ${env:BIGTREE_SKR_2.build_flags} -DUSBD_USE_CDC_MSC
+build_unflags     = ${env:BIGTREE_SKR_2.build_unflags} -DUSBD_USE_CDC
 
-[env:STM32F407VG_btt_USB_debug]
-extends           = env:STM32F407VG_btt_USB
-build_flags       = ${env:STM32F407VG_btt_USB.build_flags} -O0
-build_unflags     = ${env:STM32F407VG_btt_USB.build_unflags} -Os -NDEBUG
+[env:BIGTREE_SKR_2_USB_debug]
+extends           = env:BIGTREE_SKR_2_USB
+build_flags       = ${env:BIGTREE_SKR_2_USB.build_flags} -O0
+build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
 
 #
-# Bigtreetech SKR V2.0 (STM32F429VGT6 ARM Cortex-M4) with USB Flash Drive Support
+# Bigtreetech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
-[env:STM32F429VG_btt]
-extends                     = env:STM32F407VG_btt
+[env:BIGTREE_SKR_2_F429]
+extends                     = env:BIGTREE_SKR_2
 board                       = marlin_STM32F429VGT6
 
 #
-# BigTreeTech SKR V2.0 (STM32F429VGT6 ARM Cortex-M4) with USB Media Share Support
+# BigTreeTech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Media Share Support
 #
-[env:STM32F429VG_btt_USB]
-extends           = env:STM32F429VG_btt
-build_flags       = ${env:STM32F429VG_btt.build_flags} -DUSBD_USE_CDC_MSC
-build_unflags     = ${env:STM32F429VG_btt.build_unflags} -DUSBD_USE_CDC
+[env:BIGTREE_SKR_2_F429_USB]
+extends           = env:BIGTREE_SKR_2_F429
+build_flags       = ${env:BIGTREE_SKR_2_F429.build_flags} -DUSBD_USE_CDC_MSC
+build_unflags     = ${env:BIGTREE_SKR_2_F429.build_unflags} -DUSBD_USE_CDC
 
-[env:STM32F429VG_btt_USB_debug]
-extends           = env:STM32F429VG_btt_USB
-build_flags       = ${env:STM32F429VG_btt_USB.build_flags} -O0
-build_unflags     = ${env:STM32F429VG_btt_USB.build_unflags} -Os -NDEBUG
+[env:BIGTREE_SKR_2_F429_USB_debug]
+extends           = env:BIGTREE_SKR_2_F429_USB
+build_flags       = ${env:BIGTREE_SKR_2_F429_USB.build_flags} -O0
+build_unflags     = ${env:BIGTREE_SKR_2_F429_USB.build_unflags} -Os -NDEBUG
 
 #
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -22,7 +22,7 @@
 #
 # BigTreeTech SKR SE BX V2.0 / V3.0 (STM32H743IIT6 ARM Cortex-M7)
 #
-[env:BIGTREE_SKR_SE_BX]
+[env:BTT_SKR_SE_BX]
 extends            = stm32_variant
 # framework-arduinoststm32 uses biqu-bx-workaround branch
 platform_packages  = framework-arduinoststm32@https://github.com/thisiskeithb/Arduino_Core_STM32/archive/8b3522051a.zip


### PR DESCRIPTION
### Description

This reverts commit 2f3af438ee39bce9589b87bb8306a915f66e376a / #27301

"🔨 Rename BTT SKR V2.0 PIO envs (#27301)" does not accurately reflect what was actually done to my PR and we also specifically went from BIGTREE => BTT for board names in the past, so those unrelated changes seem backwards.

Even if we were to move everything back to "BIGTREE", it should be their actual name which is "BIGTREETECH".

### Related Issues

- #27301
