### PR TITLE
🧑‍💻 Unify DIAG endstop pins aliasing

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -43,71 +43,18 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #ifndef X_STOP_PIN
-    #define X_STOP_PIN                X_DIAG_PIN
-  #endif
-  #if X_HOME_TO_MIN
-    #ifndef X_MAX_PIN
-      #define X_MAX_PIN                    P1_28  // X+
-    #endif
-  #else
-    #ifndef X_MIN_PIN
-      #define X_MIN_PIN                    P1_28  // X+
-    #endif
-  #endif
-#else
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                      P1_29  // X-
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                      P1_28  // X+
-  #endif
+#ifndef X_STOP_PIN
+  #define X_STOP_PIN                  X_DIAG_PIN
 #endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #ifndef Y_STOP_PIN
-    #define Y_STOP_PIN                Y_DIAG_PIN
-  #endif
-  #if Y_HOME_TO_MIN
-    #ifndef Y_MAX_PIN
-      #define Y_MAX_PIN                    P1_26  // Y+
-    #endif
-  #else
-    #ifndef Y_MIN_PIN
-      #define Y_MIN_PIN                    P1_26  // Y+
-    #endif
-  #endif
-#else
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                      P1_27  // Y-
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                      P1_26  // Y+
-  #endif
+#define X_OTHR_PIN                         P1_28  // X+
+#ifndef Y_STOP_PIN
+  #define Y_STOP_PIN                  Y_DIAG_PIN
 #endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                Z_DIAG_PIN
-  #endif
-  #if Z_HOME_TO_MIN
-    #ifndef Z_MAX_PIN
-      #define Z_MAX_PIN                    P1_24  // Z+
-    #endif
-  #else
-    #ifndef Z_MIN_PIN
-      #define Z_MIN_PIN                    P1_24  // Z+
-    #endif
-  #endif
-#else
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                      P1_25  // Z-
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                      P1_24  // Z+
-  #endif
+#define Y_OTHR_PIN                         P1_26  // Y+
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                  Z_DIAG_PIN
 #endif
+#define Z_OTHR_PIN                         P1_24  // Z+
 
 #define ONBOARD_ENDSTOPPULLUPS                    // Board has built-in pullups
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -70,61 +70,14 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                      P1_26  // E0DET
-  #else
-    #define X_MIN_PIN                      P1_26  // E0DET
-  #endif
-#elif ENABLED(X_DUAL_ENDSTOPS)
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                      P1_29  // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                      P1_26  // E0DET
-  #endif
-#else
-  #define X_STOP_PIN                       P1_29  // X-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                      P1_25  // E1DET
-  #else
-    #define Y_MIN_PIN                      P1_25  // E1DET
-  #endif
-#elif ENABLED(Y_DUAL_ENDSTOPS)
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                      P1_28  // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                      P1_25  // E1DET
-  #endif
-#else
-  #define Y_STOP_PIN                       P1_28  // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
+#define X_STOP_PIN                    X_DIAG_PIN
+#define X_OTHR_PIN                         P1_26  // E0DET
+#define Y_STOP_PIN                    Y_DIAG_PIN
+#define Y_OTHR_PIN                         P1_25  // E1DET
+#ifndef Z_STOP_PIN
   #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                      P1_00  // PWRDET
-  #else
-    #define Z_MIN_PIN                      P1_00  // PWRDET
-  #endif
-#elif ENABLED(Z_MULTI_ENDSTOPS)
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                      P1_27  // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                      P1_00  // PWRDET
-  #endif
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                     P1_27  // Z-STOP
-  #endif
 #endif
+#define Z_OTHR_PIN                         P1_00  // PWRDET
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -51,41 +51,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                      P1_28  // X+
-  #else
-    #define X_MIN_PIN                      P1_28  // X+
-  #endif
-#else
-  #define X_MIN_PIN                        P1_29  // X-
-  #define X_MAX_PIN                        P1_28  // X+
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                      P1_26  // Y+
-  #else
-    #define Y_MIN_PIN                      P1_26  // Y+
-  #endif
-#else
-  #define Y_MIN_PIN                        P1_27  // Y-
-  #define Y_MAX_PIN                        P1_26  // Y+
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                      P1_24  // Z+
-  #else
-    #define Z_MIN_PIN                      P1_24  // Z+
-  #endif
-#else
-  #define Z_MIN_PIN                        P1_25  // Z-
-  #define Z_MAX_PIN                        P1_24  // Z+
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN
+#define X_OTHR_PIN                         P1_28  // X+
+#define Y_STOP_PIN                    Y_DIAG_PIN
+#define Y_OTHR_PIN                         P1_26  // Y+
+#define Z_STOP_PIN                    Z_DIAG_PIN
+#define Z_OTHR_PIN                         P1_24  // Z+
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -59,41 +59,12 @@
 //
 // Limit Switches
 //
