### PR TITLE
add LPC1768 OR LPC1769 capability for board that can have either 

### DIFF
--- a/Marlin/src/pins/lpc1768/env_validate.h
+++ b/Marlin/src/pins/lpc1768/env_validate.h
@@ -22,12 +22,14 @@
 #ifndef ENV_VALIDATE_H
 #define ENV_VALIDATE_H
 
-#if ENABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1769)
-  #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
-#elif DISABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1768)
-  #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
+#if DISABLED(REQUIRE_EITHER_LPC1768_OR_LPC1769)
+  #if ENABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1769)
+    #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
+  #elif DISABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1768)
+    #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
+  #endif
 #endif
 
 #undef REQUIRE_LPC1769
-
-#endif
+#undef REQUIRE_EITHER_LPC1768_OR_LPC1769
+#endif // ENV_VALIDATE_H

--- a/Marlin/src/pins/lpc1768/env_validate.h
+++ b/Marlin/src/pins/lpc1768/env_validate.h
@@ -22,14 +22,17 @@
 #ifndef ENV_VALIDATE_H
 #define ENV_VALIDATE_H
 
-#if DISABLED(REQUIRE_EITHER_LPC1768_OR_LPC1769)
-  #if ENABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1769)
+#if NOT_TARGET(MCU_LPC1768, MCU_LPC1769)
+  #if ENABLED(ALLOW_LPC1768_OR_9)
+    #error "Oops! Make sure you have the LPC1768 or LPC1769 environment selected in your IDE."
+  #elif ENABLED(REQUIRE_LPC1769)
     #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
-  #elif DISABLED(REQUIRE_LPC1769) && NOT_TARGET(MCU_LPC1768)
+  #else
     #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
   #endif
 #endif
 
+#undef ALLOW_LPC1768_OR_9
 #undef REQUIRE_LPC1769
-#undef REQUIRE_EITHER_LPC1768_OR_LPC1769
+
 #endif // ENV_VALIDATE_H

--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -25,6 +25,7 @@
  * Makerbase MKS SBASE pin assignments
  */
 
+#define REQUIRE_EITHER_LPC1768_OR_LPC1769
 #include "env_validate.h"
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -25,7 +25,7 @@
  * Makerbase MKS SBASE pin assignments
  */
 
-#define REQUIRE_EITHER_LPC1768_OR_LPC1769
+#define ALLOW_LPC1768_OR_9
 #include "env_validate.h"
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/lpc1769/env_validate.h
+++ b/Marlin/src/pins/lpc1769/env_validate.h
@@ -22,8 +22,9 @@
 #ifndef ENV_VALIDATE_H
 #define ENV_VALIDATE_H
 
-#if NOT_TARGET(MCU_LPC1769)
+#if NOT_TARGET(MCU_LPC1769) && DISABLED(REQUIRE_EITHER_LPC1768_OR_LPC1769)
   #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
 #endif
 
-#endif
+#undef REQUIRE_EITHER_LPC1768_OR_LPC1769
+#endif //ENV_VALIDATE_H

--- a/Marlin/src/pins/lpc1769/env_validate.h
+++ b/Marlin/src/pins/lpc1769/env_validate.h
@@ -22,9 +22,12 @@
 #ifndef ENV_VALIDATE_H
 #define ENV_VALIDATE_H
 
-#if NOT_TARGET(MCU_LPC1769) && DISABLED(REQUIRE_EITHER_LPC1768_OR_LPC1769)
+#if ENABLED(ALLOW_LPC1768_OR_9) && NOT_TARGET(MCU_LPC1768, MCU_LPC1769)
+  #error "Oops! Make sure you have the LPC1768 or LPC1769 environment selected in your IDE."
+#elif NOT_TARGET(MCU_LPC1769)
   #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
 #endif
 
-#undef REQUIRE_EITHER_LPC1768_OR_LPC1769
-#endif //ENV_VALIDATE_H
+#undef ALLOW_LPC1768_OR_9
+
+#endif // ENV_VALIDATE_H

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -26,6 +26,7 @@
  * See https://smoothieware.github.io/Webif-pack/documentation/web/html/smoothieboard.html
  */
 
+#define REQUIRE_EITHER_LPC1768_OR_LPC1769
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME   "Smoothieboard"

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -26,7 +26,7 @@
  * See https://smoothieware.github.io/Webif-pack/documentation/web/html/smoothieboard.html
  */
 
