### PR TITLE
🐛 Respect odd number of strokes when cleaning nozzle with linear pattern

### DIFF
--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -51,32 +51,23 @@ Nozzle nozzle;
         const xyz_pos_t oldpos = current_position;
       #endif
 
-      // Move to the starting point
-      #if ENABLED(NOZZLE_CLEAN_NO_Z)
-        #if ENABLED(NOZZLE_CLEAN_NO_Y)
-          do_blocking_move_to_x(start.x);
-        #else
-          do_blocking_move_to_xy(start);
-        #endif
-      #else
+      // Move Z (and XY) to the starting point, if needed
+      #if DISABLED(NOZZLE_CLEAN_NO_Z)
         do_blocking_move_to(start);
       #endif
 
-      // Start the stroke pattern
-      for (uint8_t i = 0; i < strokes >> 1; ++i) {
+      // Run the stroke pattern
+      for (uint8_t i = 0; i <= strokes; ++i) {
         #if ENABLED(NOZZLE_CLEAN_NO_Y)
-          do_blocking_move_to_x(end.x);
-          do_blocking_move_to_x(start.x);
+          if (i & 1)
+            do_blocking_move_to_x(end.x);
+          else
+            do_blocking_move_to_x(start.x);
         #else
-          do_blocking_move_to_xy(end);
-          do_blocking_move_to_xy(start);
-        #endif
-      }
-      if (strokes & 1) {
-        #if ENABLED(NOZZLE_CLEAN_NO_Y)
-          do_blocking_move_to_x(end.x);
-        #else
-          do_blocking_move_to_xy(end);
+          if (i & 1)
+            do_blocking_move_to_x(end);
+          else
+            do_blocking_move_to_x(start);
         #endif
       }
 

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -72,6 +72,13 @@ Nozzle nozzle;
           do_blocking_move_to_xy(start);
         #endif
       }
+      if (strokes & 1) {
+        #if ENABLED(NOZZLE_CLEAN_NO_Y)
+          do_blocking_move_to_x(end.x);
+        #else
+          do_blocking_move_to_xy(end);
+        #endif
+      }
 
       TERN_(NOZZLE_CLEAN_GOBACK, do_blocking_move_to(oldpos));
     }


### PR DESCRIPTION
### Description

Previously, `G12 P0 S2` and `G12 P0 S3` performed the same operation. With this change, specifying an odd number of strokes causes the cleaning sequence to end at NOZZLE_CLEAN_END_POINT, instead of unconditionally returning to NOZZLE_CLEAN_START_POINT.

`G12 P0 S3` before this change (same as `G12 P0 S2`):

![G12_P0_S3_before](https://github.com/user-attachments/assets/b2d221a5-df66-4f24-a616-15b9d556ed55)

`G12 P0 S3` after this change (one more stroke than with `G12 P0 S2`):

![G12_P0_S3_fixed](https://github.com/user-attachments/assets/2bffa8c9-392e-48e6-a07e-ca1faf658111)

### Requirements

Build with `NOZZLE_CLEAN_FEATURE` and `NOZZLE_CLEAN_PATTERN_LINE`.

### Benefits

This can be used to prevent a glob of plastic from re-adhering to the nozzle on the final cleaning stroke.

