### PR TITLE
✏️ Fix VARIANT_MAME typo

### DIFF
--- a/buildroot/share/PlatformIO/variants/README.md
+++ b/buildroot/share/PlatformIO/variants/README.md
@@ -3,7 +3,7 @@
 This `buildroot/share/PlatformIO/variants` folder contains Marlin custom variants for both generic and custom boards.
 
 Marlin specifies board variants in PlatformIO INI files in one of two ways:
-- The `board_build.variant = VARIANT_MAME` field specifies the variant subfolder name directly.
+- The `board_build.variant = VARIANT_NAME` field specifies the variant subfolder name directly.
 - The `board = board_name` field names a custom board JSON file that contains a `build.variant` field.
 
 ## Variant File Naming


### PR DESCRIPTION
### Description

`VARIANT_MAME` should be `VARIANT_NAME`

As pointed out in https://github.com/MarlinFirmware/Marlin/commit/b7a1681d38cb30e5477e0560ef8cf29791b0286c by @Sonicboom247, this was a typo.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/commit/b7a1681d38cb30e5477e0560ef8cf29791b0286c
