### PR TITLE
update aux-1 pins on ramps

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -492,9 +492,9 @@
 //         5V  GND A3  A4
 //
 #define AUX1_05                               57  // (A3)
-#define AUX1_06                                1
+#define AUX1_06                                1  // TX0
 #define AUX1_07                               58  // (A4)
-#define AUX1_08                                0
+#define AUX1_08                                0  // RX0
 
 //
 // AUX2    GND A9 D40 D42 A11

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -486,15 +486,15 @@
 #endif
 
 //
-// AUX1    5V  GND D2  D1
+// AUX1    5V  GND D1  D0
 //          2   4   6   8
 //          1   3   5   7
 //         5V  GND A3  A4
 //
 #define AUX1_05                               57  // (A3)
-#define AUX1_06                                2
+#define AUX1_06                                1
 #define AUX1_07                               58  // (A4)
-#define AUX1_08                                1
+#define AUX1_08                                0
 
 //
 // AUX2    GND A9 D40 D42 A11


### PR DESCRIPTION
### Description

While looking around the ramps 1.4 pins I noticed that the circuit diagram on reprap.org was wrong 
see https://reprap.org/mediawiki/images/archive/f/f6/20250316110106%21RAMPS1.4schematic.png
In the top right of the MEGA Conn section it has RX - D1 and TX - D2 this is in error
It actually RX - D0 and TX - D1   (I have also confirmed this on a real physical ramps 1.4) 

See https://docs.arduino.cc/retired/hacking/hardware/PinMapping2560/ for conformation
```
Pin Number	Pin Name	Mapped Pin Name
2	    PE0 ( RXD0/PCINT8 )	Digital pin 0 (RX0)
3	    PE1 ( TXD0 )	Digital pin 1 (TX0)
```
On the circuit diagram this was again copied in error to the AUX-1 Section

This was in turn copied into marlin for AUX-1

This PR fixes the pins in Marlin, and I have submitted a corrected circuit diagram image https://reprap.org/mediawiki/images/f/f6/RAMPS1.4schematic.png 

### Requirements

Anything that uses Marlin/src/pins/ramps/pins_RAMPS.h

### Benefits

Accurate documentation.

