### PR TITLE
🧑‍💻 Quieter AUTO_REPORT_SD_STATUS option

### DIFF
--- a/Marlin/src/inc/Conditionals-4-adv.h
+++ b/Marlin/src/inc/Conditionals-4-adv.h
@@ -1465,3 +1465,13 @@
 #if !HAS_ROTATIONAL_AXES
   #undef MANUAL_MOVE_DISTANCE_DEG
 #endif
+
+// Only report "Not SD printing" when the state changes
+// To get legacy behavior define AUTO_REPORT_SD_STATUS 2
+#ifdef AUTO_REPORT_SD_STATUS
+  #if ENABLED(AUTO_REPORT_SD_STATUS) // Not blank, 1, or true
+    #define QUIETER_AUTO_REPORT_SD_STATUS
+  #endif
+  #undef AUTO_REPORT_SD_STATUS
+  #define AUTO_REPORT_SD_STATUS
+#endif

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -22,6 +22,10 @@
 
 #include "../inc/MarlinConfig.h"
 
+/**
+ * cardreader.cpp - SD card / USB flash drive file handling interface
+ */
+
 #if HAS_MEDIA
 
 //#define DEBUG_CARDREADER
@@ -827,8 +831,17 @@ void CardReader::removeFile(const char * const name) {
   #endif
 }
 
-void CardReader::report_status() {
-  if (isPrinting() || isPaused()) {
+void CardReader::report_status(TERN_(QUIETER_AUTO_REPORT_SD_STATUS, const bool isauto/*=false*/)) {
+  const bool has_job = isStillPrinting() || isPaused();
+
+  #if ENABLED(QUIETER_AUTO_REPORT_SD_STATUS)
+    static uint32_t old_sdpos = 0;
+    if (!has_job) old_sdpos = 0;
+    if (isauto && sdpos == old_sdpos) return;
+    if (has_job) old_sdpos = sdpos;
+  #endif
+
+  if (has_job) {
     SERIAL_ECHOPGM(STR_SD_PRINTING_BYTE, sdpos);
     SERIAL_CHAR('/');
     SERIAL_ECHOLN(filesize);

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -21,6 +21,10 @@
  */
 #pragma once
 
+/**
+ * cardreader.h - SD card / USB flash drive file handling interface
+ */
+
 #include "../inc/MarlinConfig.h"
 
 #if HAS_MEDIA
@@ -162,7 +166,7 @@ public:
   static void selectFileByName(const char * const match);  // (working directory only)
 
   // Print job
-  static void report_status();
+  static void report_status(TERN_(QUIETER_AUTO_REPORT_SD_STATUS, const bool isauto=false));
   static void getAbsFilenameInCWD(char *dst);
   static void printSelectedFilename();
   static void openAndPrintFile(const char *name);   // (working directory or full path)
@@ -249,7 +253,7 @@ public:
     //
     // SD Auto Reporting
     //
-    struct AutoReportSD { static void report() { report_status(); } };
+    struct AutoReportSD { static void report() { report_status(TERN_(QUIETER_AUTO_REPORT_SD_STATUS, true)); } };
     static AutoReporter<AutoReportSD> auto_reporter;
   #endif
 


### PR DESCRIPTION
Reduce the amount of messages from `AUTO_REPORT_SD_STATUS`, especially when idle. Continue to check at the same interval, but only report SD status when it actually changes.

If the old behavior is wanted for some reason you can set `AUTO_REPORT_SD_STATUS` to 2.