### PR TITLE
📌 Update, pin LPC PIO framework

### DIFF
--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -14,7 +14,7 @@
 #
 [common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.3.zip
-platform_packages = framework-arduino-lpc176x@^0.2.9
+platform_packages = framework-arduino-lpc176x@https://github.com/p3p/pio-framework-arduino-lpc176x/archive/ab41696b64.zip
                     toolchain-gccarmnoneeabi@1.100301.220327
 board             = nxp_lpc1768
 lib_ldf_mode      = off


### PR DESCRIPTION
### Description

Update & pin LPC PIO framework to latest version that fixes configs with multiple drivers enabled on a single axis.

ex: Z1 and Z2 with 2209s. Z2 would not work correctly without this version.

cc: @p3p, @tombrazier

### Requirements

Any LPC config with multiple drivers enabled for a single axis.

### Benefits

LPC config with multiple drivers enabled for a single axis will work again.

### Configurations

Any LPC config

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/27341
- https://github.com/p3p/pio-framework-arduino-lpc176x/pull/55
- https://github.com/MarlinFirmware/Marlin/issues/27545
