### PR TITLE
give KILL_PIN is own pin on simulator

### DIFF
--- a/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
+++ b/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
@@ -730,5 +730,5 @@
 #endif // HAS_WIRED_LCD
 
 #ifndef KILL_PIN
-  #define KILL_PIN                   EXP2_08_PIN
+  #define KILL_PIN                            11
 #endif


### PR DESCRIPTION
### Description

KILL_PIN was found to conflict with SD_DETECT_PIN on Marlin/src/pins/native/pins_RAMPS_NATIVE.h

Gave it its on pin 11, not used by anything else. 

### Requirements

BOARD_SIMULATED

### Benefits

Simulated SD card works as expected 

### Related Issues

<li>MarlinFirmware/Marlin/issues/27636