### PR TITLE
🚸 Fix extra Z raises

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -371,7 +371,7 @@ void GcodeSuite::G28() {
           bool with_probe = ENABLED(HOMING_Z_WITH_PROBE);
           // Raise above the current Z (which should be synced in the planner)
           // The "height" for Z is a coordinate. But if Z is not trusted/homed make it relative.
-          if (seenR || !TERN(HOME_AFTER_DEACTIVATE, axis_is_trusted, axis_was_homed)(Z_AXIS)) {
+          if (seenR || !(z_min_trusted || axis_should_home(Z_AXIS))) {
             z_homing_height += current_position.z;
             with_probe = false;
           }

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -652,6 +652,9 @@
 #if DISABLED(DELTA)
   #undef DELTA_HOME_TO_SAFE_ZONE
 #endif
+#if ANY(DELTA, AXEL_TPARA)
+  #define Z_CAN_FALL_DOWN
+#endif
 
 /**
  * This setting is also used by M109 when trying to calculate

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -80,6 +80,11 @@
 // Relative Mode. Enable with G91, disable with G90.
 bool relative_mode; // = false
 
+#if HAS_Z_AXIS
+  // If Z has been powered on trust that the real Z is >= current_position.z
+  bool z_min_trusted; // = false
+#endif
+
 /**
  * Cartesian Current Position
  *   Used to track the native machine position as moves are queued.

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -433,6 +433,10 @@ void restore_feedrate_and_scaling();
 typedef bits_t(NUM_AXES) main_axes_bits_t;
 constexpr main_axes_bits_t main_axes_mask = _BV(NUM_AXES) - 1;
 
+#if HAS_Z_AXIS
+  extern bool z_min_trusted; // If Z has been powered on trust that the real Z is >= current_position.z
+#endif
+
 void set_axis_is_at_home(const AxisEnum axis);
 
 #if HAS_ENDSTOPS

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -580,6 +580,7 @@ bool Stepper::disable_axis(const AxisEnum axis) {
   // and keep a count of how many times each ENA pin has been set.
 
   // If all the axes that share the enabled bit are disabled
+  // toggle the ENA state that they all share.
   const bool can_disable = can_axis_disable(axis);
   if (can_disable) {
     #define _CASE_DISABLE(N) case N##_AXIS: DISABLE_AXIS_##N(); break;


### PR DESCRIPTION
Before homing we don't know where Z is, but on most machines we know it's above 0. And once Z has been raised we can be pretty certain it's at or above `current_position.z`.

This PR adds a flag to indicate that Z has been powered on and its Z position should be trusted to be at or above `current_position.z`. If "Z" is disabled on a machine that has a falling toolhead then the flag is cleared when the Z stepper is powered off.