### PR TITLE
Fix CREALITY_ENDER2P_V24S4 pins for BLTouch and Filament Runout

### DIFF
--- a/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
+++ b/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h
@@ -75,7 +75,7 @@
 // Servos
 //
 #ifndef SERVO0_PIN
-  #define SERVO0_PIN                        PB0   // BLTouch OUT *
+  #define SERVO0_PIN                        PB1   // BLTouch IN *
 #endif
 
 //
@@ -83,17 +83,17 @@
 //
 #define X_STOP_PIN                          PA5
 #define Y_STOP_PIN                          PA6
-#define Z_STOP_PIN                          PB0   // BLTOUCH *
+#define Z_STOP_PIN                          PB0
 
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PB1   // BLTouch IN *
+  #define Z_MIN_PROBE_PIN                   PB2   // BLTouch OUT *
 #endif
 
 //
 // Filament Runout Sensor
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                    PC15  // "Pulled-high" *
+  #define FIL_RUNOUT_PIN                    PA4  // "Pulled-high" *
 #endif
 
 //


### PR DESCRIPTION
### Description

Fixes pins for BLTouch and Filament Runout connectors on the Ender-2 Pro v2.4.S4 board. The existing definitions don't match the actual connectors.

### Requirements

- Ender-2 Pro with v2.4.S4 board
- BLTouch/CRTouch or clone
- Generic Filament Runout Sensor

### Benefits

BTouch probes and filament runout sensors can be used on this printer by changing only the configs.


### Related Issues
#27481 

