### PR TITLE
Fix ProUI LCD off freezing

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1526,15 +1526,17 @@ void hmiReturnScreen() {
   drawMainArea();
 }
 
+#if ANY(TJC_DISPLAY, DACAI_DISPLAY)
+  #define HOME_AND_KILL_ICON ICON_BLTouch
+#else
+  #define HOME_AND_KILL_ICON ICON_Printer_0
+#endif
+
 void dwinHomingStart() {
   hmiFlag.home_flag = true;
   hmiSaveProcessID(ID_Homing);
   title.showCaption(GET_TEXT_F(MSG_HOMING));
-  #if ANY(TJC_DISPLAY, DACAI_DISPLAY)
-    dwinShowPopup(ICON_BLTouch, GET_TEXT_F(MSG_HOMING), GET_TEXT_F(MSG_PLEASE_WAIT));
-  #else
-    dwinShowPopup(ICON_Printer_0, GET_TEXT_F(MSG_HOMING), GET_TEXT_F(MSG_PLEASE_WAIT));
-  #endif
+  dwinShowPopup(HOME_AND_KILL_ICON, GET_TEXT_F(MSG_HOMING), GET_TEXT_F(MSG_PLEASE_WAIT));
 }
 
 void dwinHomingDone() {
@@ -1954,23 +1956,13 @@ void MarlinUI::update() {
 
 #if HAS_LCD_BRIGHTNESS
   void MarlinUI::_set_brightness() {
-    if (backlight) {
-      dwinLCDBrightness(brightness);
-      wait_for_user = false;
-    }
-    else {
-      dwinLCDBrightness(0);
-      wait_for_user = true;
-    }
+    wait_for_user = !backlight;
+    dwinLCDBrightness(backlight ? brightness : 0);
   }
 #endif
 
 void MarlinUI::kill_screen(FSTR_P const lcd_error, FSTR_P const) {
-  #if ANY(TJC_DISPLAY, DACAI_DISPLAY)
-    dwinDrawPopup(ICON_BLTouch, GET_TEXT_F(MSG_PRINTER_KILLED), lcd_error);
-  #else
-    dwinDrawPopup(ICON_Printer_0, GET_TEXT_F(MSG_PRINTER_KILLED), lcd_error);
-  #endif
+  dwinDrawPopup(HOME_AND_KILL_ICON, GET_TEXT_F(MSG_PRINTER_KILLED), lcd_error);
   DWINUI::drawCenteredString(hmiData.colorPopupTxt, 270, GET_TEXT_F(MSG_TURN_OFF));
   dwinUpdateLCD();
 }

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1958,7 +1958,7 @@ void MarlinUI::update() {
 
 #if HAS_LCD_BRIGHTNESS
   void MarlinUI::_set_brightness() {
-    wait_for_user = !backlight;
+    if (!backlight) wait_for_user = true;
     dwinLCDBrightness(backlight ? brightness : 0);
   }
 #endif

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -927,19 +927,28 @@ void sdCardFolder(char * const dirname) {
 
 void onClickSDItem() {
   const uint16_t hasUpDir = !card.flag.workDirIsRoot;
-  if (hasUpDir && currentMenu->selected == 1) return sdCardUp();
+  if (hasUpDir && currentMenu->selected == 1) {
+    sdCardUp();
+    return;
+  }
   else {
     const uint16_t filenum = currentMenu->selected - 1 - hasUpDir;
     card.selectFileByIndexSorted(filenum);
 
     // Enter that folder!
-    if (card.flag.filenameIsDir) return sdCardFolder(card.filename);
+    if (card.flag.filenameIsDir) {
+      sdCardFolder(card.filename);
+      return;
+    }
 
-    if (card.fileIsBinary())
-      return dwinPopupConfirm(ICON_Error, F("Please check filenames"), F("Only G-code can be printed"));
+    if (card.fileIsBinary()) {
+      dwinPopupConfirm(ICON_Error, F("Please check filenames"), F("Only G-code can be printed"));
+      return;
+    }
     else {
       dwinPrintHeader(card.longest_filename()); // Save filename
-      return gotoConfirmToPrint();
+      gotoConfirmToPrint();
+      return;
     }
   }
 }
@@ -1171,7 +1180,7 @@ void onClickPauseOrStop() {
     case PRINT_STOP: if (hmiFlag.select_flag) ExtUI::stopPrint(); break; // Stop confirmed then abort print
     default: break;
   }
-  return gotoPrintProcess();
+  gotoPrintProcess();
 }
 
 // Printing
@@ -1205,10 +1214,14 @@ void hmiPrinting() {
           ExtUI::resumePrint();
           break;
         }
-        else
-          return gotoPopup(popupPauseOrStop, onClickPauseOrStop);
-      case PRINT_STOP:
-        return gotoPopup(popupPauseOrStop, onClickPauseOrStop);
+        else {
+          gotoPopup(popupPauseOrStop, onClickPauseOrStop);
+          return;
+        }
+      case PRINT_STOP: {
+        gotoPopup(popupPauseOrStop, onClickPauseOrStop);
+        return;
+      }
       default: break;
     }
   }
@@ -1257,7 +1270,8 @@ void hmiWaitForUser() {
   EncoderState encoder_diffState = get_encoder_state();
   if (encoder_diffState != ENCODER_DIFF_NO && !ui.backlight) {
     ui.refresh_brightness();
-    return hmiReturnScreen();
+    hmiReturnScreen();
+    return;
   }
   if (!wait_for_user) {
     switch (checkkey) {
@@ -1387,7 +1401,8 @@ void eachMomentUpdate() {
     }
     #if HAS_PLR_UI_FLAG
       else if (DWIN_lcd_sd_status && recovery.ui_flag_resume) { // Resume interrupted print
-        return gotoPowerLossRecovery();
+        gotoPowerLossRecovery();
+        return;
       }
     #endif
 
@@ -1426,7 +1441,8 @@ void eachMomentUpdate() {
     if (hmiFlag.select_flag) {
       queue.inject(F("M1000C"));
       select_page.reset();
-      return gotoMainMenu();
+      gotoMainMenu();
+      return;
     }
     else {
       hmiSaveProcessID(ID_NothingToDo);
@@ -2060,7 +2076,8 @@ void dwinRedrawScreen() {
     dwinResetStatusLine();
     if (hmiFlag.select_flag) {     // Confirm
       gotoMainMenu();
-      return card.openAndPrintFile(card.filename);
+      card.openAndPrintFile(card.filename);
+      return;
     }
     else
       hmiReturnScreen();
@@ -2070,7 +2087,10 @@ void dwinRedrawScreen() {
 
 void gotoConfirmToPrint() {
   #if HAS_GCODE_PREVIEW
-    if (hmiData.enablePreview) return gotoPopup(preview.drawFromSD, onClickConfirmToPrint);
+    if (hmiData.enablePreview) {
+      gotoPopup(preview.drawFromSD, onClickConfirmToPrint);
+      return;
+    }
   #endif
   card.openAndPrintFile(card.filename); // Direct print SD file
 }
@@ -2203,7 +2223,8 @@ void axisMove(AxisEnum axis) {
   #if HAS_HOTEND
     if (axis == E_AXIS && thermalManager.tooColdToExtrude(0)) {
       gcode.process_subcommands_now(F("G92E0"));  // Reset extruder position
-      return dwinPopupConfirm(ICON_TempTooLow, GET_TEXT_F(MSG_HOTEND_TOO_COLD), GET_TEXT_F(MSG_PLEASE_PREHEAT));
+      dwinPopupConfirm(ICON_TempTooLow, GET_TEXT_F(MSG_HOTEND_TOO_COLD), GET_TEXT_F(MSG_PLEASE_PREHEAT));
+      return;
     }
   #endif
   planner.synchronize();

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1256,8 +1256,8 @@ void drawMainArea() {
 void hmiWaitForUser() {
   EncoderState encoder_diffState = get_encoder_state();
   if (encoder_diffState != ENCODER_DIFF_NO && !ui.backlight) {
-    if (checkkey == ID_WaitResponse) hmiReturnScreen();
-    return ui.refresh_brightness();
+    ui.refresh_brightness();
+    return hmiReturnScreen();
   }
   if (!wait_for_user) {
     switch (checkkey) {
@@ -1937,7 +1937,16 @@ void MarlinUI::update() {
 }
 
 #if HAS_LCD_BRIGHTNESS
-  void MarlinUI::_set_brightness() { dwinLCDBrightness(backlight ? brightness : 0); }
+  void MarlinUI::_set_brightness() {
+    if (backlight) {
+      dwinLCDBrightness(brightness);
+      wait_for_user = false;
+    }
+    else {
+      dwinLCDBrightness(0);
+      wait_for_user = true;
+    }
+  }
 #endif
 
 void MarlinUI::kill_screen(FSTR_P const lcd_error, FSTR_P const) {
@@ -2252,7 +2261,7 @@ void setMoveZ() { hmiValue.axis = Z_AXIS; setPFloatOnClick(Z_MIN_POS, Z_MAX_POS,
   void applyBrightness() { ui.set_brightness(menuData.value); }
   void liveBrightness() { dwinLCDBrightness(menuData.value); }
   void setBrightness() { setIntOnClick(LCD_BRIGHTNESS_MIN, LCD_BRIGHTNESS_MAX, ui.brightness, applyBrightness, liveBrightness); }
-  void turnOffBacklight() { hmiSaveProcessID(ID_WaitResponse); ui.set_brightness(0); dwinRedrawScreen(); }
+  void turnOffBacklight() { ui.set_brightness(0); dwinRedrawScreen(); }
 #endif
 
 #if ENABLED(CASE_LIGHT_MENU)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
When using ProUI, and the LCD turns off, turning the knob may bring the LCD screen back on, however it stays frozen. The only way to bring this back is to press in the knob.

This **PR** makes it so pressing in the knob or turning it not only returns the screen back on, but functionality.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
- Ender3-V2 DWIN type LCD
- ProUI
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
No more frustration when turning the knob and finding a frozen screen.
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
