### PR TITLE
🔨 Detect package manager install paths

### DIFF
--- a/buildroot/bin/mac_gcc
+++ b/buildroot/bin/mac_gcc
@@ -7,6 +7,18 @@
 # Usage: mac_gcc apple|macports|homebrew
 #
 
+# Detect architecture
+ARCH=$(uname -m)
+
+if [[ $ARCH == "arm64" ]]; then
+  HOMEBREW_PATH="/opt/homebrew/bin"
+elif [[ $ARCH == "x86_64" ]]; then
+  HOMEBREW_PATH="/usr/local/bin"
+else
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
+
 which port >/dev/null && HAS_MACPORTS=1
 which brew >/dev/null && HAS_HOMEBREW=1
 
@@ -19,7 +31,7 @@ if [[ $1 == "apple" || $1 == "darwin" || $1 == "system" ]]; then
   fi
 
   if ((HAS_HOMEBREW)); then
-    cd /opt/homebrew/bin
+    cd $HOMEBREW_PATH
     sudo rm -f gcc g++ cc
     cd -
   fi
@@ -48,12 +60,12 @@ elif [[ $1 =~ ".*brew" ]]; then
 
   ((HAS_HOMEBREW)) || { echo "Homebrew is not installed"; exit 1; }
 
-  GCCV=$( find /opt/homebrew/bin -name "gcc-*" | sort -r | head -1 | sed 's/.*gcc-//' )
+  GCCV=$( find $HOMEBREW_PATH -name "gcc-*" | sort -r | head -1 | sed 's/.*gcc-//' )
   [[ $GCCV -ge 11 ]] || { brew install gcc@14 ; GCCV=14 }
 
   brew install glm mesa sdl2 sdl2_net
 
-  cd /opt/homebrew/bin
+  cd $HOMEBREW_PATH
   sudo rm -f gcc g++ cc
   sudo ln -s "gcc-$GCCV" gcc
   sudo ln -s "g++-$GCCV" g++

--- a/buildroot/bin/mac_gcc
+++ b/buildroot/bin/mac_gcc
@@ -7,16 +7,16 @@
 # Usage: mac_gcc apple|macports|homebrew
 #
 
-# Detect Homebrew path
-HOMEBREW_PATH=$(brew --prefix)/bin
-
 which port >/dev/null && HAS_MACPORTS=1
 which brew >/dev/null && HAS_HOMEBREW=1
+
+MACPORTS_PATH=$(dirname $(which port))
+HOMEBREW_PATH=$(brew --prefix)/bin
 
 if [[ $1 == "apple" || $1 == "darwin" || $1 == "system" ]]; then
 
   if ((HAS_MACPORTS)); then
-    cd /opt/local/bin
+    cd $MACPORTS_PATH
     sudo rm -f gcc g++ cc ld
     cd -
   fi
@@ -31,7 +31,7 @@ elif [[ $1 =~ ".*ports" ]]; then
 
   ((HAS_MACPORTS)) || { echo "MacPorts is not installed"; exit 1; }
 
-  GCCV=$( find /opt/local/bin -name "gcc-mp-*" | sort -r | head -1 | sed 's/.*gcc-mp-//' )
+  GCCV=$( find $MACPORTS_PATH -name "gcc-mp-*" | sort -r | head -1 | sed 's/.*gcc-mp-//' )
   [[ $GCCV -ge 11 ]] || GCCV=14
 
   getport() { port installed $1 | grep $1 || sudo port install $1; }
@@ -39,7 +39,7 @@ elif [[ $1 =~ ".*ports" ]]; then
 
   getports "gcc$GCCV" glm mesa libsdl2 libsdl2_net
 
-  cd /opt/local/bin
+  cd $MACPORTS_PATH
   sudo rm -f gcc g++ cc ld
   sudo ln -s "gcc-mp-$GCCV" gcc
   sudo ln -s "g++-mp-$GCCV" g++

