### PR TITLE
remove extra echo: from M218_report

### DIFF
--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -65,7 +65,7 @@ void GcodeSuite::M218() {
 void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
-  report_heading_etc(forReplay, F(STR_HOTEND_OFFSETS));
+  report_heading(forReplay, F(STR_HOTEND_OFFSETS));
   for (uint8_t e = 1; e < HOTENDS; ++e) {
     report_echo_start(forReplay);
     SERIAL_ECHOLNPGM_P(


### PR DESCRIPTION
### Description

At present M218_report (as seen in M503) displays the following with an extra "echo:", breaking some user interfaces. (eg esp3d web interface) 

```
echo:; Hotend offsets:
echo:echo:  M218 T1 X0.00 Y0.00 Z0.000
```

After this patch
```
echo:; Hotend offsets:
echo:  M218 T1 X0.00 Y0.00 Z0.000
```

also tested with 3 extruders

After this patch with 3 extruders
```
echo:; Hotend offsets:
echo:  M218 T1 X0.00 Y0.00 Z0.000
echo:  M218 T2 X0.00 Y0.00 Z0.000
```
### Requirements

HOTENDS > 1

### Benefits

Output is correctly formatted

### Related Issues
<li>MarlinFirmware/Marlin/issues/27669