### PR TITLE
GD32: Fix display for slower LCDs

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/HAL.h
+++ b/Marlin/src/HAL/GD32_MFL/HAL.h
@@ -40,7 +40,7 @@
 
 // Default graphical display delays
 #define CPU_ST7920_DELAY_1 300
-#define CPU_ST7920_DELAY_2  40
+#define CPU_ST7920_DELAY_2 150
 #define CPU_ST7920_DELAY_3 340
 
 // Serial Ports


### PR DESCRIPTION
The increase in CPU core speed is throwing some 128x64 panels out of spec.

### Description

Increases CPU_ST7920_DELAY_2 to 150 (from the default of 125).

### Requirements

GD32 v4.2.2 board.

Hoping to have @ellensp, and maybe some others verify that this value is working and stable.
Also, thanks to @ellensp for finding this issue and the fix.

### Benefits

Fixes no display issue

### Configurations

N/A

### Related Issues

N/A