### PR TITLE
🧑‍💻 Includes in Conditionals (for code dimming)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2560,7 +2560,7 @@
 
 /**
  * Minimum stepper driver pulse width (in ns)
- * If undefined, these defaults (from Conditionals_adv.h) apply:
+ * If undefined, these defaults (from Conditionals-4-adv.h) apply:
  *     100 : Minimum for TMC2xxx stepper drivers
  *     500 : Minimum for LV8729
  *    1000 : Minimum for A4988 and A5984 stepper drivers
@@ -2574,7 +2574,7 @@
 
 /**
  * Maximum stepping rate (in Hz) the stepper driver allows
- * If undefined, these defaults (from Conditionals_adv.h) apply:
+ * If undefined, these defaults (from Conditionals-4-adv.h) apply:
  *  5000000 : Maximum for TMC2xxx stepper drivers
  *  1000000 : Maximum for LV8729 stepper driver
  *   500000 : Maximum for A4988 stepper driver

--- a/Marlin/src/inc/Conditionals-1-axes.h
+++ b/Marlin/src/inc/Conditionals-1-axes.h
@@ -22,9 +22,15 @@
 #pragma once
 
 /**
- * Conditionals_axes.h
+ * Conditionals-1-axes.h
  * Conditionals that need to be set before Configuration_adv.h or pins.h
  */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "MarlinConfigPre-1-axes.h"
+//========================================================
 
 /**
  * Extruders have some combination of stepper motors and hotends

--- a/Marlin/src/inc/Conditionals-2-LCD.h
+++ b/Marlin/src/inc/Conditionals-2-LCD.h
@@ -22,9 +22,15 @@
 #pragma once
 
 /**
- * Conditionals_LCD.h
+ * Conditionals-2-LCD.h
  * Conditionals that need to be set before Configuration_adv.h or pins.h
  */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "Conditionals-1-axes.h"
+//========================================================
 
 // Support for SD Card and other file storage
 #if ENABLED(SDSUPPORT)

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -22,9 +22,15 @@
 #pragma once
 
 /**
- * Conditionals_etc.h
+ * Conditionals-3-etc.h
  * Conditionals that need to be set before Configuration_adv.h or pins.h
  */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "Conditionals-2-LCD.h"
+//========================================================
 
 #ifndef STRING_CONFIG_H_AUTHOR
   #define STRING_CONFIG_H_AUTHOR "(anonymous)"

--- a/Marlin/src/inc/Conditionals-4-adv.h
+++ b/Marlin/src/inc/Conditionals-4-adv.h
@@ -22,9 +22,15 @@
 #pragma once
 
 /**
- * Conditionals_adv.h
+ * Conditionals-4-adv.h
  * Conditionals set before pins.h and which depend on Configuration_adv.h.
  */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "MarlinConfigPre-4-adv.h"
+//========================================================
 
 #if ENABLED(MARLIN_SMALL_BUILD)
   #undef EEPROM_CHITCHAT

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -22,9 +22,15 @@
 #pragma once
 
 /**
- * Conditionals_post.h
+ * Conditionals-5-post.h
  * Internal defines that depend on Configurations and Pins but are not user-editable.
  */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "MarlinConfigPre-5-post.h"
+//========================================================
 
 #ifdef GITHUB_ACTIONS
   // Extras for CI testing
@@ -50,7 +56,7 @@
 // Determine which type of 'EEPROM' is in use
 #if ENABLED(EEPROM_SETTINGS)
   // EEPROM type may be defined by compile flags, configs, HALs, or pins
-  // Set additional flags to let HALs choose in their Conditionals_post.h
+  // Set additional flags to let HALs choose in their Conditionals-5-post.h
   #if ANY(FLASH_EEPROM_EMULATION, SRAM_EEPROM_EMULATION, SDCARD_EEPROM_EMULATION, QSPI_EEPROM)
     #define USE_EMULATED_EEPROM 1
   #elif ANY(I2C_EEPROM, SPI_EEPROM)

--- a/Marlin/src/inc/Conditionals-6-type.h
+++ b/Marlin/src/inc/Conditionals-6-type.h
@@ -1,0 +1,48 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Conditionals-6-type.h
+ * Internal defines that depend on Configurations and Pins but are not user-editable.
+ * Define conditionals in this file if they depend on core/types.h.
+ */
+
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "MarlinConfigPre-6-type.h"
+//========================================================
+
+#ifdef GITHUB_ACTIONS
+  // Extras for CI testing
+#endif
+
+// If an axis's Homing Current differs from standard current...
+#define HAS_CURRENT_HOME(N) (N##_CURRENT_HOME > 0 && N##_CURRENT_HOME != N##_CURRENT)
+
+// Does any axis have homing current?
+#define _OR_HAS_CURR_HOME(N) HAS_CURRENT_HOME(N) ||
+#if MAIN_AXIS_MAP(_OR_HAS_CURR_HOME) MAP(_OR_HAS_CURR_HOME, X2, Y2, Z2, Z3, Z4) 0
+  #define HAS_HOMING_CURRENT 1
+#endif
+#undef _OR_HAS_CURR_HOME

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -25,30 +25,11 @@
 // Prefix header for all Marlin sources
 //
 