-#if X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                      P1_28  // X+
-  #else
-    #define X_MIN_PIN                      P1_28  // X+
-  #endif
-#else
-  #define X_MIN_PIN                        P1_29  // X-
-  #define X_MAX_PIN                        P1_28  // X+
-#endif
-
-#if Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                      P1_26  // Y+
-  #else
-    #define Y_MIN_PIN                      P1_26  // Y+
-  #endif
-#else
-  #define Y_MIN_PIN                        P1_27  // Y-
-  #define Y_MAX_PIN                        P1_26  // Y+
-#endif
-
-#if Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                      P1_24  // Z+
-  #else
-    #define Z_MIN_PIN                      P1_24  // Z+
-  #endif
-#else
-  #define Z_MIN_PIN                        P1_25  // Z-
-  #define Z_MAX_PIN                        P1_24  // Z+
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-
+#define X_OTHR_PIN                         P1_28  // X+
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-
+#define Y_OTHR_PIN                         P1_26  // Y+
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-
+#define Z_OTHR_PIN                         P1_24  // Z+
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -65,57 +65,6 @@
   #define HAS_FREE_AUX2_PINS 1
 #endif
 
-//
-// Check for additional used endstop pins
-//
-#ifndef X_MIN_PIN
-  #define X_MIN_PIN 1001
-#endif
-#ifndef Y_MIN_PIN
-  #define Y_MIN_PIN 1002
-#endif
-#ifndef Z_MIN_PIN
-  #define Z_MIN_PIN 1003
-#endif
-#ifndef X_MAX_PIN
-  #define X_MAX_PIN 1004
-#endif
-#ifndef Y_MAX_PIN
-  #define Y_MAX_PIN 1005
-#endif
-#ifndef Z_MAX_PIN
-  #define Z_MAX_PIN 1006
-#endif
-#define _ENDSTOP_IS_ANY(P) (HAS_EXTRA_ENDSTOPS && (X2_STOP_PIN == P || Y2_STOP_PIN == P || Z2_STOP_PIN == P || Z3_STOP_PIN == P || Z4_STOP_PIN == P))
-#if ENABLED(DUAL_X_CARRIAGE) || _ENDSTOP_IS_ANY(X_MIN_PIN) || _ENDSTOP_IS_ANY(X_MAX_PIN)
-  #define NEEDS_X_MINMAX 1
-#endif
-#if _ENDSTOP_IS_ANY(Y_MIN_PIN) || _ENDSTOP_IS_ANY(Y_MAX_PIN)
-  #define NEEDS_Y_MINMAX 1
-#endif
-#if _ENDSTOP_IS_ANY(Z_MIN_PIN) || _ENDSTOP_IS_ANY(Z_MAX_PIN) || ALL(Z_HOME_TO_MAX, Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-  #define NEEDS_Z_MINMAX 1
-#endif
-#undef _ENDSTOP_IS_ANY
-#if X_MIN_PIN > 1000
-  #undef X_MIN_PIN
-#endif
-#if Y_MIN_PIN > 1000
-  #undef Y_MIN_PIN
-#endif
-#if Z_MIN_PIN > 1000
-  #undef Z_MIN_PIN
-#endif
-#if X_MAX_PIN > 1000
-  #undef X_MAX_PIN
-#endif
-#if Y_MAX_PIN > 1000
-  #undef Y_MAX_PIN
-#endif
-#if Z_MAX_PIN > 1000
-  #undef Z_MAX_PIN
-#endif
-
 // Test the target within the included pins file
 #ifdef __MARLIN_DEPS__
   #define NOT_TARGET(V...) 0

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -604,14 +604,30 @@
   #define NUM_SERVO_PLUGS 0
 #endif
 
-// Only used within pins files
-#undef NEEDS_X_MINMAX
-#undef NEEDS_Y_MINMAX
-#undef NEEDS_Z_MINMAX
+/**
+ * Endstop Pins
+ *
+ * The general idea is to provide STOP and MIN|MAX pins as needed...
+ *
+ *  - Standard Homing   : X_STOP_PIN with alias X_(MIN|MAX)_PIN. Same for Y, Z, etc.
+ *  - DUAL_X_CARRIAGE   : Asserts both X_MIN_PIN and X_MAX_PIN must be defined.
+ *  - X_DUAL_ENDSTOPS   : Also define X2_STOP_PIN with alias X2_(MIN|MAX)_PIN.
+ *  - Y_DUAL_ENDSTOPS   : Also define Y2_STOP_PIN with alias Y2_(MIN|MAX)_PIN.
+ *  - Z_MULTI_ENDSTOPS  : Also define Z2_STOP_PIN with alias Z2_(MIN|MAX)_PIN. Same for Z3, Z4.
+ *
+ *  Pins files should define pins according to usability:
+ *    - Define X_STOP_PIN for boards with a preferred endstop plug, including Sensorless.
+ *    - Define X_OTHR_PIN for the "other" endstop pin on the axis.
+ *    - Define X_MIN_PIN and/or X_MAX_PIN as preferred connectors.
+ *    - Allow user override of these pins for easier swapping.
+ *
+ * See also Conditionals-5-post.h >> "Endstop and probe flags"
+ */
 
 //
 // Assign endstop pins, with handling for boards that have only 3 connectors
 //
+
 #if HAS_X_AXIS
   #ifdef X_STOP_PIN
     #if X_HOME_TO_MIN
@@ -624,8 +640,19 @@
   #elif X_HOME_TO_MAX
     #define X_STOP_PIN X_MAX_PIN
   #endif
