### PR TITLE
🩹 Add unmeasured ADC reference warning for MKS_TINYBEE board (#27434)

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -899,6 +899,13 @@
 #endif
 
 /**
+ * MKS_TINYBEE Analog Reference
+ */
+#if MB(MKS_TINYBEE) && !defined(ADC_REFERENCE_VOLTAGE)
+  #warning "If you experience odd temperature readings make sure to measure the analog reference voltage. See pins_MKS_TINYBEE.h for details"
+#endif
+
+/**
  * No PWM on the Piezo Beeper?
  */
 #if PIN_EXISTS(BEEPER) && ALL(SPEAKER, NO_SPEAKER)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -901,8 +901,8 @@
 /**
  * MKS_TINYBEE Analog Reference
  */
-#if MB(MKS_TINYBEE) && !defined(ADC_REFERENCE_VOLTAGE)
-  #warning "If you experience odd temperature readings make sure to measure the analog reference voltage. See pins_MKS_TINYBEE.h for details"
+#if ENABLED(EMIT_ADC_REFERENCE_VOLTAGE_WARNING)
+  #warning "Check your ADC_REFERENCE_VOLTAGE on MKS TinyBee! Measure the Analog Reference voltage on the board. See pins_MKS_TINYBEE.h for details."
 #endif
 
 /**

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -127,7 +127,6 @@
  */
 
 #ifndef ADC_REFERENCE_VOLTAGE
-  #warning "If you experience odd temperature readings make sure to measure the analog reference voltage. See pins_MKS_TINYBEE.h for details"
   #define ADC_REFERENCE_VOLTAGE              2.565
 #endif
 

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -115,10 +115,21 @@
 //#define CONTROLLER_FAN_PIN                 148  // FAN2
 //#define E0_AUTO_FAN_PIN                    148  // FAN2
 
-//
-// ADC Reference Voltage
-//
-#define ADC_REFERENCE_VOLTAGE                  2.565  // 2.5V reference VDDA
+/**
+ * ADC Reference Voltage
+ *
+ * In some boards the voltage reference is a bit off due to low quality
+ * components. That is enough to throw off the ADC readings and thus the
+ * temperatures by more than 10°C in some cases. If you experience that
+ * problem, measure the reference voltage (VDDA) at the 2nd pin of
+ * TH1/TH2 (with the sensors disconnected) and set ADC_REFERENCE_VOLTAGE
+ * in your config.
+ */
+
+#ifndef ADC_REFERENCE_VOLTAGE
+  #warning "If you experience odd temperature readings make sure to measure the analog reference voltage. See pins_MKS_TINYBEE.h for details"
+  #define ADC_REFERENCE_VOLTAGE              2.565
+#endif
 
 /**
  *                 ------                                 ------

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -127,6 +127,7 @@
  */
 
 #ifndef ADC_REFERENCE_VOLTAGE
+  #define EMIT_ADC_REFERENCE_VOLTAGE_WARNING
   #define ADC_REFERENCE_VOLTAGE              2.565
 #endif
 


### PR DESCRIPTION
### Description

MKS_TINYBEE uses a voltage reference based on a resistor-zener circuit. In some boards the zener is of dubious quality and it leads to a poor voltage reference, which in turn throws the voltage readings off (in my case, 30°C). This PR lets the user know of that with a compiler warning, so that it can be dealt with accordingly. 

This follows up on #24142 and #24432, and closes #27434.

The reference circuit, out of the [manufacturer's schematic](https://github.com/makerbase-mks/MKS-TinyBee/blob/main/hardware/MKS%20TinyBee%20V1.0_003/MKS%20TinyBee%20V1.0_003%20SCH.pdf): 
![image](https://github.com/user-attachments/assets/17b325f0-8c67-44b1-9d79-f4c0f8d694ec)

### Requirements

MKS_TINYBEE with a different voltage reference. 

### Benefits

It lets the user know of a common case, which can be slightly hard to track down. It allows for the related constant to be defined easily. 

### Configurations

Default MKS_TINYBEE.

### Related Issues

#24142 
#27434