### PR TITLE
🧑‍💻 Common serial ports header

### DIFF
--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -35,67 +35,9 @@
 
 #include <stdint.h>
 
-#include "../../core/serial_hook.h"
-
-// ------------------------
-// Serial ports
-// ------------------------
-
-typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
-typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
-typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
-typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
-extern DefaultSerial1 MSerial0;
-extern DefaultSerial2 MSerial1;
-extern DefaultSerial3 MSerial2;
-extern DefaultSerial4 MSerial3;
-
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1 || ENABLED(EMERGENCY_PARSER)
-  #define MYSERIAL1 customizedSerial1
-#elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "The required SERIAL_PORT must be from 0 to 3, or -1 for USB Serial."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1 || ENABLED(EMERGENCY_PARSER)
-    #define MYSERIAL2 customizedSerial2
-  #elif WITHIN(SERIAL_PORT_2, 0, 3)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #error "SERIAL_PORT_2 must be from 0 to 3, or -1 for USB Serial."
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1 || ENABLED(EMERGENCY_PARSER)
-    #define MYSERIAL3 customizedSerial3
-  #elif WITHIN(SERIAL_PORT_3, 0, 3)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #error "SERIAL_PORT_3 must be from 0 to 3, or -1 for USB Serial."
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if WITHIN(MMU_SERIAL_PORT, 0, 3)
-    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-  #else
-    #error "MMU_SERIAL_PORT must be from 0 to 3."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if WITHIN(LCD_SERIAL_PORT, 0, 3)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #error "LCD_SERIAL_PORT must be from 0 to 3."
-  #endif
-#endif
+//
+// Serial Ports
+//
 
 #include "MarlinSerial.h"
 #include "MarlinSerialUSB.h"

--- a/Marlin/src/HAL/DUE/MarlinSerial.h
+++ b/Marlin/src/HAL/DUE/MarlinSerial.h
@@ -33,6 +33,21 @@
 #include "../../core/types.h"
 #include "../../core/serial_hook.h"
 
+typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
+typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
+typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
+extern DefaultSerial1 MSerial0;
+extern DefaultSerial2 MSerial1;
+extern DefaultSerial3 MSerial2;
+extern DefaultSerial4 MSerial3;
+
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#define EP_SERIAL_PORT(N) customizedSerial##N
+#define USB_SERIAL_PORT(N) customizedSerial##N
+#include "../shared/serial_ports.h"
+
 // Define constants and variables for buffering incoming serial data.  We're
 // using a ring buffer (I think), in which rx_buffer_head is the index of the
 // location to which to write the next incoming character and rx_buffer_tail

--- a/Marlin/src/HAL/HC32/HAL.h
+++ b/Marlin/src/HAL/HC32/HAL.h
@@ -36,60 +36,12 @@
 
 #include "fastio.h"
 #include "timers.h"
-#include "MarlinSerial.h"
 
 //
 // Serial Ports
 //
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-#define NUM_UARTS 4
 
