### PR TITLE
add GCODE_CASE_INSENSITIVE support to e_parser

### DIFF
--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -158,20 +158,8 @@ void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
     #endif
 
     #if ENABLED(EP_BABYSTEPPING)
-      case EP_M2:
-        switch (c) {
-          case '9': state = EP_M29;    break;
-          default: state  = EP_IGNORE;
-        }
-        break;
-
-      case EP_M29:
-        switch (c) {
-          case '3': state = EP_M293;   break;
-          case '4': state = EP_M294;   break;
-          default: state  = EP_IGNORE;
-        }
-        break;
+      case EP_M2:  state = (c == '9') ? EP_M29  : EP_IGNORE; break;
+      case EP_M29: state = (c == '3') ? EP_M293 : (c == '4') ? EP_M294 : EP_IGNORE; break;
     #endif
 
     #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -61,9 +61,15 @@ extern bool wait_for_user, wait_for_heatup;
 #endif
 
 void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
+  auto uppercase = [](char c) {
+    if (TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')))
+      c += 'A' - 'a';
+    return c;
+  };
+
   switch (state) {
     case EP_RESET:
-      switch (c) {
+      switch (uppercase(c)) {
         case ' ': case '\n': case '\r': break;
         case 'N': state = EP_N; break;
         case 'M': state = EP_M; break;
@@ -81,7 +87,7 @@ void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
       break;
 
     case EP_N:
-      switch (c) {
+      switch (uppercase(c)) {
         case '0' ... '9':
         case '-': case ' ':     break;
         case 'M': state = EP_M; break;
@@ -174,7 +180,7 @@ void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
       case EP_M87: state = (c == '6') ? EP_M876 : EP_IGNORE; break;
 
       case EP_M876:
-        switch (c) {
+        switch (uppercase(c)) {
           case ' ': break;
           case 'S': state = EP_M876S; break;
           default: state = EP_IGNORE; break;

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -62,9 +62,7 @@ extern bool wait_for_user, wait_for_heatup;
 
 void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
   auto uppercase = [](char c) {
-    if (TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')))
-      c += 'A' - 'a';
-    return c;
+    return TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')) ? c + 'A' - 'a' : c;
   };
 
   switch (state) {

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -115,9 +115,7 @@ void GCodeParser::parse(char *p) {
   reset(); // No codes to report
 
   auto uppercase = [](char c) {
-    if (TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')))
-      c += 'A' - 'a';
-    return c;
+    return TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')) ? c + 'A' - 'a' : c;
   };
 
   // Skip spaces

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -192,7 +192,7 @@ public:
     #if ENABLED(GCODE_CASE_INSENSITIVE)
       FORCE_INLINE static char* strgchr(char *p, char g) {
         auto uppercase = [](char c) {
-          return c + (WITHIN(c, 'a', 'z') ? 'A' - 'a' : 0);
+          return TERN0(GCODE_CASE_INSENSITIVE, WITHIN(c, 'a', 'z')) ? c + 'A' - 'a' : c;
         };
         const char d = uppercase(g);
         for (char cc; (cc = uppercase(*p)); p++) if (cc == d) return p;


### PR DESCRIPTION
### Description

It was noticed on Discord that with GCODE_CASE_INSENSITIVE enabled you could m0-m1 - Unconditional stop as expected, but m108 did not work.

The reason the emergency parser only looks for uppercase characters in the serial buffer.

Added support for lowercase to also work when GCODE_CASE_INSENSITIVE is enabled.

### Requirements

GCODE_CASE_INSENSITIVE
EMERGENCY_PARSER

### Benefits

EMERGENCY_PARSER works with GCODE_CASE_INSENSITIVE
