### PR TITLE
update BABYSTEP_MULTIPLICATOR_Z assert

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -505,7 +505,7 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
       static_assert(BABYSTEP_MULTIPLICATOR_XY <= 0.25f, "BABYSTEP_MULTIPLICATOR_XY must be less than or equal to 0.25mm.");
     #endif
   #else
-    static_assert((BABYSTEP_MULTIPLICATOR_Z == (int)BABYSTEP_MULTIPLICATOR_Z) && (BABYSTEP_MULTIPLICATOR_Z != 0), "BABYSTEP_MULTIPLICATOR_Z must be a non-zero integer.");
+    static_assert(BABYSTEP_MULTIPLICATOR_Z && BABYSTEP_MULTIPLICATOR_Z == int(BABYSTEP_MULTIPLICATOR_Z), "BABYSTEP_MULTIPLICATOR_Z must be a non-zero integer.");
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -500,10 +500,12 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #elif ENABLED(BABYSTEP_XY) && !defined(BABYSTEP_MULTIPLICATOR_XY)
     #error "BABYSTEP_XY requires BABYSTEP_MULTIPLICATOR_XY."
   #elif ENABLED(BABYSTEP_MILLIMETER_UNITS)
-    static_assert(BABYSTEP_MULTIPLICATOR_Z <= 0.1f, "BABYSTEP_MULTIPLICATOR_Z must be less or equal to 0.1mm.");
+    static_assert(BABYSTEP_MULTIPLICATOR_Z <= 0.1f, "BABYSTEP_MULTIPLICATOR_Z with BABYSTEP_MILLIMETER_UNITS must be less or equal to 0.1mm.");
     #if ENABLED(BABYSTEP_XY)
       static_assert(BABYSTEP_MULTIPLICATOR_XY <= 0.25f, "BABYSTEP_MULTIPLICATOR_XY must be less than or equal to 0.25mm.");
     #endif
+  #else
+    static_assert((BABYSTEP_MULTIPLICATOR_Z == (int)BABYSTEP_MULTIPLICATOR_Z) && (BABYSTEP_MULTIPLICATOR_Z != 0), "BABYSTEP_MULTIPLICATOR_Z must be a non-zero integer.");
   #endif
 #endif
 


### PR DESCRIPTION
### Description

BABYSTEP_MULTIPLICATOR_Z  has two modes
If BABYSTEP_MILLIMETER_UNITS is defined the value must be less or equal to 0.1
else (ie step mode) the value needs to be a non zero integer,

BABYSTEP_MILLIMETER_UNITS has a static assert to check if the value is valid.
step mode did not.

This lead to https://github.com/MarlinFirmware/Marlin/issues/27438
Where the user set
```
//#define BABYSTEP_MILLIMETER_UNITS       // Specify BABYSTEP_MULTIPLICATOR_(XY|Z) in mm instead of micro-steps
  #define BABYSTEP_MULTIPLICATOR_Z  0.01       // (steps or mm) Steps or millimeter distance for each Z babystep
```
Causing baby stepping to not work.

I updated the description of the original assert to make it clear that  BABYSTEP_MILLIMETER_UNITS was set.
I added a second assert to test for integers values for step mode.

### Requirements

#define BABYSTEPPING
#define BABYSTEP_MILLIMETER_UNITS  or  //#define BABYSTEP_MILLIMETER_UNITS
#define BABYSTEP_MULTIPLICATOR_Z {assorted values}

### Benefits

Less confused users

### Related Issues
<li>MarlinFirmware/Marlin/issues/27438