-#include "MarlinConfigPre.h"
-
-#ifdef __MARLIN_DEPS__
-  #include "../HAL/shared/fauxpins.h"
-#else
-  #include "../HAL/HAL.h"
-#endif
-
-#include "../pins/pins.h"
-
-#ifndef __MARLIN_DEPS__
-  #include HAL_PATH(.., timers.h)
-  #include HAL_PATH(.., spi_pins.h)
-#endif
-
-#include "Conditionals_post.h"
+#include "MarlinConfigPre-6-type.h" // Include even with __MARLIN_DEPS__
 
 #ifndef __MARLIN_DEPS__
 
-  #include HAL_PATH(.., inc/Conditionals_post.h)
-
-  #include "../core/types.h"  // Ahead of sanity-checks
-
-  #include "Conditionals_type.h"
+  #include "Conditionals-6-type.h"
   #include HAL_PATH(.., inc/Conditionals_type.h)
 
   #include "Changes.h"

--- a/Marlin/src/inc/MarlinConfigPre-1-axes.h
+++ b/Marlin/src/inc/MarlinConfigPre-1-axes.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -21,14 +21,33 @@
  */
 #pragma once
 
-//
-// Prefix header to acquire configurations
-//
-#include "Conditionals-1-axes.h"
-#include "Conditionals-2-LCD.h"
-#include "Conditionals-3-etc.h"
-#include "Conditionals-4-adv.h"
+#ifndef __MARLIN_FIRMWARE__
+#define __MARLIN_FIRMWARE__
+#endif
+
+#if __has_include("../../Config.h")
+  #include "../../Config.h"
+#else
+  #define USE_STD_CONFIGS 1
+#endif
+
+#include <stdint.h>
 
 #ifndef __MARLIN_DEPS__
-  #include HAL_PATH(.., inc/Conditionals_adv.h)
+  #include "../HAL/platforms.h"
 #endif
+
+#include "../core/macros.h"
+#include "../core/boards.h"
+
+#if USE_STD_CONFIGS
+  #include "../../Configuration.h"
+#endif
+
+#ifdef CUSTOM_VERSION_FILE
+  #if __has_include(STRINGIFY(../../CUSTOM_VERSION_FILE))
+    #include STRINGIFY(../../CUSTOM_VERSION_FILE)
+  #endif
+#endif
+
+#include "Version.h"

--- a/Marlin/src/inc/MarlinConfigPre-4-adv.h
+++ b/Marlin/src/inc/MarlinConfigPre-4-adv.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -21,14 +21,14 @@
  */
 #pragma once
 
-//
-// Prefix header to acquire configurations
-//
-#include "Conditionals-1-axes.h"
-#include "Conditionals-2-LCD.h"
 #include "Conditionals-3-etc.h"
-#include "Conditionals-4-adv.h"
 
 #ifndef __MARLIN_DEPS__
-  #include HAL_PATH(.., inc/Conditionals_adv.h)
+  #include HAL_PATH(.., inc/Conditionals_LCD.h)
+#endif
+
+#include "../core/drivers.h"
+
+#if USE_STD_CONFIGS
+  #include "../../Configuration_adv.h"
 #endif

--- a/Marlin/src/inc/MarlinConfigPre-5-post.h
+++ b/Marlin/src/inc/MarlinConfigPre-5-post.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2024 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -21,14 +21,17 @@
  */
 #pragma once
 
-//
-// Prefix header to acquire configurations
-//
-#include "Conditionals-1-axes.h"
-#include "Conditionals-2-LCD.h"
-#include "Conditionals-3-etc.h"
-#include "Conditionals-4-adv.h"
+#include "MarlinConfigPre.h"
+
+#ifdef __MARLIN_DEPS__
+  #include "../HAL/shared/fauxpins.h"
+#else
+  #include "../HAL/HAL.h"
+#endif
+
+#include "../pins/pins.h"
 
 #ifndef __MARLIN_DEPS__
-  #include HAL_PATH(.., inc/Conditionals_adv.h)
+  #include HAL_PATH(.., timers.h)
+  #include HAL_PATH(.., spi_pins.h)
 #endif

--- a/Marlin/src/inc/MarlinConfigPre-6-type.h
+++ b/Marlin/src/inc/MarlinConfigPre-6-type.h
@@ -21,22 +21,10 @@
  */
 #pragma once
 
