### PR TITLE
Added SD_ prefix for SD card pins names for ERYONE_Ery32_mini board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
@@ -200,7 +200,7 @@
 //
 #define ENABLE_SPI1
 #define SD_DETECT_PIN                       PA4
-#define SCK_PIN                             PA5
-#define MISO_PIN                            PA6
-#define MOSI_PIN                            PA7
-#define SS_PIN                              PC4
+#define SD_SCK_PIN                          PA5
+#define SD_MISO_PIN                         PA6
+#define SD_MOSI_PIN                         PA7
+#define SD_SS_PIN                           PC4


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Added missing SD_ prefix for sd card pins names. Printer could not find SD card with old names.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
