### PR TITLE
🧑‍💻 CardReader::isStillPrinting

### DIFF
--- a/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
@@ -19,7 +19,9 @@ void sd_mmc_spi_mem_init() {
 }
 
 inline bool media_ready() {
-  return IS_SD_INSERTED() && !IS_SD_PRINTING() && !IS_SD_FILE_OPEN() && card.isMounted();
+  return DISABLED(DISABLE_DUE_SD_MMC)
+          && IS_SD_MOUNTED() && IS_SD_INSERTED()
+          && !IS_SD_FILE_OPEN() && !IS_SD_PRINTING();
 }
 
 bool sd_mmc_spi_unload(bool) { return true; }
@@ -29,17 +31,14 @@ bool sd_mmc_spi_wr_protect() { return false; }
 bool sd_mmc_spi_removal() { return !media_ready(); }
 
 Ctrl_status sd_mmc_spi_test_unit_ready() {
-  #ifdef DISABLE_DUE_SD_MMC
-    return CTRL_NO_PRESENT;
-  #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
   return CTRL_GOOD;
 }
 
 // NOTE: This function is defined as returning the address of the last block
 // in the card, which is cardSize() - 1
 Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
   *nb_sector = card.diskIODriver()->cardSize() - 1;
   return CTRL_GOOD;
 }
@@ -58,10 +57,7 @@ uint8_t sector_buf[SD_MMC_BLOCK_SIZE];
 // #define DEBUG_MMC
 
 Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
-  #ifdef DISABLE_DUE_SD_MMC
-    return CTRL_NO_PRESENT;
-  #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {
@@ -97,10 +93,7 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
 }
 
 Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
-  #ifdef DISABLE_DUE_SD_MMC
-    return CTRL_NO_PRESENT;
-  #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -88,7 +88,7 @@ void GcodeSuite::M125() {
     park_point += hotend_offset[active_extruder];
   #endif
 
-  const bool sd_printing = TERN0(HAS_MEDIA, IS_SD_PRINTING());
+  const bool sd_printing = IS_SD_PRINTING();
 
   ui.pause_show_message(PAUSE_MESSAGE_PARKING, PAUSE_MODE_PAUSE_PRINT);
 

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1178,10 +1178,10 @@ namespace ExtUI {
   }
 
   bool isPrintingFromMediaPaused() {
-    return TERN0(HAS_MEDIA, IS_SD_PAUSED());
+    return IS_SD_PAUSED();
   }
 
-  bool isPrintingFromMedia() { return TERN0(HAS_MEDIA, IS_SD_PRINTING() || IS_SD_PAUSED()); }
+  bool isPrintingFromMedia() { return IS_SD_PRINTING() || IS_SD_PAUSED(); }
 
   bool isPrinting() {
     return commandsInQueue() || isPrintingFromMedia() || printJobOngoing() || printingIsPaused();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -184,7 +184,7 @@ CardReader::CardReader() {
 }
 
 //
-// Get a DOS 8.3 filename in its useful form
+// Get a DOS 8.3 filename in its useful form, e.g., "MYFILE  EXT" => "MYFILE.EXT"
 //
 char *createFilename(char * const buffer, const dir_t &p) {
   char *pos = buffer;
@@ -193,8 +193,12 @@ char *createFilename(char * const buffer, const dir_t &p) {
     if (i == 8) *pos++ = '.';
     *pos++ = p.name[i];
   }
-  *pos++ = 0;
+  *pos++ = '\0';
   return buffer;
+}
+
+inline bool extIsBIN(char *ext) {
+  return ext[0] == 'B' && ext[1] == 'I' && ext[2] == 'N';
 }
 
 //
@@ -215,9 +219,7 @@ bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD,
   ) return false;
 
   flag.filenameIsDir = DIR_IS_SUBDIR(&p);               // We know it's a File or Folder
-  setBinFlag(p.name[8] == 'B' &&                        // List .bin files (a firmware file for flashing)
-             p.name[9] == 'I' &&
-             p.name[10]== 'N');
+  setBinFlag(extIsBIN((char *)&p.name[8]));             // List .bin files (a firmware file for flashing)
 
   return (
     flag.filenameIsDir                                  // All Directories are ok
@@ -576,7 +578,7 @@ void CardReader::manage_media() {
  */
 void CardReader::release() {
   // Card removed while printing? Abort!
-  if (IS_SD_PRINTING())
+  if (isStillPrinting())
     abortFilePrintSoon();
   else
     endFilePrintNow();
@@ -993,7 +995,7 @@ void CardReader::selectFileByIndex(const int16_t nr) {
       strcpy(filename, sortshort[nr]);
       strcpy(longFilename, sortnames[nr]);
       TERN_(HAS_FOLDER_SORTING, flag.filenameIsDir = IS_DIR(nr));
-      setBinFlag(strcmp_P(strrchr(filename, '.'), PSTR(".BIN")) == 0);
+      setBinFlag(extIsBIN(strrchr(filename, '.') + 1));
       return;
     }
   #endif
@@ -1011,7 +1013,7 @@ void CardReader::selectFileByName(const char * const match) {
         strcpy(filename, sortshort[nr]);
         strcpy(longFilename, sortnames[nr]);
         TERN_(HAS_FOLDER_SORTING, flag.filenameIsDir = IS_DIR(nr));
-        setBinFlag(strcmp_P(strrchr(filename, '.'), PSTR(".BIN")) == 0);
+        setBinFlag(extIsBIN(strrchr(filename, '.') + 1));
         return;
       }
   #endif


### PR DESCRIPTION
- Add `card.isStillPrinting()`.
- Use `card.` methods directly in places where other `card.` methods are referenced directly.
- Add `IS_SD_MOUNTED`
- Add `extIsBIN` to compare to `B`,`I`,`N`.
- Add comments for `card_flags_t`

…and…
- Implement `DISABLE_DUE_SD_MMC` by always returning `false` from `media_ready()`.