### PR TITLE
fix esp32 builds

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -86,8 +86,8 @@ def search_compiler(env):
         # Use any item in $PATH corresponding to a platformio toolchain bin folder
         if ppath.match(env['PROJECT_PACKAGES_DIR'] + "/**/bin"):
             for gpath in ppath.glob(gcc_exe):
-                # Skip '*-elf-g++' (crosstool-NG)
-                if not gpath.stem.endswith('-elf-g++'):
+                # Skip '*-elf-g++' (crosstool-NG) except for xtensa32
+                if not "xtensa32" not in str(gpath) and gpath.stem.endswith('-elf-g++'):
                     gccpath = str(gpath.resolve())
                     break
 


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/commit/f2d585ac7f5dad29aa57112ea327812f91924088 attempting to build marlin for esp32 based boards under windows results in the  error.

'CC' is not recognized as an internal or external command, operable program or batch file.

The issue is 

```python
                # Skip '*-elf-g++' (crosstool-NG)
                if not gpath.stem.endswith('-elf-g++'):
                    gccpath = str(gpath.resolve())
                    break
```
But esp32 uses .platformio/packages/toolchain-xtensa32/bin/xtensa-esp32-elf-g++

Under Linux it defaults back to g++, and most systems have this compiler so it does not error.
But under windows it defaults to CC, and  windows does not have a stock compiler installed.

The fix is to also check for esp32, if "xtensa32" is in the path it is a esp32 so don't skip this *-elf-g++


```python
                # Skip '*-elf-g++' (crosstool-NG) except for xtensa32
                if not "xtensa32" not in str(gpath) and gpath.stem.endswith('-elf-g++'):
                    gccpath = str(gpath.resolve())
                    break
```
### Requirements

use a ESP32 based board eg
#define MOTHERBOARD BOARD_MKS_TINYBEE

### Benefits

Builds as expected

### Related Issues

<li>MarlinFirmware/Marlin/issues/27553