### PR TITLE
HC32: add UART3 and 4 support

### DIFF
--- a/Marlin/src/HAL/HC32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MarlinSerial.cpp
@@ -67,8 +67,21 @@ constexpr bool serial_handles_emergency(int port) {
 
 #define DEFINE_SERIAL_MARLIN(name, n) TERN(SERIAL_DMA, DEFINE_DMA_SERIAL_MARLIN(name, n), DEFINE_IRQ_SERIAL_MARLIN(name, n))
 
-DEFINE_SERIAL_MARLIN(MSerial1, 1);
-DEFINE_SERIAL_MARLIN(MSerial2, 2);
+#if defined(BOARD_USART1_RX_PIN) && defined(BOARD_USART1_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial1, 1);
+#endif
+
+#if defined(BOARD_USART2_RX_PIN) && defined(BOARD_USART2_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial2, 2);
+#endif
+
+#if defined(BOARD_USART3_RX_PIN) && defined(BOARD_USART3_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial3, 3);
+#endif
+
+#if defined(BOARD_USART4_RX_PIN) && defined(BOARD_USART4_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial4, 4);
+#endif
 
 // TODO: remove this warning when SERIAL_DMA has been tested some more
 #if ENABLED(SERIAL_DMA)

--- a/Marlin/src/HAL/HC32/MarlinSerial.h
+++ b/Marlin/src/HAL/HC32/MarlinSerial.h
@@ -92,3 +92,5 @@ typedef Serial1Class<MarlinSerial> MSerialT;
 
 extern MSerialT MSerial1;
 extern MSerialT MSerial2;
+extern MSerialT MSerial3;
+extern MSerialT MSerial4;

--- a/Marlin/src/HAL/HC32/MinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MinSerial.cpp
@@ -33,7 +33,7 @@
 // Shared by both panic and PostMortem debugging
 //
 static void minserial_begin() {
-  #if !WITHIN(SERIAL_PORT, 1, 3)
+  #if !WITHIN(SERIAL_PORT, 1, 4)
     #warning "MinSerial requires a physical UART port for output."
     #warning "Disabling MinSerial because the used serial port is not a HW port."
   #else

--- a/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
+++ b/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
@@ -220,10 +220,6 @@
 #define BOARD_USART2_TX_PIN                 PA9
 #define BOARD_USART2_RX_PIN                 PA15
 
-// Unused / Debug
-#define BOARD_USART3_TX_PIN                 PE5
-#define BOARD_USART3_RX_PIN                 PE4
-
 // Onboard LED (HIGH = off, LOW = on)
 #ifndef LED_BUILTIN
   #define LED_BUILTIN                       PA3


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

this PR adds support for using UART3 and UART4 on HC32-based boards, assuming the ports are defined in the pins header for the mainboard. 

additionally, the USART3 RX/TX pin definitions for the Aquila V1.0.1 mainboard were removed, as the pins defined for those functions are not available on that board (the variant used on that board doesn't have those pins).

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
HC32-based mainboard

### Benefits

<!-- What does this PR fix or improve? -->
Allows using a total of 4 hardware serial ports from the current 2. 
Useful for e.g. controlling stepper motors.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
N/A

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
N/A