-  #if !defined(X2_STOP_PIN) && ENABLED(X_DUAL_ENDSTOPS) && PIN_EXISTS(X_STOP)
-    #define X2_STOP_PIN X_STOP_PIN
+  #if ENABLED(X_DUAL_ENDSTOPS) && PIN_EXISTS(X_STOP)
+    #ifndef X_MIN_PIN
+      #define X_MIN_PIN X_STOP_PIN
+    #endif
+    #ifndef X2_STOP_PIN
+      #define X2_STOP_PIN X_STOP_PIN
+    #endif
+  #endif
+  #if !defined(X_MIN_PIN) && X_HOME_TO_MAX && defined(X_OTHR_PIN)
+    #define X_MIN_PIN X_OTHR_PIN
+  #endif
+  #if !defined(X_MAX_PIN) && X_HOME_TO_MIN && defined(X_OTHR_PIN)
+    #define X_MAX_PIN X_OTHR_PIN
   #endif
 #endif
 
@@ -641,8 +668,19 @@
   #elif Y_HOME_TO_MAX
     #define Y_STOP_PIN Y_MAX_PIN
   #endif
-  #if !defined(Y2_STOP_PIN) && ENABLED(Y_DUAL_ENDSTOPS) && PIN_EXISTS(Y_STOP)
-    #define Y2_STOP_PIN Y_STOP_PIN
+  #if ENABLED(Y_DUAL_ENDSTOPS) && PIN_EXISTS(Y_STOP)
+    #ifndef Y_MIN_PIN
+      #define Y_MIN_PIN Y_STOP_PIN
+    #endif
+    #ifndef Y2_STOP_PIN
+      #define Y2_STOP_PIN Y_STOP_PIN
+    #endif
+  #endif
+  #if !defined(Y_MIN_PIN) && Y_HOME_TO_MAX && defined(Y_OTHR_PIN)
+    #define Y_MIN_PIN Y_OTHR_PIN
+  #endif
+  #if !defined(Y_MAX_PIN) && Y_HOME_TO_MIN && defined(Y_OTHR_PIN)
+    #define Y_MAX_PIN Y_OTHR_PIN
   #endif
 #endif
 
@@ -653,6 +691,12 @@
     #elif Z_HOME_TO_MAX
       #define Z_MAX_PIN Z_STOP_PIN
     #endif
+  #endif
+  #if !defined(Z_MIN_PIN) && Z_HOME_TO_MAX && defined(Z_OTHR_PIN)
+    #define Z_MIN_PIN Z_OTHR_PIN
+  #endif
+  #if !defined(Z_MAX_PIN) && Z_HOME_TO_MIN && defined(Z_OTHR_PIN)
+    #define Z_MAX_PIN Z_OTHR_PIN
   #endif
   #if ENABLED(Z_MULTI_ENDSTOPS)
     #if ((Z_HOME_TO_MIN && !defined(Z2_MIN_PIN)) || (Z_HOME_TO_MAX && !defined(Z2_MAX_PIN))) && !defined(Z2_STOP_PIN)

--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -40,7 +40,9 @@
   #error "For EinsyRambo you must set all *_DRIVER_TYPE to TMC2130 in Configuration.h."
 #endif
 
-// TMC2130 Diag Pins (currently just for reference)
+//
+// Trinamic TMC2130 distinct DIAG pins
+//
 #define X_DIAG_PIN                            64
 #define Y_DIAG_PIN                            69
 #define Z_DIAG_PIN                            68
@@ -55,23 +57,23 @@
 // SERVO0_PIN and Z_MIN_PIN configuration for BLTOUCH sensor when combined with SENSORLESS_HOMING.
 //
 
-#if DISABLED(SENSORLESS_HOMING)
-
-  #define X_STOP_PIN                          12
-  #define Y_STOP_PIN                          11
-  #define Z_STOP_PIN                          10
-
-#else
+#if ENABLED(SENSORLESS_HOMING)
 
   #define X_STOP_PIN                  X_DIAG_PIN
   #define Y_STOP_PIN                  Y_DIAG_PIN
 
   #if ENABLED(BLTOUCH)
+    #define SERVO0_PIN                        10  // PROBE-S
     #define Z_STOP_PIN                        11  // Y-MIN
-    #define SERVO0_PIN                        10  // Z-MIN
   #else
-    #define Z_STOP_PIN                        10
+    #define Z_STOP_PIN                        10  // PROBE-S
   #endif
+
+#else
+
+  #define X_STOP_PIN                          12  // X-MIN
+  #define Y_STOP_PIN                          11  // Y-MIN
+  #define Z_STOP_PIN                          10  // PROBE-S
 
 #endif
 
@@ -79,7 +81,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                     10
+  #define Z_MIN_PROBE_PIN                     10  // PROBE-S
 #endif
 
 //

--- a/Marlin/src/pins/rambo/pins_EINSY_RETRO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RETRO.h
@@ -53,29 +53,20 @@
 // SERVO0_PIN and Z_MIN_PIN configuration for BLTOUCH sensor when combined with SENSORLESS_HOMING.
 //
 
-#if DISABLED(SENSORLESS_HOMING)
+#if ENABLED(SENSORLESS_HOMING)
 
-  #define X_MIN_PIN                           12  // X-
-  #define Y_MIN_PIN                           11  // Y-
-  #define X_MAX_PIN                           81  // X+
-  #define Y_MAX_PIN                           57  // Y+
-
-#else
-
+  #define X_STOP_PIN                  X_DIAG_PIN
   #if X_HOME_TO_MIN
