### PR TITLE
Limit fan speed menu

### DIFF
--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -44,6 +44,10 @@
   #define _CNT_P FAN_COUNT
 #endif
 
+#ifndef min
+  #define min std::min
+#endif
+
 /**
  * M106: Set Fan Speed
  *
@@ -85,6 +89,8 @@ void GcodeSuite::M106() {
 
   if (!got_preset && parser.seenval('S'))
     speed = parser.value_ushort();
+
+  speed = min(speed, (uint16_t) thermalManager.max_fan_speed);
 
   TERN_(FOAMCUTTER_XYUV, speed *= 2.55f); // Get command in % of max heat
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -387,6 +387,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_LED_BRIGHTNESS                 = _UxGT("Brightness");
   LSTR MSG_HOTEND_TOO_COLD                = _UxGT("Hotend too cold");
   LSTR MSG_CHAMBER                        = _UxGT("Enclosure");
+  LSTR MSG_MAX_FAN_SPEED                  = _UxGT("Max Fan Speed");
   LSTR MSG_STORED_FAN_N                   = _UxGT("Stored Fan ~");
   LSTR MSG_EXTRA_FAN_SPEED                = _UxGT("Extra Fan Speed");
   LSTR MSG_EXTRA_FAN_SPEED_N              = _UxGT("Extra Fan Speed ~");

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -241,6 +241,7 @@ void menu_temperature() {
       singlenozzle_item(7);
     #endif
 
+    EDIT_ITEM_FAST(percent, MSG_MAX_FAN_SPEED, &Temperature::max_fan_speed, 0, 255);
   #endif // HAS_FAN
 
   #if HAS_PREHEAT

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -192,6 +192,7 @@ void menu_tune() {
       singlenozzle_item(7);
     #endif
 
+    EDIT_ITEM_FAST(percent, MSG_MAX_FAN_SPEED, &Temperature::max_fan_speed, 0, 255);
   #endif // HAS_FAN
 
   //

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -436,6 +436,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 #if HAS_FAN
 
   uint8_t Temperature::fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, FAN_OFF_PWM);
+  uint8_t Temperature::max_fan_speed = 255;
 
   #if ENABLED(EXTRA_FAN_SPEED)
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -919,6 +919,7 @@ class Temperature {
 
       static uint8_t fan_speed[FAN_COUNT];
       #define FANS_LOOP(I) for (uint8_t I = 0; I < FAN_COUNT; ++I)
+      static uint8_t max_fan_speed;
 
       static void set_fan_speed(const uint8_t fan, const uint16_t speed);
 


### PR DESCRIPTION
Limit in Tune menu maximum cooling fan speed set by M106 command. Useful if wrapping or bridge blowing is detected during printing.