### PR TITLE
Fix Stow Z-Probe blocking future status messages after stowing

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -812,7 +812,7 @@ G29_TYPE GcodeSuite::G29() {
 
     #endif // AUTO_BED_LEVELING_3POINT
 
-    TERN_(HAS_STATUS_MESSAGE, ui.reset_status());
+    ui.reset_status();
 
     // Stow the probe. No raise for FIX_MOUNTED_PROBE.
     if (probe.stow()) {

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1490,6 +1490,8 @@ void MarlinUI::host_notify(const char * const cstr) {
 
     else if (ENABLED(STATUS_DO_CLEAR_EMPTY))
       msg = F("");
+    else
+      return;
 
     set_min_status(msg);
   }

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1490,8 +1490,6 @@ void MarlinUI::host_notify(const char * const cstr) {
 
     else if (ENABLED(STATUS_DO_CLEAR_EMPTY))
       msg = F("");
-    else
-      return;
 
     set_min_status(msg);
   }

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -356,7 +356,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 
     FSTR_P const ds_fstr = deploy ? GET_TEXT_F(MSG_MANUAL_DEPLOY) : GET_TEXT_F(MSG_MANUAL_STOW);
     ui.return_to_status();       // To display the new status message
-    ui.set_max_status(ds_fstr);
+    ui.set_max_status(ds_fstr);  // Set a status message that won't be overwritten by the host
     SERIAL_ECHOLN(deploy ? GET_EN_TEXT_F(MSG_MANUAL_DEPLOY) : GET_EN_TEXT_F(MSG_MANUAL_STOW));
 
     OKAY_BUZZ();
@@ -381,7 +381,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #endif
     TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
 
-    ui.reset_alert_level();
+    ui.reset_status();
 
   #endif // PAUSE_BEFORE_DEPLOY_STOW
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -381,7 +381,8 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #endif
     TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
 
-    ui.reset_status();
+    ui.reset_alert_level();
+    //ui.reset_status();
 
   #endif // PAUSE_BEFORE_DEPLOY_STOW
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -381,7 +381,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #endif
     TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
 
-    ui.reset_status();
+    ui.reset_alert_level();
 
   #endif // PAUSE_BEFORE_DEPLOY_STOW
 


### PR DESCRIPTION
### Description

When told to home using a manual z probe, (Marlin will pause and display a "Deploy Z-Probe" message, and a "Stow Z-Probe" message afterward. This is correct behavior.

What is NOT correct, is that the "Stow Z-Probe" message is then permanently displayed this is because the deploy/stow messages are set to the max alert level which is never cleared after the user presses the button to confirm probe deployed/stowed (The messages should be a high alert level as the printer is waiting for user action and that message shouldn't be overwritten by anything else). 

This 1 line fix just resets the alert level after the user has stowed the probe so messages work again. There may be a better way to fix this as I don't know the code very well, but it works for me. :smile: 

### Requirements

Requires manually deployed/stowed bed probe

### Benefits

Fixes issue #27232 

### Configurations
A simple config that adds a LCD and bed probe
[Configuration.h.zip](https://github.com/user-attachments/files/16882111/Configuration.h.zip)

