### PR TITLE
fix typos in Configuration_adv.h Assisted Tramming comments

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1110,8 +1110,8 @@
    * Screw Thread. Use one of the following defines:
    *
    *   M3_CW = M3 Clockwise, M3_CCW = M3 Counter-Clockwise
-   *   M4_CW = M3 Clockwise, M4_CCW = M4 Counter-Clockwise
-   *   M5_CW = M3 Clockwise, M5_CCW = M5 Counter-Clockwise
+   *   M4_CW = M4 Clockwise, M4_CCW = M4 Counter-Clockwise
+   *   M5_CW = M Clockwise, M5_CCW = M5 Counter-Clockwise
    *
    * :{'M3_CW':'M3 Clockwise','M3_CCW':'M3 Counter-Clockwise','M4_CW':'M4 Clockwise','M4_CCW':'M4 Counter-Clockwise','M5_CW':'M5 Clockwise','M5_CCW':'M5 Counter-Clockwise'}
    */

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1111,7 +1111,7 @@
    *
    *   M3_CW = M3 Clockwise, M3_CCW = M3 Counter-Clockwise
    *   M4_CW = M4 Clockwise, M4_CCW = M4 Counter-Clockwise
-   *   M5_CW = M Clockwise, M5_CCW = M5 Counter-Clockwise
+   *   M5_CW = M5 Clockwise, M5_CCW = M5 Counter-Clockwise
    *
    * :{'M3_CW':'M3 Clockwise','M3_CCW':'M3 Counter-Clockwise','M4_CW':'M4 Clockwise','M4_CCW':'M4 Counter-Clockwise','M5_CW':'M5 Clockwise','M5_CCW':'M5 Counter-Clockwise'}
    */


### PR DESCRIPTION
### Description

Fixes 2 typos in Assisted Tramming comments

### Requirements

Configuration_adv.h from newer than https://github.com/MarlinFirmware/Marlin/commit/45b9680c57f36fc7cab1ccfacf3ab5eb63097242

### Benefits

Comments make sense.

### Related Issues

<li>MarlinFirmware/Marlin/issues/27435
<li>MarlinFirmware/Configurations/pull/1103