### PR TITLE
Improve removing unused TEMP_SENSOR definitions

### DIFF
--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -42,32 +42,32 @@
 
 // Clean up unused temperature sensors and sub-options
 
-#define CHECK_TEMP_SENSOR(N) (!TEMP_SENSOR_##N || HOTENDS < (N+1))
-
-#if CHECK_TEMP_SENSOR(0)
+#define UNUSED_TEMP_SENSOR(N) (!TEMP_SENSOR_##N || N >= HOTENDS)
+#if UNUSED_TEMP_SENSOR(0)
   #undef TEMP_SENSOR_0
 #endif
-#if CHECK_TEMP_SENSOR(1)
+#if UNUSED_TEMP_SENSOR(1)
   #undef TEMP_SENSOR_1
 #endif
-#if CHECK_TEMP_SENSOR(2)
+#if UNUSED_TEMP_SENSOR(2)
   #undef TEMP_SENSOR_2
 #endif
-#if CHECK_TEMP_SENSOR(3)
+#if UNUSED_TEMP_SENSOR(3)
   #undef TEMP_SENSOR_3
 #endif
-#if CHECK_TEMP_SENSOR(4)
+#if UNUSED_TEMP_SENSOR(4)
   #undef TEMP_SENSOR_4
 #endif
-#if CHECK_TEMP_SENSOR(5)
+#if UNUSED_TEMP_SENSOR(5)
   #undef TEMP_SENSOR_5
 #endif
-#if CHECK_TEMP_SENSOR(6)
+#if UNUSED_TEMP_SENSOR(6)
   #undef TEMP_SENSOR_6
 #endif
-#if CHECK_TEMP_SENSOR(7)
+#if UNUSED_TEMP_SENSOR(7)
   #undef TEMP_SENSOR_7
 #endif
+#undef UNUSED_TEMP_SENSOR
 
 #if !TEMP_SENSOR_BED
   #undef TEMP_SENSOR_BED

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -42,28 +42,30 @@
 
 // Clean up unused temperature sensors and sub-options
 
-#if !TEMP_SENSOR_0
+#define CHECK_TEMP_SENSOR(N) (!TEMP_SENSOR_##N || HOTENDS < (N+1))
+
+#if CHECK_TEMP_SENSOR(0)
   #undef TEMP_SENSOR_0
 #endif
-#if !TEMP_SENSOR_1
+#if CHECK_TEMP_SENSOR(1)
   #undef TEMP_SENSOR_1
 #endif
-#if !TEMP_SENSOR_2
+#if CHECK_TEMP_SENSOR(2)
   #undef TEMP_SENSOR_2
 #endif
-#if !TEMP_SENSOR_3
+#if CHECK_TEMP_SENSOR(3)
   #undef TEMP_SENSOR_3
 #endif
-#if !TEMP_SENSOR_4
+#if CHECK_TEMP_SENSOR(4)
   #undef TEMP_SENSOR_4
 #endif
-#if !TEMP_SENSOR_5
+#if CHECK_TEMP_SENSOR(5)
   #undef TEMP_SENSOR_5
 #endif
-#if !TEMP_SENSOR_6
+#if CHECK_TEMP_SENSOR(6)
   #undef TEMP_SENSOR_6
 #endif
-#if !TEMP_SENSOR_7
+#if CHECK_TEMP_SENSOR(7)
   #undef TEMP_SENSOR_7
 #endif
 


### PR DESCRIPTION
### Description

It was noticed that unused erroneous TEMP_SENSOR_[N] defines where not being removed.
In most cases this doesn't cause issue, but thermistor type 66  has sanity checks that break building, there are probably others.

So I improved the conditionals that remove unused  TEMP_SENSOR_[N] defines to also check for a hotend. 

### Benefits

Less unused defines.

### Note
This should be considered for other branches also. (the person who brought this to my attention was using 2.1.2.5)

