### PR TITLE
🧑‍💻 Build examples --output option

### DIFF
--- a/buildroot/bin/build_all_examples
+++ b/buildroot/bin/build_all_examples
@@ -8,12 +8,14 @@
 #                     [-p|--purge]           - Purge the status file and start over
 #                     [-s|--skip]            - Continue the paused build, skipping one
 #                     [-r|--resume=<path>]   - Start at some config in the filesystem order
-#                     [-e|--export=N]        - Set CONFIG_EXPORT and export into each config folder
-#                     [-d|--debug]           - Print extra debug output (after)
 #                     [-l|--limit=#]         - Limit the number of builds in this run
-#                     [-a|--archive]         - Copy the binary to the export location
+#                     [-d|--debug]           - Print extra debug output (after)
 #                     [-n|--nobuild]         - Don't actually build anything
 #                     [-f|--nofail]          - Don't stop on a failed build
+#                     [-e|--export=N]        - Set CONFIG_EXPORT and export into each config folder
+#                     [-a|--archive]         - Copy the binary to the export location
+#                     [-o|--output]          - Redirect export / archiving to another location
+#                                              (By default export to origin config folders)
 #                     [-h|--help]            - Print usage and exit
 #
 
@@ -32,10 +34,12 @@ build_all_examples [-b|--branch=<branch>] - Branch to fetch from Configurations 
                    [-p|--purge]           - Purge the status file and start over
                    [-s|--skip]            - Continue the paused build, skipping one
                    [-r|--resume=<path>]   - Start at some config in the filesystem order
-                   [-e|--export=N]        - Set CONFIG_EXPORT and export into each config folder
+                   [-e|--export=N]        - Set CONFIG_EXPORT and export to the export location
+                   [-a|--archive]         - Copy the binary to the export location
+                   [-o|--output]          - Redirect export / archiving to another location
+                                            (By default export to origin config folders)
                    [-d|--debug]           - Print extra debug output (after)
                    [-l|--limit=#]         - Limit the number of builds in this run
-                   [-a|--archive]         - Copy the binary to the export location
                    [-n|--nobuild]         - Don't actually build anything
                    [-f|--nofail]          - Don't stop on a failed build
                    [-h|--help]            - Print usage and exit
@@ -48,36 +52,38 @@ unset FIRST_CONF
 EXIT_USAGE=
 LIMIT=1000
 
-while getopts 'aB:b:ce:fdhl:npr:sv-:' OFLAG; do
+while getopts 'aB:b:ce:fdhl:no:pr:sv-:' OFLAG; do
   case "${OFLAG}" in
-    a) ARCHIVE=1              ; bugout "Archiving" ;;
-    B) OPATH=$OPTARG          ; bugout "Base: $OPATH" ;;
-    b) BRANCH=$OPTARG         ; bugout "Branch: $BRANCH" ;;
-    f) NOFAIL=1               ; bugout "Continue on Fail" ;;
+    a) ARCHIVE=1                ; bugout "Archiving" ;;
+    B) OPATH=${OPTARG%/}        ; bugout "Base: $OPATH" ;;
+    b) BRANCH=$OPTARG           ; bugout "Branch: $BRANCH" ;;
+    f) NOFAIL=1                 ; bugout "Continue on Fail" ;;
     r) ISRES=1 ; FIRST_CONF=$OPTARG ; bugout "Resume: $FIRST_CONF" ;;
-    c) CONTINUE=1             ; bugout "Continue" ;;
-    s) CONTSKIP=1             ; bugout "Continue, skipping" ;;
-    e) CEXPORT=$OPTARG        ; bugout "Export $CEXPORT" ;;
+    c) CONTINUE=1               ; bugout "Continue" ;;
+    s) CONTSKIP=1               ; bugout "Continue, skipping" ;;
+    e) CEXPORT=$OPTARG          ; bugout "Export $CEXPORT" ;;
+    o) OUTBASE="${OPTARG%/}"    ; bugout "Archive to $OUTBASE" ;;
     h) EXIT_USAGE=1 ; break ;;