-    #define X_MIN_PIN                 X_DIAG_PIN
-    #define X_MAX_PIN                         81  // X+
+    #define X_OTHR_PIN                        81  // X+
   #else
-    #define X_MIN_PIN                         12  // X-
-    #define X_MAX_PIN                 X_DIAG_PIN
+    #define X_OTHR_PIN                        12  // X-
   #endif
 
+  #define Y_STOP_PIN                  Y_DIAG_PIN
   #if Y_HOME_TO_MIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN
-    #define Y_MAX_PIN                         57  // Y+
+    #define Y_OTHR_PIN                        57  // Y+
   #else
-    #define Y_MIN_PIN                         11  // Y-
-    #define Y_MAX_PIN                 Y_DIAG_PIN
+    #define Y_OTHR_PIN                        11  // Y-
   #endif
 
   #if ENABLED(BLTOUCH)
@@ -83,9 +74,16 @@
     #define SERVO0_PIN                        10  // Z-
   #endif
 
+#else
+
+  #define X_MIN_PIN                           12  // X-
+  #define Y_MIN_PIN                           11  // Y-
+  #define X_MAX_PIN                           81  // X+
+  #define Y_MAX_PIN                           57  // Y+
+
 #endif
 
-#define Z_MAX_PIN                              7
+#define Z_MAX_PIN                              7  // Z+
 #ifndef Z_MIN_PIN
   #define Z_MIN_PIN                           10  // Z-
 #endif
@@ -94,7 +92,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                     10
+  #define Z_MIN_PROBE_PIN                     10  // Z-
 #endif
 
 //

--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -120,7 +120,7 @@
   #define Y_STOP_PIN                          42  // AUX (1)
   #define Z_STOP_PIN                          43  // AUX (2)
   #ifndef Z2_STOP_PIN
-     #define Z2_STOP_PIN                      18  // Z-
+    #define Z2_STOP_PIN                       18  // Z-
   #endif
 
   #ifndef Z_MIN_PROBE_PIN

--- a/Marlin/src/pins/sam/pins_ARCHIM2.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM2.h
@@ -71,20 +71,18 @@
   #define E0_DIAG_PIN                         78  // PB23
   #define E1_DIAG_PIN                         25  // PD0
 
+  #define X_STOP_PIN                  X_DIAG_PIN
   #if X_HOME_TO_MIN
-    #define X_MIN_PIN                 X_DIAG_PIN
-    #define X_MAX_PIN                         32
+    #define X_OTHR_PIN                        32  // PD10 MAX ES1
   #else
-    #define X_MIN_PIN                         14
-    #define X_MAX_PIN                 X_DIAG_PIN
+    #define X_OTHR_PIN                        14  // PD4 MIN ES1
   #endif
 
+  #define Y_STOP_PIN                  Y_DIAG_PIN
   #if Y_HOME_TO_MIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN
-    #define Y_MAX_PIN                         15
+    #define Y_OTHR_PIN                        15  // PD5 MAX ES2
   #else
-    #define Y_MIN_PIN                         29
-    #define Y_MAX_PIN                 Y_DIAG_PIN
+    #define Y_OTHR_PIN                        29  // PD6 MIN ES2
   #endif
 
 #else
@@ -103,7 +101,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                     32
+  #define Z_MIN_PROBE_PIN                     32  // PD10 MAX ES1
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V9.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V9.h
@@ -23,11 +23,11 @@
 
 #define BOARD_INFO_NAME "Chitu3D V9"
 
-#define Z_STOP_PIN                          PA14
-
 #define Z2_ENABLE_PIN                       PF3
 #define Z2_STEP_PIN                         PF5
 #define Z2_DIR_PIN                          PF1
+
+#define Z_STOP_PIN                          PA14
 #define Z2_STOP_PIN                         PA13
 
 #ifndef Z_MIN_PROBE_PIN

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V521.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V521.h
@@ -67,11 +67,11 @@
 //
 // Limit Switches
 //
-#define X_STOP_PIN                          PD10  // X
-#define X2_STOP_PIN                         PE15  // X2
+#define X_MIN_PIN                           PD10  // X
+#define X_MAX_PIN                           PE15  // X2
 #define Y_STOP_PIN                          PE0   // Y
-#define Z_STOP_PIN                          PE1   // Z
-#define Z2_STOP_PIN                         PE2   // Z2
+#define Z_MIN_PIN                           PE1   // Z
+#define Z_MAX_PIN                           PE2   // Z2
 
 #ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN                   PD12  // BLTouch IN

--- a/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
+++ b/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
@@ -40,27 +40,10 @@
 //
 // Limit Switches
 //
-#if (X_HOME_DIR == 1)
-  #define X_MIN_PIN                         -1
-  #define X_MAX_PIN                         PA2
-#else
-  #define X_MIN_PIN                         PA2
-  #define X_MAX_PIN                         -1
-#endif
-#if (Y_HOME_DIR == 1)
-  #define Y_MIN_PIN                         -1
-  #define Y_MAX_PIN                         PA1
-#else
-  #define Y_MIN_PIN                         PA1
-  #define Y_MAX_PIN                         -1
-#endif
-#if (Z_HOME_DIR == 1)
-  #define Z_MIN_PIN                         PC2
-  #define Z_MAX_PIN                         PA0
-#else
-  #define Z_MIN_PIN                         PA0
-  #define Z_MAX_PIN                         PC2
-#endif
+#define X_STOP_PIN                          PA2
+#define Y_STOP_PIN                          PA1
+#define Z_STOP_PIN                          PA0
+#define Z_OTHR_PIN                          PC2
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -68,38 +68,24 @@
 //
 #ifdef X_STALL_SENSITIVITY
   #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // X+
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // X+
-  #endif
+  #define X_OTHR_PIN                        PG14  // X+
 #else
