### PR TITLE
mks_ui bugfix print finished wifi status still printing

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -123,6 +123,7 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
     #endif
   }
   else if (DIALOG_IS(TYPE_FINISH_PRINT)) {
+    uiCfg.print_state = IDLE;      
     clear_cur_ui();
     lv_draw_ready_print();
   }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

after a success full print the wifi interface still thinks the printer is  still printing

### Requirements

MKS_UI

### Benefits

the wifi interface now knows after a success full print, that printer is ready

### Configurations



### Related Issues