-#define REQUIRE_EITHER_LPC1768_OR_LPC1769
+#define ALLOW_LPC1768_OR_9
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME   "Smoothieboard"

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -456,9 +456,9 @@
 //
 
 #elif MB(RAMPS_14_RE_ARM_EFB, RAMPS_14_RE_ARM_EEB, RAMPS_14_RE_ARM_EFF, RAMPS_14_RE_ARM_EEF, RAMPS_14_RE_ARM_SF)
-  #include "lpc1768/pins_RAMPS_RE_ARM.h"            // LPC1768                              env:LPC1768
+  #include "lpc1768/pins_RAMPS_RE_ARM.h"            // LPC1768/9                            env:LPC1768 env:LPC1769
 #elif MB(MKS_SBASE)
-  #include "lpc1768/pins_MKS_SBASE.h"               // LPC1768                              env:LPC1768
+  #include "lpc1768/pins_MKS_SBASE.h"               // LPC1768/9                            env:LPC1768 env:LPC1769
 #elif MB(AZSMZ_MINI)
   #include "lpc1768/pins_AZSMZ_MINI.h"              // LPC1768                              env:LPC1768
 #elif MB(BIQU_BQ111_A4)
@@ -497,7 +497,7 @@
 #elif MB(COHESION3D_MINI)
   #include "lpc1769/pins_COHESION3D_MINI.h"         // LPC1769                              env:LPC1769
 #elif MB(SMOOTHIEBOARD)
-  #include "lpc1769/pins_SMOOTHIEBOARD.h"           // LPC1769                              env:LPC1769
+  #include "lpc1769/pins_SMOOTHIEBOARD.h"           // LPC1769                              env:LPC1768 env:LPC1769
 #elif MB(TH3D_EZBOARD)
   #include "lpc1769/pins_TH3D_EZBOARD.h"            // LPC1769                              env:LPC1769
 #elif MB(BTT_SKR_V1_4_TURBO)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -497,7 +497,7 @@
 #elif MB(COHESION3D_MINI)
   #include "lpc1769/pins_COHESION3D_MINI.h"         // LPC1769                              env:LPC1769
 #elif MB(SMOOTHIEBOARD)
-  #include "lpc1769/pins_SMOOTHIEBOARD.h"           // LPC1769                              env:LPC1768 env:LPC1769
+  #include "lpc1769/pins_SMOOTHIEBOARD.h"           // LPC1768/9                            env:LPC1768 env:LPC1769
 #elif MB(TH3D_EZBOARD)
   #include "lpc1769/pins_TH3D_EZBOARD.h"            // LPC1769                              env:LPC1769
 #elif MB(BTT_SKR_V1_4_TURBO)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -456,7 +456,7 @@
 //
 
 #elif MB(RAMPS_14_RE_ARM_EFB, RAMPS_14_RE_ARM_EEB, RAMPS_14_RE_ARM_EFF, RAMPS_14_RE_ARM_EEF, RAMPS_14_RE_ARM_SF)
-  #include "lpc1768/pins_RAMPS_RE_ARM.h"            // LPC1768/9                            env:LPC1768 env:LPC1769
+  #include "lpc1768/pins_RAMPS_RE_ARM.h"            // LPC1768                              env:LPC1768
 #elif MB(MKS_SBASE)
   #include "lpc1768/pins_MKS_SBASE.h"               // LPC1768/9                            env:LPC1768 env:LPC1769
 #elif MB(AZSMZ_MINI)


### PR DESCRIPTION
### Description

It was discovered that some boards can have either a LPC1768 or LPC1769
In particular a MKS_SBASE was just recently found in the wild with a LPC1769

![mks_sbase_lpc1769](https://github.com/user-attachments/assets/76154030-508a-4877-b971-2282f7b8197b)

When looking into this I also noticed that the SMOOTHIEBOARD also didn't accept LPC1768 or LPC1769 and I know from personal experience this board can have either

Before someone says what about the BTT_SKR_V1_4, it has LPC1768 and LPC1769
No it doesnt
BTT_SKR_V1_4 is LPC1768 while BTT_SKR_V1_4_TURBO is LPC1769

### Requirements

SMOOTHIEBOARD or MKS_SBASE board with either LPC1768 or LPC1769

### Benefits

Builds as expected

### Related Issues
https://discord.com/channels/461605380783472640/1315708058353143939/1316814832502050836