### PR TITLE
MKS UI long filename WiFi upload

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_print_file.h
+++ b/Marlin/src/lcd/extui/mks_ui/draw_print_file.h
@@ -42,12 +42,8 @@ extern DIR_OFFSET dir_offset[10];
 
 typedef struct {
   char file_name[FILE_NUM][FILENAME_LENGTH * MAX_DIR_LEVEL + 1];
+  char long_name[FILE_NUM][TERN(LONG_FILENAME_WRITE_SUPPORT, LONG_FILENAME_LENGTH, FILENAME_LENGTH * 2) + 1];
   char curDirPath[FILENAME_LENGTH * MAX_DIR_LEVEL + 1];
-  #if ENABLED(LONG_FILENAME_WRITE_SUPPORT)
-  char long_name[FILE_NUM][LONG_FILENAME_LENGTH + 1];
-  #else
-  char long_name[FILE_NUM][FILENAME_LENGTH * 2 + 1];
-  #endif
   bool IsFolder[FILE_NUM];
   char Sd_file_cnt;
   char sd_file_index;

--- a/Marlin/src/lcd/extui/mks_ui/draw_print_file.h
+++ b/Marlin/src/lcd/extui/mks_ui/draw_print_file.h
@@ -19,6 +19,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
+#include "../../../sd/SdFatConfig.h"
+
 #pragma once
 
 #ifdef __cplusplus
@@ -33,15 +35,19 @@ typedef struct {
 extern DIR_OFFSET dir_offset[10];
 
 #define FILE_NUM 6
-#define SHORT_NAME_LEN 13
+
 #define NAME_CUT_LEN 23
 
 #define MAX_DIR_LEVEL  10
 
 typedef struct {
-  char file_name[FILE_NUM][SHORT_NAME_LEN * MAX_DIR_LEVEL + 1];
-  char curDirPath[SHORT_NAME_LEN * MAX_DIR_LEVEL + 1];
-  char long_name[FILE_NUM][SHORT_NAME_LEN * 2 + 1];
+  char file_name[FILE_NUM][FILENAME_LENGTH * MAX_DIR_LEVEL + 1];
+  char curDirPath[FILENAME_LENGTH * MAX_DIR_LEVEL + 1];
+  #if ENABLED(LONG_FILENAME_WRITE_SUPPORT)
+  char long_name[FILE_NUM][LONG_FILENAME_LENGTH + 1];
+  #else
+  char long_name[FILE_NUM][FILENAME_LENGTH * 2 + 1];
+  #endif
   bool IsFolder[FILE_NUM];
   char Sd_file_cnt;
   char sd_file_index;


### PR DESCRIPTION
### Description
This fix enables file uploads via Wi-Fi with long filenames when LONG_FILENAME_WRITE_SUPPORT is enabled.

Additionally, it resolves a bug in the length calculation for the char long_name variable in draw_print_file.h

### Requirements

MKS UI

### Benefits
Supports uploading files with long filenames to the SD card.

### Configurations

LONG_FILENAME_WRITE_SUPPORT

### Related Issues


