### PR TITLE
🔨 Tweak Tronxy CXY build

### DIFF
--- a/buildroot/share/PlatformIO/scripts/tronxy_cxy_446_v10.py
+++ b/buildroot/share/PlatformIO/scripts/tronxy_cxy_446_v10.py
@@ -10,29 +10,31 @@ if pioutil.is_pio_build():
     env = pioutil.env
 
     # Check whether the "update" folder exists
-    outpath = "update"
+    outpath = f"{env['PROJECT_BUILD_DIR']}/{env['PIOENV']}/update"
     if not os.path.exists(outpath): os.makedirs(outpath)
 
     # Build "fmw_tronxy.hex" and place in "update" folder
     def output_target_hex():
-        tar_hex = f"{outpath}/fmw_tronxy.hex"
+        hex_path  = f"update/fmw_tronxy.hex"
+        hex_long = f"$PROJECT_BUILD_DIR/$PIOENV/{hex_path}"
         env.AddPostAction(
             "$BUILD_DIR/${PROGNAME}.elf",
             env.VerboseAction(" ".join([
                 "$OBJCOPY", "-O", "ihex", "-R", ".eeprom",
-                "$BUILD_DIR/${PROGNAME}.elf", tar_hex
-            ]), "Building %s" % tar_hex)
+                "$BUILD_DIR/${PROGNAME}.elf", hex_long
+            ]), f"Building {hex_path}")
         )
 
     # Build "fmw_tronxy.bin" and place in "update" folder
     def output_target_bin():
-        tar_bin = f"{outpath}/fmw_tronxy.bin"
+        bin_path  = f"update/fmw_tronxy.bin"
+        bin_long = f"$PROJECT_BUILD_DIR/$PIOENV/{bin_path}"
         env.AddPostAction(
             "$BUILD_DIR/${PROGNAME}.elf",
             env.VerboseAction(" ".join([
                 "$OBJCOPY", "-O", "binary", "-R", ".eeprom",
-                "$BUILD_DIR/${PROGNAME}.elf", tar_bin
-            ]), "Building %s" % tar_bin)
+                "$BUILD_DIR/${PROGNAME}.elf", bin_long
+            ]), f"Building {bin_path}")
         )
 
     output_target_hex()

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -819,7 +819,6 @@ extends              = stm32_variant
 board                = marlin_STM32F446ZET_tronxy
 board_build.ldscript = buildroot/share/PlatformIO/variants/MARLIN_F446Zx_TRONXY/ldscript.ld
 board_build.offset   = 0x10000
-board_build.rename   = fmw_tronxy.bin
 build_flags          = ${stm32_variant.build_flags}
                        -DSTM32F4xx -DUSE_USB_HS
                        -DUSE_USB_HS_IN_FS


### PR DESCRIPTION
- Keep build products within the '`build/TRONXY_CXY_446_V10`' folder.
- BIN/HEX go into an '`update`' folder currently. If that folder is not needed for SD flashing that might go away.
- May also need accompanying Configurations for the newer X5SA models that ship with a CXY board.

On another Tronxy-related note, they specify that GD32 processors need a [modified Arduino core](//github.com/tronxy3d/F4xx-SIM480x272). This information could be useful for other boards based on GD32.

Related issues: #26179