### PR TITLE
update typo PIN_EXIST to PIN_EXISTS

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1224,7 +1224,7 @@ void MarlinUI::init() {
           #ifdef NEOPIXEL_BKGD_INDEX_FIRST
             neo.set_background_off();
             neo.show();
-          #elif PIN_EXIST(LCD_BACKLIGHT)
+          #elif PIN_EXISTS(LCD_BACKLIGHT)
             WRITE(LCD_BACKLIGHT_PIN, LOW); // Backlight off
           #endif
           backlight_off_ms = 0;


### PR DESCRIPTION
### Description

Discord user Dri noticed a typo in a macro name 
```
Marlin\src\lcd\marlinui.cpp:1197:26: error: missing binary operator before token "("
           #elif PIN_EXIST(LCD_BACKLIGHT)

```
Updated to PIN_EXISTS

### Requirements

LCD Backlight Timeoutie LCD_BACKLIGHT_TIMEOUT_MINS and not a neo pixel.

### Benefits

Builds as expected.

