### PR TITLE
📝 Update Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://www.facebook.com/groups/1049718498464482
     about: Please ask and answer questions here.
   - name: 🕹 Marlin on Discord
-    url: https://discord.gg/n5NJ59y
+    url: https://discord.com/servers/marlin-firmware-461605380783472640
     about: Join the Discord server for support and discussion.
   - name: 🔗 Marlin Discussion Forum
     url: https://reprap.org/forum/list.php?415

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -43,7 +43,7 @@ We have a Message Board and a Facebook group where our knowledgable user communi
 
 If chat is more your speed, you can join the MarlinFirmware Discord server:
 
-* Use the link https://discord.gg/n5NJ59y to join up as a General User.
+* Use the link https://discord.com/servers/marlin-firmware-461605380783472640 to join up as a General User.
 * Even though our Discord is pretty active, it may take a while for community members to respond &mdash; please be patient!
 * Use the `#general` channel for general questions or discussion about Marlin.
 * Other channels exist for certain topics or are limited to Patrons. Check the channel list.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Every new HAL opens up a world of hardware. At this time we need HALs for RP2040
 The Issue Queue is reserved for Bug Reports and Feature Requests. Please use the following resources for help with configuration and troubleshooting:
 
 - [Marlin Documentation](https://marlinfw.org) - Official Marlin documentation
-- [Marlin Discord](https://discord.gg/n5NJ59y) - Discuss issues with Marlin users and developers
+- [Marlin Discord](https://discord.com/servers/marlin-firmware-461605380783472640) - Discuss issues with Marlin users and developers
 - Facebook Group ["Marlin Firmware"](https://www.facebook.com/groups/1049718498464482/)
 - RepRap.org [Marlin Forum](https://forums.reprap.org/list.php?415)
 - Facebook Group ["Marlin Firmware for 3D Printers"](https://www.facebook.com/groups/3Dtechtalk/)


### PR DESCRIPTION
### Description

Point to server landing page instead of old invite link.

https://github.com/MarlinFirmware/MarlinDocumentation/commit/04f0c9c452bdf6886404701884ebbba25bb160d0 used a new invite link (https://discord.gg/marlin-firmware-461605380783472640) instead of the server landing page that was posted to Twitter, but I think it's better to point to the landing page so users could read about the server before actually joining.