-  #define X_MIN_PIN                   X_DIAG_PIN  // X-
-  #define X_MAX_PIN                  E0_DIAG_PIN  // X+
+  #define X_MIN_PIN                         PF2   // X-
+  #define X_MAX_PIN                         PG14  // X+
 #endif
-
 #ifdef Y_STALL_SENSITIVITY
   #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // Y+
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // Y+
-  #endif
+  #define Y_OTHR_PIN                        PG9   // Y+
 #else
-  #define Y_MIN_PIN                   Y_DIAG_PIN  // Y-
-  #define Y_MAX_PIN                  E1_DIAG_PIN  // Y+
+  #define Y_MIN_PIN                         PC13  // Y-
+  #define Y_MAX_PIN                         PG9   // Y+
 #endif
-
 #ifdef Z_STALL_SENSITIVITY
   #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // Z+
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // Z+
-  #endif
+  #define Z_OTHR_PIN                        PD3   // Z+
 #else
-  #define Z_MIN_PIN                   Z_DIAG_PIN  // Z-
-  #define Z_MAX_PIN                  E2_DIAG_PIN  // Z+
+  #define Z_MIN_PIN                         PE0   // Z-
+  #define Z_MAX_PIN                         PD3   // Z+
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -65,59 +65,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // E0DET
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // E1DET
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-STOP
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-STOP
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-STOP
+#define X_OTHR_PIN                   E0_DIAG_PIN  // E0DET
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // E1DET
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // E2DET
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -70,41 +70,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                       PE15  // E0
-  #else
-    #define X_MIN_PIN                       PE15  // E0
-  #endif
-#else
-  #define X_MIN_PIN                         PB10  // X-
-  #define X_MAX_PIN                         PE15  // E0
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                       PE10  // E1
-  #else
-    #define Y_MIN_PIN                       PE10  // E1
-  #endif
-#else
-  #define Y_MIN_PIN                         PE12  // Y-
-  #define Y_MAX_PIN                         PE10  // E1
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                       PG5   // E2
-  #else
-    #define Z_MIN_PIN                       PG5   // E2
-  #endif
-#else
-  #define Z_MIN_PIN                         PG8   // Z-
-  #define Z_MAX_PIN                         PG5   // E2
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-
+#define X_OTHR_PIN                          PE15  // E0
+#define Y_OTHR_PIN                          PE10  // E1
+#define Z_OTHR_PIN                          PG5   // E2
 
 //
 // Z Probe must be this pin

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -71,61 +71,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                       PC2   // E0DET
-  #else
-    #define X_MIN_PIN                       PC2   // E0DET
-  #endif
-#elif ENABLED(X_DUAL_ENDSTOPS)
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                       PC1   // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                       PC2   // E0DET
-  #endif
-#else
-  #define X_STOP_PIN                        PC1   // X-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                       PA0   // E1DET
-  #else
-    #define Y_MIN_PIN                       PA0   // E1DET
-  #endif
-#elif ENABLED(Y_DUAL_ENDSTOPS)
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                       PC3   // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                       PA0   // E1DET
-  #endif
-#else
-  #define Y_STOP_PIN                        PC3   // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                       PC15  // PWRDET
-  #else
-    #define Z_MIN_PIN                       PC15  // PWRDET
-  #endif
-#elif ENABLED(Z_MULTI_ENDSTOPS)
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                       PC0   // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                       PC15  // PWRDET
-  #endif
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                      PC0   // Z-STOP
-  #endif
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-STOP
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-STOP
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-STOP
+#define X_OTHR_PIN                          PC2   // E0DET
+#define Y_OTHR_PIN                          PA0   // E1DET
+#define Z_OTHR_PIN                          PC15  // PWRDET
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32f4/pins_I3DBEEZ9.h
+++ b/Marlin/src/pins/stm32f4/pins_I3DBEEZ9.h
@@ -77,53 +77,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                       PE15  // E0
-  #else
-    #define X_MIN_PIN                       PE15  // E0
-  #endif
-#else
-  #define X_MIN_PIN                         PB10  // X-
-  #define X_MAX_PIN                         PE15  // E0
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                       PE10  // E1
-  #else
-    #define Y_MIN_PIN                       PE10  // E1
-  #endif
-#else
-  #define Y_MIN_PIN                         PE12  // Y-
-  #define Y_MAX_PIN                         PE10  // E1
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                       PG5   // E2
-  #else
-    #define Z_MIN_PIN                       PG5   // E2
-  #endif
-#else
-  #define Z_MIN_PIN                         PG8   // Z-
-  #define Z_MAX_PIN                         PG5   // E2
-#endif
-
-#ifdef Z2_STALL_SENSITIVITY
-  #define Z2_STOP_PIN                E1_DIAG_PIN
-  #if Z2_HOME_TO_MIN
-    #define Z2_MAX_PIN                      PD0   // E3
-  #else
-    #define Z2_MIN_PIN                      PD0   // E3
-  #endif
-#else
-  #define Z2_MIN_PIN                        PD0   // Z2- [E3]
-  #define Z2_MAX_PIN                        PD6   // E4
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-
+#define X_OTHR_PIN                          PE15  // E0
+#define Y_OTHR_PIN                          PE10  // E1
+#define Z_OTHR_PIN                          PG5   // E2
 
 //
 // Z Probe must be this pin

