### PR TITLE
🚸 Add BTT SKRat UART driver sanity check

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
@@ -309,16 +309,18 @@
   //
   // Software serial
   //
-  #define X_SERIAL_TX_PIN                   PF10
-  #define Y_SERIAL_TX_PIN                   PD4
-  #define Z_SERIAL_TX_PIN                   PC8
-  #define E0_SERIAL_TX_PIN                  PD8
-  #define E1_SERIAL_TX_PIN                  PB11
+  //#define X_SERIAL_TX_PIN                 PF10
+  //#define Y_SERIAL_TX_PIN                 PD4
+  //#define Z_SERIAL_TX_PIN                 PC8
+  //#define E0_SERIAL_TX_PIN                PD8
+  //#define E1_SERIAL_TX_PIN                PB11
 
   // Reduce baud rate to improve software serial reliability
-  #ifndef TMC_BAUD_RATE
-    #define TMC_BAUD_RATE                  19200
-  #endif
+  //#ifndef TMC_BAUD_RATE
+  //  #define TMC_BAUD_RATE                19200
+  //#endif
+
+  #error "UART-based drivers are not supported on this board."
 
 #endif
 


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/27361 was merged before UART-based driver issues could get worked out, so add a sanity check for now.

Full testing process was outlined in https://github.com/MarlinFirmware/Marlin/pull/27361, but UART drivers work fine under Klipper.

### Requirements

BTT SKRat motherboard with UART-based TMC drivers.

### Benefits

Users will receive an error when compiling with unsupported drivers.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/27361
