### PR TITLE
📝 Malyan LCD is not a touchscreen

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3282,7 +3282,7 @@
 #endif
 
 //
-// Touch-screen LCD for Malyan M200/M300 printers
+// LCD for Malyan M200/M300 printers
 //
 //#define MALYAN_LCD
 


### PR DESCRIPTION
### Description

M200 variant uses a rotary encoder and M300 variant uses three buttons to navigate the UI.

### Requirements

Malyan M200/M300 printer (or the Monoprice i3 / Delta Mini rebrands)

### Benefits

Clearer documentation