--- a/Marlin/src/pins/stm32f4/pins_MELLOW_FLY_E3_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MELLOW_FLY_E3_V2.h
@@ -66,24 +66,14 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-#else
-  #define X_STOP_PIN                        PE7   // X-STOP
+#ifndef X_STOP_PIN
+  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
 #endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-#else
-  #define Y_STOP_PIN                        PE8   // Y-STOP
+#ifndef Y_STOP_PIN
+  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
 #endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                      PE9   // Z-STOP
-  #endif
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
@@ -56,49 +56,15 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN  // X-
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // X-
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // MT-DET
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // X-
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z+
+#define X_OTHR_PIN                   E0_DIAG_PIN  // MT-DET
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // NEOPIXEL
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // PWRDET
 
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // NEOPIXEL
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // Z-
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // Z+
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-
-#endif
-
-#if DISABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) || ENABLED(USE_PROBE_FOR_Z_HOMING)
-  #ifndef Z_MIN_PROBE_PIN
-    #define Z_MIN_PROBE_PIN          E2_DIAG_PIN  // defaults to 'Z+' connector
-  #endif
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN            E2_DIAG_PIN  // Z+
 #endif
 
 //

--- a/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
@@ -37,20 +37,43 @@
 #endif
 
 //
+// Timers
+//
+#define STEP_TIMER  2
+
+//
+// Servos
+//
+#define SERVO0_PIN                            26  // PWM_EXT1
+#define SERVO1_PIN                            27  // PWM_EXT2
+
+//
 // Limit Switches
 //
-#if DISABLED(SENSORLESS_HOMING)
-  #define X_MIN_PIN                           58
-  #define X_MAX_PIN                           59
-  #define Y_MIN_PIN                           60
-  #define Y_MAX_PIN                           61
-  #define Z_MAX_PIN                           63
+#define X_DIAG_PIN                            36
+#define Y_DIAG_PIN                            39
+#define Z_DIAG_PIN                            42
+
+// Direct endstop pin references
+#define _X_MIN_PIN                            58
+#define _X_MAX_PIN                            59
+#define _Y_MIN_PIN                            60
+#define _Y_MAX_PIN                            61
+#define _Z_MIN_PIN                            62
+#define _Z_MAX_PIN                            63
+
+#if ENABLED(SENSORLESS_HOMING)
+  #define X_STOP_PIN                  X_DIAG_PIN
+  #define Y_STOP_PIN                  Y_DIAG_PIN
+  #define Z_STOP_PIN                  Z_DIAG_PIN
 #else
-  #define X_STOP_PIN                          36
-  #define Y_STOP_PIN                          39
-  #define Z_MAX_PIN                           42
+  #define X_MIN_PIN                   _X_MIN_PIN
+  #define X_MAX_PIN                   _X_MAX_PIN
+  #define Y_MIN_PIN                   _Y_MIN_PIN
+  #define Y_MAX_PIN                   _Y_MAX_PIN
+  #define Z_MIN_PIN                   _Z_MIN_PIN
+  #define Z_MAX_PIN                   _Z_MAX_PIN
 #endif
-#define Z_MIN_PIN                             62
 
 //
 // Z Probe (when not Z_MIN_PIN)
@@ -105,19 +128,17 @@
 #endif
 
 //
-// Servos
+// SD Card
 //
-#define SERVO0_PIN                            26  // PWM_EXT1
-#define SERVO1_PIN                            27  // PWM_EXT2
-
+#define SD_DETECT_PIN                         56  // SD_CARD_DET
 #define SD_SS_PIN                             57  // Onboard SD card reader
 //#define SD_SS_PIN                            9  // LCD SD card reader
+
 #define LED_PIN                               21  // STATUS_LED
 
 //
 // LCD / Controller
 //
-#define SD_DETECT_PIN                         56  // SD_CARD_DET
 #define BEEPER_PIN                            46  // LCD_BEEPER
 #define LCD_PINS_RS                           49  // LCD_RS
 #define LCD_PINS_EN                           48  // LCD_EN
@@ -128,9 +149,3 @@
 #define BTN_EN1                               54  // BTN_EN1
 #define BTN_EN2                               55  // BTN_EN2
 #define BTN_ENC                               47  // BTN_ENC
-
-//
-// Timers
-//
-
-#define STEP_TIMER  2

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_common.h
@@ -76,43 +76,11 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // MIN5
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // MIN5
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // MIN1
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // MIN5
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // MIN1
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // MIN6
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // MIN6
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // MIN2
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // MIN6
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // MIN2
-#endif
-
+#define X_STOP_PIN                    X_DIAG_PIN  // MIN1
+#define Y_STOP_PIN                    Y_DIAG_PIN  // MIN2
 #define Z_STOP_PIN                    Z_DIAG_PIN  // MIN3
