### PR TITLE
Flash wear leveling support for STM32H7

### DIFF
--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -74,25 +74,13 @@
   #define EEPROM_SLOTS            ((FLASH_UNIT_SIZE) / (MARLIN_EEPROM_SIZE))
   #define SLOT_ADDRESS(slot)      (FLASH_ADDRESS_START + (slot * (MARLIN_EEPROM_SIZE)))
 
-#ifdef STM32H7xx
-  #define FLASHWORD_SIZE          32U //  STM32H7xx a FLASHWORD is 32 bytes (256 bits)
-  #define UNLOCK_FLASH()          if (!flash_unlocked) { \
-                                    HAL_FLASH_Unlock(); \
-                                    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | \
-                                                           FLASH_FLAG_PGSERR); \
-                                    flash_unlocked = true; \
-                                  }
-#else
-  #define FLASHWORD_SIZE          4U // STM32F4xx a FLASHWORD is 4 bytes sizeof(uint32_t)
-  #define UNLOCK_FLASH()          if (!flash_unlocked) { \
-                                    HAL_FLASH_Unlock(); \
-                                    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | \
-                                                           FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR); \
-                                    flash_unlocked = true; \
-                                  }
-#endif
-
-  #define LOCK_FLASH()            if (flash_unlocked) { HAL_FLASH_Lock(); flash_unlocked = false; }
+  #ifdef STM32H7xx
+    #define FLASHWORD_SIZE          32U //  STM32H7xx a FLASHWORD is 32 bytes (256 bits)
+    #define FLASH_FLAGS_TO_CLEAR    (FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGSERR)
+  #else
+    #define FLASHWORD_SIZE          4U // STM32F4xx a FLASHWORD is 4 bytes sizeof(uint32_t)
+    #define FLASH_FLAGS_TO_CLEAR    (FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR)
+  #endif
 
   #define EMPTY_UINT32            ((uint32_t)-1)
   #define EMPTY_UINT8             ((uint8_t)-1)
@@ -186,7 +174,12 @@ bool PersistentStore::access_finish() {
         EraseInitStruct.NbSectors = 1;
 
         current_slot = EEPROM_SLOTS - 1;
-        UNLOCK_FLASH();
+
+        if (!flash_unlocked) {
+          HAL_FLASH_Unlock();
+          __HAL_FLASH_CLEAR_FLAG(FLASH_FLAGS_TO_CLEAR);
+          flash_unlocked = true;
+        }
 
         TERN_(HAS_PAUSE_SERVO_OUTPUT, PAUSE_SERVO_OUTPUT());
         hal.isr_off();
@@ -197,17 +190,23 @@ bool PersistentStore::access_finish() {
           DEBUG_ECHOLNPGM("HAL_FLASHEx_Erase=", status);
           DEBUG_ECHOLNPGM("GetError=", HAL_FLASH_GetError());
           DEBUG_ECHOLNPGM("SectorError=", SectorError);
-          LOCK_FLASH();
+          if (flash_unlocked) {
+            HAL_FLASH_Lock();
+            flash_unlocked = false;
+          }
           return false;
         }
       }
 
-      UNLOCK_FLASH();
+      if (!flash_unlocked) {
+        HAL_FLASH_Unlock();
+        __HAL_FLASH_CLEAR_FLAG(FLASH_FLAGS_TO_CLEAR);
+        flash_unlocked = true;
+      }
 
       uint32_t offset = 0,
                address = SLOT_ADDRESS(current_slot),
                address_end = address + MARLIN_EEPROM_SIZE;
-//               data = 0;
 
       bool success = true;
 
@@ -215,8 +214,8 @@ bool PersistentStore::access_finish() {
         #ifdef STM32H7xx
           status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, address, uint32_t(ram_eeprom + offset));
         #else
-//          memcpy(&data, ram_eeprom + offset, sizeof(data)); // IRON, IMPROVED
-//          status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data);
+          //memcpy(&data, ram_eeprom + offset, sizeof(data)); // IRON, IMPROVED
+          //status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data);
           status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, *(uint32_t*)(ram_eeprom + offset)); // IRON, OPTIMIZED
         #endif
         if (status == HAL_OK) {
@@ -232,7 +231,10 @@ bool PersistentStore::access_finish() {
         }
       }
 
