### PR TITLE
[2.1.x] Add missing BTT_SKR_MINI_E3_V3_0_1 to pins.h

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -670,6 +670,8 @@
   #include "stm32f4/pins_RUMBA32_BTT.h"             // STM32F4                              env:rumba32
 #elif MB(BLACK_STM32F407VE)
   #include "stm32f4/pins_BLACK_STM32F407VE.h"       // STM32F4                              env:STM32F407VE_black
+#elif MB(BTT_SKR_MINI_E3_V3_0_1)
+  #include "stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h"  // STM32F4                              env:STM32F401RC_btt env:STM32F401RC_btt_xfer
 #elif MB(BTT_SKR_PRO_V1_1)
   #include "stm32f4/pins_BTT_SKR_PRO_V1_1.h"        // STM32F4                              env:BIGTREE_SKR_PRO env:BIGTREE_SKR_PRO_usb_flash_drive
 #elif MB(BTT_SKR_PRO_V1_2)


### PR DESCRIPTION
### Description

> [!NOTE]  
> This is for branch `MarlinFirmware:2.1.x`  as release `2.1.2.5` has this issue

A user on discord attempted to use `BOARD_BTT_SKR_MINI_E3_V3_0_1` on release `2.1.2.5` only to find it said Unknown Motherboard.

Most of it is in there. Issue is the code needed to support `BTT_SKR_MINI_E3_V3_0_1` was missing from pins.h

This adds this missing code to `MarlinFirmware:2.1.x `

### Requirements

`BTT_SKR_MINI_E3_V3_0_1`

### Benefits

Builds as expected

