### PR TITLE
Remove conditional blocking run out sensor use

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -221,10 +221,10 @@
 #endif
 
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET_1
 #endif
 #ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+  #define FIL_RUNOUT2_PIN                   PE6   // MT_DET_2
 #endif
 #ifndef FIL_RUNOUT_STATE
   #define FIL_RUNOUT_STATE                LOW

--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -220,16 +220,14 @@
   //#define PS_ON_PIN                       PA3   // PW_CN /PW_OFF
 #endif
 
-#if HAS_TFT_LVGL_UI
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
-  #endif
-  #ifndef FIL_RUNOUT2_PIN
-    #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
-  #endif
-  #ifndef FIL_RUNOUT_STATE
-    #define FIL_RUNOUT_STATE                LOW
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+#endif
+#ifndef FIL_RUNOUT_STATE
+  #define FIL_RUNOUT_STATE                LOW
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -211,10 +211,10 @@
 // Misc. Functions
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET_1
 #endif
 #ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+  #define FIL_RUNOUT2_PIN                   PE6   // MT_DET_2
 #endif
 #ifndef FIL_RUNOUT_STATE
   #define FIL_RUNOUT_STATE                LOW

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -210,17 +210,17 @@
 //
 // Misc. Functions
 //
-#if HAS_TFT_LVGL_UI
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
-  #endif
-  #ifndef FIL_RUNOUT2_PIN
-    #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
-  #endif
-  #ifndef FIL_RUNOUT_STATE
-    #define FIL_RUNOUT_STATE                LOW
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+#endif
+#ifndef FIL_RUNOUT_STATE
+  #define FIL_RUNOUT_STATE                LOW
+#endif
 
+#if HAS_TFT_LVGL_UI
   #define WIFI_IO0_PIN                      PC13
   #define WIFI_IO1_PIN                      PC7
   #define WIFI_RESET_PIN                    PE9
@@ -236,8 +236,6 @@
 #else
   //#define POWER_LOSS_PIN                  PA2   // PW_DET
   //#define PS_ON_PIN                       PB2   // PW_OFF
-  #define FIL_RUNOUT_PIN                    PA4
-  #define FIL_RUNOUT2_PIN                   PE6
 #endif
 
 //#define LED_PIN                           PB2

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -148,25 +148,22 @@
 //
 // Misc. Functions
 //
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+#endif
+#ifndef FIL_RUNOUT_STATE
+  #define FIL_RUNOUT_STATE                LOW
+#endif
+  //#define POWER_LOSS_PIN                  PA2   // PW_DET
+  //#define PS_ON_PIN                       PB2   // PW_OFF
+  
 #if HAS_TFT_LVGL_UI
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
-  #endif
-  #ifndef FIL_RUNOUT2_PIN
-    #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
-  #endif
-  #ifndef FIL_RUNOUT_STATE
-    #define FIL_RUNOUT_STATE                LOW
-  #endif
-
   #define WIFI_IO0_PIN                      PC13
   #define WIFI_IO1_PIN                      PC7
   #define WIFI_RESET_PIN                    PA5
-#else
-  //#define POWER_LOSS_PIN                  PA2   // PW_DET
-  //#define PS_ON_PIN                       PB2   // PW_OFF
-  #define FIL_RUNOUT_PIN                    PA4
-  #define FIL_RUNOUT2_PIN                   PE6
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -149,17 +149,17 @@
 // Misc. Functions
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET_1
 #endif
 #ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+  #define FIL_RUNOUT2_PIN                   PE6   // MT_DET_2
 #endif
 #ifndef FIL_RUNOUT_STATE
   #define FIL_RUNOUT_STATE                LOW
 #endif
   //#define POWER_LOSS_PIN                  PA2   // PW_DET
   //#define PS_ON_PIN                       PB2   // PW_OFF
-  
+
 #if HAS_TFT_LVGL_UI
   #define WIFI_IO0_PIN                      PC13
   #define WIFI_IO1_PIN                      PC7

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -146,16 +146,14 @@
 //
 // Misc. Functions
 //
-#if HAS_TFT_LVGL_UI
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
-  #endif
-  #ifndef FIL_RUNOUT2_PIN
-    #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
-  #endif
-  #ifndef FIL_RUNOUT_STATE
-    #define FIL_RUNOUT_STATE                LOW
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+#endif
+#ifndef FIL_RUNOUT_STATE
+  #define FIL_RUNOUT_STATE                LOW
 #endif
 
 #ifndef POWER_LOSS_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -147,10 +147,10 @@
 // Misc. Functions
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                  PA4   // MT_DET_1
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET_1
 #endif
 #ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN                 PE6   // MT_DET_2
+  #define FIL_RUNOUT2_PIN                   PE6   // MT_DET_2
 #endif
 #ifndef FIL_RUNOUT_STATE
   #define FIL_RUNOUT_STATE                LOW


### PR DESCRIPTION
### Description

PR #27640 made it necessary to have HAS_TFT_LVGL_UI for some boards to be able to use a run out sensor. Removed conditional blocking use from MKS boards and FL Sun board.

### Requirements

MKS board or FLSUN board

### Benefits

Restores the ability to use run out sensors 

### Configurations


