### PR TITLE
GD32: Bump platform to V1.0.3

### DIFF
--- a/ini/gd32.ini
+++ b/ini/gd32.ini
@@ -10,7 +10,7 @@
 ####################################
 
 [gd32_base]
-platform            = https://github.com/bmourit/platform-mfl/archive/refs/tags/V1.0.2.zip
+platform            = https://github.com/bmourit/platform-mfl/archive/refs/tags/V1.0.3.zip
 board_build.core    = gd32
 build_src_filter    = ${common.default_src_filter} +<src/HAL/GD32_MFL> +<src/HAL/shared/backtrace>
 build_unflags       = -std=gnu++11 -std=gnu++14 -std=gnu++17


### PR DESCRIPTION
Uses platform V1.0.3 which uses Arduino Core V1.0.4.

### Description

Bump platform to V1.0.3 for the latest Arduino Core bug fixes

### Requirements

Should be merged with:
https://github.com/MarlinFirmware/Marlin/pull/27800

### Benefits

Fixes a number of bugs and improves safety and efficiency.

### Configurations

N/A

### Related Issues

None
