### PR TITLE
Fixes and improvements to PID.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -895,7 +895,7 @@
 #if ANY(PIDTEMP, PIDTEMPBED, PIDTEMPCHAMBER)
   //#define PID_OPENLOOP          // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX
   //#define SLOW_PWM_HEATERS      // PWM with very low frequency (roughly 0.125Hz=8s) and minimum state time of approximately 1s useful for heaters driven by a relay
-  #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
+  #define PID_FUNCTIONAL_RANGE 20 // If the temperature difference between the target temperature and the actual temperature
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
 
   //#define PID_EDIT_MENU         // Add PID editing to the "Advanced Settings" menu. (~700 bytes of flash)

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -173,8 +173,10 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
   struct PID_t {
     protected:
       bool pid_reset = true;
+      bool pid_below = false;
       float temp_iState = 0.0f, temp_dState = 0.0f;
       float work_p = 0, work_i = 0, work_d = 0;
+      float max_power_over_i_gain = 255.0f;
 
     public:
       float Kp = 0, Ki = 0, Kd = 0;
@@ -189,13 +191,13 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
       float cTerm() const { return 0; }
       float fTerm() const { return 0; }
       void set_Kp(float p) { Kp = p; }
-      void set_Ki(float i) { Ki = scalePID_i(i); }
+      void set_Ki(float i) { Ki = scalePID_i(i); max_power_over_i_gain = float(MAX_POW) / Ki - float(MIN_POW);}
       void set_Kd(float d) { Kd = scalePID_d(d); }
       void set_Kc(float) {}
       void set_Kf(float) {}
       int low() const { return MIN_POW; }
       int high() const { return MAX_POW; }
-      void reset() { pid_reset = true; }
+      void reset() { pid_reset = true; pid_below = false;}
       void set(float p, float i, float d, float c=1, float f=0) { set_Kp(p); set_Ki(i); set_Kd(d); set_Kc(c); set_Kf(f); }
       void set(const raw_pid_t &raw) { set(raw.p, raw.i, raw.d); }
       void set(const raw_pidcf_t &raw) { set(raw.p, raw.i, raw.d, raw.c, raw.f); }
@@ -213,24 +215,32 @@ typedef struct { float p, i, d, c, f; } raw_pidcf_t;
         }
         else if (pid_error > PID_FUNCTIONAL_RANGE) {
           pid_reset = true;
+          pid_below = true;
+          temp_dState = current;
           output_pow = MAX_POW;
         }
-        else {
-          if (pid_reset) {
-            pid_reset = false;
-            temp_iState = 0.0;
-            work_d = 0.0;
+        else if (pid_reset) {          
+          pid_reset = false;
+          work_d = 0;
+          if(pid_below) 
+          {
+            temp_iState = max_power_over_i_gain;
+            pid_below = false;
           }
-
-          const float max_power_over_i_gain = float(MAX_POW) / Ki - float(MIN_POW);
-          temp_iState = constrain(temp_iState + pid_error, 0, max_power_over_i_gain);
-
-          work_p = Kp * pid_error;
-          work_i = Ki * temp_iState;
-          work_d = work_d + PID_K2 * (Kd * (temp_dState - current) - work_d);
-
-          output_pow = constrain(work_p + work_i + work_d + float(MIN_POW), 0, MAX_POW);
+          else
+          {
+            temp_iState = 0;
+          }
         }
+
+        temp_iState = constrain(temp_iState + pid_error, temp_iState = -max_power_over_i_gain/4.0f, max_power_over_i_gain);
+
+        work_p = Kp * pid_error;
+        work_i = Ki * temp_iState;
+        work_d = work_d + PID_K2 * (Kd * (temp_dState - current) - work_d);
+
+        output_pow = constrain(work_p + work_i + work_d + float(MIN_POW), 0, MAX_POW);
+        
 
         temp_dState = current;
 


### PR DESCRIPTION
### Description

Following a bug issue https://github.com/MarlinFirmware/Marlin/issues/27734 I examined the PID procedure and found, that it does not follow an actual PID algorithm as it constraints I term to only positive values. I also found, that in typical configuration during handover from max heating to PID, there is a pause to heating.

The constraining of the I term to non-negative values, may cause PID to improperly function, particularly when large flow changes are experienced during the print. Normally this term may be negative to offset the differentiating term and proportional term, by limiting it to zero we effectively reduce PID to PD over target temperature.

The uneven heating during handover to PID when heating is due to starting with I term at zero. During handover we come from a temperature outside of PID work range, typically from room temperature. As the I term is limited to max heater power in every iteration of the loop, starting with max I term value allows for smooth handover, and reduces total time to stabilize significantly. It will also reduce occurrence of alarms due to too slow heating, that were sometimes causing print aborts in printers with less powerful hot end heaters. Images comparing heating process are pasted in the issue linked above.

I also moved the max_I_term determining point outside loop - this value changes only when Ki is changed and there is no need to recompute it every iteration.

### Requirements

No additional requirements. Couple of extra bytes in programme.

### Benefits

Improves time to reach target temperature from room temperature and general temperature stability, particularly when large flow changes are experienced.

### Configurations

Change should improve all configurations with PID enabled.

### Related Issues

See  https://github.com/MarlinFirmware/Marlin/issues/27734.
