### PR TITLE
Fix for pioarduino support due to different path than platformio

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -87,8 +87,8 @@ def search_compiler(env):
         # Use any item in $PATH corresponding to a platformio toolchain bin folder
         if ppath.match(env['PROJECT_PACKAGES_DIR'] + "/**/bin"):
             for gpath in ppath.glob(gcc_exe):
-                # Skip '*-elf-g++' (crosstool-NG) except for xtensa32
-                if not gpath.stem.endswith('-elf-g++') or "xtensa32" in str(gpath):
+                # Skip '*-elf-g++' (crosstool-NG) except for xtensa32/xtensa-esp32
+                if not gpath.stem.endswith('-elf-g++') or "xtensa" in str(gpath):
                     gccpath = str(gpath.resolve())
                     break
 


### PR DESCRIPTION
### Description

Allow to use pioarduino for esp32 boards that handle latest esp32 arduino cores (3.X+)

Since november 2023 espressif stop to support platformio:

https://github.com/platformio/platform-espressif32/issues/1225

Which mean any release after esp32 arduino 2.x is not supported by platformio neither, because no solution was found between both side, the community launched https://github.com/pioarduino, and especialy : https://github.com/pioarduino/platform-espressif32
This repository release platformio package for every 3.x release done for esp32 arduino core

Due to prebuild changes in 2.1.3 detection of g++ failed under windows and compilation do not even start.
This fix allow detection of g++ with platformio package and pioarduino package

Even the issue is not currently visible because latest core updates are not yet used, I have found the issue when doing the porting of esp3dlib 3.0 - so it is more an heads up to prepare the PR for ESP3DLib 3.0 and also coming boards that will come with esp32s3 and new espressif chips

I am still working on porting but at least prebuild script will be ready for any core update 

### Requirements

ESP32 boards using platformio under window

### Benefits

That allows to support latest esp32 core versions that include bugfixes and new chips, using pioarduino package under platformio on windows OS,  because platformio do not do this support anymore and keep compatible with current esp32 platformio package.

### Related Issues

Fix https://github.com/MarlinFirmware/Marlin/issues/27689
