### PR TITLE
🚸 Rotate Towers for Malyan M300 / Monoprice Mini Delta 

### DIFF
--- a/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
+++ b/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
@@ -46,9 +46,15 @@
 //
 // Limit Switches
 //
-#define X_STOP_PIN                          PC13
-#define Y_STOP_PIN                          PC14
-#define Z_STOP_PIN                          PC15
+#if ENABLED(M300_ROTATE_TOWERS)
+  #define X_STOP_PIN                        PC14
+  #define Y_STOP_PIN                        PC15
+  #define Z_STOP_PIN                        PC13
+#else
+  #define X_STOP_PIN                        PC13
+  #define Y_STOP_PIN                        PC14
+  #define Z_STOP_PIN                        PC15
+#endif
 
 #ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN                   PB7
@@ -57,17 +63,31 @@
 //
 // Steppers
 //
-#define X_STEP_PIN                          PB14
-#define X_DIR_PIN                           PB13
-#define X_ENABLE_PIN                        PB10
+#if ENABLED(M300_ROTATE_TOWERS)
+  #define X_STEP_PIN                        PB12
+  #define X_DIR_PIN                         PB11
+  #define X_ENABLE_PIN                      PB10
 
-#define Y_STEP_PIN                          PB12
-#define Y_DIR_PIN                           PB11
-#define Y_ENABLE_PIN                        PB10
+  #define Y_STEP_PIN                        PB2
+  #define Y_DIR_PIN                         PB1
+  #define Y_ENABLE_PIN                      PB10
 
-#define Z_STEP_PIN                          PB2
-#define Z_DIR_PIN                           PB1
-#define Z_ENABLE_PIN                        PB10
+  #define Z_STEP_PIN                        PB14
+  #define Z_DIR_PIN                         PB13
+  #define Z_ENABLE_PIN                      PB10
+#else
+  #define X_STEP_PIN                        PB14
+  #define X_DIR_PIN                         PB13
+  #define X_ENABLE_PIN                      PB10
+
+  #define Y_STEP_PIN                        PB12
+  #define Y_DIR_PIN                         PB11
+  #define Y_ENABLE_PIN                      PB10
+
+  #define Z_STEP_PIN                        PB2
+  #define Z_DIR_PIN                         PB1
+  #define Z_ENABLE_PIN                      PB10
+#endif
 
 #define E0_STEP_PIN                         PA7
 #define E0_DIR_PIN                          PA6


### PR DESCRIPTION
### Description

Add a config flag to change board pins/rotate the towers for the Malyan M300 / Monoprice Mini Delta.

These printers ship with wiring so that the "front" is rotated 120° / faces the back-left and a common mod is to change the wiring to fix this.

Tested on a Monoprice Mini Delta.

Original wiring mod for reference ([source](https://www.mpminidelta.com/howto/face_forward?s[]=wiring)):

| Example 1 | Example 2 |
|---|---|
| ![image](https://github.com/user-attachments/assets/3c80efc9-7016-49e8-92e6-5ebd3ad5a633) | ![image](https://github.com/user-attachments/assets/9b84f77f-e87d-4f7f-844b-090941cd88ac)  |

### Requirements

Malyan M300 / Monoprice Mini Delta

### Benefits

Instead of forcing users to do this hardware mod, they can add/enable `M300_ROTATE_TOWERS` in their config instead.

### Configurations

https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/delta/Malyan%20M300

I'll submit a PR over there to add this option if it is merged (along with some other improvements).

### Related Issues

None
