### PR TITLE
add comments to tinybee pins file

### DIFF
--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -43,7 +43,7 @@
 //
 // Servos
 //
-#define SERVO0_PIN                             2  // 3D TOUCH, Pin is level shifted to 5v, and cannot be used as an input pin
+#define SERVO0_PIN                             2  // 3D TOUCH, Pin is level-shifted to 5V, and cannot be used as an INPUT pin!
 
 //
 // Limit Switches
@@ -130,7 +130,7 @@
  *                 ------                                 ------
  *                  EXP1                                   EXP2
  *
- * * = Note: Pin is level shifted to 5v, cannot be used as an input pin
+ * * = Note: Pin is level-shifted to 5V. Cannot be used as an INPUT pin!
  *           Displays like a CR10_STOCKDISPLAY that require inputs on EXP1 cannot be plugged straight into this board.
  */
 

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -43,7 +43,7 @@
 //
 // Servos
 //
-#define SERVO0_PIN                             2  // 3D TOUCH
+#define SERVO0_PIN                             2  // 3D TOUCH, Pin is level shifted to 5v, and cannot be used as an input pin
 
 //
 // Limit Switches
@@ -121,14 +121,17 @@
 #define ADC_REFERENCE_VOLTAGE                  2.565  // 2.5V reference VDDA
 
 /**
- *                ------                                 ------
- *  (BEEPER) 149 | 1  2 | 13 (BTN_ENC)    (SPI MISO) 19 | 1  2 | 18 (SPI SCK)
- *  (LCD_EN)  21 | 3  4 |  4 (LCD_RS)      (BTN_EN1) 14 | 3  4 |  5 (SPI CS)
- *  (LCD_D4)   0 | 5  6   16 (LCD_D5)      (BTN_EN2) 12 | 5  6   23 (SPI MOSI)
- *  (LCD_D6)  15 | 7  8 | 17 (LCD_D7)      (SPI_DET) 34 | 7  8 | RESET
- *           GND | 9 10 | 5V                        GND | 9 10 | 3.3V
- *                ------                                 ------
- *                 EXP1                                   EXP2
+ *                 ------                                 ------
+ *  (BEEPER)  149 | 1  2 | 13  (BTN_ENC)   (SPI MISO) 19 | 1  2 | 18 (SPI SCK)
+ *  (LCD_EN)  21* | 3  4 |  4* (LCD_RS)     (BTN_EN1) 14 | 3  4 |  5 (SPI CS)
+ *  (LCD_D4)   0* | 5  6   16* (LCD_D5)     (BTN_EN2) 12 | 5  6   23 (SPI MOSI)
+ *  (LCD_D6)  15* | 7  8 | 17* (LCD_D7)     (SPI_DET) 34 | 7  8 | RESET
+ *            GND | 9 10 | 5V                        GND | 9 10 | 3.3V
+ *                 ------                                 ------
+ *                  EXP1                                   EXP2
+ *
+ * * = Note: Pin is level shifted to 5v, cannot be used as an input pin
+ *           Displays like a CR10_STOCKDISPLAY that require inputs on EXP1 cannot be plugged straight into this board.
  */
 
 #define EXP1_01_PIN                          149


### PR DESCRIPTION
### Description

Was trying to help a user to add a CR10_STOCKDISPLAY to the tinybee.
Simple right? just update the boards pins file.    But no...

Many of the EXP1 pins are level shifted to 5v and as such are now outputs only. and cannot be used as inputs. So in this case the encoder BTN_EN1 and BTN_EN2 will not work.

Added comments to Marlin/src/pins/esp32/pins_MKS_TINYBEE.h to warn anyone else trying this. 

### Requirements

Marlin/src/pins/esp32/pins_MKS_TINYBEE.h

### Benefits

More documentation in pins file

