### PR TITLE
✏️ Fix Creality UI PLR typo

### DIFF
--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -2516,7 +2516,7 @@ void itemAdvBedPID(const uint8_t row) {
     }
     else {
       #ifdef USE_STRING_TITLES
-        dwinDrawLabel(row, GET_TEXT_F(MSG_ZPROBE_OFFSETS));
+        dwinDrawLabel(row, GET_TEXT_F(MSG_OUTAGE_RECOVERY));
       #else
         itemAreaCopy(1, 208, 137, 221, row);  // "Power-loss Recovery"
       #endif


### PR DESCRIPTION
### Description

Fix PLR typo for Creality UI

### Requirements

Ender-3 V2 LCD with `DWIN_CREALITY_LCD` / Creality UI / `POWER_LOSS_RECOVERY`

### Benefits

Print recovery screen will display the correct text.

### Configurations

Any config with this display/UI/`POWER_LOSS_RECOVERY` combo.

### Related Issues

- #27942
