### PR TITLE
add missing SLIM_LCD_MENUS checks

### DIFF
--- a/Marlin/src/lcd/menu/menu_probe_level.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_level.cpp
@@ -243,7 +243,7 @@
 void menu_probe_level() {
   const bool can_babystep_z = TERN0(BABYSTEP_ZPROBE_OFFSET, babystep.can_babystep(Z_AXIS));
 
-  #if HAS_LEVELING
+  #if HAS_LEVELING && DISABLED(SLIM_LCD_MENUS)
     const bool is_homed = all_axes_homed(),
                is_valid = leveling_is_valid();
   #endif

--- a/Marlin/src/lcd/menu/menu_probe_level.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_level.cpp
@@ -266,7 +266,7 @@ void menu_probe_level() {
       if (!is_trusted) GCODES_ITEM(MSG_AUTO_HOME, FPSTR(G28_STR));
     #endif
 
-    #if HAS_LEVELING
+    #if HAS_LEVELING && DISABLED(SLIM_LCD_MENUS)
 
       // Homed and leveling is valid? Then leveling can be toggled.
       if (is_homed && is_valid) {

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -646,8 +646,10 @@ void _lcd_ubl_level_bed() {
   START_MENU();
   BACK_ITEM(MSG_MOTION);
 
-  bool show_state = planner.leveling_active;
-  EDIT_ITEM(bool, MSG_BED_LEVELING, &show_state, _lcd_toggle_bed_leveling);
+  #if DISABLED(SLIM_LCD_MENUS)
+    bool show_state = planner.leveling_active;
+    EDIT_ITEM(bool, MSG_BED_LEVELING, &show_state, _lcd_toggle_bed_leveling);
+  #endif
 
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
     editable.decimal = planner.z_fade_height;


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/pull/27393 SLIM_LCD_MENUS is broken.

When SLIM_LCD_MENUS is enabled   void _lcd_toggle_bed_leveling() is not defined.
resulting in  this error

```CPP
In file included from Marlin/src/lcd/menu/menu_probe_level.cpp:31:0:
Marlin/src/lcd/menu/menu_probe_level.cpp: In function 'void menu_probe_level()':
Marlin/src/lcd/menu/menu_probe_level.cpp:274:56: error: '_lcd_toggle_bed_leveling' was not declared in this scope
         EDIT_ITEM(bool, MSG_BED_LEVELING, &show_state, _lcd_toggle_bed_leveling);
                                                        ^
Marlin/src/lcd/menu/menu_item.h:290:39: note: in definition of macro '_MENU_INNER_F'
```

Added missing SLIM_LCD_MENUS checks.

### Requirements

#define SLIM_LCD_MENUS
A probe I used #define FIX_MOUNTED_PROBE
A LCD I used REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
Bed leveling I used AUTO_BED_LEVELING_UBL
and to satify the requirments
#define Z_SAFE_HOMING
#define EEPROM_SETTINGS

### Benefits

Builds as expected

### Configurations

[Configuration.zip](https://github.com/user-attachments/files/17022209/Configuration.zip)

