### PR TITLE
Update hc32.ini - reduce warnings

### DIFF
--- a/Marlin/src/HAL/HC32/README.md
+++ b/Marlin/src/HAL/HC32/README.md
@@ -11,7 +11,7 @@ The HC32F460 HAL is designed to be generic enough for any HC32F460-based board. 
    - Examine the board's main processor. (Refer the naming key in `hc32.ini`.)
    - Extend the `HC32F460C_common` base env for 256K, or `HC32F460E_common` for 512K.
 3. Determine your board's application start address (see [below](#finding-the-application-start-address))
-4. Set `board_build.ld_args.flash_start` to the app start address once you've found it. If your board doesn't use a bootloader, you may be able to use the "ICSP" header or DFU. This document will be updated once we have more information about flashing without a bootloader.
+4. Set `board_upload.offset_address` to the app start address once you've found it. If your board doesn't use a bootloader, you may be able to use the "ICSP" header or DFU. This document will be updated once we have more information about flashing without a bootloader.
 
 ### Finding the application start address
 

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -65,14 +65,14 @@ board_build.flags.cpp = -fno-threadsafe-statics  # Disable thread-safe statics (
 #
 [HC32F460C_base]
 extends = HC32F460_base
-board_upload.ld_args.maximum_size = 256K
+board_upload.maximum_size = 262144
 
 #
 # Base HC32F460xExx (512K Flash)
 #
 [HC32F460E_base]
 extends = HC32F460_base
-board_upload.ld_args.maximum_size = 512K
+board_upload.maximum_size = 524288
 
 #
 # Voxelab Aquila V1.0.0/V1.0.1/V1.0.2/V1.0.3 as found in the Voxelab Aquila X2 & C2

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -35,12 +35,12 @@ build_src_filter  = ${common.default_src_filter} +<src/HAL/HC32> +<src/HAL/share
 build_type        = release
 build_flags       = -D ARDUINO_ARCH_HC32
                     -D PLATFORM_M997_SUPPORT  # Enable M997 command
-                                              # note: ddl and arduino debug mode are
+                                              # NOTE: DDL and Arduino debug mode are
                                               # automatically enabled with MARLIN_DEV_MODE
                    #-D __DEBUG                # force DDL debug mode
                    #-D __CORE_DEBUG           # force Arduino core debug mode
 
-# hc32 app configuration file
+# HC32 app configuration file
 board_build.app_config = Marlin/src/HAL/HC32/app_config.h
 
 # Drivers and Middleware required by the HC32 HAL
@@ -51,40 +51,40 @@ board_build.ddl.timer0 = true
 board_build.ddl.timera = true
 board_build.mw.sd_card = true
 
-# extra build flags
-board_build.flags.common = -g3                # Force emit debug symbols to elf. this does not affect the final binary size
-                           -fno-signed-char   # Force unsigned chars. this is required for meatpack to work
+# Extra build flags
+board_build.flags.common = -g3                   # Force emit debug symbols to elf. This does not affect the final binary size
+                           -fno-signed-char      # Force unsigned char. This is required for meatpack to work
 
 # Additional flags to reduce binary size
-board_build.flags.cpp = -fno-threadsafe-statics   # Disable thread-safe statics (only one core anyway)
-                        -fno-exceptions           # Disable exceptions (not used by marlin)
-                        -fno-rtti                 # Disable RTTI (not used by marlin)
+board_build.flags.cpp = -fno-threadsafe-statics  # Disable thread-safe statics (only one core anyway)
+                        -fno-exceptions          # Disable exceptions (not used by Marlin)
+                        -fno-rtti                # Disable RTTI (not used by Marlin)
 
 #
 # Base HC32F460xCxx (256K Flash)
 #
 [HC32F460C_base]
 extends = HC32F460_base
-board_build.ld_args.flash_size = 256K
+board_upload.ld_args.maximum_size = 256K
 
 #
 # Base HC32F460xExx (512K Flash)
 #
 [HC32F460E_base]
 extends = HC32F460_base
-board_build.ld_args.flash_size = 512K
+board_upload.ld_args.maximum_size = 512K
 
 #
 # Voxelab Aquila V1.0.0/V1.0.1/V1.0.2/V1.0.3 as found in the Voxelab Aquila X2 & C2
 #
 [env:HC32F460C_aquila_101]
 extends = HC32F460C_base
-board_build.ld_args.flash_start = 0xC000    # Bootloader start address, as logged by the bootloader on boot
-board_build.ld_args.boot_mode = secondary   # Save ~1.4k of flash by compiling as secondary firmware
+board_upload.offset_address = 0xC000  # Bootloader start address, as logged by the bootloader on boot
+board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as secondary firmware
 
 #
 # Creality Ender 2 Pro v2.4.S4_170 (HC32f460kcta) (256K Flash, 192K RAM).
 #
 [env:HC32F460C_e2p24s4]
 extends = HC32F460C_base
-board_build.ld_args.flash_start = 0x8000
+board_upload.offset_address = 0x8000


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
`HC32F460C_aquila_101` gives the following warnings:

```r
linker parameters: FLASH_START=49152, FLASH_SIZE=262144; BOOT_MODE=2; usable flash size: 212992     
Warning: you appear to be using legacy option 'build.ld_args.flash_start'! Use 'upload.offset_address' instead.
Warning: you appear to be using legacy option 'build.ld_args.flash_size'! Use 'upload.maximum_size' instead.
Warning: you appear to be using legacy option 'build.ld_args.boot_mode'! Use 'build.boot_mode' instead.
```

- Updated **hc32.ini** (cosmetic)
- Changed build parameters to reduce warnings.


<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
