### PR TITLE
Partially revert changes from #27392 to fix due LCD SPI

### DIFF
--- a/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
@@ -32,14 +32,14 @@ Ctrl_status sd_mmc_spi_test_unit_ready() {
   #ifdef DISABLE_DUE_SD_MMC
     return CTRL_NO_PRESENT;
   #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
   return CTRL_GOOD;
 }
 
 // NOTE: This function is defined as returning the address of the last block
 // in the card, which is cardSize() - 1
 Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
   *nb_sector = card.diskIODriver()->cardSize() - 1;
   return CTRL_GOOD;
 }
@@ -61,7 +61,7 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
   #ifdef DISABLE_DUE_SD_MMC
     return CTRL_NO_PRESENT;
   #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {
@@ -100,7 +100,7 @@ Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
   #ifdef DISABLE_DUE_SD_MMC
     return CTRL_NO_PRESENT;
   #endif
-  if (!media_ready()) return CTRL_NO_PRESENT;
+  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {

--- a/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
@@ -19,7 +19,7 @@ void sd_mmc_spi_mem_init() {
 }
 
 inline bool media_ready() {
-  return IS_SD_INSERTED() && !IS_SD_PRINTING() && !IS_SD_FILE_OPEN() && card.isMounted();
+  return IS_SD_MOUNTED() && IS_SD_INSERTED() && !IS_SD_FILE_OPEN() && !IS_SD_PRINTING();
 }
 
 bool sd_mmc_spi_unload(bool) { return true; }

--- a/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/DUE/usb/sd_mmc_spi_mem.cpp
@@ -19,9 +19,7 @@ void sd_mmc_spi_mem_init() {
 }
 
 inline bool media_ready() {
-  return DISABLED(DISABLE_DUE_SD_MMC)
-          && IS_SD_MOUNTED() && IS_SD_INSERTED()
-          && !IS_SD_FILE_OPEN() && !IS_SD_PRINTING();
+  return IS_SD_INSERTED() && !IS_SD_PRINTING() && !IS_SD_FILE_OPEN() && card.isMounted();
 }
 
 bool sd_mmc_spi_unload(bool) { return true; }
@@ -31,14 +29,17 @@ bool sd_mmc_spi_wr_protect() { return false; }
 bool sd_mmc_spi_removal() { return !media_ready(); }
 
 Ctrl_status sd_mmc_spi_test_unit_ready() {
-  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
+  #ifdef DISABLE_DUE_SD_MMC
+    return CTRL_NO_PRESENT;
+  #endif
+  if (!media_ready()) return CTRL_NO_PRESENT;
   return CTRL_GOOD;
 }
 
 // NOTE: This function is defined as returning the address of the last block
 // in the card, which is cardSize() - 1
 Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
-  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
+  if (!media_ready()) return CTRL_NO_PRESENT;
   *nb_sector = card.diskIODriver()->cardSize() - 1;
   return CTRL_GOOD;
 }
@@ -57,7 +58,10 @@ uint8_t sector_buf[SD_MMC_BLOCK_SIZE];
 // #define DEBUG_MMC
 
 Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
-  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
+  #ifdef DISABLE_DUE_SD_MMC
+    return CTRL_NO_PRESENT;
+  #endif
+  if (!media_ready()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {
@@ -93,7 +97,10 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
 }
 
 Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
-  if (sd_mmc_spi_removal()) return CTRL_NO_PRESENT;
+  #ifdef DISABLE_DUE_SD_MMC
+    return CTRL_NO_PRESENT;
+  #endif
+  if (!media_ready()) return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
   {

--- a/Marlin/src/feature/easythreed_ui.cpp
+++ b/Marlin/src/feature/easythreed_ui.cpp
@@ -189,7 +189,7 @@ void EasythreedUI::printButton() {
             blink_interval_ms = LED_BLINK_2;                        // Blink the indicator LED at 1 second intervals
             print_key_flag = PF_PAUSE;                              // The "Print" button now pauses the print
             card.mount();                                           // Force SD card to mount - now!
-            if (!card.isMounted) {                                  // Failed to mount?
+            if (!card.isMounted()) {                                // Failed to mount?
               blink_interval_ms = LED_OFF;                          // Turn off LED
               print_key_flag = PF_START;
               return;                                               // Bail out


### PR DESCRIPTION
Changes to SPI in #27392 break Lulzbot TFT SPI communication. Reverting the changes to this file restore operation.

Cardreader changes need investigation, as with these changes machine will boot loop with USB inserted.  Removing the usb at boot, then inserting after init allows it to complete. Does not occur with all changes from this the origin PR reverted.

