### PR TITLE
🔧 Direct Stepping sanity checks

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4335,7 +4335,7 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 #if ENABLED(DIRECT_STEPPING)
   #if ENABLED(CPU_32_BIT)
     #error "Direct Stepping is not supported on 32-bit boards."
-  #elif DISABLED(IS_FULL_CARTESIAN)
+  #elif !IS_FULL_CARTESIAN
     #error "Direct Stepping is incompatible with enabled kinematics."
   #endif
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4330,6 +4330,17 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 #endif
 
 /**
+ * Direct Stepping requirements
+ */
+#if ENABLED(DIRECT_STEPPING)
+  #if ENABLED(CPU_32_BIT)
+    #error "Direct Stepping is not supported on 32-bit boards."
+  #elif DISABLED(IS_FULL_CARTESIAN)
+    #error "Direct Stepping is incompatible with enabled kinematics."
+  #endif
+#endif
+
+/**
  * Input Shaping requirements
  */
 #if HAS_ZV_SHAPING


### PR DESCRIPTION
### Description

Direct stepping is incompatible with 32-bit boards (though, @colinrgodsey plans to eventually add support). It's also incompatible with core/delta/etc. kinematics, so let's sanity check them.

### Requirements

`DIRECT_STEPPING`

### Benefits

Build-time sanity checks to inform users of incompatible config options.

### Related Issues

None. Found while helping someone on Facebook.