### PR TITLE
Fix EEPROM CRC display error

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2993,7 +2993,7 @@ void MarlinSettings::postprocess() {
       }
       else if (!validating) {
         DEBUG_ECHO_START();
-        DEBUG_ECHOLN(version_str, F(" stored settings retrieved ("), eeprom_total, F(" bytes; crc "), working_crc, ')');
+        DEBUG_ECHOLN(version_str, F(" stored settings retrieved ("), eeprom_total, F(" bytes; crc "), working_crc, ")");
         TERN_(HOST_EEPROM_CHITCHAT, hostui.notify(F("Stored settings retrieved")));
       }
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2993,7 +2993,7 @@ void MarlinSettings::postprocess() {
       }
       else if (!validating) {
         DEBUG_ECHO_START();
-        DEBUG_ECHOLN(version_str, F(" stored settings retrieved ("), eeprom_total, F(" bytes; crc "), working_crc, ")");
+        DEBUG_ECHOLN(version_str, F(" stored settings retrieved ("), eeprom_total, F(" bytes; crc "), working_crc, C(')'));
         TERN_(HOST_EEPROM_CHITCHAT, hostui.notify(F("Stored settings retrieved")));
       }
 


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/27199 introduced EEPROM CRC display error

Eg.   "echo:V90 stored settings retrieved (952 bytes; crc 6475841"  The 41 is meant to be a )
This should have been "echo:V90 stored settings retrieved (952 bytes; crc 64758)" 

Changed ')' back to a ")"

### Requirements

EEPROM

### Benefits

Displays Correctly

### Related Issues

<li>MarlinFirmware/Marlin/issues/27625