### PR TITLE
GD32 Creality V4.2.7 board support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -386,7 +386,7 @@
 #define BOARD_CREALITY_V422           5039  // Creality v4.2.2 (STM32F103RC / STM32F103RE) ... GD32 Variant Below!
 #define BOARD_CREALITY_V423           5040  // Creality v4.2.3 (STM32F103RC / STM32F103RE)
 #define BOARD_CREALITY_V425           5041  // Creality v4.2.5 (STM32F103RC / STM32F103RE)
-#define BOARD_CREALITY_V427           5042  // Creality v4.2.7 (STM32F103RC / STM32F103RE)
+#define BOARD_CREALITY_V427           5042  // Creality v4.2.7 (STM32F103RC / STM32F103RE) ... GD32 Variant Below!
 #define BOARD_CREALITY_V4210          5043  // Creality v4.2.10 (STM32F103RC / STM32F103RE) as found in the CR-30
 #define BOARD_CREALITY_V431           5044  // Creality v4.3.1 (STM32F103RC / STM32F103RE)
 #define BOARD_CREALITY_V431_A         5045  // Creality v4.3.1a (STM32F103RC / STM32F103RE)
@@ -563,6 +563,7 @@
 //
 
 #define BOARD_CREALITY_V422_GD32_MFL  7400  // Creality V4.2.2 MFL (GD32F303RE) ... STM32 Variant Above!
+#define BOARD_CREALITY_V427_GD32_MFL  7401  // Creality V4.2.7 MFL (GD32F303RE) ... STM32 Variant Above!
 
 //
 // Raspberry Pi

--- a/Marlin/src/pins/gd32f3/pins_CREALITY_V427_GD32_MFL.h
+++ b/Marlin/src/pins/gd32f3/pins_CREALITY_V427_GD32_MFL.h
@@ -22,12 +22,27 @@
 #pragma once
 
 /**
- * Creality MFL GD32 V4.2.2 (GD32F303RE) board pin assignments
+ * Creality MFL GD32 V4.2.7 (GD32F303RE) board pin assignments
  */
 
 #define ALLOW_GD32F3
 
-#define BOARD_INFO_NAME      "Creality V4.2.2 MFL"
-#define DEFAULT_MACHINE_NAME "Ender-3 MFL"
+#define BOARD_INFO_NAME      "Creality V4.2.7 MFL"
+#define DEFAULT_MACHINE_NAME "Creality3D MFL"
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PB9
+#define X_DIR_PIN                           PC2
+
+#define Y_STEP_PIN                          PB7
+#define Y_DIR_PIN                           PB8
+
+#define Z_STEP_PIN                          PB5
+#define Z_DIR_PIN                           PB6
+
+#define E0_STEP_PIN                         PB3
+#define E0_DIR_PIN                          PB4
 
 #include "../stm32f1/pins_CREALITY_V4.h"

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -977,6 +977,8 @@
 
 #elif MB(CREALITY_V422_GD32_MFL)
   #include "gd32f3/pins_CREALITY_V422_GD32_MFL.h"   // GD32F303RE                           env:GD32F303RE_creality_mfl
+#elif MB(CREALITY_V427_GD32_MFL)
+  #include "gd32f3/pins_CREALITY_V427_GD32_MFL.h"   // GD32F303RE                           env:GD32F303RE_creality_mfl
 
 //
 // Raspberry Pi RP2040


### PR DESCRIPTION

### Description

This adds support for building with native GD32 for the Creality V4.2.7 board ("Silent" board). 

### Requirements

Creality V4.2.7 board with GD32F303RE MCU

### Benefits

Native support

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/27795