+#define X_OTHR_PIN                   E0_DIAG_PIN  // MIN5
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // MIN6
 
 //
 // Filament Runout Sensors

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
@@ -79,61 +79,18 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                       PF4   // E0_DET
-  #else
-    #define X_MIN_PIN                       PF4   // E0_DET
-  #endif
-#elif ENABLED(X_DUAL_ENDSTOPS)
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                       PB5   // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                       PF4   // E0_DET
-  #endif
-#else
-  #define X_STOP_PIN                        PB5   // X-STOP
+#ifndef X_STOP_PIN
+  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
 #endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                       PF5   // E1_DET
-  #else
-    #define Y_MIN_PIN                       PF5   // E1_DET
-  #endif
-#elif ENABLED(Y_DUAL_ENDSTOPS)
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                       PC1   // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                       PF5   // E1_DET
-  #endif
-#else
-  #define Y_STOP_PIN                        PC1   // Y-STOP
+#ifndef Y_STOP_PIN
+  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
 #endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                       PE12  // PWR_DET
-  #else
-    #define Z_MIN_PIN                       PE12  // PWR_DET
-  #endif
-#elif ENABLED(Z_MULTI_ENDSTOPS)
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                       PC0   // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                       PE12  // PWR_DET
-  #endif
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                      PC0   // Z-STOP
-  #endif
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
 #endif
+#define X_OTHR_PIN                          PF4   // E0_DET
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // E1_DET
+#define Z_OTHR_PIN                          PE12  // PWR_DET
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_KRAKEN_V1_0.h
@@ -65,59 +65,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // MIN4
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // MIN4
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // MIN1
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // MIN4
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // MIN1
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // MIN5
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // MIN5
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // MIN2
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // MIN5
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // MIN2
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // MIN6
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // MIN6
-  #endif
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // MIN3
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // MIN6
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // MIN3
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // MIN1
+#define Y_STOP_PIN                    Y_DIAG_PIN  // MIN2
+#define Z_STOP_PIN                    Z_DIAG_PIN  // MIN3
+#define X_OTHR_PIN                   E0_DIAG_PIN  // MIN4
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // MIN5
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // MIN6
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_MANTA_M8P_V2_0.h
@@ -64,59 +64,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN  // M1-STOP
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // M4-STOP
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // M4-STOP
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // M1-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // M4-STOP
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // M1-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // M2-STOP
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-STOP
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // M5-STOP
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // M2-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-STOP
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // M2-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // M3-STOP
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // M6-STOP
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // M6-STOP
-  #endif
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // M3-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // M6-STOP
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // M3-STOP
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // M1-STOP
+#define Y_STOP_PIN                    Y_DIAG_PIN  // M2-STOP
+#define Z_STOP_PIN                    Z_DIAG_PIN  // M3-STOP
+#define X_OTHR_PIN                   E0_DIAG_PIN  // M4-STOP
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // M5-STOP
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // M6-STOP
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -59,59 +59,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // M4-DET
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // M4-DET
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // M4-DET
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-DET
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // M5-DET
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // M5-DET
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // M1-STOP
+#define Y_STOP_PIN                    Y_DIAG_PIN  // M2-STOP
+#define Z_STOP_PIN                    Z_DIAG_PIN  // M3-STOP
+#define X_OTHR_PIN                   E0_DIAG_PIN  // M5-STOP
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // M6-STOP
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // M7-STOP
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -59,59 +59,12 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
-  #else
-    #define X_MIN_PIN                E0_DIAG_PIN  // E0DET
-  #endif
-#elif NEEDS_X_MINMAX
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                E0_DIAG_PIN  // E0DET
-  #endif
-#else
-  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
-#endif
-
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
-  #else
-    #define Y_MIN_PIN                E1_DIAG_PIN  // E1DET
-  #endif
-#elif NEEDS_Y_MINMAX
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                 Y_DIAG_PIN  // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                E1_DIAG_PIN  // E1DET
-  #endif
-#else
-  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #else
-    #define Z_MIN_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#elif NEEDS_Z_MINMAX
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                 Z_DIAG_PIN  // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                E2_DIAG_PIN  // PWRDET
-  #endif
-#else
-  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
-#endif
+#define X_STOP_PIN                    X_DIAG_PIN  // X-STOP
+#define Y_STOP_PIN                    Y_DIAG_PIN  // Y-STOP
+#define Z_STOP_PIN                    Z_DIAG_PIN  // Z-STOP
+#define X_OTHR_PIN                   E0_DIAG_PIN  // E0DET
+#define Y_OTHR_PIN                   E1_DIAG_PIN  // E1DET
+#define Z_OTHR_PIN                   E2_DIAG_PIN  // E2DET
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -70,61 +70,19 @@
 //
 // Limit Switches
 //
-#ifdef X_STALL_SENSITIVITY
-  #define X_STOP_PIN                  X_DIAG_PIN
-  #if X_HOME_TO_MIN
-    #define X_MAX_PIN                       PC2   // E0DET
-  #else
-    #define X_MIN_PIN                       PC2   // E0DET
-  #endif
-#elif ENABLED(X_DUAL_ENDSTOPS)
-  #ifndef X_MIN_PIN
-    #define X_MIN_PIN                       PC1   // X-STOP
-  #endif
-  #ifndef X_MAX_PIN
-    #define X_MAX_PIN                       PC2   // E0DET
-  #endif
-#else
-  #define X_STOP_PIN                        PC1   // X-STOP
+#ifndef X_STOP_PIN
+  #define X_STOP_PIN                  X_DIAG_PIN  // X-STOP
 #endif
