### PR TITLE
Replace microns/micrometers (µm) w/ 0.1mm

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2444,7 +2444,7 @@
     #define PTC_PROBE_START   30    // (°C)
     #define PTC_PROBE_RES      5    // (°C)
     #define PTC_PROBE_COUNT   10
-    #define PTC_PROBE_ZOFFS   { 0 } // (µm) Z adjustments per sample
+    #define PTC_PROBE_ZOFFS   { 0 } // (0.1mm) Z adjustments per sample
   #endif
 
   #if ENABLED(PTC_BED)
@@ -2452,7 +2452,7 @@
     #define PTC_BED_START     60    // (°C)
     #define PTC_BED_RES        5    // (°C)
     #define PTC_BED_COUNT     10
-    #define PTC_BED_ZOFFS     { 0 } // (µm) Z adjustments per sample
+    #define PTC_BED_ZOFFS     { 0 } // (0.1mm) Z adjustments per sample
   #endif
 
   #if ENABLED(PTC_HOTEND)
@@ -2460,7 +2460,7 @@
     #define PTC_HOTEND_START 180    // (°C)
     #define PTC_HOTEND_RES     5    // (°C)
     #define PTC_HOTEND_COUNT  20
-    #define PTC_HOTEND_ZOFFS  { 0 } // (µm) Z adjustments per sample
+    #define PTC_HOTEND_ZOFFS  { 0 } // (0.1mm) Z adjustments per sample
   #endif
 
   // G76 options

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -191,7 +191,7 @@ void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const celsius
     return p1.y + (p2.y - p1.y) / (p2.x - p1.x) * (x - p1.x);
   };
 
-  // offset in µm
+  // offset in 0.1mm
   float offset = 0.0f;
 
   #if PTC_LINEAR_EXTRAPOLATION

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -65,13 +65,13 @@ class ProbeTempComp {
 
     static int16_t *sensor_z_offsets[TSI_COUNT];
     #if ENABLED(PTC_PROBE)
-      static int16_t z_offsets_probe[PTC_PROBE_COUNT]; // (µm)
+      static int16_t z_offsets_probe[PTC_PROBE_COUNT];   // (0.1mm)
     #endif
     #if ENABLED(PTC_BED)
-      static int16_t z_offsets_bed[PTC_BED_COUNT];   // (µm)
+      static int16_t z_offsets_bed[PTC_BED_COUNT];       // (0.1mm)
     #endif
     #if ENABLED(PTC_HOTEND)
-      static int16_t z_offsets_hotend[PTC_HOTEND_COUNT];   // (µm)
+      static int16_t z_offsets_hotend[PTC_HOTEND_COUNT]; // (0.1mm)
     #endif
 
     static void reset_index() { calib_idx = 0; };

--- a/Marlin/src/gcode/calibrate/G76_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M871.cpp
@@ -306,7 +306,7 @@
  *
  * With B, P, or E:
  *    I[index] - Index in the array
- *    V[value] - Adjustment in µm
+ *    V[value] - Adjustment in 0.1mm
  */
 void GcodeSuite::M871() {
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
A micron/micometer is 1/1000 of a millimeter, not 1/10.

Correct me if I'm wrong but aren't these values measured in 1/10th of a millimeter, not Microns?

Unless 
The actual unit denotation should be (*dmm*) - decimillimeter, but `0.1mm` or perhaps `1/10mm` makes more sense.


<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
in **Marlin\src\feature\probe_temp_comp.cpp**
I am a bit confused by this, something doesn't add up:
```y
  // offset in µm   -   changed to 0.1mm
  float offset = 0.0f;
...
  // convert offset to mm and apply it
  meas_z -= offset / 1000.0f;
```
if `offset` is 1/10mm, to convert to mm then that would be " * 10 ".
so if this were actually in microns, then dividing by 1000 you get nanometers.
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
