### PR TITLE
Add a G29 S{value} lower limit check for AUTO_BED_LEVELING_LINEAR and AUTO_BED_LEVELING_BILINEAR

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1646,15 +1646,15 @@
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
 #define PROBING_MARGIN 10
 
-// X and Y axis travel speed (mm/min) between probes.
+// X and Y axis travel speed between probes.
 // Leave undefined to use the average of the current XY homing feedrate.
-#define XY_PROBE_FEEDRATE (133*60)
+#define XY_PROBE_FEEDRATE   (133*60)  // (mm/min)
 
 // Feedrate (mm/min) for the first approach when double-probing (MULTIPLE_PROBING == 2)
-#define Z_PROBE_FEEDRATE_FAST (4*60)
+#define Z_PROBE_FEEDRATE_FAST (4*60)  // (mm/min)
 
 // Feedrate (mm/min) for the "accurate" probe of each point
-#define Z_PROBE_FEEDRATE_SLOW (Z_PROBE_FEEDRATE_FAST / 2)
+#define Z_PROBE_FEEDRATE_SLOW (Z_PROBE_FEEDRATE_FAST / 2) // (mm/min)
 
 /**
  * Probe Activation Switch

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -346,7 +346,7 @@ enum AxisEnum : uint8_t {
 #define LOOP_DISTINCT_E(VAR) for (uint8_t VAR = 0; VAR < DISTINCT_E; ++VAR)
 
 //
-// feedRate_t is just a humble float
+// feedRate_t is just a humble float that can represent mm/s or mm/min
 //
 typedef float feedRate_t;
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -392,9 +392,8 @@ G29_TYPE GcodeSuite::G29() {
 
     #if ABL_USES_GRID
 
+      const feedRate_t min_probe_feedrate_mm_s = MMM_TO_MMS(_MAX(5.0f, XY_PROBE_FEEDRATE_MIN, XY_PROBE_FEEDRATE));
       xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
-
-      const feedRate_t min_probe_feedrate_mm_s = MMM_TO_MMS(_MAX(1.0f, _MIN(XY_PROBE_FEEDRATE_MIN, XY_PROBE_FEEDRATE)));
       if (xy_probe_feedrate_mm_s < min_probe_feedrate_mm_s) {
         xy_probe_feedrate_mm_s = min_probe_feedrate_mm_s;
         SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_probe_feedrate_mm_s, ")"));

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -393,6 +393,12 @@ G29_TYPE GcodeSuite::G29() {
     #if ABL_USES_GRID
 
       xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
+      #ifdef XY_PROBE_FEEDRATE_MIN
+        if (xy_probe_feedrate_mm_s <= MMM_TO_MMS(XY_PROBE_FEEDRATE_MIN)) {
+          SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Probe XY feedrate set too low. using default XY_PROBE_FEEDRATE"));
+          xy_probe_feedrate_mm_s = MMM_TO_MMS(XY_PROBE_FEEDRATE);
+        }
+      #endif
 
       const float x_min = probe.min_x(), x_max = probe.max_x(),
                   y_min = probe.min_y(), y_max = probe.max_y();

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -392,7 +392,7 @@ G29_TYPE GcodeSuite::G29() {
 
     #if ABL_USES_GRID
 
-      const feedRate_t min_probe_feedrate_mm_s = MMM_TO_MMS(_MAX(5.0f, XY_PROBE_FEEDRATE_MIN, XY_PROBE_FEEDRATE));
+      constexpr feedRate_t min_probe_feedrate_mm_s = XY_PROBE_FEEDRATE_MIN;
       xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
       if (xy_probe_feedrate_mm_s < min_probe_feedrate_mm_s) {
         xy_probe_feedrate_mm_s = min_probe_feedrate_mm_s;

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -394,10 +394,10 @@ G29_TYPE GcodeSuite::G29() {
 
       xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
 
-      const feedRate_t min_feedrate_mm_s = MMM_TO_MMS(_MAX(1.0f, _MIN(XY_PROBE_FEEDRATE_MIN, XY_PROBE_FEEDRATE)));
-      if (xy_probe_feedrate_mm_s < min_feedrate_mm_s) {
-        xy_probe_feedrate_mm_s = min_feedrate_mm_s;
-        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_feedrate_mm_s, ")"));
+      const feedRate_t min_probe_feedrate_mm_s = MMM_TO_MMS(_MAX(1.0f, _MIN(XY_PROBE_FEEDRATE_MIN, XY_PROBE_FEEDRATE)));
+      if (xy_probe_feedrate_mm_s < min_probe_feedrate_mm_s) {
+        xy_probe_feedrate_mm_s = min_probe_feedrate_mm_s;
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_probe_feedrate_mm_s, ")"));
       }
 
       const float x_min = probe.min_x(), x_max = probe.max_x(),

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -494,7 +494,7 @@
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
   #define ABL_USES_GRID 1
   #ifndef XY_PROBE_FEEDRATE_MIN
-    #define XY_PROBE_FEEDRATE_MIN 5 // Minimum mm/min value for 'G29 S<feedrate>'
+    #define XY_PROBE_FEEDRATE_MIN 60 // Minimum mm/min value for 'G29 S<feedrate>'
   #endif
 #endif
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR, AUTO_BED_LEVELING_3POINT)

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -493,6 +493,9 @@
 #endif
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
   #define ABL_USES_GRID 1
+  #ifndef XY_PROBE_FEEDRATE_MIN
+    #define XY_PROBE_FEEDRATE_MIN 5 // Minimum feedrate for probing moves in mm/minute
+  #endif
 #endif
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR, AUTO_BED_LEVELING_3POINT)
   #define HAS_ABL_NOT_UBL 1

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -494,7 +494,7 @@
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
   #define ABL_USES_GRID 1
   #ifndef XY_PROBE_FEEDRATE_MIN
-    #define XY_PROBE_FEEDRATE_MIN 5 // Minimum feedrate for probing moves in mm/minute
+    #define XY_PROBE_FEEDRATE_MIN 5 // Minimum mm/min value for 'G29 S<feedrate>'
   #endif
 #endif
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR, AUTO_BED_LEVELING_3POINT)


### PR DESCRIPTION
### Description

Both AUTO_BED_LEVELING_LINEAR and AUTO_BED_LEVELING_BILINEAR allow the user to override XY_PROBE_FEEDRATE with G29 S{value}
There is no sanity checking for this value, so the user can set it to 0, which for a feed rates makes moves take (quite literally) forever   

I have added a lower limit to check against  XY_PROBE_FEEDRATE_MIN
This can be changed if the user wishes to add it to their config, but by default it is set to 5mm/min 
Now any attempt to use set G29 S{value} equal or lower XY_PROBE_FEEDRATE_MIN will error with "Probe XY feedrate set too low. using default XY_PROBE_FEEDRATE"

I added this to stop users who are using UBL gcode examples eg "G29 S0  // save to slot 0" on a  BILINEAR or LINEAR bed leveling system. As this stops all probing movement.

I chose 5mm/mm as the default as most ubl user don't use that many slots so the examples have low S values. I also found that 1mm/min also result in no movement. (something to dig into another time)

 ### Requirements

AUTO_BED_LEVELING_LINEAR or AUTO_BED_LEVELING_BILINEAR

### Benefits

 BILINEAR or LINEAR the user cannot set the G29 S{value} so low that movement stops.

### Related Issues

<li>MarlinFirmware/Marlin/issues/27577