### PR TITLE
guard e variables in G61

### DIFF
--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -75,7 +75,9 @@ void GcodeSuite::G61(int8_t slot/*=-1*/) {
 
   // No XYZ...E parameters, move to stored position
 
-  float epos = stored_position[slot].e;
+  #if HAS_EXTRUDERS
+    float epos = stored_position[slot].e;
+  #endif
   if (!parser.seen_axis()) {
     DEBUG_ECHOLNPGM(STR_RESTORING_POSITION, slot, " (all axes)");
     // Move to the saved position, all axes except E


### PR DESCRIPTION
### Description

G61 assumes the extruder exists
Added a check that extruder actually exists. 

### Requirements

SAVED_POSITIONS

### Benefits

Builds as expected

### Configurations

Ramp based example 
[Configuration.zip](https://github.com/user-attachments/files/17686458/Configuration.zip)

### Related Issues

<li>MarlinFirmware/Marlin/issues/27477
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
