### PR TITLE
🔧 Update BIQU BX SPI driver conditionals

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3470,7 +3470,7 @@
    *
    * It is recommended to set HOMING_BUMP_MM to { 0, 0, 0 }.
    *
-   * SPI_ENDSTOPS  *** TMC2130/TMC5160 Only ***
+   * SPI_ENDSTOPS  *** TMC2130, TMC2240, and TMC5160 Only ***
    * Poll the driver through SPI to determine load when homing.
    * Removes the need for a wire from DIAG1 to an endstop pin.
    *

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
@@ -124,16 +124,19 @@
 #endif
 
 //
-// SPI pins for TMC2130 stepper drivers
+// SPI pins for TMC2130, TMC2160, TMC2240, TMC2660, TMC5130, or TMC5160 stepper drivers
 //
-#ifndef TMC_SPI_MOSI
-  #define TMC_SPI_MOSI                      PC6
-#endif
-#ifndef TMC_SPI_MISO
-  #define TMC_SPI_MISO                      PG3
-#endif
-#ifndef TMC_SPI_SCK
-  #define TMC_SPI_SCK                       PC7
+#if HAS_TMC_SPI
+  #define TMC_USE_SW_SPI
+  #ifndef TMC_SPI_MOSI
+    #define TMC_SPI_MOSI                    PC6
+  #endif
+  #ifndef TMC_SPI_MISO
+    #define TMC_SPI_MISO                    PG3
+  #endif
+  #ifndef TMC_SPI_SCK
+    #define TMC_SPI_SCK                     PC7
+  #endif
 #endif
 
 #if HAS_TMC_UART


### PR DESCRIPTION
### Description

Update BIQU BX SPI driver conditionals

We're consistently inconsistent with `HAS_TMC_SPI` checks in pins files, but I updated the BX pins file to include this check + enable `TMC_USE_SW_SPI` like we do for other boards. I also added a missed 2240 comment from https://github.com/MarlinFirmware/Marlin/pull/27880

### Requirements

BIQU BX with SPI drivers

### Benefits

One fewer config item for BX owners to update when switching to SPI drivers since the printer won't boot without it enabled.

### Configurations

Stock BX config: https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/BIQU/BX

Change all `*_DRIVER_TYPE`s to `2240` and enable `TMC_USE_SW_SPI` or use the attached modified config: [Configurations-config-examples-BIQU-BX.zip](https://github.com/user-attachments/files/20446655/Configurations-config-examples-BIQU-BX.zip)

### Related Issues

None, but I found this while working through issues with the recently added TMC2240 driver support.
