### PR TITLE
Fix analog thermocouple Boards reading incorrectly.

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/temp_soc.h
+++ b/Marlin/src/HAL/GD32_MFL/temp_soc.h
@@ -26,4 +26,4 @@
 #define TS_TYPICAL_SLOPE  4.5
 
 // TODO: Implement voltage scaling (calibrated Vrefint) and ADC resolution scaling (when applicable)
-#define TEMP_SOC_SENSOR(RAW) ((TS_TYPICAL_V - (RAW) / float(OVERSAMPLENR) / float(HAL_ADC_RANGE) * (float(ADC_VREF_MV) / 1000)) / ((TS_TYPICAL_SLOPE) / 1000) + TS_TYPICAL_TEMP)
+#define TEMP_SOC_SENSOR(RAW) ((TS_TYPICAL_V - (RAW) / float(OVERSAMPLENR) / float(HAL_ADC_RANGE) * (float(ADC_VREF_MV) / 1000.0f)) / ((TS_TYPICAL_SLOPE) / 1000.0f) + TS_TYPICAL_TEMP)

--- a/Marlin/src/HAL/STM32/temp_soc.h
+++ b/Marlin/src/HAL/STM32/temp_soc.h
@@ -341,6 +341,6 @@
 
 #elif defined(TS_TYPICAL_V) && defined(TS_TYPICAL_SLOPE) && defined(TS_TYPICAL_TEMP)
 
-  #define TEMP_SOC_SENSOR(RAW) ((TS_TYPICAL_V - (RAW) / float(OVERSAMPLENR) / float(HAL_ADC_RANGE) * (float(ADC_VREF_MV) / 1000.0f)) / ((TS_TYPICAL_SLOPE) / 1000) + TS_TYPICAL_TEMP)
+  #define TEMP_SOC_SENSOR(RAW) ((TS_TYPICAL_V - (RAW) / float(OVERSAMPLENR) / float(HAL_ADC_RANGE) * (float(ADC_VREF_MV) / 1000.0f)) / ((TS_TYPICAL_SLOPE) / 1000.0f) + TS_TYPICAL_TEMP)
 
 #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2457,9 +2457,9 @@ void Temperature::task() {
 }
 
 // For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
-#define TEMP_AD595(RAW)  ((RAW) * (ADC_VREF_MV / 10) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
+#define TEMP_AD595(RAW)  ((RAW) * (ADC_VREF_MV / 10.0) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
 // For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
