### PR TITLE
Addition of G34 (Z Steppers Auto-Alignment) to ProUI Homing menu

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2207,6 +2207,13 @@ void setMoveX() { hmiValue.axis = X_AXIS; setPFloatOnClick(X_MIN_POS, X_MAX_POS,
 void setMoveY() { hmiValue.axis = Y_AXIS; setPFloatOnClick(Y_MIN_POS, Y_MAX_POS, UNITFDIGITS, applyMove, liveMove); }
 void setMoveZ() { hmiValue.axis = Z_AXIS; setPFloatOnClick(Z_MIN_POS, Z_MAX_POS, UNITFDIGITS, applyMove, liveMove); }
 
+#if ENABLED(Z_STEPPER_AUTO_ALIGN)
+  void autoZAlign() {
+    LCD_MESSAGE(MSG_AUTO_Z_ALIGN);
+    queue.inject(F("G34"));
+  }
+#endif
+
 #if HAS_HOTEND
   void setMoveE() {
     const float e_min = current_position.e - (EXTRUDE_MAXLENGTH),
@@ -4101,6 +4108,9 @@ void drawMaxAccelMenu() {
       #endif
       #if HAS_Z_AXIS
         MENU_ITEM(ICON_HomeZ, MSG_AUTO_HOME_Z, onDrawMenuItem, homeZ);
+      #endif
+      #if ENABLED(Z_STEPPER_AUTO_ALIGN)
+        MENU_ITEM(ICON_HomeZ, MSG_AUTO_Z_ALIGN, onDrawMenuItem, autoZAlign);
       #endif
       #if ENABLED(MESH_BED_LEVELING)
         EDIT_ITEM(ICON_ZAfterHome, MSG_Z_AFTER_HOME, onDrawPInt8Menu, setZAfterHoming, &hmiData.zAfterHoming);


### PR DESCRIPTION
### Description

This is a feature update to add the `G34` (Z Steppers Auto-Alignment) command to the ProUI `Homing` menu. 
I noticed it was missing when `Z_STEPPER_AUTO_ALIGN` was defined and which does enable it on the older LCD.

### Requirements

Requires a ProUI compatible display, `Z_STEPPER_AUTO_ALIGN` to be defined in `Configuration_adv.h` and of course the printer to have multiple individually controlled Z motors.

### Benefits

You can auto align multiple z axis motors using the ProUI display.

### Configurations

Just define `Z_STEPPER_AUTO_ALIGN` in `Configuration_adv.h`

### Related Issues

None
