### PR TITLE
GD32: Fast GPIO optimization

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/fastio.h
+++ b/Marlin/src/HAL/GD32_MFL/fastio.h
@@ -29,17 +29,17 @@
 #include <PinOpsMap.hpp>
 
 template<typename T>
-FORCE_INLINE static inline void fast_write_pin_wrapper(pin_size_t IO, T V) {
+FORCE_INLINE static void fast_write_pin_wrapper(pin_size_t IO, T V) {
   const PortPinPair& pp = port_pin_map[IO];
   gpio::fast_write_pin(pp.port, pp.pin, static_cast<bool>(V));
 }
 
-FORCE_INLINE static inline auto fast_read_pin_wrapper(pin_size_t IO) -> bool {
+FORCE_INLINE static auto fast_read_pin_wrapper(pin_size_t IO) -> bool {
   const PortPinPair& pp = port_pin_map[IO];
   return gpio::fast_read_pin(pp.port, pp.pin);
 }
 
-FORCE_INLINE static inline void fast_toggle_pin_wrapper(pin_size_t IO) {
+FORCE_INLINE static void fast_toggle_pin_wrapper(pin_size_t IO) {
   const PortPinPair& pp = port_pin_map[IO];
   gpio::fast_toggle_pin(pp.port, pp.pin);
 }

--- a/Marlin/src/HAL/GD32_MFL/fastio.h
+++ b/Marlin/src/HAL/GD32_MFL/fastio.h
@@ -29,17 +29,17 @@
 #include <PinOpsMap.hpp>
 
 template<typename T>
-static inline void fast_write_pin_wrapper(pin_size_t IO, T V) {
+FORCE_INLINE static inline void fast_write_pin_wrapper(pin_size_t IO, T V) {
   const PortPinPair& pp = port_pin_map[IO];
   gpio::fast_write_pin(pp.port, pp.pin, static_cast<bool>(V));
 }
 
-static inline auto fast_read_pin_wrapper(pin_size_t IO) -> bool {
+FORCE_INLINE static inline auto fast_read_pin_wrapper(pin_size_t IO) -> bool {
   const PortPinPair& pp = port_pin_map[IO];
   return gpio::fast_read_pin(pp.port, pp.pin);
 }
 
-static inline void fast_toggle_pin_wrapper(pin_size_t IO) {
+FORCE_INLINE static inline void fast_toggle_pin_wrapper(pin_size_t IO) {
   const PortPinPair& pp = port_pin_map[IO];
   gpio::fast_toggle_pin(pp.port, pp.pin);
 }


### PR DESCRIPTION
### Description

Adding FORCE_INLINE to the fast GPIO functions gives us a couple benefits.
First, code folding will reduce these functions to their direct register accesses - which is ideal.
Second, it allows us to optimize away the pin-port map - reducing code size (~250 bytes or so) as well as eliminating all overhead.

This has been verified via decompilation.

The only down side is that the EEPROM (software IIC) seems to rely on this overhead to meet timing requirements, and since we now have zero overhead, writing to the EEPROM is broken.

I'll submit another PR with that fix.

### Requirements

GD32 Board

### Benefits

Zero overhead for IO and smaller code size.

### Configurations

N/A

### Related Issues

N/A
