### PR TITLE
Add Z_MAX_POS limit to LCD_BED_TRAMMING BED_TRAMMING_Z_HOP move.

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_tramming.cpp
@@ -144,7 +144,7 @@ static void _lcd_goto_next_corner() {
     }
   }
 
-  float z = current_position.z + (BED_TRAMMING_Z_HOP);
+  float z = _MIN(current_position.z + (BED_TRAMMING_Z_HOP), Z_MAX_POS);
   #if ALL(BED_TRAMMING_USE_PROBE, BLTOUCH)
     z += bltouch.z_extra_clearance();
   #endif


### PR DESCRIPTION
### Description

LCD_BED_TRAMMING homes and then follows up with the first Z Hop before moving XY to the first tramming point. On printers that home to Z Max instead of Z Min this creates a situation where the first move after homing is to attempt exceeding Z Max. This can be worked around by setting `HOMING_BACKOFF_POST_MM` Z value to exceed the `BED_TRAMMING_Z_HOP` value. While that solution is simple I do not believe there is a reason to allow bed tramming to command beyond Z_MAX_POS.

### Requirements

LCD_BED_TRAMMING

### Benefits

Prevents the first LCD_BED_TRAMMING Z Hop move after homing (or any) from exceeding Z_MAX_POS on printers homing to Z Max.

### Configurations

[MakerGearM2H-NoHomingBackoffPostMM.zip](https://github.com/user-attachments/files/20873142/MakerGearM2H-NoHomingBackoffPostMM.zip)

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/27937
