### PR TITLE
Couple quick fixes/suggestions

### DIFF
--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -200,10 +200,6 @@ struct SerialBase {
 
   // Print a number with the given base
   NO_INLINE void printNumber_unsigned(uint_fixed_print_t n, PrintBase base) {
-    if (base < 2 || base > 36) { // Check for invalid base
-        write('?'); // Indicate an error (Division by zero)
-        return;
-    }
     if (n) {
       unsigned char buf[8 * sizeof(long)]; // Enough space for base 2
       int8_t i = 0;

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -200,6 +200,10 @@ struct SerialBase {
 
   // Print a number with the given base
   NO_INLINE void printNumber_unsigned(uint_fixed_print_t n, PrintBase base) {
+    if (base < 2 || base > 36) { // Check for invalid base
+        write('?'); // Indicate an error (Division by zero)
+        return;
+    }
     if (n) {
       unsigned char buf[8 * sizeof(long)]; // Enough space for base 2
       int8_t i = 0;

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -227,7 +227,7 @@ struct Flags<N, true> {
   // Proxy class for handling bit assignment
   class BitProxy {
   public:
-    BitProxy(uint8_t data[], int n) : data_(data[n >> 3]), bit_(n & 7) {}
+    BitProxy(const uint8_t data[], int n) : data_(data[n >> 3]), bit_(n & 7) {}
 
     // Assignment operator
     BitProxy& operator=(const bool value) {

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -227,7 +227,7 @@ struct Flags<N, true> {
   // Proxy class for handling bit assignment
   class BitProxy {
   public:
-    BitProxy(const uint8_t data[], int n) : data_(data[n >> 3]), bit_(n & 7) {}
+    BitProxy(uint8_t data[], int n) : data_(data[n >> 3]), bit_(n & 7) {}
 
     // Assignment operator
     BitProxy& operator=(const bool value) {
@@ -242,7 +242,7 @@ struct Flags<N, true> {
     operator bool() const { return TEST(data_, bit_); }
 
   private:
-    const uint8_t& data_;
+    uint8_t& data_;
     uint8_t bit_;
   };
 
@@ -1017,8 +1017,6 @@ struct XYZEarray {
 
   FI XYZEval<T> operator[](const int n) const { return XYZval<T>(LOGICAL_AXIS_ARRAY(e[n], x[n], y[n], z[n], i[n], j[n], k[n], u[n], v[n], w[n])); }
 };
-
-class AxisBits;
 
 class AxisBits {
 public:

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -242,7 +242,7 @@ struct Flags<N, true> {
     operator bool() const { return TEST(data_, bit_); }
 
   private:
-    uint8_t& data_;
+    const uint8_t& data_;
     uint8_t bit_;
   };
 

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -180,6 +180,8 @@ template <class L, class R> struct IF<true, L, R> { typedef L type; };
 #define uvalue_t(V) typename IF<((V)>65535), uint32_t, typename IF<((V)>255), uint16_t, uint8_t>::type>::type
 #define value_t(V)  typename IF<((V)>32767),  int32_t, typename IF<((V)>127),  int16_t,  int8_t>::type>::type
 
+class BitProxy;
+
 // Define a template for a bit field of N bits, using the smallest type that can hold N bits
 template<size_t N, bool UseArray = (N > 64)>
 struct Flags;


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Under **PlatformIO** icon > Project Tasks > STM32F103RE_creality (or any other selected board) > Advanced > *Check*

this will perform a sort of debugging check, and I found some things that probably could use improvements.


### For **types.h**
#### Warning
[low:style] Parameter 'data' can be declared as const array [constParameter] indicates that the parameter data can be declared as a constant array because it is not modified inside the constructor. Specifically, you're passing data[] as an array of uint8_t values to the constructor, but you don't modify the array, just use a reference to an element in it.

#### Problem
The warning suggests that you should use const for the data parameter to ensure that it is not accidentally modified, and to communicate clearly that the array will not be changed within the constructor.

#### Solution
Since you're only using data_ to refer to a specific element in the array and never modifying the array itself, you should declare data[] as a const uint8_t[] in the constructor.

#### Conclusion
However, making these changing causes errors.

---

### Actual changes

Removed forward declaration of 
```y
  
// Forward declaration does not seem to be necessary 
class AxisBits;

class AxisBits {
public:
...
```
Used `class BitProxy;` as forward declaration instead
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
One of these checks could be looked into.
```yml
Marlin/src/core/types.h:788: [low:performance] Function parameter 'pxy' should be passed by const reference. [passedByValue]
```
this basically is saying to add `&` to `FI void set(const XYval<T> &pxy)  ...` to be passed by reference instead of value, which may free up some space or what not.
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
