### PR TITLE
Filament motion encoder steps counter

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2121,6 +2121,8 @@
         //#define FIL_MOTION8_PULLUP
         //#define FIL_MOTION8_PULLDOWN
       #endif // FILAMENT_SWITCH_AND_MOTION
+
+      //#define MOTION_STEPS_COUNTER //Adds menu that displays/resets number of pulses from filament motion encoder. Use calibration mode to count without motion.
     #endif // FILAMENT_MOTION_SENSOR
   #endif // FILAMENT_RUNOUT_DISTANCE_MM
 #endif // FILAMENT_RUNOUT_SENSOR

--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -55,6 +55,11 @@ bool FilamentMonitorBase::enabled = true,
     bool RunoutResponseDelayed::ignore_motion = false;
     float RunoutResponseDelayed::motion_distance_mm = FILAMENT_MOTION_DISTANCE_MM;
   #endif
+  #if ENABLED(MOTION_STEPS_COUNTER)
+    uint16_t FilamentSensorEncoder::encoder_steps;
+    bool     FilamentSensorEncoder::extruding;
+    bool     FilamentSensorEncoder::calibration;
+  #endif
 #else
   int8_t RunoutResponseDebounced::runout_count[NUM_RUNOUT_SENSORS]; // = 0
 #endif

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -263,6 +263,11 @@ class FilamentSensorBase {
                       change    = old_state ^ new_state;
         old_state = new_state;
 
+        #if ENABLED(MOTION_STEPS_COUNTER)
+          if (change && (extruding || calibration))
+            encoder_steps++;
+        #endif
+
         #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
           if (change) {
             SERIAL_ECHOPGM("Motion detected:");
@@ -276,6 +281,12 @@ class FilamentSensorBase {
       }
 
     public:
+      #if ENABLED(MOTION_STEPS_COUNTER)
+        static bool     extruding;
+        static bool     calibration;
+        static uint16_t encoder_steps;
+      #endif
+
       // Called from ISR context to indicate a block was completed
       static void block_completed(const block_t * const b) {
         // If the sensor wheel has moved since the last call to

--- a/Marlin/src/gcode/control/M1111.cpp
+++ b/Marlin/src/gcode/control/M1111.cpp
@@ -1,0 +1,12 @@
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(MOTION_STEPS_COUNTER)
+
+#include "../gcode.h"
+#include "../../feature/runout.h"
+
+void GcodeSuite::M1111() {
+  FilamentSensorEncoder::encoder_steps = 0;
+}
+
+#endif // MOTION_STEPS_COUNTER

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1163,6 +1163,10 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
         case 3426: M3426(); break;                                // M3426: Read MCP3426 ADC (over i2c)
       #endif
 
+      #if ENABLED(MOTION_STEPS_COUNTER)
+        case 1111: M1111(); break;
+      #endif
+
       default: parser.unknown_command_warning(); break;
     }
     break;

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1376,6 +1376,10 @@ private:
     static void M710_report(const bool forReplay=true);
   #endif
 
+  #if ENABLED(MOTION_STEPS_COUNTER)
+    static void M1111();
+  #endif
+
   static void T(const int8_t tool_index) IF_DISABLED(HAS_TOOLCHANGE, { UNUSED(tool_index); });
 
 };

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -939,6 +939,10 @@ namespace LanguageNarrow_en {
   LSTR MSG_FTM_RESONANCE_FREQ             = _UxGT("Resonance Freq.");
   LSTR MSG_FTM_TIMELINE_FREQ              = _UxGT("Timeline (s)");
   LSTR MSG_TOUCH_CALIBRATION              = _UxGT("Touch Calibration");
+  LSTR MSG_ENCODER_INFO                   = _UxGT("Filament motion");
+  LSTR MSG_ENCODER_STEPS                  = _UxGT("Steps/reset");
+  LSTR MSG_ENCODER_CALIBRATION            = _UxGT("Calibration mode");
+
   LSTR MSG_MARLIN                         = _UxGT("Marlin");
   LSTR MSG_PID_P                          = _UxGT("PID-P");
   LSTR MSG_PID_P_E                        = _UxGT("PID-P *");

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -66,6 +66,10 @@
   #include "../../feature/repeat.h"
 #endif
 
+#if ENABLED(MOTION_STEPS_COUNTER)
+  #include "../../feature/runout.h"
+#endif
+
 void menu_tune();
 void menu_cancelobject();
 void menu_motion();
@@ -244,6 +248,16 @@ void menu_configuration();
   }
 
 #endif // CUSTOM_MENU_MAIN
+
+#if ENABLED(MOTION_STEPS_COUNTER)
+  void encoder_info_menu() {
+    START_MENU();
+    BACK_ITEM(MSG_MAIN_MENU);
+    EDIT_ITEM(uint16_5, MSG_ENCODER_STEPS,   &FilamentSensorEncoder::encoder_steps, 0, 1);
+    EDIT_ITEM(bool, MSG_ENCODER_CALIBRATION, &FilamentSensorEncoder::calibration);
+    END_MENU();
+  }
+#endif
 
 void menu_main() {
   const bool busy = marlin.printingIsActive();
@@ -457,6 +471,10 @@ void menu_main() {
     // MMU3 can show print stats which can be useful during
     // the print, so MMU menus are required for MMU3.
     if (TERN1(HAS_PRUSA_MMU2, !busy)) SUBMENU(MSG_MMU2_MENU, menu_mmu2);
+  #endif
+
+  #if ENABLED(MOTION_STEPS_COUNTER)
+    SUBMENU(MSG_ENCODER_INFO,encoder_info_menu);
   #endif
 
   SUBMENU(MSG_CONFIGURATION, menu_configuration);

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -126,6 +126,10 @@ Stepper stepper; // Singleton
   #include "../HAL/ESP32/i2s.h"
 #endif
 
+#if ENABLED(MOTION_STEPS_COUNTER)
+  #include "../feature/runout.h"
+#endif
+
 // public:
 
 #if ANY(HAS_EXTRA_ENDSTOPS, Z_STEPPER_AUTO_ALIGN)
@@ -2975,6 +2979,8 @@ void Stepper::isr() {
             }
           #endif
         #endif
+
+      TERN_(MOTION_STEPS_COUNTER, FilamentSensorEncoder::extruding = XYZ_HAS_STEPS(current_block));
       }
     } // !current_block
 

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -389,3 +389,4 @@ HAS_MICROSTEPS                         = build_src_filter=+<src/gcode/control/M3
                                          luc-github/ESP32SSDP@1.1.1
                                          lib_ignore=ESPAsyncTCP
                                          build_flags=-DSRCHOME=${platformio.src_dir}/src -DHALHOME=SRCHOME
+MOTION_STEPS_COUNTER                   = build_src_filter=+<src/gcode/control/M1111.cpp>


### PR DESCRIPTION
This PR adds counter of filament motion encoder steps. It could be very useful for various measurement and and calculations, like flow calibration for non-linear extrusion or total filament consumption length.

![image](https://github.com/user-attachments/assets/0a61b49d-e22f-4af3-ac42-154b511bcc11)

![image](https://github.com/user-attachments/assets/5c1388db-15a8-40ca-ad30-e6e369633cad)
When calibration mode off (default) retraction/unretraction (i.e. filament motion without axis movement) are not counted.

![image](https://github.com/user-attachments/assets/5062ca90-8121-438a-a446-280d031089e4)
To reset counter enter to steps editing and click. Only zero value could be chosen.
