### PR TITLE
swap order of cp in buildroot/bin/build_example

### DIFF
--- a/buildroot/bin/build_example
+++ b/buildroot/bin/build_example
@@ -76,7 +76,8 @@ rm -f Marlin/_Bootscreen.h Marlin/_Statusscreen.h
 
 # Copy configurations into the Marlin folder
 echo "Getting configuration files from $SUB"
-cp "$BASE/config/default"/*.h "$SUB"/*.h Marlin/ 2>/dev/null
+cp "$SUB"/*.h "$BASE/config/default"/*.h Marlin/ 2>/dev/null
+
 
 rm -f Marlin/Config.h Marlin/Config-export.h
 


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/commit/fe56f5d3a679a68a1c9b4e1aea08ddc232078c88#diff-ba8daaa49132ee3b4bb63ec9a5d62bd56649e76a0bf90c24e8dbed8219bace15 the script build_all_examples has been 'faking it'.

The change in buildroot/bin/build_example was innocent looking enough 

```BASH
cp "$BASE/config/default"/*.h    Marlin/
cp "$SUB"/Config.h            Marlin/ 2>/dev/null
cp "$SUB"/Configuration.h     Marlin/ 2>/dev/null
cp "$SUB"/Configuration_adv.h Marlin/ 2>/dev/null
cp "$SUB"/_Bootscreen.h       Marlin/ 2>/dev/null
cp "$SUB"/_Statusscreen.h     Marlin/ 2>/dev/null

```
was replaced with 

```BASH
cp "$BASE/config/default"/*.h "$SUB"/*.h Marlin/ 2>/dev/null
```

But on running the updated code you got weird results for eg:

```
Getting configuration files from ./.pio/build-import-2.1.x/config/examples/Anet/ET4X
Building example Anet/ET4X ...

Auto Build...
Detected "RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)" | RAMPS_14_EFB (1020).
Selected mega2560
```

This is wrong. This example has BOARD_ANET_ET4  which is a env:Anet_ET4_no_bootloader


Digging into this I removed the redirecting of error to null and was presented with this error


```
cp: will not overwrite just-created 'Marlin/Configuration_adv.h' with './.pio/build-import-2.1.x/config/examples/Anet/ET4X/Configuration_adv.h'
cp: will not overwrite just-created 'Marlin/Configuration.h' with './.pio/build-import-2.1.x/config/examples/Anet/ET4X/Configuration.h'

``` 

Ie you cannot use it in one line like that

So what it is really doing is: It copies the `$BASE/config/default"/*.h`  but since its on the same command  it refuses to copy over `"$SUB"/*.h` as its the same files names.

This results in the build_all_examples script building the default config over and over while telling you its building the example configs.


So I purpose we simply swap the two operators

`cp "$SUB"/*.h "$BASE/config/default"/*.h Marlin/ 2>/dev/null
` 

So now it will copy the new configs over and only if a file is missing will it copy over the default file.


Note: I do not know if this will work on all OS's implementing bash.
This change was tested and found to work as desired on Ubuntu 24.04.1 LTS

Other operating systems may need another option like simply having two lines.

```BASH
cp "$BASE/config/default"/*.h Marlin/ 2>/dev/null
cp "$SUB"/*.h Marlin/ 2>/dev/null
```

### Requirements

Marlin

### Benefits

build_all_examples script works as expected

### Configurations

All example configs.

### Related Issues
https://github.com/MarlinFirmware/Marlin/commit/fe56f5d3a679a68a1c9b4e1aea08ddc232078c88#diff-ba8daaa49132ee3b4bb63ec9a5d62bd56649e76a0bf90c24e8dbed8219bace15