### PR TITLE
PLR: trigger power lost by timeout

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1808,6 +1808,8 @@
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
     #endif
 
+    #define POWER_LOSS_TIMEOUT           10 // (ms) Power loss duration to raise event
+
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!
     //#define POWER_LOSS_RECOVER_ZHOME
     #if ENABLED(POWER_LOSS_RECOVER_ZHOME)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1808,7 +1808,7 @@
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
     #endif
 
-    #define POWER_LOSS_TIMEOUT           10 // (ms) Power loss duration to raise event
+    //#define POWER_LOSS_TIMEOUT         10 // (ms) Power loss duration to raise event, three idle() calls otherwise
 
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!
     //#define POWER_LOSS_RECOVER_ZHOME

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -211,14 +211,12 @@ class PrintJobRecovery {
 
     #if PIN_EXISTS(POWER_LOSS)
       static void outage() {
-        static constexpr uint8_t OUTAGE_THRESHOLD = 3;
-        static uint8_t outage_counter = 0;
-        if (enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) {
-          outage_counter++;
-          if (outage_counter >= OUTAGE_THRESHOLD) _outage();
-        }
+        static unsigned long last_power_on;
+        if ( enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE
+          && millis() - last_power_on >= POWER_LOSS_TIMEOUT
+        ) _outage();
         else
-          outage_counter = 0;
+          last_power_on = millis();
       }
     #endif
 

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -211,12 +211,23 @@ class PrintJobRecovery {
 
     #if PIN_EXISTS(POWER_LOSS)
       static void outage() {
-        static unsigned long last_power_on;
-        if ( enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE
-          && millis() - last_power_on >= POWER_LOSS_TIMEOUT
-        ) _outage();
-        else
-          last_power_on = millis();
+        #if defined(POWER_LOSS_TIMEOUT)
+          static unsigned long last_power_on;
+          if ( enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) {
+            if (millis() - last_power_on >= POWER_LOSS_TIMEOUT) _outage();
+          }
+          else
+            last_power_on = millis();
+        #else
+          static constexpr uint8_t OUTAGE_THRESHOLD = 3;
+          static uint8_t outage_counter = 0;
+          if (enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) {
+            outage_counter++;
+            if (outage_counter >= OUTAGE_THRESHOLD) _outage();
+          }
+          else
+            outage_counter = 0;
+        #endif
       }
     #endif
 


### PR DESCRIPTION
Trigger power lost event basing on timeout, rather than on cycle counter. It provides more control and allow to skip false triggering.

Depending on UPS/PSU capacitors, DC/AC bed, it could be 0.1-0.5 second. I put default 10ms, I guess it more or less matches current 3 idle() calls.

To prolong this timeout heaters could be disabled during outage period until power is back.