### PR TITLE
fix menu homing feedrate display

### DIFF
--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -410,17 +410,17 @@ void menu_advanced_settings();
 
     #if ENABLED(MENUS_ALLOW_INCH_UNITS)
       #define _EDIT_HOMING_FR(A) do{ \
+        const float minfr = MMS_TO_MMM(planner.settings.min_feedrate_mm_s); \
         const float maxfr = MMS_TO_MMM(planner.settings.max_feedrate_mm_s[_AXIS(A)]); \
         editable.decimal = A##_AXIS_UNIT(homing_feedrate_mm_m.A); \
-        EDIT_ITEM(float5, MSG_HOMING_FEEDRATE_N, &editable.decimal, \
-          A##_AXIS_UNIT(10), A##_AXIS_UNIT(maxfr), []{ \
+        EDIT_ITEM_FAST_N(float5, _AXIS(A), MSG_HOMING_FEEDRATE_N, &editable.decimal, \
+          A##_AXIS_UNIT(minfr), A##_AXIS_UNIT(maxfr), []{ \
           homing_feedrate_mm_m.A = parser.axis_value_to_mm(_AXIS(A), editable.decimal); \
         }); \
       }while(0);
     #else
-      #define _EDIT_HOMING_FR(A) do{ \
-        EDIT_ITEM(float5, MSG_HOMING_FEEDRATE_N, &homing_feedrate_mm_m.A, 10, MMS_TO_MMM(planner.settings.max_feedrate_mm_s[_AXIS(A)])); \
-      }while(0);
+      #define _EDIT_HOMING_FR(A)  \
+        EDIT_ITEM_FAST_N(float5, _AXIS(A), MSG_HOMING_FEEDRATE_N, &homing_feedrate_mm_m.A, MMS_TO_MMM(planner.settings.min_feedrate_mm_s), MMS_TO_MMM(planner.settings.max_feedrate_mm_s[_AXIS(A)]));
     #endif
 
     MAIN_AXIS_MAP(_EDIT_HOMING_FR);

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -419,7 +419,7 @@ void menu_advanced_settings();
         }); \
       }while(0);
     #else
-      #define _EDIT_HOMING_FR(A)  \
+      #define _EDIT_HOMING_FR(A) \
         EDIT_ITEM_FAST_N(float5, _AXIS(A), MSG_HOMING_FEEDRATE_N, &homing_feedrate_mm_m.A, MMS_TO_MMM(planner.settings.min_feedrate_mm_s), MMS_TO_MMM(planner.settings.max_feedrate_mm_s[_AXIS(A)]));
     #endif
 


### PR DESCRIPTION
### Description

The Menu homing feedrate displays incorrectly, repeating the axis name vs unique axis names. 

![Screenshot from 2024-11-05 17-19-00](https://github.com/user-attachments/assets/f03d8b80-d5e9-4e37-98a9-f053cb7f330d)

### Requirements

An appropriate LCD
#define EDITABLE_HOMING_FEEDRATE
optionally with 
#define MENUS_ALLOW_INCH_UNITS and #define INCH_MODE_SUPPORT

### Benefits

Menu displays correctly in both metric and imperial modes.

### Configurations

[Sim Configuration.zip](https://github.com/user-attachments/files/17680893/Sim.Configuration.zip)

### Related Issues

<li>MarlinFirmware/Marlin/issues/27513