### PR TITLE
Configure FILAMENT_SWITCH_AND_MOTION

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1203,7 +1203,7 @@
                                                   //   ZVD, MZV : FTM_RATIO
                                                   //   2HEI     : FTM_RATIO * 3 / 2
                                                   //   3HEI     : FTM_RATIO * 2
-#endif
+#endif // FT_MOTION
 
 /**
  * Input Shaping

--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -54,7 +54,7 @@ bool FilamentMonitorBase::enabled = true,
 
   #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
     bool RunoutResponseDelayed::ignore_motion = false;
-    constexpr float RunoutResponseDelayed::motion_distance_mm;
+    float RunoutResponseDelayed::motion_distance_mm = FILAMENT_MOTION_DISTANCE_MM;
   #endif
 #else
   int8_t RunoutResponseDebounced::runout_count[NUM_RUNOUT_SENSORS]; // = 0

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -122,6 +122,8 @@ class TFilamentMonitor : public FilamentMonitorBase {
       static void filament_motion_present(const uint8_t extruder) {
         response.filament_motion_present(extruder);
       }
+      static float& motion_distance() { return response.motion_distance_mm; }
+      static void set_motion_distance(const_float_t mm) { response.motion_distance_mm = mm; }
     #endif
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
@@ -380,7 +382,7 @@ class FilamentSensorBase {
       static float runout_distance_mm;
 
       #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-        static constexpr float motion_distance_mm = FILAMENT_MOTION_DISTANCE_MM;
+        static float motion_distance_mm;
       #endif
 
       static void set_ignore_motion(const bool ignore=true) { ignore_motion = ignore; }

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -50,12 +50,18 @@ void GcodeSuite::M412() {
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       if (parser.seenval('D')) runout.set_runout_distance(parser.value_linear_units());
     #endif
+    #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+      if (parser.seenval('M')) runout.set_motion_distance(parser.value_linear_units());
+    #endif
   }
   else {
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Filament runout ", ON_OFF(runout.enabled));
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       SERIAL_ECHOPGM(" ; Distance ", runout.runout_distance(), "mm");
+    #endif
+    #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+      SERIAL_ECHOPGM(" ; Motion distance ", runout.motion_distance(), "mm");
     #endif
     #if ENABLED(HOST_ACTION_COMMANDS)
       SERIAL_ECHOPGM(" ; Host handling ", ON_OFF(runout.host_handling));
@@ -72,6 +78,9 @@ void GcodeSuite::M412_report(const bool forReplay/*=true*/) {
     "  M412 S", runout.enabled
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       , " D", LINEAR_UNIT(runout.runout_distance())
+    #endif
+    #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+      , " M", LINEAR_UNIT(runout.motion_distance())
     #endif
     , " ; Sensor ", ON_OFF(runout.enabled)
   );

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -778,6 +778,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Runout Sensor");
   LSTR MSG_SENSOR                         = _UxGT("Sensor");
   LSTR MSG_RUNOUT_DISTANCE_MM             = _UxGT("Runout Dist mm");
+  LSTR MSG_MOTION_DISTANCE_MM             = _UxGT("Motion Dist mm");
   LSTR MSG_EXTRUDER_MIN_TEMP              = _UxGT("Extruder Min Temp.");  // ProUI
   LSTR MSG_FANCHECK                       = _UxGT("Fan Tacho Check");
   LSTR MSG_KILL_HOMING_FAILED             = _UxGT("Homing Failed");

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -181,11 +181,12 @@ void menu_backlash();
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
       auto set_runout_distance = []{ runout.set_runout_distance(editable.decimal); };
-      #if ENABLED(FILAMENT_MOTION_SENSOR)
-        EDIT_ITEM_FAST(float31, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 0.1, 10, set_runout_distance, true);
-      #else
-        EDIT_ITEM_FAST(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 999, set_runout_distance, true);
-      #endif
+      EDIT_ITEM_FAST(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 999, set_runout_distance, true);
+    #endif
+    #if ENABLED(FILAMENT_MOTION_SENSOR)
+      editable.decimal = runout.motion_distance();
+      auto set_motion_distance = []{ runout.set_motion_distance(editable.decimal); };
+      EDIT_ITEM_FAST(float31, MSG_MOTION_DISTANCE_MM, &editable.decimal, 0.1, 10, set_motion_distance, true);
     #endif
 
     END_MENU();

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -36,7 +36,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V90"
+#define EEPROM_VERSION "V91"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -260,6 +260,7 @@ typedef struct SettingsDataStruct {
   //
   bool runout_sensor_enabled;                           // M412 S
   float runout_distance_mm;                             // M412 D
+  float motion_distance_mm;                             // M412 M
 
   //
   // ENABLE_LEVELING_FADE_HEIGHT
@@ -987,6 +988,13 @@ void MarlinSettings::postprocess() {
         constexpr float runout_distance_mm = 0;
       #endif
       EEPROM_WRITE(runout_distance_mm);
+
+      #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+        const float &motion_distance_mm = runout.motion_distance();
+      #else
+        constexpr float motion_distance_mm = 0;
+      #endif
+      EEPROM_WRITE(motion_distance_mm);
     }
 
     //
@@ -2040,6 +2048,12 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(runout_distance_mm);
         #if HAS_FILAMENT_RUNOUT_DISTANCE
           if (!validating) runout.set_runout_distance(runout_distance_mm);
+        #endif
+
+        float motion_distance_mm;
+        EEPROM_READ(motion_distance_mm);
+        #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
+          if (!validating) runout.set_motion_distance(motion_distance_mm);
         #endif
       }
 
@@ -3351,6 +3365,7 @@ void MarlinSettings::reset() {
     runout.enabled = FIL_RUNOUT_ENABLED_DEFAULT;
     runout.reset();
     TERN_(HAS_FILAMENT_RUNOUT_DISTANCE, runout.set_runout_distance(FILAMENT_RUNOUT_DISTANCE_MM));
+    TERN_(FILAMENT_SWITCH_AND_MOTION,   runout.set_motion_distance(FILAMENT_MOTION_DISTANCE_MM));
   #endif
 
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -36,7 +36,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V91"
+#define EEPROM_VERSION "V90"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.


### PR DESCRIPTION
Followup to  **Separate endstop and motion sensor thresholds in filament runout detection #27812** 

Configure `FILAMENT_SWITCH_AND_MOTION` with `M412` and menu (not all GUIs implemented).