### PR TITLE
💚 Fix Simulator CI build

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -188,6 +188,7 @@ jobs:
 
     - name: Install Simulator dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install build-essential
         sudo apt-get install libsdl2-dev
         sudo apt-get install libsdl2-net-dev


### PR DESCRIPTION
### Description

CI build tests started to fail ~4 days ago with the following error: `Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`

This doesn't appear to be in GitHub's list of things to fix on their end, so fix it here based on the suggestion to run `sudo apt-get update`.

### Benefits

CI build tests on PRs will work again