### PR TITLE
use vol for volume info in lpc176x upload script in windows.

### DIFF
--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -54,18 +54,25 @@ if pioutil.is_pio_build():
                     final_drive_name = drive + ':'
                     # print ('disc check: {}'.format(final_drive_name))
                     try:
-                        volume_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))
+                        volume_info = str(subprocess.check_output('cmd /C vol ' + final_drive_name, stderr=subprocess.STDOUT))
                     except Exception as e:
                         print ('error:{}'.format(e))
                         continue
                     else:
-                        if target_drive in volume_info and not target_file_found:  # set upload if not found target file yet
-                            target_drive_found = True
+                        if target_drive in volume_info:  # set upload
                             upload_disk = PureWindowsPath(final_drive_name)
-                        if target_filename in volume_info:
-                            if not target_file_found:
+                            target_drive_found = True
+                            break
+                        try:
+                            dir_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))
+                        except Exception as e:
+                            print ('error:{}'.format(e))
+                            continue
+                        else:
+                            if target_filename in dir_info:
                                 upload_disk = PureWindowsPath(final_drive_name)
-                            target_file_found = True
+                                target_file_found = True
+                                break
 
             elif current_OS == 'Linux':
                 #


### PR DESCRIPTION
### Description

While looking into a issue a user was having on a skr 1.4 controller I noticed a bug in the upload script under windows.

The script looks for either the volume name == REARM or root directory has the file FIRMWARE.CUR to identify the target media for the upload. 

The script uses command line "dir" to get a root directory and the volume name. 

The issue is when the media is empty, dir returns an error and the script loses the volume name.
So even if the volume name is REARM it is skipped.

Updated the script to use the vol command for the volume information, and use dir command for directory contents. 

### Requirements

A windows user using a Lpc176x based board 

### Benefits

Upload script finds the media with the correct volume name, even if the drive is empty 