-    l) LIMIT=$OPTARG          ; bugout "Limit to $LIMIT build(s)" ;;
-  d|v) DEBUG=1                ; bugout "Debug ON" ;;
-    n) DRYRUN=1               ; bugout "Dry Run" ;;
-    p) PURGE=1                ; bugout "Purge stat file" ;;
+    l) LIMIT=$OPTARG            ; bugout "Limit to $LIMIT build(s)" ;;
+  d|v) DEBUG=1                  ; bugout "Debug ON" ;;
+    n) DRYRUN=1                 ; bugout "Dry Run" ;;
+    p) PURGE=1                  ; bugout "Purge stat file" ;;
     -) IFS="=" read -r ONAM OVAL <<< "$OPTARG"
        case "$ONAM" in
-      archive) ARCHIVE=1      ; bugout "Archiving" ;;
-         base) OPATH=$OVAL    ; bugout "Base: $OPATH" ;;
-       branch) BRANCH=$OVAL   ; bugout "Branch: $BRANCH" ;;
-       nofail) NOFAIL=1       ; bugout "Continue on Fail" ;;
+      archive) ARCHIVE=1        ; bugout "Archiving" ;;
+         base) OPATH=${OVAL%/}  ; bugout "Base: $OPATH" ;;
+       branch) BRANCH=$OVAL     ; bugout "Branch: $BRANCH" ;;
+       nofail) NOFAIL=1         ; bugout "Continue on Fail" ;;
        resume) ISRES=1 ; FIRST_CONF=$OVAL ; bugout "Resume: $FIRST_CONF" ;;
-     continue) CONTINUE=1     ; bugout "Continue" ;;
-         skip) CONTSKIP=1     ; bugout "Continue, skipping" ;;
-       export) CEXPORT=$OVAL  ; bugout "Export $EXPORT" ;;
-        limit) LIMIT=$OVAL    ; bugout "Limit to $LIMIT build(s)" ;;
+     continue) CONTINUE=1       ; bugout "Continue" ;;
+         skip) CONTSKIP=1       ; bugout "Continue, skipping" ;;
+       export) CEXPORT=$OVAL    ; bugout "Export $EXPORT" ;;
+       output) OUTBASE="${OVAL%/}" ; bugout "Archive to $OUTBASE" ;;
+        limit) LIMIT=$OVAL      ; bugout "Limit to $LIMIT build(s)" ;;
          help) [[ -z "$OVAL" ]] || perror "option can't take value $OVAL" $ONAM ; EXIT_USAGE=1 ;;
-        debug) DEBUG=1        ; bugout "Debug ON" ;;
-      nobuild) DRYRUN=1       ; bugout "Dry Run" ;;
-        purge) PURGE=1        ; bugout "Purge stat file" ;;
+        debug) DEBUG=1          ; bugout "Debug ON" ;;
+      nobuild) DRYRUN=1         ; bugout "Dry Run" ;;
+        purge) PURGE=1          ; bugout "Purge stat file" ;;
             *) EXIT_USAGE=2 ; echo "$SELF: unrecognized option \`--$ONAM'" ; break ;;
        esac
        ;;
@@ -167,11 +173,14 @@ for CONF in $CONF_TREE ; do
   # Exporting? Add -e argument
   ((CEXPORT)) && CARGS+=("-e" "$CEXPORT")
 
-  # Continue on fail? Add -n argument
-  ((NOFAIL)) && CARGS+=("-n")
+  # Continue on fail? Add -f argument
+  ((NOFAIL)) && CARGS+=("-f")
 
   # Archive the build? Add -a argument
   ((ARCHIVE)) && CARGS+=("-a")
+
+  # Redirecting the export/archive output? Add -o argument
+  [[ -n $OUTBASE ]] && CARGS+=("-o" "$OUTBASE")
 
   # Build or print build command for --nobuild
   if ((DRYRUN)); then

--- a/buildroot/bin/build_example
+++ b/buildroot/bin/build_example
@@ -4,13 +4,32 @@
 #
 #  build_example  -b|--base=<path>    - Configurations root folder (e.g., ./.pio/build-BRANCH)
 #                 -c|--config=<rel>   - Sub-path of the configs to build (within config/examples)
