### PR TITLE
🩹 Followup to ♻️ BTT_SKR_V3_0 => BTT_SKR_3 / 3a6bd69

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -1052,9 +1052,9 @@
     #error "BOARD_TRONXY_V10 is now BOARD_TRONXY_CXY_446_V10. Please update your configuration."
   #elif MB(VAKE403D)
     #error "BOARD_VAKE403D is no longer supported in Marlin."
-  #elif MB(BOARD_BTT_SKR_V3_0)
+  #elif MB(BTT_SKR_V3_0)
     #error "BOARD_BTT_SKR_V3_0 is now BOARD_BTT_SKR_3."
-  #elif MB(BOARD_BTT_SKR_V3_0_EZ)
+  #elif MB(BTT_SKR_V3_0_EZ)
     #error "BOARD_BTT_SKR_V3_0_EZ is now BOARD_BTT_SKR_3_EZ."
   #elif defined(MOTHERBOARD)
     #error "Unknown MOTHERBOARD value set in Configuration.h."


### PR DESCRIPTION
### Description

Fix improper `MB()` macro usage from "♻️ BTT_SKR_V3_0 => BTT_SKR_3" / 3a6bd69

### Requirements

SKR V3, SKR V3 EZ

### Benefits

Renamed motherboard sanity checks will work correctly.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/commit/3a6bd6920e445a334a95704453ee310bed0c367a
