### PR TITLE
🩹 Fix Sensorless Homing Current Warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -737,25 +737,25 @@
   #warning "High homing currents can lead to damage if a sensor fails or is set up incorrectly."
 #endif
 
-#if USE_SENSORLESS
-  #if defined(X_CURRENT_HOME) && !HAS_CURRENT_HOME(X)
-    #warning "It's recommended to set X_CURRENT_HOME lower than X_CURRENT with SENSORLESS_HOMING."
-  #elif defined(X2_CURRENT_HOME) && !HAS_CURRENT_HOME(X2)
-    #warning "It's recommended to set X2_CURRENT_HOME lower than X2_CURRENT with SENSORLESS_HOMING."
+#if USE_SENSORLESS && DISABLED(NO_HOMING_CURRENT_WARNING)
+  #if ENABLED(X_SENSORLESS) && defined(X_CURRENT_HOME) && !HAS_CURRENT_HOME(X)
+    #warning "It's recommended to set X_CURRENT_HOME lower than X_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
+  #elif ENABLED(X2_SENSORLESS) && defined(X2_CURRENT_HOME) && !HAS_CURRENT_HOME(X2)
+    #warning "It's recommended to set X2_CURRENT_HOME lower than X2_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
   #endif
-  #if defined(Y_CURRENT_HOME) && !HAS_CURRENT_HOME(Y)
-    #warning "It's recommended to set Y_CURRENT_HOME lower than Y_CURRENT with SENSORLESS_HOMING."
-  #elif defined(Y2_CURRENT_HOME) && !HAS_CURRENT_HOME(Y2)
-    #warning "It's recommended to set Y2_CURRENT_HOME lower than Y2_CURRENT with SENSORLESS_HOMING."
+  #if ENABLED(Y_SENSORLESS) && defined(Y_CURRENT_HOME) && !HAS_CURRENT_HOME(Y)
+    #warning "It's recommended to set Y_CURRENT_HOME lower than Y_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
+  #elif ENABLED(Y2_SENSORLESS) && defined(Y2_CURRENT_HOME) && !HAS_CURRENT_HOME(Y2)
+    #warning "It's recommended to set Y2_CURRENT_HOME lower than Y2_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
   #endif
-  #if defined(Z_CURRENT_HOME) && !HAS_CURRENT_HOME(Z)
-    #warning "It's recommended to set Z_CURRENT_HOME lower than Z_CURRENT with SENSORLESS_HOMING."
-  #elif defined(Z2_CURRENT_HOME) && !HAS_CURRENT_HOME(Z2)
-    #warning "It's recommended to set Z2_CURRENT_HOME lower than Z2_CURRENT with SENSORLESS_HOMING."
-  #elif defined(Z3_CURRENT_HOME) && !HAS_CURRENT_HOME(Z3)
-    #warning "It's recommended to set Z3_CURRENT_HOME lower than Z3_CURRENT with SENSORLESS_HOMING."
-  #elif defined(Z4_CURRENT_HOME) && !HAS_CURRENT_HOME(Z4)
-    #warning "It's recommended to set Z4_CURRENT_HOME lower than Z4_CURRENT with SENSORLESS_HOMING."
+  #if ENABLED(Z_SENSORLESS) && defined(Z_CURRENT_HOME) && !HAS_CURRENT_HOME(Z)
+    #warning "It's recommended to set Z_CURRENT_HOME lower than Z_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
+  #elif ENABLED(Z2_SENSORLESS) && defined(Z2_CURRENT_HOME) && !HAS_CURRENT_HOME(Z2)
+    #warning "It's recommended to set Z2_CURRENT_HOME lower than Z2_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
+  #elif ENABLED(Z3_SENSORLESS) && defined(Z3_CURRENT_HOME) && !HAS_CURRENT_HOME(Z3)
+    #warning "It's recommended to set Z3_CURRENT_HOME lower than Z3_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
+  #elif ENABLED(Z4_SENSORLESS) && defined(Z4_CURRENT_HOME) && !HAS_CURRENT_HOME(Z4)
+    #warning "It's recommended to set Z4_CURRENT_HOME lower than Z4_CURRENT with SENSORLESS_HOMING. (Define NO_HOMING_CURRENT_WARNING to suppress this warning.)"
   #endif
 #endif
 


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/26714 added sensorless homing current warnings, but only used the generic `USE_SENSORLESS` macro. This means you would get a warning for every axis, even for those without sensorless homing enabled. There are now axis-specific flags included in each conditional to to prevent unnecessary warnings.  

I also added the ability to suppress these warnings with a `NO_HOMING_CURRENT_WARNING` define like most other warnings we add.

### Requirements

TMCs with sensorless homing

### Benefits

Users won't receive warnings to lower homing current on an axis they aren't using sensorless homing on (primarily Z).

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26714
