### PR TITLE
Forbid SMOOTH_LIN_ADVANCE + NONLINEAR_EXTRUSION

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -856,6 +856,8 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
       #error "SMOOTH_LIN_ADVANCE requires a 32-bit CPU."
     #elif ENABLED(S_CURVE_ACCELERATION)
       #error "SMOOTH_LIN_ADVANCE is not compatible with S_CURVE_ACCELERATION."
+    #elif ENABLED(NONLINEAR_EXTRUSION)
+      #error "SMOOTH_LIN_ADVANCE doesn't currently support NONLINEAR_EXTRUSION."
     #elif ENABLED(INPUT_SHAPING_E_SYNC) && NONE(INPUT_SHAPING_X, INPUT_SHAPING_Y)
       #error "INPUT_SHAPING_E_SYNC requires INPUT_SHAPING_X or INPUT_SHAPING_Y."
     #endif


### PR DESCRIPTION
### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Smooth linear advance ignores NONLINEAR_EXTRUSION, so it is now forbidden by sanity check.

It wouldn't be hard to implement (it should only involve adding a factor to the ~~`target_adv_steps`~~ `total_step_rate` computation.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
