### PR TITLE
followup to  27561 fix stm32 build

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -87,7 +87,7 @@ def search_compiler(env):
         if ppath.match(env['PROJECT_PACKAGES_DIR'] + "/**/bin"):
             for gpath in ppath.glob(gcc_exe):
                 # Skip '*-elf-g++' (crosstool-NG) except for xtensa32
-                if not "xtensa32" not in str(gpath) and gpath.stem.endswith('-elf-g++'):
+                if not ("xtensa32" not in str(gpath) and gpath.stem.endswith('-elf-g++')):
                     gccpath = str(gpath.resolve())
                     break
 

--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -87,7 +87,7 @@ def search_compiler(env):
         if ppath.match(env['PROJECT_PACKAGES_DIR'] + "/**/bin"):
             for gpath in ppath.glob(gcc_exe):
                 # Skip '*-elf-g++' (crosstool-NG) except for xtensa32
-                if not ("xtensa32" not in str(gpath) and gpath.stem.endswith('-elf-g++')):
+                if not gpath.stem.endswith('-elf-g++') or "xtensa32" in str(gpath):
                     gccpath = str(gpath.resolve())
                     break
 
@@ -95,7 +95,7 @@ def search_compiler(env):
         for ppath in envpath:
             for gpath in ppath.glob(gcc_exe):
                 # Skip macOS Clang
-                if gpath != 'usr/bin/g++' or env['PLATFORM'] != 'darwin':
+                if not (gpath == 'usr/bin/g++' and env['PLATFORM'] == 'darwin'):
                     gccpath = str(gpath.resolve())
                     break
 


### PR DESCRIPTION
### Description

PR 27561 made it worse due to missing brackets. now all non esp32 fail with CC error on windows.
Added missing brackets.  retested again.

### Requirements

attempt to build a non esp32 board or a exp32 based board under windows, both should work.

### Benefits

Builds as expected

### Related

<li>MarlinFirmware/Marlin/pull/27561
