### PR TITLE
Update platform for MKS Tinybee and others

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -209,16 +209,17 @@ int MarlinHAL::freeMemory() { return ESP.getFreeHeap(); }
 // ADC
 // ------------------------
 
-#define ADC1_CHANNEL(pin) ADC1_GPIO ## pin ## _CHANNEL
-
+// https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/peripherals/adc.html
 adc1_channel_t get_channel(int pin) {
   switch (pin) {
-    case 39: return ADC1_CHANNEL(39);
-    case 36: return ADC1_CHANNEL(36);
-    case 35: return ADC1_CHANNEL(35);
-    case 34: return ADC1_CHANNEL(34);
-    case 33: return ADC1_CHANNEL(33);
-    case 32: return ADC1_CHANNEL(32);
+    case 39: return ADC1_CHANNEL_3;
+    case 36: return ADC1_CHANNEL_0;
+    case 35: return ADC1_CHANNEL_7;
+    case 34: return ADC1_CHANNEL_6;
+    case 33: return ADC1_CHANNEL_5;
+    case 32: return ADC1_CHANNEL_4;
+    case 37: return ADC1_CHANNEL_1;
+    case 38: return ADC1_CHANNEL_2;
   }
   return ADC1_CHANNEL_MAX;
 }

--- a/Marlin/src/HAL/ESP32/timers.cpp
+++ b/Marlin/src/HAL/ESP32/timers.cpp
@@ -90,7 +90,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
   config.counter_en  = TIMER_PAUSE;
   config.alarm_en    = TIMER_ALARM_EN;
   config.intr_type   = TIMER_INTR_LEVEL;
-  config.auto_reload = true;
+  config.auto_reload = TIMER_AUTORELOAD_EN;
 
   // Select and initialize the timer
   timer_init(timer.group, timer.idx, &config);

--- a/Marlin/src/inc/MarlinConfigPre-1-axes.h
+++ b/Marlin/src/inc/MarlinConfigPre-1-axes.h
@@ -25,7 +25,7 @@
 #define __MARLIN_FIRMWARE__
 #endif
 
-#if __has_include("../../Config.h")
+#if __has_include("../../../Marlin/Config.h")
   #include "../../Config.h"
 #else
   #define USE_STD_CONFIGS 1

--- a/buildroot/share/PlatformIO/boards/marlin_MKS_TinyBee.json
+++ b/buildroot/share/PlatformIO/boards/marlin_MKS_TinyBee.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "MKS TinyBee V1.0",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 524288,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800,
+    "offset_address": 65536
+  },
+  "url": "https://github.com/makerbase-mks/MKS-TinyBee",
+  "vendor": "MKS Makerbase"
+}

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -39,9 +39,14 @@ board_build.partitions = Marlin/src/HAL/ESP32/esp32.csv
 upload_speed           = 115200
 monitor_speed          = 115200
 
+# New espressif32 packages require a valid board definition file.
 [env:mks_tinybee]
 extends                = env:esp32
+board                  = marlin_MKS_TinyBee
+platform               = espressif32@~3.5.0
 board_build.partitions = default_8MB.csv
+build_src_flags        = -O3 -Wno-volatile
+monitor_filters        = esp32_exception_decoder
 
 [env:godi_esp32]
 extends                = env:esp32

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -40,11 +40,6 @@ HAS_MARLINUI_HD44780                   = build_src_filter=+<src/lcd/HD44780>
 HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@0.5.4
                                          build_src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = build_src_filter=+<src/lcd/tft_io>
-HAS_LTDC_TFT                           = build_src_filter=+<src/HAL/STM32/tft/tft_ltdc.cpp>
-HAS_FSMC_TFT                           = build_src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>
-HAS_SPI_TFT                            = build_src_filter=+<src/HAL/STM32/tft/tft_spi.cpp> +<src/HAL/STM32F1/tft/tft_spi.cpp> +<src/HAL/LPC1768/tft/tft_spi.cpp>
-HAS_TFT_XPT2046                        = build_src_filter=+<src/HAL/STM32/tft/xpt2046.cpp> +<src/HAL/STM32F1/tft/xpt2046.cpp> +<src/HAL/LPC1768/tft/xpt2046.cpp>
-TFT_TOUCH_DEVICE_GT911                 = build_src_filter=+<src/HAL/STM32/tft/gt911.cpp>
 I2C_EEPROM                             = build_src_filter=+<src/HAL/shared/eeprom_if_i2c.cpp>
 SOFT_I2C_EEPROM                        = SlowSoftI2CMaster, SlowSoftWire=https://github.com/felias-fogg/SlowSoftWire/archive/f34d777f39.zip
 SPI_EEPROM                             = build_src_filter=+<src/HAL/shared/eeprom_if_spi.cpp>

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -30,6 +30,10 @@ build_flags       = ${common.build_flags} -DU8G_HAL_LINKS  -DPLATFORM_M997_SUPPO
                     #-funwind-tables
                     #-mpoke-function-name
 build_src_flags   = -std=gnu++20 -Wno-volatile
