### PR TITLE
Bugfix jg aurora a1

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_JGAURORA_A5S_A1.h
+++ b/Marlin/src/pins/stm32f1/pins_JGAURORA_A5S_A1.h
@@ -49,7 +49,7 @@
 // Enable EEPROM Emulation for this board, so that we don't overwrite factory data
 #if NO_EEPROM_SELECTED
   //#define I2C_EEPROM                            // AT24C64
-  //#define FLASH_EEPROM_EMULATION
+  #define FLASH_EEPROM_EMULATION
 #endif
 
 #if ENABLED(I2C_EEPROM)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Zx/start.S
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Zx/start.S
@@ -1,0 +1,104 @@
+/**
+  *************** (C) COPYRIGHT 2017 STMicroelectronics ************************
+  * @file      startup_stm32f101xe.s
+  * @author    MCD Application Team
+  * @brief     STM32F101xE Value Line Devices vector table for Atollic toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Configure the clock system
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M3 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m3
+  .fpu softvfp
+  .thumb
+
+.global g_pfnVectors
+.global Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word _sidata
+/* start address for the .data section. defined in linker script */
+.word _sdata
+/* end address for the .data section. defined in linker script */
+.word _edata
+/* start address for the .bss section. defined in linker script */
+.word _sbss
+/* end address for the .bss section. defined in linker script */
+.word _ebss
+
+.equ  BootRAM,        0xF1E0F85F
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+  .section .text.Reset_Handler
+  .weak Reset_Handler
+  .type Reset_Handler, %function
+Reset_Handler:
+
+  /* Disable SysTick interrupt (was enabled by jg aurora bootloader) */
+  ldr r2,SysTick
+  movs r1, #0
+  str r1, [r2]
+  /* Copy the data segment initializers from flash to SRAM */
+  b LoopCopyDataInit
+SysTick:
+  .word 0xE000E010
+CopyDataInit:
+  ldr r3, =_sidata
+  ldr r3, [r3, r1]
+  str r3, [r0, r1]
+  adds r1, r1, #4
+
+LoopCopyDataInit:
+  ldr r0, =_sdata
+  ldr r3, =_edata
+  adds r2, r0, r1
+  cmp r2, r3
+  bcc CopyDataInit
+  ldr r2, =_sbss
+  b LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs r3, #0
+  str r3, [r2], #4
+
+LoopFillZerobss:
+  ldr r3, = _ebss
+  cmp r2, r3
+  bcc FillZerobss
+
+/* Call the clock system intitialization function.*/
+    bl  SystemInit
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+  bl main
+  bx lr
+
+.size Reset_Handler, .-Reset_Handler

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -364,6 +364,8 @@ board_build.offset          = 0xA000
 board_upload.offset_address = 0x0800A000
 build_flags                 = ${stm32_variant.build_flags}
                               -DSTM32F1xx -DSTM32_XL_DENSITY
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC
 extra_scripts               = ${stm32_variant.extra_scripts}
                               buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
 


### PR DESCRIPTION
### Description

The currently available jg aurora firmware (https://firmware.jgmakerwiki.com/) is a little outdated.
So I tried to update my printer to the latest marlinfw but I immediately ran into problems.
I got a hard fault exception on application startup and it took me many hours of bootloader reversing before I found out that the bootloader SysTick interrupt was firing during application run. This causes two major issues: 1) In the non-maple build on of the first RAM locations store GPIO bases addresses and those get incremented by the bootloader interrupt. 2) The bootloader stores 3 function poiners in RAM and calls them periodically from the SysTick interrupt. When this happens after datainit or .bsszero, the bootloader attempts to execute an invalid instruction and this leads to the hard fault exception.

The fix is to disable the SysTick interrupt before memory initialization.
I also found two other minor improvements to achive a working printer with equal functionality as with the old firmware.

### Requirements

jg aurora a1

### Benefits

Fix hard fault exception on startup.
Fix GPIOA base reference in RAM (allows normal control of heaters and fan).
Compile without USB support, since this printer does not use the STM32 USB port.
Enable with FLASH_EEPROM_EMULATION, in order to allow operation without a SD card inserted.

### Configurations

jg aurora a1

### Related Issues

N/A
