### PR TITLE
Change DMA2 to DMA1 for FSMC TFT on STM32F1xx

### DIFF
--- a/Marlin/src/HAL/STM32/sdio.cpp
+++ b/Marlin/src/HAL/STM32/sdio.cpp
@@ -238,7 +238,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef *hsd) {
     hdma_sdio.Init.MemInc = DMA_MINC_ENABLE;
     hdma_sdio.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
     hdma_sdio.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
-    hdma_sdio.Init.Priority = DMA_PRIORITY_LOW;
+    hdma_sdio.Init.Priority = DMA_PRIORITY_MEDIUM;
     __HAL_LINKDMA(&hsd, hdmarx, hdma_sdio);
     __HAL_LINKDMA(&hsd, hdmatx, hdma_sdio);
 

--- a/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
@@ -182,6 +182,7 @@ void TFT_FSMC::transmitDMA(uint32_t memoryIncrease, uint16_t *data, uint16_t cou
   DMAtx.Init.PeriphInc = memoryIncrease;
   HAL_DMA_Init(&DMAtx);
   HAL_DMA_Start(&DMAtx, (uint32_t)data, (uint32_t)&(LCD->RAM), count);
+  TERN_(TFT_SHARED_IO, while (isBusy()));
 }
 
 void TFT_FSMC::transmit(uint32_t memoryIncrease, uint16_t *data, uint16_t count) {

--- a/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
@@ -111,11 +111,11 @@ void TFT_FSMC::init() {
 
   HAL_SRAM_Init(&SRAMx, &timing, &extTiming);
 
-  __HAL_RCC_DMA2_CLK_ENABLE();
-
   #ifdef STM32F1xx
-    DMAtx.Instance                = DMA2_Channel1;
+    __HAL_RCC_DMA1_CLK_ENABLE();
+    DMAtx.Instance                = DMA1_Channel1;
   #elif defined(STM32F4xx)
+    __HAL_RCC_DMA2_CLK_ENABLE();
     DMAtx.Instance                = DMA2_Stream0;
     DMAtx.Init.Channel            = DMA_CHANNEL_0;
     DMAtx.Init.FIFOMode           = DMA_FIFOMODE_ENABLE;

--- a/Marlin/src/HAL/STM32/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_spi.cpp
@@ -337,7 +337,7 @@ void TFT_SPI::transmitDMA(uint32_t memoryIncrease, uint16_t *data, uint16_t coun
     SET_BIT(SPIx.Instance->CR2, SPI_CR2_TXDMAEN);   // Enable Tx DMA Request
   #endif
 
-  TERN_(TFT_SHARED_IO, while (isBusy()) { /* nada */ });
+  TERN_(TFT_SHARED_IO, while (isBusy()));
 }
 
 void TFT_SPI::transmit(uint32_t memoryIncrease, uint16_t *data, uint16_t count) {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This PR fixes the #26970 bug where it's impossible to start a print from SD card using COLOR_UI interface. I've changed TFT DMA channel from 2 to 1.
Basically it reverts the part that initializes DMA to the behaviour before [commit 9364cbb](https://github.com/MarlinFirmware/Marlin/commit/9364cbb4b53a5ef77cf2b843ba228afffb4c1725?diff=unified&w=0#diff-f64f057c8653ee97ebf3be2065e2d0e14ec568be6ab1e03c98b5282fbf1e4ecfL104).

I've guessed that there's something involving differences in STM32 and GD32 features that manifests in #26970 and that was it.
I don't know the details of this change and how this will impact other features, but it fixed this bug in my printer.

#### Prior art:
- https://github.com/MarlinFirmware/Marlin/pull/25359
- https://github.com/MarlinFirmware/Marlin/issues/25157#issuecomment-1424559222
- https://github.com/jmz52/Marlin/commit/1940418bbe89d07863ed05c6cddb1edf285a5a31#diff-f64f057c8653ee97ebf3be2065e2d0e14ec568be6ab1e03c98b5282fbf1e4ecf
- https://github.com/MarlinFirmware/Marlin/issues/25393#issuecomment-1433888776

### Requirements

- KP3S (or maybe other boards) with GD32F103VE

### Benefits

Fixes #26970

### Configurations

Attached in #26970

### Related Issues

#26970 #26927
