### PR TITLE
HC32: add environments for OpenHC32Boot bootloader

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -944,9 +944,9 @@
 //
 
 #elif MB(AQUILA_V101)
-  #include "hc32f4/pins_AQUILA_101.h"               // HC32F460                             env:HC32F460C_aquila_101
+  #include "hc32f4/pins_AQUILA_101.h"               // HC32F460                             env:HC32F460C_aquila_101 env:HC32F460C_openhc32boot
 #elif MB(CREALITY_ENDER2P_V24S4)
-  #include "hc32f4/pins_CREALITY_ENDER2P_V24S4.h"   // HC32F460                             env:HC32F460C_e2p24s4
+  #include "hc32f4/pins_CREALITY_ENDER2P_V24S4.h"   // HC32F460                             env:HC32F460C_e2p24s4 env:HC32F460C_openhc32boot
 
 //
 // Raspberry Pi RP2040

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -80,7 +80,7 @@ board_upload.maximum_size = 524288
 [env:HC32F460C_aquila_101]
 extends = HC32F460C_base
 board_upload.offset_address = 0xC000  # Bootloader start address, as logged by the bootloader on boot
-board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as secondary firmware
+board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as secondary firmware (no ICG)
 
 #
 # Creality Ender 2 Pro v2.4.S4_170 (HC32f460kcta) (256K Flash, 192K RAM).
@@ -88,3 +88,27 @@ board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as seco
 [env:HC32F460C_e2p24s4]
 extends = HC32F460C_base
 board_upload.offset_address = 0x8000
+
+#
+# OpenHC32Boot (256K Flash).
+# This can be used with any HC32F460C printer, provided it has OpenHC32Boot installed.
+# see https://github.com/shadow578/OpenHC32Boot for more information
+#
+[env:HC32F460C_openhc32boot]
+extends = HC32F460C_base
+board_upload.offset_address = 0x4000
+board_build.boot_mode = secondary
+build_flags =
+  ${HC32F460C_base.build_flags}
+  -D CORE_DONT_RESTORE_DEFAULT_CLOCKS=1     # OpenHC32Boot doesn't mess with the clock settings, so we can skip clock restore in the core
+
+#
+# OpenHC32Boot (512K Flash)
+#
+[env:HC32F460E_openhc32boot]
+extends = HC32F460E_base
+board_upload.offset_address = 0x4000
+board_build.boot_mode = secondary
+build_flags =
+  ${HC32F460E_base.build_flags}
+  -D CORE_DONT_RESTORE_DEFAULT_CLOCKS=1


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

This PR adds PlatformIO environments for compiling Marlin for printers running the [OpenHC32Boot](https://github.com/shadow578/OpenHC32Boot) bootloader.
OpenHC32Boot is a alternative and open-source bootloader for HC32.



### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
- HC32-based printer with OpenHC32Boot installed

### Benefits

<!-- What does this PR fix or improve? -->
OpenHC32Boot is a lot smaller than the stock bootloaders normally found on HC32-based printers.
Thus, using it frees 16K to 32K of flash to be used by marlin.


### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
N/A
