### PR TITLE
Added new 'P' (precise probing) option to G28

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -530,6 +530,18 @@ void GcodeSuite::G28() {
 
     #endif // DUAL_X_CARRIAGE
 
+    #if HAS_BED_PROBE
+      // Perform precise homing using the same probing procedure as bed leveling
+      if (parser.seen_test('P')) {
+          xy_pos_t xyPos = { current_position.x, current_position.y };
+          float probedZHeight = probe.probe_at_point(xyPos, PROBE_PT_RAISE, 0, false);
+          DEBUG_ECHOLNPGM("Probed ZHeight (correction amount): ", probedZHeight);
+
+          current_position.z -= probedZHeight;
+          sync_plan_position();
+      }
+    #endif
+
     endstops.not_homing();
 
     // Clear endstop state for polled stallGuard endstops


### PR DESCRIPTION
### Description

This feature addesses feature request #9802 and adds a new flag ('P' for precise homing) to G28 (Homing) that provides an alternative to the 'bump' option which is an option configured in Marlin via `HOMING_BUMP_MM` that causes G28 to perform a second slower and more accurate probe. The 'P' option causes the G28 gcode to use the same algorithm used by bed leveling.

The new 'P' flag is very useful for machines that have probing accuracy issues that cannot be solved by bump. Since the 'P' option allows for all the same flags and options to be configured as for bed leveling, it is possible to configure multiple probes as well as turn off stepper motors and bed heating functions to reduce EMI interferance (as per what already exists for bed leveling). A first probe is still necessary for an initial home as the 'P' option will take the error that it finds and use that as a correction to the homing position.

It is recommend although not mandatory to use this with safe homing as `Z_SAFE_HOMING_X_POINT` and `Z_SAFE_HOMING_Y_POINT` can then be set to precisely match a known reference point (e.g. a point on the UBL mesh that is always adjusted to be at Z 0).

If this change looks acceptable then i will follow up with a PR to update the G28 documentation also. I know that this feature has been requested since 2018 so hopefully this is a welcomed addition :)

### Requirements

Requires a Bed Probe (i.e. #define HAS_BED_PROBE)

### Benefits

Useful alternative to G28 'bump' that allows the G28 homing to be much for configurable. In particular it can benefit for stepper motor and bed heater control to mitigate EMI as well as to use the MULTIPLE_PROBING  and EXTRA_PROBING options. 
The way that these existing options work (and have always worked but perhaps been scarcely documented) is as follows (this code can be found in probe.cpp):

1. The machine will probe TOTAL_PROBING ((MULTIPLE_PROBING + EXTRA_PROBING) number of times.
2. The results of the probe will be sorted
3. If EXTRA_PROBING is greater than zero then the values fartherest from the middle will be removed. This is accomplished by iteratively comparing both the start and the end values against the middle value and upon each iteration, remove the start or end value that deviates the most from the middle value.
4. Take the average of all that remain and return this as the final value.

I believe this is actually a very good way to remove outliers and works very well for probes that periodically return erroneous results that are significant outliers and would otherwise throw off the whole average.

### Configurations

*No configuration required*

### Related Issues

* Closes #9802