-/**
- * Conditionals_type.h
- * Internal defines that depend on Configurations and Pins but are not user-editable.
- * Define conditionals in this file if they depend on core/types.h.
- */
+#include "MarlinConfigPre-5-post.h"
+#include "Conditionals-5-post.h"
 
-#ifdef GITHUB_ACTIONS
-  // Extras for CI testing
+#ifndef __MARLIN_DEPS__
+  #include HAL_PATH(.., inc/Conditionals_post.h)
+  #include "../core/types.h"  // Ahead of sanity-checks
 #endif
-
-// If an axis's Homing Current differs from standard current...
-#define HAS_CURRENT_HOME(N) (N##_CURRENT_HOME > 0 && N##_CURRENT_HOME != N##_CURRENT)
-
-// Does any axis have homing current?
-#define _OR_HAS_CURR_HOME(N) HAS_CURRENT_HOME(N) ||
-#if MAIN_AXIS_MAP(_OR_HAS_CURR_HOME) MAP(_OR_HAS_CURR_HOME, X2, Y2, Z2, Z3, Z4) 0
-  #define HAS_HOMING_CURRENT 1
-#endif
-#undef _OR_HAS_CURR_HOME

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -27,6 +27,12 @@
  * Test configuration values for errors at compile-time.
  */
 
+//========================================================
+// Get requirements for the benefit of IntelliSense, etc.
+//
+#include "MarlinConfig.h"
+//========================================================
+
 /**
  * Require gcc 4.7 or newer (first included with Arduino 1.6.8) for C++11 features.
  */

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -38,7 +38,7 @@
 #define BOARD_WEBSITE_URL    "github.com/makerbase-mks/MKS-TinyBee"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
-// MAX_EXPANDER_BITS is defined for MKS TinyBee in HAL/ESP32/inc/Conditionals_adv.h
+// MAX_EXPANDER_BITS is defined for MKS TinyBee in HAL/ESP32/inc/Conditionals-4-adv.h
 
 //
 // Servos

--- a/Marlin/src/pins/mega/pins_CNCONTROLS_11.h
+++ b/Marlin/src/pins/mega/pins_CNCONTROLS_11.h
@@ -149,8 +149,8 @@
   #if HAS_MARLINUI_U8GLIB
     #define DOGLCD_A0                         26
     #define DOGLCD_CS                         24
-    #define DOGLCD_MOSI                       -1  // Prevent auto-define by Conditionals_post.h
-    #define DOGLCD_SCK                        -1
+    //#define DOGLCD_MOSI                     -1  // Prevent auto-define by Conditionals-5-post.h
+    //#define DOGLCD_SCK                      -1
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -146,8 +146,8 @@
   #define TFT_BACKLIGHT_PIN                 PD12
   #define TFT_BACKLIGHT_PWM                 150   // Brightness with alt. TIM4 chan 1 (1-255)
 
-  #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
-  #define DOGLCD_SCK                        -1
+  //#define DOGLCD_MOSI                     -1    // Prevent auto-define by Conditionals-5-post.h
+  //#define DOGLCD_SCK                      -1
 
   // Buffer for Color UI
   #define TFT_BUFFER_WORDS                  3200

--- a/Marlin/src/pins/stm32f1/pins_MD_D301.h
+++ b/Marlin/src/pins/stm32f1/pins_MD_D301.h
@@ -187,8 +187,8 @@
  * to let the bootloader init the screen.
  */
 
-#define DOGLCD_MOSI                         -1    // Prevent auto-define by Conditionals_post.h
-#define DOGLCD_SCK                          -1
+//#define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals-5-post.h
+//#define DOGLCD_SCK                        -1
 
 //
 // TFT with FSMC interface

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -192,8 +192,8 @@
   #define TFT_RESET_PIN                     PC6   // FSMC_RST
   #define TFT_BACKLIGHT_PIN                 PD13
 
-  #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
-  #define DOGLCD_SCK                        -1
+  //#define DOGLCD_MOSI                     -1    // Prevent auto-define by Conditionals-5-post.h
+  //#define DOGLCD_SCK                      -1
 
   #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
   #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -195,7 +195,7 @@ def apply_sections(cp, ckey='all'):
             apply_ini_by_name(cp, 'config:basic')
 
         # Apply historically Configuration_adv.h settings everywhere
-        # (Some of which rely on defines in 'Conditionals_LCD.h')
+        # (Some of which rely on defines in 'Conditionals-2-LCD.h')
         elif ckey in ('adv', 'advanced'):
             apply_ini_by_name(cp, 'config:advanced')
 


### PR DESCRIPTION
Add `#include` lines to Conditionals files so that code editors are more easily able to see and parse the dependencies.