-#define TEMP_AD8495(RAW) ((RAW) * (ADC_VREF_MV /  5) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD8495_GAIN) + TEMP_SENSOR_AD8495_OFFSET)
+#define TEMP_AD8495(RAW) ((RAW) * (ADC_VREF_MV /  5.0) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD8495_GAIN) + TEMP_SENSOR_AD8495_OFFSET)
 
 /**
  * Bisect search for the range of the 'raw' value, then interpolate

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2456,17 +2456,6 @@ void Temperature::task() {
   UNUSED(ms);
 }
 
-// For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
-static constexpr celsius_float_t temp_ad595(const adc_raw_t raw) {
-  return raw * (float(ADC_VREF_MV) / 10.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
-             * (TEMP_SENSOR_AD595_GAIN) + (TEMP_SENSOR_AD595_OFFSET);
-}
-// For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
-static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
-  return raw * (float(ADC_VREF_MV) /  5.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
-             * (TEMP_SENSOR_AD8495_GAIN) + (TEMP_SENSOR_AD8495_OFFSET);
-}
-
 /**
  * Bisect search for the range of the 'raw' value, then interpolate
  * proportionally between the under and over values.
@@ -2603,6 +2592,22 @@ static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
 
     // Return degrees C (up to 999, as the LCD only displays 3 digits)
     return _MIN(value + THERMISTOR_ABS_ZERO_C, 999);
+  }
+#endif
+
+#if ANY_THERMISTOR_IS(-1)
+  // For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
+  static constexpr celsius_float_t temp_ad595(const adc_raw_t raw) {
+    return raw * (float(ADC_VREF_MV) / 10.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
+               * (TEMP_SENSOR_AD595_GAIN) + (TEMP_SENSOR_AD595_OFFSET);
+  }
+#endif
+
+#if ANY_THERMISTOR_IS(-4)
+  // For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
+  static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
+    return raw * (float(ADC_VREF_MV) /  5.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
+               * (TEMP_SENSOR_AD8495_GAIN) + (TEMP_SENSOR_AD8495_OFFSET);
   }
 #endif
 
@@ -2841,14 +2846,11 @@ static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
 #if HAS_TEMP_SOC
   // For SoC temperature measurement.
   celsius_float_t Temperature::analog_to_celsius_soc(const raw_adc_t raw) {
-    return (
-      #ifdef TEMP_SOC_SENSOR
-        TEMP_SOC_SENSOR(raw)
-      #else
-        0
-        #error "TEMP_SENSOR_SOC requires the TEMP_SOC_SENSOR(RAW) macro to be defined for your board."
-      #endif
-    );
+    #ifndef TEMP_SOC_SENSOR
+      #error "TEMP_SENSOR_SOC requires the TEMP_SOC_SENSOR(RAW) macro to be defined for your board."
+      #define TEMP_SOC_SENSOR(...) 0
+    #endif
+    return TEMP_SOC_SENSOR(raw);
   }
 #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2457,9 +2457,9 @@ void Temperature::task() {
 }
 
 // For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
-#define TEMP_AD595(RAW)  ((RAW) * (ADC_VREF_MV / 10.0) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
+#define TEMP_AD595(RAW)  ((RAW) * float(ADC_VREF_MV / 10) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
 // For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
-#define TEMP_AD8495(RAW) ((RAW) * (ADC_VREF_MV /  5.0) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD8495_GAIN) + TEMP_SENSOR_AD8495_OFFSET)
+#define TEMP_AD8495(RAW) ((RAW) * float(ADC_VREF_MV /  5) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD8495_GAIN) + TEMP_SENSOR_AD8495_OFFSET)
 
 /**
  * Bisect search for the range of the 'raw' value, then interpolate

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2597,7 +2597,7 @@ void Temperature::task() {
 
 #if ANY_THERMISTOR_IS(-1)
   // For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
-  static constexpr celsius_float_t temp_ad595(const adc_raw_t raw) {
+  static constexpr celsius_float_t temp_ad595(const raw_adc_t raw) {
     return raw * (float(ADC_VREF_MV) / 10.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
                * (TEMP_SENSOR_AD595_GAIN) + (TEMP_SENSOR_AD595_OFFSET);
   }
@@ -2605,7 +2605,7 @@ void Temperature::task() {
 
 #if ANY_THERMISTOR_IS(-4)
   // For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
-  static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
+  static constexpr celsius_float_t temp_ad8495(const raw_adc_t raw) {
     return raw * (float(ADC_VREF_MV) /  5.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
                * (TEMP_SENSOR_AD8495_GAIN) + (TEMP_SENSOR_AD8495_OFFSET);
   }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2457,9 +2457,15 @@ void Temperature::task() {
 }
 
 // For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)
-#define TEMP_AD595(RAW)  ((RAW) * float(ADC_VREF_MV / 10) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
+static constexpr celsius_float_t temp_ad595(const adc_raw_t raw) {
+  return raw * (float(ADC_VREF_MV) / 10.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
+             * (TEMP_SENSOR_AD595_GAIN) + (TEMP_SENSOR_AD595_OFFSET);
+}
 // For a 5V input the AD8495 returns a value scaled with 5mV per °C. (Minimum input voltage is 2.7V.)
-#define TEMP_AD8495(RAW) ((RAW) * float(ADC_VREF_MV /  5) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD8495_GAIN) + TEMP_SENSOR_AD8495_OFFSET)
+static constexpr celsius_float_t temp_ad8495(const adc_raw_t raw) {
+  return raw * (float(ADC_VREF_MV) /  5.0f) / float(HAL_ADC_RANGE) / (OVERSAMPLENR)
+             * (TEMP_SENSOR_AD8495_GAIN) + (TEMP_SENSOR_AD8495_OFFSET);
+}
 
 /**
  * Bisect search for the range of the 'raw' value, then interpolate
@@ -2626,9 +2632,9 @@ void Temperature::task() {
             return (int16_t)raw * 0.25f;
           #endif
         #elif TEMP_SENSOR_0_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_0_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2645,9 +2651,9 @@ void Temperature::task() {
             return (int16_t)raw * 0.25f;
           #endif
         #elif TEMP_SENSOR_1_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_1_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2664,9 +2670,9 @@ void Temperature::task() {
             return (int16_t)raw * 0.25f;
           #endif
         #elif TEMP_SENSOR_2_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_2_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2674,9 +2680,9 @@ void Temperature::task() {
         #if TEMP_SENSOR_3_IS_CUSTOM
           return user_thermistor_to_deg_c(CTI_HOTEND_3, raw);
         #elif TEMP_SENSOR_3_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_3_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2684,9 +2690,9 @@ void Temperature::task() {
         #if TEMP_SENSOR_4_IS_CUSTOM
           return user_thermistor_to_deg_c(CTI_HOTEND_4, raw);
         #elif TEMP_SENSOR_4_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_4_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2694,9 +2700,9 @@ void Temperature::task() {
         #if TEMP_SENSOR_5_IS_CUSTOM
           return user_thermistor_to_deg_c(CTI_HOTEND_5, raw);
         #elif TEMP_SENSOR_5_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_5_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2704,9 +2710,9 @@ void Temperature::task() {
         #if TEMP_SENSOR_6_IS_CUSTOM
           return user_thermistor_to_deg_c(CTI_HOTEND_6, raw);
         #elif TEMP_SENSOR_6_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_6_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2714,9 +2720,9 @@ void Temperature::task() {
         #if TEMP_SENSOR_7_IS_CUSTOM
           return user_thermistor_to_deg_c(CTI_HOTEND_7, raw);
         #elif TEMP_SENSOR_7_IS_AD595
-          return TEMP_AD595(raw);
+          return temp_ad595(raw);
         #elif TEMP_SENSOR_7_IS_AD8495
-          return TEMP_AD8495(raw);
+          return temp_ad8495(raw);
         #else
           break;
         #endif
@@ -2750,9 +2756,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_BED_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_BED, TEMPTABLE_BED_LEN);
     #elif TEMP_SENSOR_BED_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_BED_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;
@@ -2768,9 +2774,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_CHAMBER_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_CHAMBER, TEMPTABLE_CHAMBER_LEN);
     #elif TEMP_SENSOR_CHAMBER_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_CHAMBER_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;
@@ -2786,9 +2792,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_COOLER_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_COOLER, TEMPTABLE_COOLER_LEN);
     #elif TEMP_SENSOR_COOLER_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_COOLER_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;
@@ -2804,9 +2810,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_PROBE_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_PROBE, TEMPTABLE_PROBE_LEN);
     #elif TEMP_SENSOR_PROBE_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_PROBE_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;
@@ -2822,9 +2828,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_BOARD_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_BOARD, TEMPTABLE_BOARD_LEN);
     #elif TEMP_SENSOR_BOARD_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_BOARD_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;
@@ -2860,9 +2866,9 @@ void Temperature::task() {
     #elif TEMP_SENSOR_REDUNDANT_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_REDUNDANT, TEMPTABLE_REDUNDANT_LEN);
     #elif TEMP_SENSOR_REDUNDANT_IS_AD595
-      return TEMP_AD595(raw);
+      return temp_ad595(raw);
     #elif TEMP_SENSOR_REDUNDANT_IS_AD8495
-      return TEMP_AD8495(raw);
+      return temp_ad8495(raw);
     #else
       UNUSED(raw);
       return 0;


### PR DESCRIPTION
### Description


RainMotorsports on discord noticed that thermistor type -1 (AD595  with Thermocouple) was not working.
They traced it back to https://github.com/MarlinFirmware/Marlin/pull/26021 where a float to int conversion was introduced

The macro TEMP_AD595(RAW) is not working correctly.

I generated a quick Arduino test with values for a RAMPS

```cpp
#define ADC_VREF_MV   5000
#define HAL_ADC_RESOLUTION  10
#define OVERSAMPLENR 16
#define TEMP_SENSOR_AD595_GAIN    1.0
#define TEMP_SENSOR_AD595_OFFSET  0.0

#define _BV(b) (1 << (b))
#define HAL_ADC_RANGE _BV(HAL_ADC_RESOLUTION)

// For a 5V input the AD595 returns a value scaled with 10mV per °C. (Minimum input voltage is 5V.)

#define TEMP_AD595_a(RAW)  ((RAW) * (ADC_VREF_MV / 10) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)
#define TEMP_AD595_b(RAW)  ((RAW) * (ADC_VREF_MV / 10.0) / float(HAL_ADC_RANGE) / (OVERSAMPLENR) * (TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET)

void processTemperature() {
  for (int raw_adc_value = 0; raw_adc_value < (1024 * 8); raw_adc_value += 64) {
    // Calculate the temperature using the TEMP_AD595 macro
    float temperature_a = TEMP_AD595_a(raw_adc_value);
    float temperature_b = TEMP_AD595_b(raw_adc_value);

    // Print the raw ADC value and the calculated temperature
    Serial.print("Raw ADC Value: ");
    Serial.print(raw_adc_value);
    Serial.print(" -> Temperature A: ");
    Serial.print(temperature_a);
    Serial.print(" B: ");
    Serial.print(temperature_b);
    Serial.println(" °C");
    delay(100);
  }
}

void setup() {
  Serial.begin(9600);
  while (!Serial) {
    ; // Wait for Serial to be ready
  }
  Serial.println("AD595 Temperature Sensor Test");
  processTemperature();
}

void loop() {
} 
```

Temperature A: is the current code
Temperature B: is the fixed code.

Truncated results

```
AD595 Temperature Sensor Test
Raw ADC Value: 0 -> Temperature A: 0.00 B: 0.00 °C
Raw ADC Value: 64 -> Temperature A: 1.95 B: 1.95 °C
Raw ADC Value: 128 -> Temperature A: -0.09 B: 3.91 °C
Raw ADC Value: 192 -> Temperature A: 1.86 B: 5.86 °C
Raw ADC Value: 256 -> Temperature A: -0.19 B: 7.81 °C
Raw ADC Value: 320 -> Temperature A: 1.77 B: 9.77 °C
Raw ADC Value: 384 -> Temperature A: -0.28 B: 11.72 °C
Raw ADC Value: 448 -> Temperature A: 1.67 B: 13.67 °C
Raw ADC Value: 512 -> Temperature A: -0.37 B: 15.63 °C
Raw ADC Value: 576 -> Temperature A: 1.58 B: 17.58 °C
Raw ADC Value: 640 -> Temperature A: -0.47 B: 19.53 °C
Raw ADC Value: 704 -> Temperature A: 1.48 B: 21.48 °C
Raw ADC Value: 768 -> Temperature A: -0.56 B: 23.44 °C
Raw ADC Value: 832 -> Temperature A: 1.39 B: 25.39 °C
Raw ADC Value: 896 -> Temperature A: -0.66 B: 27.34 °C
Raw ADC Value: 960 -> Temperature A: 1.30 B: 29.30 °C
...
```

On examination this bug is also in thermistor type -4 (AD8495 with Thermocouple)

Updated both TEMP_AD595 and TEMP_AD8495

### Requirements

type -1 or -4 thermistor

### Benefits

Works as expected

### Related Issues

https://discord.com/channels/461605380783472640/1376429364303892480