+#ifndef Y_STOP_PIN
+  #define Y_STOP_PIN                  Y_DIAG_PIN  // Y-STOP
+#endif
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                  Z_DIAG_PIN  // Z-STOP
+#endif
+#define X_OTHR_PIN                          PC2   // E0DET
+#define Y_OTHR_PIN                          PA0   // E1DET
+#define Z_OTHR_PIN                          PC15  // PWRDET
 
-#ifdef Y_STALL_SENSITIVITY
-  #define Y_STOP_PIN                  Y_DIAG_PIN
-  #if Y_HOME_TO_MIN
-    #define Y_MAX_PIN                       PA0   // E1DET
-  #else
-    #define Y_MIN_PIN                       PA0   // E1DET
-  #endif
-#elif ENABLED(Y_DUAL_ENDSTOPS)
-  #ifndef Y_MIN_PIN
-    #define Y_MIN_PIN                       PC3   // Y-STOP
-  #endif
-  #ifndef Y_MAX_PIN
-    #define Y_MAX_PIN                       PA0   // E1DET
-  #endif
-#else
-  #define Y_STOP_PIN                        PC3   // Y-STOP
-#endif
-
-#ifdef Z_STALL_SENSITIVITY
-  #define Z_STOP_PIN                  Z_DIAG_PIN
-  #if Z_HOME_TO_MIN
-    #define Z_MAX_PIN                       PC15  // PWRDET
-  #else
-    #define Z_MIN_PIN                       PC15  // PWRDET
-  #endif
-#elif ENABLED(Z_MULTI_ENDSTOPS)
-  #ifndef Z_MIN_PIN
-    #define Z_MIN_PIN                       PC0   // Z-STOP
-  #endif
-  #ifndef Z_MAX_PIN
-    #define Z_MAX_PIN                       PC15  // PWRDET
-  #endif
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN                      PC0   // Z-STOP
-  #endif
-#endif
 #define ONBOARD_ENDSTOPPULLUPS                    // Board has built-in pullups
 
 //


### PR DESCRIPTION
### Background
In the distant past the presence of an endstop pin define was used to determine if the endstop was monitored, and later we added defines to indicate which endstop plugs were in use to preserve the needed endstop pin defines. We then refactored endstops and removed those defines, using configuration alone to determine whether endstop pins are needed, enabled, monitored, and reported.

### Physical Endstop Pins
- RAMPS-style boards have 6 pins labeled XYZ "MIN" and "MAX" endstops. Typically these are wired as-labeled, leaving the unused pins for other uses (e.g., other end safety). Some OEM printer boards may use other default arrangements (e.g., to shorten wires).
- At minimum boards with endstop headers for switch/opto endstops will have three, XYZ, labeled as "STOP."
- DIAG pins are wired on a per-stepper-driver basis, named in correspondence with axes "E0", "E1", etc. So any number of endstops can be be pre-designated to certain axes based on configuration. When auto-mapping extra axis steppers these specific endstops must automatically correspond when sensorless homing is being used for the given axis stepper.

### Endstop Pin Defines
Our ideal is to have all endstop pin defaults defined at the board level based on standard patterns:
- If there are 3 endstop pins, they are named STOP (later aliased as MIN/MAX/SAFETY etc.)
- If there are 6 endstop pins, they are named MIN/MAX (later aliased as STOP/SAFETY etc.)
- Extra endstop pins should be defined in Config examples but boards can also provide layouts.
- Even standard endstop pins should be overridable on boards with pin headers.
- Unused endstop pin names are not `#undef` so they can be used by name for other functions.
- As for active DIAG pins, they:
  - Route to a specific pin header (usually STOP/MIN);
  - Can alias to all of MIN/MAX/STOP/SAFETY at once;
  - May include En_DIAG, allowing repurposing as sensorless homing steppers (e.g., Z2);
  - Leave "the OTHER XYZ endstop pins" free to become MIN, MAX, SAFETY.

It all makes for an interesting challenge to account for DIAG pins that may require a jumper, may include the E axes, on boards with variable numbers of exposed headers for wired endstops….

---
Most boards should aim to keep the labeled "MIN" and "MAX" pins on the board from flipping around —at the board pins definition level— because we need to consider future repurposing on top of the board's original intended use. For that it's good to have pin names match the silk-screen whenever possible.

Boards with DIAG pins are unique –some of them– in having DIAG route to pin labeled "MIN" when it could be either end. So there is no set MIN/MAX for either pin in that configuration. One is "STOP" and the other is –well– "OTHR" I suppose.

---
This PR aims to move redundant handling of DIAG aliases to `pins_postprocess.h` and to clarify how DIAG pins and other endstop pins are aliased in different endstop configurations. Boards that have DIAG pins routed to one pin can define the "`*_OTHR_PIN`" and that will be automatically aliased to MIN/MAX (the other end of the axis).

There are some boards (Einsy Retro) that pick different "OTHR" endstop pins depending on the homing direction, but this is not needed for most cases.

Overall the result is a simpler set of pin definitions in the board pins files, centralized definition of DIAG pin aliasing, and a stage for future standardization of this important facet.