### PR TITLE
Fix compilation error/warn

### DIFF
--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -91,9 +91,9 @@ uint32_t FTMotion::interpIdx = 0;               // Index of current data point b
 #if HAS_X_AXIS
   FTMotion::shaping_t FTMotion::shaping = {
     0,
-    x:{ false, { 0.0f }, { 0.0f }, { 0 }, { 0 } },            // ena, d_zi, Ai, Ni, max_i
+    x:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 },            // ena, d_zi, Ai, Ni, max_i
     #if HAS_Y_AXIS
-      y:{ false, { 0.0f }, { 0.0f }, { 0 }, { 0 } }           // ena, d_zi, Ai, Ni, max_i
+      y:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 }           // ena, d_zi, Ai, Ni, max_i
     #endif
   };
 #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

There is a compile error in ft_motion.cpp by using `arm-none-eabi-g++` of PlatformIO Core 6.1.15 on Windows 11. The error message is:

```
Marlin\src\module\ft_motion.cpp:98:3: error: braces around scalar initializer for type 'uint32_t {aka long unsigned int}'
```

The error occurs at scalar initializer `{ 0 }`. I think braced scalar initializers are valid. However, the g++ reported an error. Maybe other versions of g++ may warn.

Other scalar initializers in ft_motion.cpp are not braced. I think it is good to unify by using the same syntax. This PR unbrace two scalar initializers.

note:

In #26848, I found @yunline also commented the same error. But suggested code was not included in the merge. This PR is the same as @yunline's code.

* https://github.com/MarlinFirmware/Marlin/commit/f0bc4274f817166fcce82949d94330bd1c441c15#r145003786
* https://github.com/MarlinFirmware/Marlin/commit/f0bc4274f817166fcce82949d94330bd1c441c15#r145003794
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