+custom_marlin.USES_LIQUIDCRYSTAL = arduino-libraries/LiquidCrystal@~1.0.7
+custom_marlin.NEOPIXEL_LED       = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
+custom_marlin.HAS_SPI_TFT        = build_src_filter=+<src/HAL/LPC1768/tft/tft_spi.cpp>
+custom_marlin.HAS_TFT_XPT2046    = build_src_filter=+<src/HAL/LPC1768/tft/xpt2046.cpp>
 
 #
 # NXP LPC176x ARM Cortex-M3

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -14,23 +14,22 @@
 #
 [common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.3.zip
-platform_packages = framework-arduino-lpc176x@^0.2.8
+platform_packages = framework-arduino-lpc176x@^0.2.9
                     toolchain-gccarmnoneeabi@1.100301.220327
 board             = nxp_lpc1768
 lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = ${common.extra_scripts}
-  Marlin/src/HAL/LPC1768/upload_extra_script.py
+                    Marlin/src/HAL/LPC1768/upload_extra_script.py
 build_src_filter  = ${common.default_src_filter} +<src/HAL/LPC1768> -<src/HAL/LPC1768/tft> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
-  Servo
-custom_marlin.USES_LIQUIDCRYSTAL = arduino-libraries/LiquidCrystal@~1.0.7
-custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
+                    Servo
 build_flags       = ${common.build_flags} -DU8G_HAL_LINKS  -DPLATFORM_M997_SUPPORT
                     -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g
-  # debug options for backtrace
-  #-funwind-tables
-  #-mpoke-function-name
+                    # debug options for backtrace
+                    #-funwind-tables
+                    #-mpoke-function-name
+build_src_flags   = -std=gnu++20 -Wno-volatile
 
 #
 # NXP LPC176x ARM Cortex-M3

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -19,6 +19,12 @@ build_unflags    = -std=gnu++11
 build_src_filter = ${common.default_src_filter} +<src/HAL/STM32> -<src/HAL/STM32/tft> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}
                    pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+custom_marlin.HAS_LTDC_TFT           = build_src_filter=+<src/HAL/STM32/tft/tft_ltdc.cpp>
+custom_marlin.HAS_FSMC_TFT           = build_src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp>
+                                       build_flags=-DHAL_SRAM_MODULE_ENABLED
+custom_marlin.HAS_SPI_TFT            = build_src_filter=+<src/HAL/STM32/tft/tft_spi.cpp>
+custom_marlin.HAS_TFT_XPT2046        = build_src_filter=+<src/HAL/STM32/tft/xpt2046.cpp>
+custom_marlin.TFT_TOUCH_DEVICE_GT911 = build_src_filter=+<src/HAL/STM32/tft/gt911.cpp>
 
 #
 # STM32 board based on a variant.

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -23,7 +23,7 @@
 # HAL/STM32F1 Common Environment values
 #
 [STM32F1_maple]
-platform          = ststm32@~12.1
+platform          = ststm32@~15.4.1
 board_build.core  = maple
 build_flags       = !python buildroot/share/PlatformIO/scripts/STM32F1_build_flags.py
                     ${common.build_flags} -DARDUINO_ARCH_STM32 -DMAPLE_STM32F1 -DPLATFORM_M997_SUPPORT
@@ -32,12 +32,15 @@ build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32F1> -<src/HAL/ST
 lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
                     SoftwareSerialM
-platform_packages = tool-stm32duino
+platform_packages = tool-stm32duino, toolchain-gccarmnoneeabi@1.100301.220327
 extra_scripts     = ${common.extra_scripts}
                     pre:buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
                     pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
                         buildroot/share/PlatformIO/scripts/custom_board.py
                         buildroot/share/PlatformIO/scripts/offset_and_rename.py
