### PR TITLE
🔧 Update BTT002 SPI driver conditionals

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -108,16 +108,19 @@
 #endif
 
 //
-// SPI pins for TMC2130 stepper drivers
+// SPI pins for TMC2130, TMC2160, TMC2240, TMC2660, TMC5130, or TMC5160 stepper drivers
 //
-#ifndef TMC_SPI_MOSI
-  #define TMC_SPI_MOSI                      PB15
-#endif
-#ifndef TMC_SPI_MISO
-  #define TMC_SPI_MISO                      PB14
-#endif
-#ifndef TMC_SPI_SCK
-  #define TMC_SPI_SCK                       PB13
+#if HAS_TMC_SPI
+  #define TMC_USE_SW_SPI
+  #ifndef TMC_SPI_MOSI
+    #define TMC_SPI_MOSI                    PB15
+  #endif
+  #ifndef TMC_SPI_MISO
+    #define TMC_SPI_MISO                    PB14
+  #endif
+  #ifndef TMC_SPI_SCK
+    #define TMC_SPI_SCK                     PB13
+  #endif
 #endif
 
 #if HAS_TMC_UART


### PR DESCRIPTION
### Description

Update BTT002 SPI driver conditionals

We're consistently inconsistent with `HAS_TMC_SPI` checks in pins files, but I updated the BTT002 pins file to include this check + enable `TMC_USE_SW_SPI` like we do for other boards.

### Requirements

BTT022 with SPI drivers

### Benefits

One fewer config item for BTT002 owners to update when switching to SPI drivers.

### Configurations

Prusa MK3 with BTT002 motherboard & SPI drivers like 5160s or 2240s: https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.1.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002

### Related Issues

None, but I found this while working through issues with the recently added TMC2240 driver support.
