### PR TITLE
Update apply_modifiers()

### DIFF
--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -782,13 +782,13 @@ class Planner {
     #endif
 
     #if HAS_POSITION_MODIFIERS
-      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING)) {
+      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
         TERN_(SKEW_CORRECTION, skew(pos));
         if (leveling) apply_leveling(pos);
         TERN_(FWRETRACT, apply_retract(pos));
       }
 
-      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING)) {
+      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
         TERN_(FWRETRACT, unapply_retract(pos));
         if (leveling) unapply_leveling(pos);
         TERN_(SKEW_CORRECTION, unskew(pos));

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -782,13 +782,13 @@ class Planner {
     #endif
 
     #if HAS_POSITION_MODIFIERS
-      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
+      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING)) {
         TERN_(SKEW_CORRECTION, skew(pos));
         if (leveling) apply_leveling(pos);
         TERN_(FWRETRACT, apply_retract(pos));
       }
 
-      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
+      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING)) {
         TERN_(FWRETRACT, unapply_retract(pos));
         if (leveling) unapply_leveling(pos);
         TERN_(SKEW_CORRECTION, unskew(pos));

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -782,13 +782,13 @@ class Planner {
     #endif
 
     #if HAS_POSITION_MODIFIERS
-      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
+      FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, const bool leveling=ENABLED(PLANNER_LEVELING)) {
         TERN_(SKEW_CORRECTION, skew(pos));
         if (leveling) apply_leveling(pos);
         TERN_(FWRETRACT, apply_retract(pos));
       }
 
-      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
+      FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, const bool leveling=ENABLED(PLANNER_LEVELING)) {
         TERN_(FWRETRACT, unapply_retract(pos));
         if (leveling) unapply_leveling(pos);
         TERN_(SKEW_CORRECTION, unskew(pos));


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Update **planner.h**:
- Use `TERN0` in `void apply_modifiers()`


**Marlin/src/module/planner.h**
```diff
-     FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
...
-     FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {


+     FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
...
+     FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=TERN0(PLANNER_LEVELING, 1)) {
```

While `ENABLED(PLANNER_LEVELING)` does return the correct usage, it is better as `TERN0`.

---

### Tangent
What I do not understand is how `PLANNER_LEVELING` gets defined.  
in **Conditionals-3-ect.h**, it gets defined by *not* having **UBL**
```y
#if ANY(HAS_ABL_OR_UBL, MESH_BED_LEVELING)
  #define HAS_LEVELING 1
  #if DISABLED(AUTO_BED_LEVELING_UBL)
    #define PLANNER_LEVELING 1
  #endif
#endif
```

yet `apply_modifiers()` has `if (leveling) apply_leveling(pos);`. so with **UBL** enabled, it doesn't use `apply_leveling()` even though perhaps it should?

I mean, logically to me it would make sense to use that function while using **UBL**.  
`HAS_POSITION_MODIFIERS` is enabled when `HAS_LEVELING`.  
so, then either `PLANNER_LEVELING` should be enabled with **UBL**.

otherwise I don't get why `AUTO_BED_LEVELING_UBL` is treated this way (or not the same as) since it is just like **ABL** or `AUTO_BED_LEVELING_BILINEAR`.

lets say we enable `PLANNER_LEVELING` with `AUTO_BED_LEVELING_UBL` by omitting the `#if DISABLED` line above, then this will only effect `BEZIER_CURVE_SUPPORT` - **planner_bezier.cpp** and `ARC_SUPPORT` - **G2_G3.cpp** (and `apply_modifiers()` as said above).

but then we would change the following in those files:
```diff
- #if HAS_LEVELING && !PLANNER_LEVELING
    planner.apply_leveling(some variable);
  #endif

+ #if HAS_LEVELING && (!PLANNER_LEVELING || ENABLED(AUTO_BED_LEVELING_UBL))
    planner.apply_leveling(some variable);
  #endif
``` 

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