+custom_marlin.HAS_SPI_TFT     = build_src_filter=+<src/HAL/STM32F1/tft/tft_spi.cpp>
+custom_marlin.HAS_TFT_XPT2046 = build_src_filter=+<src/HAL/STM32F1/tft/xpt2046.cpp>
+custom_marlin.HAS_FSMC_TFT    = build_src_filter=+<src/HAL/STM32F1/tft/tft_fsmc.cpp>
 
 #
 # Generic STM32F103RC environment

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -71,7 +71,7 @@ build_flags       = ${env:STM32F103RC_btt.build_flags}
                     -DUSBD_IRQ_PRIO=5
                     -DUSBD_IRQ_SUBPRIO=6
                     -DUSBD_USE_CDC_MSC
-build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
+build_unflags     = ${env:STM32F103RC_btt.build_unflags} -DUSBD_USE_CDC
 
 #
 # Panda Pi V2.9 - Standalone (STM32F103RC)
@@ -83,8 +83,8 @@ build_flags                 = ${common_STM32F103RC_variant.build_flags}
                               -DTIMER_SERVO=TIM1
 board_build.offset          = 0x5000
 board_upload.offset_address = 0x08005000
-lib_deps =
-  markyue/Panda_SoftMasterI2C@1.0.3
+lib_deps                    = markyue/Panda_SoftMasterI2C@1.0.3
+
 #
 # MKS Robin (STM32F103ZET6)
 # Uses HAL STM32 to support Marlin UI for TFT screen with optional touch panel

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -153,7 +153,7 @@ extends                     = Anet_ET4
 board_build.encode          = firmware.srec
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
-extra_scripts               = ${stm32_variant.extra_scripts}
+extra_scripts               = ${Anet_ET4.extra_scripts}
                               buildroot/share/PlatformIO/scripts/openblt.py
 
 #
@@ -497,7 +497,8 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 extends           = env:mks_robin_nano_v3_usb_flash_drive
 build_flags       = ${env:mks_robin_nano_v3_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
-build_unflags     = -DUSBD_USE_CDC
+build_unflags     = ${env:mks_robin_nano_v3_usb_flash_drive.build_unflags}
+                    -DUSBD_USE_CDC
 
 #
 # MKS Robin Nano V3_1
@@ -626,7 +627,7 @@ extends                     = TH3D_EZBoard_V2
 board_build.encode          = firmware.bin
 board_build.offset          = 0xC000
 board_upload.offset_address = 0x0800C000
-extra_scripts               = ${stm32_variant.extra_scripts}
+extra_scripts               = ${TH3D_EZBoard_V2.extra_scripts}
                               buildroot/share/PlatformIO/scripts/openblt.py
 
 [mks_robin_nano_v1_3_f4_common]
@@ -647,11 +648,11 @@ upload_protocol             = jlink
 #
 [env:mks_robin_nano_v1_3_f4]
 extends       = mks_robin_nano_v1_3_f4_common
-build_flags   = ${stm32_variant.build_flags}
+build_flags   = ${mks_robin_nano_v1_3_f4_common.build_flags}
                 -DMCU_STM32F407VE -DENABLE_HWSERIAL3 -DSTM32_FLASH_SIZE=512
                 -DTIMER_SERVO=TIM2 -DTIMER_TONE=TIM3 -DSS_TIMER=4
                 -DHAL_SD_MODULE_ENABLED -DHAL_SRAM_MODULE_ENABLED
-build_unflags = ${stm32_variant.build_unflags}
+build_unflags = ${mks_robin_nano_v1_3_f4_common.build_unflags}
                 -DUSBCON -DUSBD_USE_CDC
 
 #
@@ -659,7 +660,7 @@ build_unflags = ${stm32_variant.build_unflags}
 #
 [env:mks_robin_nano_v1_3_f4_usbmod]
 extends       = mks_robin_nano_v1_3_f4_common
-build_flags   = ${stm32_variant.build_flags}
+build_flags   = ${mks_robin_nano_v1_3_f4_common.build_flags}
                 -DMCU_STM32F407VE -DSTM32_FLASH_SIZE=512
                 -DTIMER_SERVO=TIM2 -DTIMER_TONE=TIM3 -DSS_TIMER=4
                 -DHAL_SD_MODULE_ENABLED -DHAL_SRAM_MODULE_ENABLED


### PR DESCRIPTION
- Update MKS Tinybee env with board def, specific ESP32 platform.
- Update to newer Maple STM32.
- Use TFT code for specific HALs.
- Refer to specific extended env in derived fields.

From  #25327 by @quiret