-#                [-e|--export=N]      - Set CONFIG_EXPORT before build and export into the config folder
-#                [-n|--nofail]        - Don't stop on a failed build
-#                [-r|--reveal]        - Reveal the config folder after the build
-#                [-h|--help]          - Print usage and exit
+#                [-e|--export=N]      - Set CONFIG_EXPORT before build and export
 #                [-a|--archive]       - Archive the build (to the export location)
+#                [-o|--output]        - Redirect export / archiving to another location
+#                                       (By default export to origin config folder)
+#                [-f|--nofail]        - Don't stop on a failed build
+#                [-w|--nowarn]        - Suppress warnings with extra config options
+#                [-r|--reveal]        - Reveal the config/export folder after the build
+#                [-h|--help]          - Print usage and exit
 #                [--allow]            - Allow this script to run standalone
 #
+
+usage() { echo "Usage:
+
+build_example  -b|--base=<path>    - Configurations root folder (e.g., ./.pio/build-BRANCH)
+               -c|--config=<rel>   - Sub-path of the configs to build (within config/examples)
+              [-e|--export=N]      - Set CONFIG_EXPORT before build and export
+              [-a|--archive]       - Archive the build (to the export location)
+              [-o|--output]        - Redirect export / archiving to another location
+                                     (By default export to origin config folder)
+              [-f|--nofail]        - Don't stop on a failed build
+              [-w|--nowarn]        - Suppress warnings with extra config options
+              [-r|--reveal]        - Reveal the config/export folder after the build
+              [-h|--help]          - Print usage and exit
+              [--allow]            - Allow this script to run standalone
+"
+}
 
 HERE=`dirname $0`
 
@@ -28,14 +47,16 @@ CONFIG=
 REVEAL=
 EXPNUM=
 NOFAIL=
-while getopts 'ab:c:e:hinr-:' OFLAG; do
+OUTBASE=
+while getopts 'ab:c:e:fhio:r-:' OFLAG; do
   case "${OFLAG}" in
     a) ARCHIVE=1 ;;
     b) BASE="${OPTARG%/}" ;;
     c) CONFIG="${OPTARG%/}" ;;
     e) EXPNUM="$OPTARG" ;;
+    o) OUTBASE="${OPTARG%/}" ;;
     h) EXIT_USAGE=1 ; break ;;
-    n) NOFAIL=1 ;;
+    f) NOFAIL=1 ;;
     r) REVEAL=1 ;;
     -) IFS="=" read -r ONAM OVAL <<< "$OPTARG"
        case "$ONAM" in
@@ -44,21 +65,30 @@ while getopts 'ab:c:e:hinr-:' OFLAG; do
            base) BASE="${OVAL%/}" ;;
          config) CONFIG="${OVAL%/}" ;;
          export) EXPNUM="$OVAL" ;;
+         output) OUTBASE="${OVAL%/}" ;;
            help) EXIT_USAGE=1 ; break ;;
          nofail) NOFAIL=1 ;;
          reveal) REVEAL=1 ;;
               *) EXIT_USAGE=2 ; echo "$SELF: unrecognized option \`--$ONAM'" ; break ;;
        esac
        ;;
+    *) EXIT_USAGE=2 ; break ;;
   esac
 done
 
 # Must be called from another script (or with --allow)
 [[ $ALLOW || $SHLVL -gt 2 ]] || { echo "Don't call this script directly, use build_all_examples instead." ; exit 1 ; }
 
+# Exit with helpful usage information
+((EXIT_USAGE)) && { usage ; let EXIT_USAGE-- ; exit $EXIT_USAGE ; }
+
 # -b|--base and -c|--config are required
 [[ -z $BASE ]] && { echo "-b|--base is required" ; exit 1 ; }
 [[ -z $CONFIG ]] && { echo "-c|--config is required" ; exit 1 ; }
