### PR TITLE
Add TMC2240 temperature reading

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -992,8 +992,8 @@
       TMC_REPORT("Analog in (v)",    TMC_VAIN);
       TMC_REPORT("Supply (v)",       TMC_VSUPPLY);
       TMC_REPORT("Temp (°C)",        TMC_TEMP);
-      TMC_REPORT("OT pre warn (v)",  TMC_OVERTEMP);
-      TMC_REPORT("OV theshold (°C)", TMC_OVERVOLT_THD);
+      TMC_REPORT("OT pre warn (°C)", TMC_OVERTEMP);
+      TMC_REPORT("OV theshold (v)",  TMC_OVERVOLT_THD);
     #endif
     SERIAL_EOL();
   }

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -526,7 +526,12 @@
     TMC_HSTRT,
     TMC_SGT,
     TMC_MSCNT,
-    TMC_INTERPOLATE
+    TMC_INTERPOLATE,
+    TMC_VAIN,
+    TMC_VSUPPLY,
+    TMC_TEMP,
+    TMC_OVERTEMP,
+    TMC_OVERVOLT_THD
   };
   enum TMC_drv_status_enum : char {
     TMC_DRV_CODES,
@@ -701,6 +706,11 @@
         case TMC_PWM_GRAD_AUTO: SERIAL_ECHO(st.pwm_grad_auto()); break;
         case TMC_STEALTHCHOP: print_true_or_false(st.stealth()); break;
         case TMC_INTERPOLATE: print_true_or_false(st.intpol()); break;
+        case TMC_VAIN: SERIAL_ECHO(st.get_ain_voltage()); break;
+        case TMC_VSUPPLY: SERIAL_ECHO(st.get_vsupply_voltage()); break;
+        case TMC_TEMP: SERIAL_ECHO(st.get_chip_temperature()); break;
+        case TMC_OVERTEMP: SERIAL_ECHO(st.get_overtemp_prewarn_celsius()); break;
+        case TMC_OVERVOLT_THD: SERIAL_ECHO(st.get_overvoltage_threshold_voltage()); break;
         default: break;
       }
     }
@@ -978,6 +988,13 @@
       DRV_REPORT("s2vsb\t",          TMC_S2VSB);
     #endif
     DRV_REPORT("Driver registers:\n",TMC_DRV_STATUS_HEX);
+    #if HAS_DRIVER(TMC2240)
+      TMC_REPORT("Analog in (v)",    TMC_VAIN);
+      TMC_REPORT("Supply (v)",       TMC_VSUPPLY);
+      TMC_REPORT("Temp (°C)",        TMC_TEMP);
+      TMC_REPORT("OT pre warn (v)",  TMC_OVERTEMP);
+      TMC_REPORT("OV theshold (°C)", TMC_OVERVOLT_THD);
+    #endif
     SERIAL_EOL();
   }
 

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -20,7 +20,7 @@ MARLIN_TEST_BUILD                      = build_src_filter=+<src/tests>
 POSTMORTEM_DEBUGGING                   = build_src_filter=+<src/HAL/shared/cpu_exception> +<src/HAL/shared/backtrace>
                                          build_flags=-funwind-tables
 MKS_WIFI_MODULE                        = QRCode=https://github.com/makerbase-mks/QRCode/archive/261c5a696a.zip
-HAS_TRINAMIC_CONFIG                    = TMCStepper=https://github.com/MarlinFirmware/TMCStepper/archive/v0.8.5.zip
+HAS_TRINAMIC_CONFIG                    = TMCStepper=https://github.com/dbuezas/TMCStepper/archive/refs/heads/dbuezas/tmc-2240-temperature-reading.zip
                                          build_src_filter=+<src/module/stepper/trinamic.cpp> +<src/gcode/feature/trinamic/M122.cpp> +<src/gcode/feature/trinamic/M906.cpp> +<src/gcode/feature/trinamic/M911-M914.cpp> +<src/gcode/feature/trinamic/M919.cpp>
 HAS_STEPPER_CONTROL                    = build_src_filter=+<src/module/stepper/control.cpp>
 HAS_T(RINAMIC_CONFIG|MC_SPI)           = build_src_filter=+<src/feature/tmc_util.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -20,7 +20,7 @@ MARLIN_TEST_BUILD                      = build_src_filter=+<src/tests>
 POSTMORTEM_DEBUGGING                   = build_src_filter=+<src/HAL/shared/cpu_exception> +<src/HAL/shared/backtrace>
                                          build_flags=-funwind-tables
 MKS_WIFI_MODULE                        = QRCode=https://github.com/makerbase-mks/QRCode/archive/261c5a696a.zip
-HAS_TRINAMIC_CONFIG                    = TMCStepper=https://github.com/dbuezas/TMCStepper/archive/refs/heads/dbuezas/tmc-2240-temperature-reading.zip
+HAS_TRINAMIC_CONFIG                    = TMCStepper=https://github.com/MarlinFirmware/TMCStepper/archive/v0.8.6.zip
                                          build_src_filter=+<src/module/stepper/trinamic.cpp> +<src/gcode/feature/trinamic/M122.cpp> +<src/gcode/feature/trinamic/M906.cpp> +<src/gcode/feature/trinamic/M911-M914.cpp> +<src/gcode/feature/trinamic/M919.cpp>
 HAS_STEPPER_CONTROL                    = build_src_filter=+<src/module/stepper/control.cpp>
 HAS_T(RINAMIC_CONFIG|MC_SPI)           = build_src_filter=+<src/feature/tmc_util.cpp>


### PR DESCRIPTION
```
M122
[...]
Analog in (v)	1.7799	1.8043	1.7970	1.8019
Supply (v)	24.2132	24.2521	24.2229	24.2813
Temp (°C)	34.8052	36.8831	35.7143	35.3247
OT pre warn (°C)	120.0000	120.0000	120.0000	120.0000
OV theshold (v)	37.7310	37.7310	37.7310	37.7310
Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
ok P63 B15
```

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
