### PR TITLE
Switch to Static asserts to allow use of floats on DUAL_X_CARRIAGE configurations 

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1921,10 +1921,6 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
  * Dual X Carriage requirements
  */
 #if ENABLED(DUAL_X_CARRIAGE)
-  constexpr const_float_t sanity_X1_MAX_POS = X1_MAX_POS;
-  constexpr const_float_t sanity_X1_HOME_POS = X1_MIN_POS;
-  constexpr const_float_t sanity_X2_HOME_POS = X2_HOME_POS;
-  constexpr const_float_t sanity_X2_MIN_POS = X2_MIN_POS;
   #if EXTRUDERS < 2
     #error "DUAL_X_CARRIAGE requires 2 (or more) extruders."
   #elif ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)
@@ -1937,9 +1933,10 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "DUAL_X_CARRIAGE requires X2_HOME_POS, X2_MIN_POS, and X2_MAX_POS."
   #elif X_HOME_TO_MAX
     #error "DUAL_X_CARRIAGE requires X_HOME_DIR -1."
+  #else
+    static_assert((X2_HOME_POS) > (X1_MAX_POS), "X2_HOME_POS must be greater than X1_MAX_POS (i.e., X_BED_SIZE).");
+    static_assert((X2_MIN_POS) > (X1_MIN_POS), "X2_MIN_POS must be greater than X1_MIN_POS (i.e., X_MIN_POS).");
   #endif
-  static_assert(sanity_X2_HOME_POS > sanity_X1_MAX_POS, "X2_HOME_POS must be greater then X1_MAX_POS.");
-  static_assert(sanity_X2_MIN_POS > sanity_X1_HOME_POS, "X2_MIN_POS must be greater than X1_MIN_POS.");
 #endif
 
 #undef GOOD_AXIS_PINS

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1921,6 +1921,11 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
  * Dual X Carriage requirements
  */
 #if ENABLED(DUAL_X_CARRIAGE)
+  constexpr const_float_t sanity_X1_MAX_POS = X1_MAX_POS;
+  constexpr const_float_t sanity_X1_HOME_POS = X1_MIN_POS;
+  constexpr const_float_t sanity_X2_HOME_POS = X2_HOME_POS;
+  constexpr const_float_t sanity_X2_MIN_POS = X2_MIN_POS;
+  
   #if EXTRUDERS < 2
     #error "DUAL_X_CARRIAGE requires 2 (or more) extruders."
   #elif ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)
@@ -1933,9 +1938,9 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "DUAL_X_CARRIAGE requires X2_HOME_POS, X2_MIN_POS, and X2_MAX_POS."
   #elif X_HOME_TO_MAX
     #error "DUAL_X_CARRIAGE requires X_HOME_DIR -1."
-  #elif (X2_HOME_POS <= X1_MAX_POS) || (X2_MAX_POS < X1_MAX_POS)
-    #error "DUAL_X_CARRIAGE will crash if X1 can meet or exceed X2 travel."
   #endif
+  static_assert(sanity_X2_HOME_POS > sanity_X1_MAX_POS, "X2_HOME_POS must be greater then X1_MAX_POS.");
+  static_assert(sanity_X2_MIN_POS > sanity_X1_HOME_POS, "X2_MIN_POS must be greater than X1_MIN_POS.");
 #endif
 
 #undef GOOD_AXIS_PINS

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1925,7 +1925,6 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   constexpr const_float_t sanity_X1_HOME_POS = X1_MIN_POS;
   constexpr const_float_t sanity_X2_HOME_POS = X2_HOME_POS;
   constexpr const_float_t sanity_X2_MIN_POS = X2_MIN_POS;
-  
   #if EXTRUDERS < 2
     #error "DUAL_X_CARRIAGE requires 2 (or more) extruders."
   #elif ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)


### PR DESCRIPTION
### Description

This will allow Floats to be used for X2_MAX_POS, X2_HOME_POS, X1_MIN_POS & X1_MAX_POS on DUAL_X_CARRIAGE configurations. 
I also removed a redundant check on the X2_MAX_POS and replaced with a check to avoid the X2 hitting X1 while X1 is parked.

### Requirements

Tested using the configuration from the below Issue

### Benefits

Allows for using Floats when using DUAL_X_CARRIAGE

### Configurations

[configuration.zip](https://github.com/user-attachments/files/18912473/configuration.zip)


### Related Issues
(https://github.com/MarlinFirmware/Marlin/issues/27623)