+
+# Expand ~ to $HOME in provided arguments
+BASE=${BASE/#\~/$HOME}
+CONFIG=${CONFIG/#\~/$HOME}
 
 # Make sure the examples exist
 SUB1="$BASE/config/examples"
@@ -71,12 +101,21 @@ SUB="$SUB1/$CONFIG"
 # ...and contains Configuration.h or Configuration_adv.h
 [[ -n $(compgen -G "$SUB/Configuration*.h") ]] || { echo "No configuration files found in $SUB" ; exit 1 ; }
 
+# Get the location for exports and archives
+if [[ -n $OUTBASE ]]; then
+  ARCSUB="${OUTBASE/#\~/$HOME}/$CONFIG"
+  mkdir -p "$ARCSUB"
+else
+  ARCSUB="$SUB"
+fi
+
 # Delete any config files from previous builds
 rm -f Marlin/_Bootscreen.h Marlin/_Statusscreen.h
 
 # Copy configurations into the Marlin folder
 echo "Getting configuration files from $SUB"
-cp "$BASE/config/default"/*.h "$SUB"/*.h Marlin/ 2>/dev/null
+cp "$BASE"/config/default/*.h Marlin/
+cp "$SUB"/*.h Marlin/
 
 rm -f Marlin/Config.h Marlin/Config-export.h
 
@@ -87,6 +126,9 @@ IFS=$'\n'; set -f
 $SED -i~ -e "20,30{/#error/d}" Marlin/Configuration.h
 rm Marlin/Configuration.h~
 unset IFS; set +f
+
+# Hide several warnings when not exporting
+[[ -z $EXPNUM ]] && CLEANER=1
 
 # Suppress fatal warnings
 if ((CLEANER)); then
@@ -104,11 +146,13 @@ if ((CLEANER)); then
   opt_add NO_HOMING_CURRENT_WARNING
 fi
 
+# Possible exported file names (in the build folder)
 ENAME=("-name" "marlin_config.json" \
   "-o" "-name" "config.ini" \
   "-o" "-name" "schema.json" \
   "-o" "-name" "schema.yml")
 
+# Possible built firmware names (in the build folder)
 BNAME=("-type" "f" \
        "-name" 'firmware*.hex' \
   "-o" "-name" "firmware*.bin" \
@@ -139,29 +183,32 @@ set -e
 # Copy exports back to the configs
 if [[ -n $EXPNUM ]]; then
   annc "Exporting $EXPNUM"
-  [[ -f Marlin/Config-export.h ]] && { cp Marlin/Config-export.h "$SUB"/Config.h ; }
-  find "$BUILD" "${ENAME[@]}" -exec cp "{}" "$SUB" \;
+  [[ -f Marlin/Config-export.h ]] && { cp Marlin/Config-export.h "$ARCSUB"/Config.h ; }
+  find "$BUILD" "${ENAME[@]}" -exec cp "{}" "$ARCSUB" \;
 fi
 
+# Copy potential firmware files into the config folder
+# TODO: Consider firmware that needs an STM32F4_UPDATE folder.
+#       Currently only BOARD_CREALITY_F401RE env:STM32F401RE_creality
 if ((ARCHIVE)); then
   annc "Archiving"
   find "$BUILD" \( "${BNAME[@]}" \) -exec sh -c '
-    SUB="$1"
+    ARCSUB="$1"
     shift 1
     for file in "$@"; do
       cd "$(dirname "$file")"
       base=$(basename "$file")
-      tar -czf "$SUB/$base.tar.gz" "$base"
+      tar -czf "$ARCSUB/$base.tar.gz" "$base"
       rm "$base"
       cd - >/dev/null
     done
-  ' sh "$SUB" {} +
+  ' sh "$ARCSUB" {} +
 fi
 
 # Exit with error unless --nofail is set
 [[ $ERR -gt 0 && -z $NOFAIL ]] && exit $ERR
 
 # Reveal the configs after the build, if requested
-((REVEAL)) && { annc "Revealing $SUB" ; open "$SUB" ; }
+((REVEAL)) && { annc "Revealing $ARCSUB" ; open "$ARCSUB" ; }
 
 exit 0


### PR DESCRIPTION
Fixes #27386

- Fix: Some versions of `cp` won't copy more than one source file of the same name to the same destination.
- Suppress warnings (with prepended config options) when not exporting.
- Add `--output` to both `build_example` and `build_all_examples` to redirect export / archive to another location.
- Change `build_example` flag `-n` to `-f` to match `build_all_examples`.
- Add usage to `build_example`.
- Expand `~` to `$HOME` in path arguments
