### PR TITLE
🩹 Fix Bluesky badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/MarlinFirmware/Marlin/actions/workflows/ci-build-tests.yml"><img alt="CI Status" src="https://github.com/MarlinFirmware/Marlin/actions/workflows/ci-build-tests.yml/badge.svg"></a>
     <a href="https://github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
     <br />
-    <a href="https://bsky.app/profile/marlinfw.org"><img alt="Follow marlinfw.org on Bluesky" src="https://img.shields.io/static/v1?label=&message=Follow @marlinfw.org&color=1185FE&logo=bluesky&logoColor=white"></a>
+    <a href="https://bsky.app/profile/marlinfw.org"><img alt="Follow marlinfw.org on Bluesky" src="https://img.shields.io/badge/Follow%20@marlinfw.org-0085ff?logo=bluesky&logoColor=white"></a>
     <a href="https://fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
 </p>
 


### PR DESCRIPTION
### Description

Update Bluesky badge to link to prevent "Error Fetching Resource" / broken image issue.

I also updated the color to #0085FF. Pulled directly from the butterfly logo SVG on Bluesky.

Current badge (broken):

<img width="286" alt="image" src="https://github.com/user-attachments/assets/5dbdfdfa-acc6-4764-8d00-9579ef663ea5" />

Fixed:

<img width="191" alt="image" src="https://github.com/user-attachments/assets/b4618bbc-589d-40ba-bc0f-ab6f4d9fe0d0" />
