### PR TITLE
Specify the baud rate of the tmc softserial

### DIFF
--- a/Marlin/src/pins/stm32f0/pins_FLY_D5.h
+++ b/Marlin/src/pins/stm32f0/pins_FLY_D5.h
@@ -119,7 +119,7 @@
 #ifndef TMC_BAUD_RATE
   #define TMC_BAUD_RATE                    9600
 #endif
-  
+
 #endif
 
 //

--- a/Marlin/src/pins/stm32f0/pins_FLY_D5.h
+++ b/Marlin/src/pins/stm32f0/pins_FLY_D5.h
@@ -114,6 +114,12 @@
   #define Z_SERIAL_TX_PIN                   PA3
   #define E0_SERIAL_TX_PIN                  PA7
   #define E1_SERIAL_TX_PIN                  PB1
+
+// Reduce baud rate to improve software serial reliability
+#ifndef TMC_BAUD_RATE
+  #define TMC_BAUD_RATE                    9600
+#endif
+  
 #endif
 
 //

--- a/Marlin/src/pins/stm32f0/pins_FLY_D7.h
+++ b/Marlin/src/pins/stm32f0/pins_FLY_D7.h
@@ -133,6 +133,12 @@
   #define E1_SERIAL_TX_PIN                  PB1
   #define E2_SERIAL_TX_PIN                  PB6
   #define E3_SERIAL_TX_PIN                  PC10
+
+// Reduce baud rate to improve software serial reliability
+#ifndef TMC_BAUD_RATE
+  #define TMC_BAUD_RATE                    9600
+#endif
+
 #endif
 
 //


### PR DESCRIPTION
Fix the bug that FLY_D5 and FLY_D7 cannot use uart to drive tmc2209.