### PR TITLE
Fix compile error in menu_motion when enabled FT_MOTION_MENU

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -434,6 +434,7 @@ void menu_move() {
 
     bool show_state = c.active;
     EDIT_ITEM(bool, MSG_FIXED_TIME_MOTION, &show_state, []{
+      ft_config_t &c = ftMotion.cfg;
       c.active ^= true;
       ftMotion.update_shaping_params();
     });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -434,8 +434,7 @@ void menu_move() {
 
     bool show_state = c.active;
     EDIT_ITEM(bool, MSG_FIXED_TIME_MOTION, &show_state, []{
-      ft_config_t &c = ftMotion.cfg;
-      c.active ^= true;
+      ftMotion.cfg.active ^= true;
       ftMotion.update_shaping_params();
     });
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

There is a compile error in menu_motion.cpp when enabled `FT_MOTION_MENU`. The error message is:

```
Marlin\src\lcd\menu\menu_motion.cpp: In lambda function:
Marlin\src\lcd\menu\menu_motion.cpp:437:7: error: 'c' is not captured
       c.active ^= true;
       ^
```
The error occurs at capturing the `c` in the lambda function due to it not using capture syntax `[&]`.
However, when using `[&]`, the new error occurs because it cannot be converted from `<lambda()>` to `screenFunc_t`.

This PR fixes the error by declaring the new reference `c` within lambda. That is the same reference as the upper `c`.

This code may not be optimal, for example it can change `ftMotion.cfg.active` directly without using the `c` as before #26670. But I think it's readable to use the `c` for consistency with other codes.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