--- a/buildroot/bin/mac_gcc
+++ b/buildroot/bin/mac_gcc
@@ -10,8 +10,8 @@
 which port >/dev/null && HAS_MACPORTS=1
 which brew >/dev/null && HAS_HOMEBREW=1
 
-MACPORTS_PATH=$(dirname $(which port))
-HOMEBREW_PATH=$(brew --prefix)/bin
+MACPORTS_PATH=$(dirname "$(which port)")
+HOMEBREW_PATH="$(brew --prefix)/bin"
 
 if [[ $1 == "apple" || $1 == "darwin" || $1 == "system" ]]; then
 

--- a/buildroot/bin/mac_gcc
+++ b/buildroot/bin/mac_gcc
@@ -7,17 +7,8 @@
 # Usage: mac_gcc apple|macports|homebrew
 #
 
-# Detect architecture
-ARCH=$(uname -m)
-
-if [[ $ARCH == "arm64" ]]; then
-  HOMEBREW_PATH="/opt/homebrew/bin"
-elif [[ $ARCH == "x86_64" ]]; then
-  HOMEBREW_PATH="/usr/local/bin"
-else
-  echo "Unsupported architecture: $ARCH"
-  exit 1
-fi
+# Detect Homebrew path
+HOMEBREW_PATH=$(brew --prefix)/bin
 
 which port >/dev/null && HAS_MACPORTS=1
 which brew >/dev/null && HAS_HOMEBREW=1

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -103,7 +103,12 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 #
 #  brew install gcc@14 glm mesa sdl2 sdl2_net
 #
+# arm64 (Apple Silicon):
 #  cd /opt/homebrew/bin
+#
+# x86_64 (Intel):
+#  cd /usr/local/bin
+#
 #  sudo rm -f gcc g++ cc
 #  sudo ln -s gcc-14 gcc ; sudo ln -s g++-14 g++ ; sudo ln -s g++ cc
 #  cd -

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -89,7 +89,7 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 #
 #  sudo port install gcc14 glm mesa libsdl2 libsdl2_net
 #
-#  cd /opt/local/bin
+#  cd $(dirname $(which port))
 #  sudo rm gcc g++ cc ld
 #  sudo ln -s gcc-mp-14 gcc ; sudo ln -s g++-mp-14 g++ ; sudo ln -s g++ cc
 #  sudo ln -s ld-classic ld

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -89,7 +89,7 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 #
 #  sudo port install gcc14 glm mesa libsdl2 libsdl2_net
 #
-#  cd $(dirname $(which port))
+#  cd $(dirname "$(which port)")
 #  sudo rm gcc g++ cc ld
 #  sudo ln -s gcc-mp-14 gcc ; sudo ln -s g++-mp-14 g++ ; sudo ln -s g++ cc
 #  sudo ln -s ld-classic ld
@@ -103,7 +103,7 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 #
 #  brew install gcc@14 glm mesa sdl2 sdl2_net
 #
-#  cd $(brew --prefix)/bin
+#  cd "$(brew --prefix)/bin"
 #  sudo rm -f gcc g++ cc
 #  sudo ln -s gcc-14 gcc ; sudo ln -s g++-14 g++ ; sudo ln -s g++ cc
 #  cd -

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -103,12 +103,7 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 #
 #  brew install gcc@14 glm mesa sdl2 sdl2_net
 #
-# arm64 (Apple Silicon):
-#  cd /opt/homebrew/bin
-#
-# x86_64 (Intel):
-#  cd /usr/local/bin
-#
+#  cd $(brew --prefix)/bin
 #  sudo rm -f gcc g++ cc
 #  sudo ln -s gcc-14 gcc ; sudo ln -s g++-14 g++ ; sudo ln -s g++ cc
 #  cd -


### PR DESCRIPTION
### Description

Update `mac_gcc` script to detect MacPorts & Homebrew install paths.

### Benefits

Script will be more universal (and work on Intel Macs)

### Related Issues

- 442f0baf1485c72be3bbe4d11f1b295fe00cea5d
