### PR TITLE
update SanityCheck, AZTEEG_X3_PRO does not need DIGIPOTS_I2C_SDA_*

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3578,7 +3578,7 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
 #if HAS_MOTOR_CURRENT_I2C
   #if ALL(DIGIPOT_MCP4018, DIGIPOT_MCP4451)
     #error "Enable only one of DIGIPOT_MCP4018 or DIGIPOT_MCP4451."
-  #elif !MB(MKS_SBASE, AZTEEG_X5_GT, AZTEEG_X5_MINI, AZTEEG_X5_MINI_WIFI) \
+  #elif !MB(MKS_SBASE, AZTEEG_X3_PRO, AZTEEG_X5_GT, AZTEEG_X5_MINI, AZTEEG_X5_MINI_WIFI) \
     && (!defined(DIGIPOTS_I2C_SDA_X) || !defined(DIGIPOTS_I2C_SDA_Y) || !defined(DIGIPOTS_I2C_SDA_Z) || !defined(DIGIPOTS_I2C_SDA_E0) || !defined(DIGIPOTS_I2C_SDA_E1))
       #error "DIGIPOT_MCP4018/4451 requires DIGIPOTS_I2C_SDA_* pins to be defined."
   #endif


### PR DESCRIPTION
### Description

SanityCheck.h incorrectly errors telling users with a AZTEEG_X3_PRO with DIGIPOT_MCP4451 enabled "DIGIPOT_MCP4018/4451 requires DIGIPOTS_I2C_SDA_* pins to be defined."

This is not the case for this controller.
If you examine the circuit diagram this board is using hardware i2c pins, not software i2c so does not require these pin defines.
[AZTEEG X3 PRO - schematic.pdf](https://github.com/user-attachments/files/16536148/AZTEEG.X3.PRO.-.schematic.pdf)

 
### Requirements

AZTEEG_X3_PRO, DIGIPOT_MCP4451

### Benefits

Builds without error

