### PR TITLE
add default LEVELING_COMMANDS for TOUCH_UI_FTDI_EVE

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
@@ -70,6 +70,10 @@ using namespace Theme;
   #define BACK_POS           BTN_POS(1,6), BTN_SIZE(3,1)
 #endif
 
+#ifndef LEVELING_COMMANDS
+  #define LEVELING_COMMANDS "G34"
+#endif
+
 void LevelingMenu::onRedraw(draw_mode_t what) {
   if (what & BACKGROUND) {
     CommandProcessor cmd;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
@@ -70,8 +70,8 @@ using namespace Theme;
   #define BACK_POS           BTN_POS(1,6), BTN_SIZE(3,1)
 #endif
 
-#ifndef LEVELING_COMMANDS
-  #define LEVELING_COMMANDS "G34"
+#ifndef Z_ALIGN_COMMANDS
+  #define Z_ALIGN_COMMANDS "G34"
 #endif
 
 void LevelingMenu::onRedraw(draw_mode_t what) {
@@ -120,7 +120,7 @@ bool LevelingMenu::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1: GOTO_PREVIOUS(); break;
     #if ANY(Z_STEPPER_AUTO_ALIGN, MECHANICAL_GANTRY_CALIBRATION, X_LEVEL_SEQUENCE)
-      case 2: SpinnerDialogBox::enqueueAndWait(F(LEVELING_COMMANDS)); break;
+      case 2: SpinnerDialogBox::enqueueAndWait(F(Z_ALIGN_COMMANDS)); break;
     #endif
     #if HAS_BED_PROBE
       case 3:


### PR DESCRIPTION
### Description

FTDI EVE display fails to build when FTDI_LEVELING_MENU is enabled 

It throws an error 'LEVELING_COMMANDS' not declared - did you mean 'BED_LEVELING_COMMANDS'? for /extui/ftdi_eve_touch_ui/generic/leling_menu.cpp

![Image](https://github.com/user-attachments/assets/5744210a-3d83-4c18-9340-57795631c803)

Code was updated in https://github.com/MarlinFirmware/Marlin/pull/27275

from  `case 2: SpinnerDialogBox::enqueueAndWait(F("G34")); break;` 
to       `case 2: SpinnerDialogBox::enqueueAndWait(F(LEVELING_COMMANDS)); break;`

'They' added LEVELING_COMMANDS to their example Configuration_adv.h 
https://gitlab.com/lulzbot3d/marlin/-/blob/master/Marlin/Configuration_adv.h#L4149
But forgot about everyone else

Added a default LEVELING_COMMAND set to "G34"  as it was originally, but will allow Configuration files to change it.

### Requirements

Lots, see attached example Configs
TOUCH_UI_FTDI_EVE, some form of probe, some form of bed leveling

### Benefits

Builds as expected

### Configurations

[Configuration.zip](https://github.com/user-attachments/files/18655137/Configuration.zip)

### Related Issues

<li>MarlinFirmware/Marlin/issues/27661