-#if SERIAL_PORT == -1
-  #error "USB Serial is not supported on HC32F460"
-#elif WITHIN(SERIAL_PORT, 1, NUM_UARTS)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #define MYSERIAL1 MSERIAL(1) // Dummy port
-  static_assert(false, "SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ".")
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1
-    #error "USB Serial is not supported on HC32F460"
-  #elif WITHIN(SERIAL_PORT_2, 1, NUM_UARTS)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #define MYSERIAL2 MSERIAL(1) // Dummy port
-    static_assert(false, "SERIAL_PORT_2 must be from 1 to " STRINGIFY(NUM_UARTS) ".")
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1
-    #error "USB Serial is not supported on HC32F460"
-  #elif WITHIN(SERIAL_PORT_3, 1, NUM_UARTS)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #define MYSERIAL3 MSERIAL(1) // Dummy port
-    static_assert(false, "SERIAL_PORT_3 must be from 1 to " STRINGIFY(NUM_UARTS) ".")
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if LCD_SERIAL_PORT == -1
-    #error "USB Serial is not supported on HC32F460"
-  #elif WITHIN(LCD_SERIAL_PORT, 1, NUM_UARTS)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #define LCD_SERIAL MSERIAL(1) // Dummy port
-    static_assert(false, "LCD_SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ".")
-  #endif
-
-  #if HAS_DGUS_LCD
-    #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
-  #endif
-#endif
+#include "MarlinSerial.h"
 
 //
 // Emergency Parser

--- a/Marlin/src/HAL/HC32/MarlinSerial.h
+++ b/Marlin/src/HAL/HC32/MarlinSerial.h
@@ -24,6 +24,14 @@
 #include "../../core/serial_hook.h"
 #include <drivers/usart/Usart.h>
 
+#define SERIAL_INDEX_MIN 1
+#define SERIAL_INDEX_MAX 4
+#include "../shared/serial_ports.h"
+
+#if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
+  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+#endif
+
 // Optionally set uart IRQ priority to reduce overflow errors
 //#define UART_RX_IRQ_PRIO 1
 //#define UART_TX_IRQ_PRIO 1

--- a/Marlin/src/HAL/LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL.cpp
@@ -35,8 +35,6 @@
 #include <CDCSerial.h>
 #include <usb/mscuser.h>
 
-DefaultSerial1 USBSerial(false, UsbSerial);
-
 uint32_t MarlinHAL::adc_result = 0;
 pin_t MarlinHAL::adc_pin = 0;
 

--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -38,72 +38,15 @@ extern "C" volatile uint32_t _millis;
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"
 #include "fastio.h"
-#include "MarlinSerial.h"
 
 #include <adc.h>
 #include <pinmapping.h>
-#include <CDCSerial.h>
 
-// ------------------------
-// Serial ports
-// ------------------------
+//
+// Serial Ports
+//
 
-typedef ForwardSerial1Class< decltype(UsbSerial) > DefaultSerial1;
-extern DefaultSerial1 USBSerial;
-
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 USBSerial
-#elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1
-    #define MYSERIAL2 USBSerial
-  #elif WITHIN(SERIAL_PORT_2, 0, 3)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #error "SERIAL_PORT_2 must be from 0 to 3. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1
-    #define MYSERIAL3 USBSerial
-  #elif WITHIN(SERIAL_PORT_3, 0, 3)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #error "SERIAL_PORT_3 must be from 0 to 3. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if MMU_SERIAL_PORT == -1
-    #define MMU_SERIAL USBSerial
-  #elif WITHIN(MMU_SERIAL_PORT, 0, 3)
-    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-  #else
-    #error "MMU_SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL USBSerial
-  #elif WITHIN(LCD_SERIAL_PORT, 0, 3)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #error "LCD_SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-  #endif
-  #if ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
-    #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.available()
-  #endif
-#endif
+#include "MarlinSerial.h"
 
 //
 // Interrupts

--- a/Marlin/src/HAL/LPC1768/MarlinSerial.cpp
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.cpp
@@ -25,6 +25,8 @@
 
 #include "../../inc/MarlinConfig.h"
 
+DefaultSerial1 USBSerial(false, UsbSerial);
+
 #if USING_HW_SERIAL0
   MarlinSerial _MSerial0(LPC_UART0);
   MSerialT MSerial0(true, _MSerial0);

--- a/Marlin/src/HAL/LPC1768/MarlinSerial.h
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <CDCSerial.h>
 #include <HardwareSerial.h>
 #include <WString.h>
 
@@ -29,6 +30,18 @@
   #include "../../feature/e_parser.h"
 #endif
 #include "../../core/serial_hook.h"
+
+typedef ForwardSerial1Class< decltype(UsbSerial) > DefaultSerial1;
+extern DefaultSerial1 USBSerial;
+
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#define USB_SERIAL_PORT(...) USBSerial
+#include "../shared/serial_ports.h"
+
+#if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
+  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.available()
+#endif
 
 class MarlinSerial : public HardwareSerial<RX_BUFFER_SIZE, TX_BUFFER_SIZE> {
 public:

--- a/Marlin/src/HAL/NATIVE_SIM/HAL.h
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL.h
@@ -71,37 +71,10 @@ extern MSerialT serial_stream_2;
 extern MSerialT serial_stream_3;
 
 #define _MSERIAL(X) serial_stream_##X
-#define MSERIAL(X) _MSERIAL(X)
 
-#if WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "SERIAL_PORT must be from 0 to 3. Please update your configuration."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if WITHIN(SERIAL_PORT_2, 0, 3)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #error "SERIAL_PORT_2 must be from 0 to 3. Please update your configuration."
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if WITHIN(MMU_SERIAL_PORT, 0, 3)
-    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-  #else
-    #error "MMU_SERIAL_PORT must be from 0 to 3. Please update your configuration."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if WITHIN(LCD_SERIAL_PORT, 0, 3)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #error "LCD_SERIAL_PORT must be from 0 to 3. Please update your configuration."
-  #endif
-#endif
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#include "../shared/serial_ports.h"
 
 // ------------------------
 // Interrupts

--- a/Marlin/src/HAL/RP2040/HAL.h
+++ b/Marlin/src/HAL/RP2040/HAL.h
@@ -35,73 +35,16 @@
 #include "fastio.h"
 //#include "Servo.h"
 #include "watchdog.h"
-#include "MarlinSerial.h"
 
 #include "../../inc/MarlinConfigPre.h"
 
 #include <stdint.h>
 
-// ------------------------
-// Serial ports
-// ------------------------
+//
+// Serial Ports
+//
 
-#include "../../core/serial_hook.h"
-typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
-extern DefaultSerial1 MSerial0;
-
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 MSerial0
-#elif WITHIN(SERIAL_PORT, 0, 6)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "SERIAL_PORT must be from 0 to 6. You can also use -1 if the board supports Native USB."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1
-    #define MYSERIAL2 MSerial0
-  #elif WITHIN(SERIAL_PORT_2, 0, 6)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #error "SERIAL_PORT_2 must be from 0 to 6. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1
-    #define MYSERIAL3 MSerial0
-  #elif WITHIN(SERIAL_PORT_3, 0, 6)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #error "SERIAL_PORT_3 must be from 0 to 6. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef MMU2_SERIAL_PORT
-  #if MMU2_SERIAL_PORT == -1
-    #define MMU2_SERIAL MSerial0
-  #elif WITHIN(MMU2_SERIAL_PORT, 0, 6)
-    #define MMU2_SERIAL MSERIAL(MMU2_SERIAL_PORT)
-  #else
-    #error "MMU2_SERIAL_PORT must be from 0 to 6. You can also use -1 if the board supports Native USB."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL MSerial0
-  #elif WITHIN(LCD_SERIAL_PORT, 0, 6)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #error "LCD_SERIAL_PORT must be from 0 to 6. You can also use -1 if the board supports Native USB."
-  #endif
-  #if HAS_DGUS_LCD
-    #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
-  #endif
-#endif
+#include "MarlinSerial.h"
 
 // ------------------------
 // Defines

--- a/Marlin/src/HAL/RP2040/MarlinSerial.h
+++ b/Marlin/src/HAL/RP2040/MarlinSerial.h
@@ -29,24 +29,22 @@
 
 #include "../../core/serial_hook.h"
 
+typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+extern DefaultSerial1 MSerial0;
+typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
+extern USBSerialType USBSerial;
+
 #define Serial0 Serial
 #define _DECLARE_SERIAL(X) \
   typedef ForwardSerial1Class<decltype(Serial##X)> DefaultSerial##X; \
   extern DefaultSerial##X MSerial##X
 #define DECLARE_SERIAL(X) _DECLARE_SERIAL(X)
 
-typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
-extern USBSerialType USBSerial;
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 6
+#define USB_SERIAL_PORT(...) MSerial0
+#include "../shared/serial_ports.h"
 
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
- // #define MYSERIAL1 USBSerial this is already done in the HAL
-#elif WITHIN(SERIAL_PORT, 0, 3)
- #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-  DECLARE_SERIAL(SERIAL_PORT);
-#else
-  #error "SERIAL_PORT must be from 0 to 3, or -1 for Native USB."
+#if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
+  #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
 #endif
-

--- a/Marlin/src/HAL/SAMD21/HAL.h
+++ b/Marlin/src/HAL/SAMD21/HAL.h
@@ -36,11 +36,11 @@
 // ------------------------
 // Serial ports
 // ------------------------
+
 #include "../../core/serial_hook.h"
 typedef ForwardSerial1Class< decltype(SerialUSB) > DefaultSerial1;
 extern DefaultSerial1 MSerialUSB;
 
-// Serial ports
 typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
 typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
 
@@ -51,43 +51,10 @@ extern DefaultSerial3 MSerial1;
 #define _MSERIAL(X) __MSERIAL(X)
 #define MSERIAL(X) _MSERIAL(INCREMENT(X))
 
-#if WITHIN(SERIAL_PORT, 0, 1)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#elif SERIAL_PORT == -1
-  #define MYSERIAL1 MSerialUSB
-#else
-  #error "SERIAL_PORT must be -1 (Native USB only)."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if WITHIN(SERIAL_PORT_2, 0, 1)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT)
-  #elif SERIAL_PORT_2 == -1
-    #define MYSERIAL2 MSerialUSB
-  #else
-    #error "SERIAL_PORT_2 must be -1 (Native USB only)."
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if WITHIN(MMU_SERIAL_PORT, 0, 1)
-    #define MMU_SERIAL MSERIAL(SERIAL_PORT)
-  #elif MMU_SERIAL_PORT == -1
-    #define MMU_SERIAL MSerialUSB
-  #else
-    #error "MMU_SERIAL_PORT must be -1 (Native USB only)."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if WITHIN(LCD_SERIAL_PORT, 0, 1)
-    #define LCD_SERIAL MSERIAL(SERIAL_PORT)
-  #elif LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL MSerialUSB
-  #else
-    #error "LCD_SERIAL_PORT must be -1 (Native USB only)."
-  #endif
-#endif
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 1
+#define USB_SERIAL_PORT(...) MSerialUSB
+#include "../shared/serial_ports.h"
 
 typedef int8_t pin_t;
 

--- a/Marlin/src/HAL/SAMD51/HAL.h
+++ b/Marlin/src/HAL/SAMD51/HAL.h
@@ -34,72 +34,7 @@
 
 #ifdef ADAFRUIT_GRAND_CENTRAL_M4
   #include "MarlinSerial_AGCM4.h"
-
-  // Serial ports
-  typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
-  typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
-  typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
-  typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
-  typedef ForwardSerial1Class< decltype(Serial4) > DefaultSerial5;
-  extern DefaultSerial1 MSerial0;
-  extern DefaultSerial2 MSerial1;
-  extern DefaultSerial3 MSerial2;
-  extern DefaultSerial4 MSerial3;
-  extern DefaultSerial5 MSerial4;
-
-  #define __MSERIAL(X) MSerial##X
-  #define _MSERIAL(X) __MSERIAL(X)
-  #define MSERIAL(X) _MSERIAL(INCREMENT(X))
-
-  #if SERIAL_PORT == -1
-    #define MYSERIAL1 MSerial0
-  #elif WITHIN(SERIAL_PORT, 0, 3)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-  #else
-    #error "SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-  #endif
-
-  #ifdef SERIAL_PORT_2
-    #if SERIAL_PORT_2 == -1
-      #define MYSERIAL2 MSerial0
-    #elif WITHIN(SERIAL_PORT_2, 0, 3)
-      #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-    #else
-      #error "SERIAL_PORT_2 must be from 0 to 3. You can also use -1 if the board supports Native USB."
-    #endif
-  #endif
-
-  #ifdef SERIAL_PORT_3
-    #if SERIAL_PORT_3 == -1
-      #define MYSERIAL3 MSerial0
-    #elif WITHIN(SERIAL_PORT_3, 0, 3)
-      #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-    #else
-      #error "SERIAL_PORT_3 must be from 0 to 3. You can also use -1 if the board supports Native USB."
-    #endif
-  #endif
-
-  #ifdef MMU_SERIAL_PORT
-    #if MMU_SERIAL_PORT == -1
-      #define MMU_SERIAL MSerial0
-    #elif WITHIN(MMU_SERIAL_PORT, 0, 3)
-      #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-    #else
-      #error "MMU_SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-    #endif
-  #endif
-
-  #ifdef LCD_SERIAL_PORT
-    #if LCD_SERIAL_PORT == -1
-      #define LCD_SERIAL MSerial0
-    #elif WITHIN(LCD_SERIAL_PORT, 0, 3)
-      #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-    #else
-      #error "LCD_SERIAL_PORT must be from 0 to 3. You can also use -1 if the board supports Native USB."
-    #endif
-  #endif
-
-#endif // ADAFRUIT_GRAND_CENTRAL_M4
+#endif
 
 typedef int8_t pin_t;
 

--- a/Marlin/src/HAL/SAMD51/MarlinSerial_AGCM4.h
+++ b/Marlin/src/HAL/SAMD51/MarlinSerial_AGCM4.h
@@ -32,3 +32,24 @@ typedef Serial1Class<Uart> UartT;
 extern UartT Serial2;
 extern UartT Serial3;
 extern UartT Serial4;
+
+typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
+typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
+typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
+typedef ForwardSerial1Class< decltype(Serial4) > DefaultSerial5;
+
+extern DefaultSerial1 MSerial0;
+extern DefaultSerial2 MSerial1;
+extern DefaultSerial3 MSerial2;
+extern DefaultSerial4 MSerial3;
+extern DefaultSerial5 MSerial4;
+
+#define __MSERIAL(X) MSerial##X
+#define _MSERIAL(X) __MSERIAL(X)
+#define MSERIAL(X) _MSERIAL(INCREMENT(X))
+
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#define USB_SERIAL_PORT(...) MSerial0
+#include "../shared/serial_ports.h"

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -30,7 +30,6 @@
 #include "temp_soc.h"
 #include "fastio.h"
 #include "Servo.h"
-#include "MarlinSerial.h"
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -43,87 +42,11 @@
 #define CPU_ST7920_DELAY_2  40
 #define CPU_ST7920_DELAY_3 340
 
-// ------------------------
-// Serial ports
-// ------------------------
-#ifdef USBCON
-  #include <USBSerial.h>
-  #include "../../core/serial_hook.h"
-  typedef ForwardSerial1Class< decltype(SerialUSB) > DefaultSerial1;
-  extern DefaultSerial1 MSerialUSB;
-#endif
+//
+// Serial Ports
+//
 
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if WITHIN(SERIAL_PORT, 1, 9)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#elif !defined(USBCON)
-  #error "SERIAL_PORT must be from 1 to 9."
-#elif SERIAL_PORT == -1
-  #define MYSERIAL1 MSerialUSB
-#else
-  #error "SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if WITHIN(SERIAL_PORT_2, 1, 9)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #elif !defined(USBCON)
-    #error "SERIAL_PORT_2 must be from 1 to 9."
-  #elif SERIAL_PORT_2 == -1
-    #define MYSERIAL2 MSerialUSB
-  #else
-    #error "SERIAL_PORT_2 must be from 1 to 9, or -1 for Native USB."
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if WITHIN(SERIAL_PORT_3, 1, 9)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #elif !defined(USBCON)
-    #error "SERIAL_PORT_3 must be from 1 to 9."
-  #elif SERIAL_PORT_3 == -1
-    #define MYSERIAL3 MSerialUSB
-  #else
-    #error "SERIAL_PORT_3 must be from 1 to 9, or -1 for Native USB."
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if WITHIN(MMU_SERIAL_PORT, 1, 9)
-    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-  #elif !defined(USBCON)
-    #error "MMU_SERIAL_PORT must be from 1 to 9."
-  #elif MMU_SERIAL_PORT == -1
-    #define MMU_SERIAL MSerialUSB
-  #else
-    #error "MMU_SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if WITHIN(LCD_SERIAL_PORT, 1, 9)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #elif !defined(USBCON)
-    #error "LCD_SERIAL_PORT must be from 1 to 9."
-  #elif LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL MSerialUSB
-  #else
-    #error "LCD_SERIAL_PORT must be from 1 to 9, or -1 for Native USB."
-  #endif
-  #if ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
-    #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
-  #endif
-#endif
-
-#ifdef RS485_SERIAL_PORT
-  #if WITHIN(RS485_SERIAL_PORT, 1, 9)
-    #define RS485_SERIAL MSERIAL(RS485_SERIAL_PORT)
-  #else
-    #error "RS485_SERIAL_PORT must be from 1 to 9."
-  #endif
-#endif
+#include "MarlinSerial.h"
 
 /**
  * TODO: review this to return 1 for pins that are not analog input

--- a/Marlin/src/HAL/STM32/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32/MarlinSerial.h
@@ -33,6 +33,21 @@
 
 #include "../../core/serial_hook.h"
 
+#ifdef USBCON
+  #include <USBSerial.h>
+  typedef ForwardSerial1Class< decltype(SerialUSB) > DefaultSerial1;
+  extern DefaultSerial1 MSerialUSB;
+  #define USB_SERIAL_PORT(...) MSerialUSB
+#endif
+
+#define SERIAL_INDEX_MIN 1
+#define SERIAL_INDEX_MAX 9
+#include "../shared/serial_ports.h"
+
+#if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
+  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+#endif
+
 #if ENABLED(SERIAL_DMA)
 
   struct MarlinSerial : public HAL_HardwareSerial {

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -43,8 +43,6 @@
   #include "msc_sd.h"
 #endif
 
-#include "MarlinSerial.h"
-
 // ------------------------
 // Defines
 // ------------------------
@@ -64,95 +62,11 @@
   #endif
 #endif
 
-// ------------------------
-// Serial ports
-// ------------------------
+//
+// Serial Ports
+//
 
-#ifdef SERIAL_USB
-  typedef ForwardSerial1Class< USBSerial > DefaultSerial1;
-  extern DefaultSerial1 MSerial0;
-  #if HAS_SD_HOST_DRIVE
-    #define UsbSerial MarlinCompositeSerial
-  #else
-    #define UsbSerial MSerial0
-  #endif
-#endif
-
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if ANY(STM32_HIGH_DENSITY, STM32_XL_DENSITY)
-  #define NUM_UARTS 5
-#else
-  #define NUM_UARTS 3
-#endif
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 UsbSerial
-#elif WITHIN(SERIAL_PORT, 1, NUM_UARTS)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #define MYSERIAL1 MSERIAL(1) // dummy port
-  static_assert(false, "SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ". You can also use -1 if the board supports Native USB.")
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1
-    #define MYSERIAL2 UsbSerial
-  #elif WITHIN(SERIAL_PORT_2, 1, NUM_UARTS)
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #define MYSERIAL2 MSERIAL(1) // dummy port
-    static_assert(false, "SERIAL_PORT_2 must be from 1 to " STRINGIFY(NUM_UARTS) ". You can also use -1 if the board supports Native USB.")
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1
-    #define MYSERIAL3 UsbSerial
-  #elif WITHIN(SERIAL_PORT_3, 1, NUM_UARTS)
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #define MYSERIAL3 MSERIAL(1) // dummy port
-    static_assert(false, "SERIAL_PORT_3 must be from 1 to " STRINGIFY(NUM_UARTS) ". You can also use -1 if the board supports Native USB.")
-  #endif
-#endif
-
-#ifdef MMU_SERIAL_PORT
-  #if MMU_SERIAL_PORT == -1
-    #define MMU_SERIAL UsbSerial
-  #elif WITHIN(MMU_SERIAL_PORT, 1, NUM_UARTS)
-    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
-  #else
-    #define MMU_SERIAL MSERIAL(1) // dummy port
-    static_assert(false, "MMU_SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ". You can also use -1 if the board supports Native USB.")
-  #endif
-#endif
-
-#ifdef LCD_SERIAL_PORT
-  #if LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL UsbSerial
-  #elif WITHIN(LCD_SERIAL_PORT, 1, NUM_UARTS)
-    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
-  #else
-    #define LCD_SERIAL MSERIAL(1) // dummy port
-    static_assert(false, "LCD_SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ". You can also use -1 if the board supports Native USB.")
-  #endif
-  #if ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
-    #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
-  #endif
-#endif
-
-#ifdef RS485_SERIAL_PORT
-  #if RS485_SERIAL_PORT == -1
-    #define RS485_SERIAL UsbSerial
-  #elif WITHIN(RS485_SERIAL_PORT, 1, NUM_UARTS)
-    #define RS485_SERIAL MSERIAL(RS485_SERIAL_PORT)
-  #else
-    #define RS485_SERIAL MSERIAL(1) // dummy port
-    static_assert(false, "RS485_SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ".")
-  #endif
-#endif
+#include "MarlinSerial.h"
 
 /**
  * TODO: review this to return 1 for pins that are not analog input

--- a/Marlin/src/HAL/STM32F1/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32F1/MarlinSerial.h
@@ -28,6 +28,29 @@
 #include "../../inc/MarlinConfigPre.h"
 #include "../../core/serial_hook.h"
 
+#ifdef SERIAL_USB
+  typedef ForwardSerial1Class< USBSerial > DefaultSerial1;
+  extern DefaultSerial1 MSerial0;
+  #if HAS_SD_HOST_DRIVE
+    #define UsbSerial MarlinCompositeSerial
+  #else
+    #define UsbSerial MSerial0
+  #endif
+#endif
+
+#define SERIAL_INDEX_MIN 1
+#if ANY(STM32_HIGH_DENSITY, STM32_XL_DENSITY)
+  #define SERIAL_INDEX_MAX 5
+#else
+  #define SERIAL_INDEX_MAX 3
+#endif
+#define USB_SERIAL_PORT(...) UsbSerial
+#include "../shared/serial_ports.h"
+
+#if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
+  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+#endif
+
 // Increase priority of serial interrupts, to reduce overflow errors
 #define UART_IRQ_PRIO 1
 

--- a/Marlin/src/HAL/TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.h
@@ -64,17 +64,10 @@
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 USBSerial
-#elif WITHIN(SERIAL_PORT, 0, 3)
-  DECLARE_SERIAL(SERIAL_PORT);
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "The required SERIAL_PORT must be from 0 to 3, or -1 for Native USB."
-#endif
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#define USB_SERIAL_PORT(...) USBSerial
+#include "../shared/serial_ports.h"
 
 // ------------------------
 // Types

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -70,17 +70,10 @@
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 USBSerial
-#elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-  DECLARE_SERIAL(SERIAL_PORT);
-#else
-  #error "SERIAL_PORT must be from 0 to 3, or -1 for Native USB."
-#endif
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 3
+#define USB_SERIAL_PORT(...) USBSerial
+#include "../shared/serial_ports.h"
 
 // ------------------------
 // Types

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -78,41 +78,11 @@
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
-#define _MSERIAL(X) MSerial##X
-#define MSERIAL(X) _MSERIAL(X)
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL1 USBSerial
-#elif WITHIN(SERIAL_PORT, 0, 8)
-  DECLARE_SERIAL(SERIAL_PORT);
-  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
-#else
-  #error "The required SERIAL_PORT must be from 0 to 8, or -1 for Native USB."
-#endif
-
-#ifdef SERIAL_PORT_2
-  #if SERIAL_PORT_2 == -1
-    #define MYSERIAL2 USBSerial
-  #elif SERIAL_PORT_2 == -2
-    #define MYSERIAL2 ethernet.telnetClient
-  #elif WITHIN(SERIAL_PORT_2, 0, 8)
-    DECLARE_SERIAL(SERIAL_PORT_2);
-    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
-  #else
-    #error "SERIAL_PORT_2 must be from 0 to 8, or -1 for Native USB, or -2 for Ethernet."
-  #endif
-#endif
-
-#ifdef SERIAL_PORT_3
-  #if SERIAL_PORT_3 == -1
-    #define MYSERIAL3 USBSerial
-  #elif WITHIN(SERIAL_PORT_3, 0, 8)
-    DECLARE_SERIAL(SERIAL_PORT_3);
-    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
-  #else
-    #error "SERIAL_PORT_3 must be from 0 to 8, or -1 for Native USB."
-  #endif
-#endif
+#define SERIAL_INDEX_MIN 0
+#define SERIAL_INDEX_MAX 8
+#define USB_SERIAL_PORT(...) USBSerial
+#define ETH_SERIAL_PORT(...) ethernet.telnetClient
+#include "../shared/serial_ports.h"
 
 // ------------------------
 // Types

--- a/Marlin/src/HAL/shared/serial_ports.h
+++ b/Marlin/src/HAL/shared/serial_ports.h
@@ -1,0 +1,178 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2025 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * serial_ports.h - Define Marlin serial port macros and optionally declare ports
+ *
+ * This header defines one or more of the serial ports...
+ *   - MYSERIAL1/2/3 ..... for host devices
+ *   - MMU_SERIAL ........ for Multi-Material color changers
+ *   - LCD_SERIAL ........ for serial LCDs
+ *   - RS485_SERIAL ...... for CAN bus devices
+ *
+ * Before including this header define the following macros:
+ *   - SERIAL_INDEX_MIN, SERIAL_INDEX_MAX to provide the valid range of serial port indexes.
+ *   - _MSERIAL(X) and MSERIAL(X) to provide the instance name of Serial Port X. (Default: MSerial##X)
+ *   - EP_SERIAL_PORT(X) to provide the instance name of Emergency Parser serial port X (if it is special).
+ *   - USB_SERIAL_PORT(X) to provide the instance name of the USB serial port (if any).
+ *   - ETH_SERIAL_PORT(X) to provide the instance name of the Ethernet serial port (if any).
+ *   - DECLARE_SERIAL(X) to declare standard a serial port with the given index.
+ */
+
+#ifndef _MSERIAL
+  #define _MSERIAL(X) MSerial##X
+#endif
+#ifndef MSERIAL
+  #define MSERIAL(X) _MSERIAL(X)
+#endif
+
+#define INDEX_RANGE_MSG " must be from " STRINGIFY(SERIAL_INDEX_MIN) " to " STRINGIFY(SERIAL_INDEX_MAX)
+#if defined(USB_SERIAL_PORT) && defined(ETH_SERIAL_PORT)
+  #define MORE_INDEXES_MSG ", -1 for Native USB, or -2 for Ethernet"
+#elif defined(USB_SERIAL_PORT)
+  #define MORE_INDEXES_MSG ", or -1 for Native USB"
+#elif defined(ETH_SERIAL_PORT)
+  #define MORE_INDEXES_MSG ", or -2 for Ethernet"
+#else
+  #define MORE_INDEXES_MSG
+#endif
+
+//
+// SERIAL_PORT => MYSERIAL1
+//
+
+#if defined(EP_SERIAL_PORT) && ENABLED(EMERGENCY_PARSER)
+  #define MYSERIAL1 EP_SERIAL_PORT(1)
+#elif WITHIN(SERIAL_PORT, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
+  #ifdef DECLARE_SERIAL
+    DECLARE_SERIAL(SERIAL_PORT);
+  #endif
+#elif SERIAL_PORT == -1 && defined(USB_SERIAL_PORT)
+  #define MYSERIAL1 USB_SERIAL_PORT(1)
+#elif SERIAL_PORT == -2 && defined(ETH_SERIAL_PORT)
+  #define MYSERIAL1 ETH_SERIAL_PORT(1)
+#endif
+#ifndef MYSERIAL1
+  static_assert(false, "SERIAL_PORT" INDEX_RANGE_MSG MORE_INDEXES_MSG ".");
+  #define MYSERIAL1 _MSERIAL(1) // Dummy port
+#endif
+
+//
+// SERIAL_PORT_2 => MYSERIAL2
+//
+
+#ifdef SERIAL_PORT_2
+  #if defined(EP_SERIAL_PORT) && ENABLED(EMERGENCY_PARSER)
+    #define MYSERIAL2 EP_SERIAL_PORT(2)
+  #elif WITHIN(SERIAL_PORT_2, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
+    #ifdef DECLARE_SERIAL
+      DECLARE_SERIAL(SERIAL_PORT_2);
+    #endif
+  #elif SERIAL_PORT_2 == -1 && defined(USB_SERIAL_PORT)
+    #define MYSERIAL2 USB_SERIAL_PORT(2)
+  #elif SERIAL_PORT_2 == -2 && defined(ETH_SERIAL_PORT)
+    #define MYSERIAL2 ETH_SERIAL_PORT(2)
+  #endif
+  #ifndef MYSERIAL2
+    static_assert(false, "SERIAL_PORT_2" INDEX_RANGE_MSG MORE_INDEXES_MSG ".");
+    #define MYSERIAL2 _MSERIAL(1) // Dummy port
+  #endif
+#endif
+
+//
+// SERIAL_PORT_3 => MYSERIAL3
+//
+
+#ifdef SERIAL_PORT_3
+  #if defined(EP_SERIAL_PORT) && ENABLED(EMERGENCY_PARSER)
+    #define MYSERIAL3 EP_SERIAL_PORT(3)
+  #elif WITHIN(SERIAL_PORT_3, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+    #define MYSERIAL3 MSERIAL(SERIAL_PORT_3)
+    #ifdef DECLARE_SERIAL
+      DECLARE_SERIAL(SERIAL_PORT_3);
+    #endif
+  #elif SERIAL_PORT_3 == -1 && defined(USB_SERIAL_PORT)
+    #define MYSERIAL3 USB_SERIAL_PORT(3)
+  #elif SERIAL_PORT_3 == -2 && defined(ETH_SERIAL_PORT)
+    #define MYSERIAL3 ETH_SERIAL_PORT(3)
+  #endif
+  #ifndef MYSERIAL3
+    static_assert(false, "SERIAL_PORT_3" INDEX_RANGE_MSG MORE_INDEXES_MSG ".");
+    #define MYSERIAL3 _MSERIAL(1) // Dummy port
+  #endif
+#endif
+
+//
+// MMU_SERIAL_PORT => MMU_SERIAL
+//
+
+#ifdef MMU_SERIAL_PORT
+  #if WITHIN(MMU_SERIAL_PORT, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+    #define MMU_SERIAL MSERIAL(MMU_SERIAL_PORT)
+    #ifdef DECLARE_SERIAL
+      DECLARE_SERIAL(MMU_SERIAL_PORT);
+    #endif
+  #else
+    static_assert(false, "MMU_SERIAL_PORT" INDEX_RANGE_MSG ".");
+    #define MMU_SERIAL _MSERIAL(1) // Dummy port
+  #endif
+#endif
+
+//
+// LCD_SERIAL_PORT => LCD_SERIAL
+//
+
+#ifdef LCD_SERIAL_PORT
+  #if WITHIN(LCD_SERIAL_PORT, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+    #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
+    #ifdef DECLARE_SERIAL
+      DECLARE_SERIAL(LCD_SERIAL_PORT);
+    #endif
+  #else
+    static_assert(false, "LCD_SERIAL_PORT" INDEX_RANGE_MSG ".");
+    #define LCD_SERIAL _MSERIAL(1) // Dummy port
+  #endif
+#endif
+
+//
+// RS485_SERIAL_PORT => RS485_SERIAL
+//
+
+#ifdef RS485_SERIAL_PORT
+  #if WITHIN(RS485_SERIAL_PORT, SERIAL_INDEX_MIN, SERIAL_INDEX_MAX)
+    #define RS485_SERIAL MSERIAL(RS485_SERIAL_PORT)
+    #ifdef DECLARE_SERIAL
+      DECLARE_SERIAL(RS485_SERIAL_PORT);
+    #endif
+  #else
+    static_assert(false, "RS485_SERIAL_PORT" INDEX_RANGE_MSG ".");
+    #define RS485_SERIAL _MSERIAL(1) // Dummy port
+  #endif
+#endif
+
+#undef DECLARE_SERIAL
+#undef SERIAL_INDEX_MIN
+#undef SERIAL_INDEX_MAX
+#undef INDEX_RANGE_MSG


### PR DESCRIPTION
Move serial port declarations to a common header. This may help ensure all platforms are covered when adding new serial ports. Not all boards can support all types of ports, but this allows for some flexibility with serial multiplexers, etc.