### PR TITLE
Fix warnings with GCC14 and C++23

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1582,7 +1582,9 @@ void Planner::quick_stop() {
   const bool was_enabled = stepper.suspend();
 
   // Drop all queue entries
-  block_buffer_nonbusy = block_buffer_head = block_buffer_tail;
+  const uint8_t tail_value = block_buffer_tail; // Read tail value once
+  block_buffer_head = tail_value;
+  block_buffer_nonbusy = tail_value;
 
   // Restart the block delay for the first movement - As the queue was
   // forced to empty, there's no risk the ISR will touch this.

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -816,7 +816,11 @@ class Planner {
     FORCE_INLINE static uint8_t nonbusy_movesplanned() { return block_dec_mod(block_buffer_head, block_buffer_nonbusy); }
 
     // Remove all blocks from the buffer
-    FORCE_INLINE static void clear_block_buffer() { block_buffer_nonbusy = block_buffer_head = block_buffer_tail = 0; }
+    FORCE_INLINE static void clear_block_buffer() {
+      block_buffer_tail = 0;
+      block_buffer_head = 0;
+      block_buffer_nonbusy = 0;
+    }
 
     // Check if movement queue is full
     FORCE_INLINE static bool is_full() { return block_buffer_tail == next_block_index(block_buffer_head); }

--- a/ini/gd32.ini
+++ b/ini/gd32.ini
@@ -21,7 +21,6 @@ build_flags         = -std=gnu++23
                       -DADC_RESOLUTION=12
                       -DCORE_DEBUG
                       -Wno-deprecated-declarations
-                      -Wno-volatile
 extra_scripts       = ${common.extra_scripts}
 
 #


### PR DESCRIPTION
### Description

This fixes two warnings found in the planner.h/.cpp code when building using GCC14 and C++23. Also removed the flag to suppress the warning for the GD32 MFL platform.

Note:
Unfortunately, GD32 still needs to suppress deprecated warnings due to the latest Arduino API (Binary.h) causing spam with C++14 and later and not using binary literals. However, changing to binary literals in Marlin would break building with older compilers and other platforms.

### Requirements

None

### Benefits

No build warnings.

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/27767
