### PR TITLE
📌 Pin Ubuntu Runner to 22.04

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,7 @@ jobs:
   autolabel:
     name: Auto Label
     if: github.repository == 'MarlinFirmware/Marlin'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Auto Label for [BUG]
       uses: actions/github-script@v7

--- a/.github/workflows/bump-date.yml
+++ b/.github/workflows/bump-date.yml
@@ -14,7 +14,7 @@ jobs:
     name: Bump Distribution Date
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -18,7 +18,7 @@ jobs:
     name: PR Bad Target
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: superbrothers/close-pull-request@v3

--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build Test
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: true

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
     # pulls them into additional branches.
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out the PR

--- a/.github/workflows/ci-validate-boards.yml
+++ b/.github/workflows/ci-validate-boards.yml
@@ -23,7 +23,7 @@ jobs:
     name: Validate boards.h
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out the PR

--- a/.github/workflows/ci-validate-pins.yml
+++ b/.github/workflows/ci-validate-pins.yml
@@ -26,7 +26,7 @@ jobs:
     name: Validate Pins Files
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out the PR

--- a/.github/workflows/clean-closed.yml
+++ b/.github/workflows/clean-closed.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   remove_label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,7 +14,7 @@ jobs:
     name: Close Stale Issues
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/stale@v9

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lock Closed Issues
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: dessant/lock-threads@v5

--- a/.github/workflows/unlock-reopened.yml
+++ b/.github/workflows/unlock-reopened.yml
@@ -14,7 +14,7 @@ jobs:
     name: Unlock Reopened
     if: github.repository == 'MarlinFirmware/Marlin'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: OSDKDev/unlock-issues@v1.1


### PR DESCRIPTION
### Description

GitHub recently updated `ubuntu-latest` to Ubuntu 24, but rolled it back due to it causing various issues (see https://github.com/actions/runner-images/issues/10636) with a bunch of Actions, which included breaking our own build tests for a short time. To prevent this from happening again, it's recommended that we pin the runner image version instead of using `ubuntu-latest`.

### Related Issues

- https://github.com/actions/runner-images/issues/10636
