### PR TITLE
FT_MOTION Fix possible nullptr dereference

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
@@ -243,10 +243,10 @@ static void set_value_confirm() {
     #if HAS_Z_AXIS
       case ZMaxFeedRate:  planner.settings.max_feedrate_mm_s[Z_AXIS] = atof(key_value); break;
     #endif
-    #if HAS_E0_AXIS
+    #if HAS_EXTRUDERS
       case E0MaxFeedRate: planner.settings.max_feedrate_mm_s[E_AXIS] = atof(key_value); break;
     #endif
-    #if HAS_E1_AXIS
+    #if HAS_MULTI_EXTRUDER
       case E1MaxFeedRate: planner.settings.max_feedrate_mm_s[E_AXIS_N(1)] = atof(key_value); break;
     #endif
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -89,6 +89,8 @@ xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
+uint8_t FTMotion::current_extruder_idx = 0;     // Cached extruder index.
+
 // Shaping variables.
 #if HAS_FTM_SHAPING
   FTMotion::shaping_t FTMotion::shaping = {
@@ -391,6 +393,8 @@ void FTMotion::reset() {
   TERN_(HAS_EXTRUDERS, e_raw_z1 = e_advanced_z1 = 0.0f);
 
   axis_move_end_ti.reset();
+
+  current_extruder_idx = 0;
 }
 
 // Private functions.
@@ -453,6 +457,9 @@ void FTMotion::init() {
 
 // Load / convert block data from planner to fixed-time control variables.
 void FTMotion::loadBlockData(block_t * const current_block) {
+
+  // Cache the extruder index for this block
+  current_extruder_idx = current_block->extruder;
 
   const float totalLength = current_block->millimeters,
               oneOverLength = 1.0f / totalLength;
@@ -721,7 +728,7 @@ void FTMotion::convertToSteps(const uint32_t idx) {
   #if ENABLED(STEPS_ROUNDING)
     #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] + (trajMod.A[idx] < 0.0f ? -0.5f : 0.5f))
     const xyze_long_t steps_tar = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, E_AXIS_N(stepper.current_block->extruder)), // May be eliminated if guaranteed positive.
+      TOSTEPS(e, E_AXIS_N(current_extruder_idx)), // May be eliminated if guaranteed positive.
       TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
       TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
       TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)
@@ -730,7 +737,7 @@ void FTMotion::convertToSteps(const uint32_t idx) {
   #else
     #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B]) - steps.A
     xyze_long_t delta = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, E_AXIS_N(stepper.current_block->extruder)),
+      TOSTEPS(e, E_AXIS_N(current_extruder_idx)),
       TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
       TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
       TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -149,6 +149,12 @@ void FTMotion::loop() {
       continue;
     }
     loadBlockData(stepper.current_block);
+
+    // If the endstop is already pressed, endstop interrupts won't invoke
+    // endstop_triggered and the move will grind. So check here for a
+    // triggered endstop, which shortly marks the block for discard.
+    endstops.update();
+
     blockProcRdy = true;
     // Some kinematics track axis motion in HX, HY, HZ
     #if ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)
@@ -577,12 +583,6 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   #endif
   TERN_(HAS_Z_AXIS, _SET_MOVE_END(Z));
   SECONDARY_AXIS_MAP(_SET_MOVE_END);
-
-  // If the endstop is already pressed, endstop interrupts won't invoke
-  // endstop_triggered and the move will grind. So check here for a
-  // triggered endstop, which shortly marks the block for discard.
-  endstops.update();
-
 }
 
 // Generate data points of the trajectory.

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -89,7 +89,11 @@ xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
-uint8_t FTMotion::current_extruder_idx = 0;     // Cached extruder index.
+#if ENABLED(DISTINCT_E_FACTORS)
+  uint8_t FTMotion::block_extruder_axis;        // Cached E Axis from last-fetched block
+#else
+  constexpr uint8_t FTMotion::block_extruder_axis;
+#endif
 
 // Shaping variables.
 #if HAS_FTM_SHAPING
@@ -391,10 +395,9 @@ void FTMotion::reset() {
   #endif
 
   TERN_(HAS_EXTRUDERS, e_raw_z1 = e_advanced_z1 = 0.0f);
+  TERN_(DISTINCT_E_FACTORS, block_extruder_axis = E_AXIS);
 
   axis_move_end_ti.reset();
-
-  current_extruder_idx = 0;
 }
 
 // Private functions.
@@ -457,16 +460,15 @@ void FTMotion::init() {
 
 // Load / convert block data from planner to fixed-time control variables.
 void FTMotion::loadBlockData(block_t * const current_block) {
-
   // Cache the extruder index for this block
-  current_extruder_idx = current_block->extruder;
+  TERN_(DISTINCT_E_FACTORS, block_extruder_axis = E_AXIS_N(current_block->extruder));
 
   const float totalLength = current_block->millimeters,
               oneOverLength = 1.0f / totalLength;
 
   startPosn = endPosn_prevBlock;
   const xyze_pos_t moveDist = LOGICAL_AXIS_ARRAY(
-    current_block->steps.e * planner.mm_per_step[E_AXIS_N(current_block->extruder)] * (current_block->direction_bits.e ? 1 : -1),
+    current_block->steps.e * planner.mm_per_step[block_extruder_axis] * (current_block->direction_bits.e ? 1 : -1),
     current_block->steps.x * planner.mm_per_step[X_AXIS] * (current_block->direction_bits.x ? 1 : -1),
     current_block->steps.y * planner.mm_per_step[Y_AXIS] * (current_block->direction_bits.y ? 1 : -1),
     current_block->steps.z * planner.mm_per_step[Z_AXIS] * (current_block->direction_bits.z ? 1 : -1),
@@ -728,7 +730,7 @@ void FTMotion::convertToSteps(const uint32_t idx) {
   #if ENABLED(STEPS_ROUNDING)
     #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] + (trajMod.A[idx] < 0.0f ? -0.5f : 0.5f))
     const xyze_long_t steps_tar = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, E_AXIS_N(current_extruder_idx)), // May be eliminated if guaranteed positive.
+      TOSTEPS(e, block_extruder_axis), // May be eliminated if guaranteed positive.
       TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
       TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
       TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)
@@ -737,7 +739,7 @@ void FTMotion::convertToSteps(const uint32_t idx) {
   #else
     #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B]) - steps.A
     xyze_long_t delta = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, E_AXIS_N(current_extruder_idx)),
+      TOSTEPS(e, block_extruder_axis),
       TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
       TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
       TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -169,7 +169,11 @@ class FTMotion {
 
     static xyze_long_t steps;
 
-    static uint8_t current_extruder_idx;
+    #if ENABLED(DISTINCT_E_FACTORS)
+      static uint8_t block_extruder_axis;  // Cached extruder axis index
+    #else
+      static constexpr uint8_t block_extruder_axis = E_AXIS;
+    #endif
 
     // Shaping variables.
     #if HAS_FTM_SHAPING

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -169,6 +169,8 @@ class FTMotion {
 
     static xyze_long_t steps;
 
+    static uint8_t current_extruder_idx;
+
     // Shaping variables.
     #if HAS_FTM_SHAPING
 


### PR DESCRIPTION
### Description

While looking through the ft_motion code, looking to fix remaining bugs before the next release, I came across some areas that (I believe) could lead to undefined behavior. It is possible someone with a better understanding of this code can correct me if this is wrong, but from what I can see, there are some cases that exist that could lead to null pointer dereferencing and divide-by-zero cases. I may have added more checks than needed, especially if we know for certain these cases can never happen?? 

I'm hoping someone will double check this for me.

From what I can see, in the loop() function stepper.current_block can be set to nullptr by discard_planner_block_protected() when a block is finished processing (!blockProcRdy). However, the convertToSteps() function, which might still be processing the last batch of that same block (batchRdyForInterp is true), uses stepper.current_block->extruder to get the extruder number for axis_steps_per_mm. If stepper.current_block is nullptr at this point, it will cause a null pointer dereference, leading to a crash or undefined behavior, which could manifest as violent movement or a complete halt.

The other issue is if FTMotion::loadBlockData() receives a planner block (current_block) where current_block->millimeters (totalLength) is zero or extremely small, calculations like oneOverLength = 1.0f / totalLength or spm = totalLength / current_block->step_event_count can result in Inf or NaN. 

If this is somehow impossible due to some other code I somehow missed, then we can close this. If not - here are some fixes.

### Requirements

FT_MOTION should be enabled

### Benefits

Prevents divide by zero (possible NaN) and handles very small or zero length blocks that would otherwise lead to undefined behavior.

### Configurations

N/A

### Related Issues

Might fix (needs testing):

- https://github.com/MarlinFirmware/Marlin/issues/27405
- https://github.com/MarlinFirmware/Marlin/issues/27535
- https://github.com/MarlinFirmware/Marlin/issues/27344

UPDATE!
For now, limiting this to the more likely case of possible nullptr dereference. The fix is fairly simple, using a cached extruder index in the problem area.