-      LOCK_FLASH();
+      if (flash_unlocked) {
+        HAL_FLASH_Lock();
+        flash_unlocked = false;
+      }
 
       if (success) {
         eeprom_data_written = false;

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -160,12 +160,13 @@ bool PersistentStore::access_finish() {
 
   if (eeprom_data_written) {
 
-    #ifdef STM32H7xx
+    #ifdef STM32F4xx
       // MCU may come up with flash error bits which prevent some flash operations.
       // Clear flags prior to flash operations to prevent errors.
-      __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGSERR);
-    #else
       __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
+    #endif
+    #ifdef STM32H7xx
+      __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGSERR);
     #endif
 
     #if ENABLED(FLASH_EEPROM_LEVELING)

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -74,12 +74,24 @@
   #define EEPROM_SLOTS            ((FLASH_UNIT_SIZE) / (MARLIN_EEPROM_SIZE))
   #define SLOT_ADDRESS(slot)      (FLASH_ADDRESS_START + (slot * (MARLIN_EEPROM_SIZE)))
 
+#ifdef STM32H7xx
+  #define FLASHWORD_SIZE          32U //  STM32H7xx a FLASHWORD is 32 bytes (256 bits)
+  #define UNLOCK_FLASH()          if (!flash_unlocked) { \
+                                    HAL_FLASH_Unlock(); \
+                                    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | \
+                                                           FLASH_FLAG_PGSERR); \
+                                    flash_unlocked = true; \
+                                  }
+#else
+  #define FLASHWORD_SIZE          4U // STM32F4xx a FLASHWORD is 4 bytes sizeof(uint32_t)
   #define UNLOCK_FLASH()          if (!flash_unlocked) { \
                                     HAL_FLASH_Unlock(); \
                                     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | \
                                                            FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR); \
                                     flash_unlocked = true; \
                                   }
+#endif
+
   #define LOCK_FLASH()            if (flash_unlocked) { HAL_FLASH_Lock(); flash_unlocked = false; }
 
   #define EMPTY_UINT32            ((uint32_t)-1)
@@ -88,7 +100,7 @@
   static uint8_t ram_eeprom[MARLIN_EEPROM_SIZE] __attribute__((aligned(4))) = {0};
   static int current_slot = -1;
 
-  static_assert(0 == MARLIN_EEPROM_SIZE % 4, "MARLIN_EEPROM_SIZE must be a multiple of 4"); // Ensure copying as uint32_t is safe
+  static_assert(0 == MARLIN_EEPROM_SIZE % FLASHWORD_SIZE, "MARLIN_EEPROM_SIZE must be a multiple of the FLASHWORD size"); // Ensure copying as uint32_t is safe
   static_assert(0 == FLASH_UNIT_SIZE % MARLIN_EEPROM_SIZE, "MARLIN_EEPROM_SIZE must divide evenly into your FLASH_UNIT_SIZE");
   static_assert(FLASH_UNIT_SIZE >= MARLIN_EEPROM_SIZE, "FLASH_UNIT_SIZE must be greater than or equal to your MARLIN_EEPROM_SIZE");
   static_assert(IS_FLASH_SECTOR(FLASH_SECTOR), "FLASH_SECTOR is invalid");
@@ -147,9 +159,12 @@ bool PersistentStore::access_start() {
 bool PersistentStore::access_finish() {
 
   if (eeprom_data_written) {
-    #ifdef STM32F4xx
+
+    #ifdef STM32H7xx
       // MCU may come up with flash error bits which prevent some flash operations.
       // Clear flags prior to flash operations to prevent errors.
+      __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGSERR);
+    #else
       __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
     #endif
 
@@ -190,17 +205,22 @@ bool PersistentStore::access_finish() {
 
       uint32_t offset = 0,
                address = SLOT_ADDRESS(current_slot),
-               address_end = address + MARLIN_EEPROM_SIZE,
-               data = 0;
+               address_end = address + MARLIN_EEPROM_SIZE;
+//               data = 0;
 
       bool success = true;
 
       while (address < address_end) {
-        memcpy(&data, ram_eeprom + offset, sizeof(data));
-        status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data);
+        #ifdef STM32H7xx
+          status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, address, uint32_t(ram_eeprom + offset));
+        #else
+//          memcpy(&data, ram_eeprom + offset, sizeof(data)); // IRON, IMPROVED
+//          status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data);
+          status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, *(uint32_t*)(ram_eeprom + offset)); // IRON, OPTIMIZED
+        #endif
         if (status == HAL_OK) {
-          address += sizeof(uint32_t);
-          offset += sizeof(uint32_t);
+          address += FLASHWORD_SIZE;
+          offset += FLASHWORD_SIZE;
         }
         else {
           DEBUG_ECHOLNPGM("HAL_FLASH_Program=", status);

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -36,8 +36,8 @@
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
 
-#if !defined(STM32F4xx) && ENABLED(FLASH_EEPROM_LEVELING)
-  #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4 hardware."
+#if !ANY(STM32F4xx, STM32H7xx) && ENABLED(FLASH_EEPROM_LEVELING)
+  #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4/H7 hardware." // IRON
 #endif
 
 #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -36,7 +36,7 @@
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
 
-#if !ANY(STM32F4xx, STM32H7xx) && ENABLED(FLASH_EEPROM_LEVELING)
+#if NONE(STM32F4xx, STM32H7xx) && ENABLED(FLASH_EEPROM_LEVELING)
   #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4/H7 hardware." // IRON
 #endif
 


### PR DESCRIPTION
Adds flash wear leveling support for STM32H7

### Benefits
Adds STM32H7 hardware support for flash wear leveling

### Configurations
Just enable FLASH_EEPROM_EMULATION and FLASH_EEPROM_LEVELING on supported hardware.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/27629
