### PR TITLE
fix compile error 27374 TJC_DISPLAY font size errors

### DIFF
--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -93,16 +93,18 @@ bool dwinHandshake() {
 // Get font character width
 uint8_t fontWidth(uint8_t cfont) {
   switch (cfont) {
-    case font6x12 : return 6;
+    #if DISABLED(TJC_DISPLAY)
+      case font6x12 : return 6;
+      case font20x40: return 20;
+      case font24x48: return 24;
+      case font28x56: return 28;
+      case font32x64: return 32;
+    #endif
     case font8x16 : return 8;
     case font10x20: return 10;
     case font12x24: return 12;
     case font14x28: return 14;
     case font16x32: return 16;
-    case font20x40: return 20;
-    case font24x48: return 24;
-    case font28x56: return 28;
-    case font32x64: return 32;
     default: return 0;
   }
 }
@@ -110,16 +112,18 @@ uint8_t fontWidth(uint8_t cfont) {
 // Get font character height
 uint8_t fontHeight(uint8_t cfont) {
   switch (cfont) {
-    case font6x12 : return 12;
+    #if DISABLED(TJC_DISPLAY)
+      case font6x12 : return 12;
+      case font20x40: return 40;
+      case font24x48: return 48;
+      case font28x56: return 56;
+      case font32x64: return 64;
+    #endif
     case font8x16 : return 16;
     case font10x20: return 20;
     case font12x24: return 24;
     case font14x28: return 28;
     case font16x32: return 32;
-    case font20x40: return 40;
-    case font24x48: return 48;
-    case font28x56: return 56;
-    case font32x64: return 64;
     default: return 0;
   }
 }


### PR DESCRIPTION
### Description

Enabling TJC_DISPLAY cause compile errors

```
Marlin/src/lcd/e3v2/common/dwin_api.cpp:96:10: error: 'font6x12' was not declared in this scope; did you mean 'font8x16'?
   96 |     case font6x12 : return 6;
      |          ^~~~~~~~
      |          font8x16

```
Some font are not supported on the TJC_DISPLAY
They where removed in https://github.com/MarlinFirmware/Marlin/pull/26003 but this code was not updated

### Requirements

TJC_DISPLAY, PRO_UI

### Benefits

Builds as expected

### Configurations

[Configuration.zip](https://github.com/user-attachments/files/16791294/Configuration.zip)

### Related issues

<li> MarlinFirmware/Marlin/issues/27374

