### PR TITLE
Save ABL bilinear mesh in PLR resume data.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1813,6 +1813,10 @@
     #if ENABLED(POWER_LOSS_RECOVER_ZHOME)
       //#define POWER_LOSS_ZHOME_POS { 0, 0 } // Safe XY position to home Z while avoiding objects on the bed
     #endif
+
+    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      //#define POWER_LOSS_SAVE_BILINEAR_MESH // Save bilinear mesh in resume data
+    #endif
   #endif
 
   /**

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -262,7 +262,7 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
     info.flag.dryrun = !!(marlin_debug_flags & MARLIN_DEBUG_DRYRUN);
     info.flag.allow_cold_extrusion = TERN0(PREVENT_COLD_EXTRUSION, thermalManager.allow_cold_extrude);
 
-    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    #if ENABLED(POWER_LOSS_SAVE_BILINEAR_MESH)
       info.grid_spacing = bedlevel.grid_spacing;
       info.grid_start   = bedlevel.grid_start;
       memcpy(info.z_values, bedlevel.z_values, sizeof(bed_mesh_t));
@@ -484,7 +484,7 @@ void PrintJobRecovery::resume() {
   set_all_homed();
 
   #if HAS_LEVELING
-    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    #if ENABLED(POWER_LOSS_SAVE_BILINEAR_MESH)
       bedlevel.set_grid(info.grid_spacing, info.grid_start);
       memcpy(bedlevel.z_values, info.z_values,  sizeof(bed_mesh_t));
 

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -262,6 +262,12 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
     info.flag.dryrun = !!(marlin_debug_flags & MARLIN_DEBUG_DRYRUN);
     info.flag.allow_cold_extrusion = TERN0(PREVENT_COLD_EXTRUSION, thermalManager.allow_cold_extrude);
 
+    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      info.grid_spacing = bedlevel.grid_spacing;
+      info.grid_start   = bedlevel.grid_start;
+      memcpy(info.z_values, bedlevel.z_values, sizeof(bed_mesh_t));
+    #endif
+
     write();
   }
 }
@@ -478,6 +484,13 @@ void PrintJobRecovery::resume() {
   set_all_homed();
 
   #if HAS_LEVELING
+    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      bedlevel.set_grid(info.grid_spacing, info.grid_start);
+      memcpy(bedlevel.z_values, info.z_values,  sizeof(bed_mesh_t));
+
+      TERN_(EXTENSIBLE_UI, GRID_LOOP(x, y) ExtUI::onMeshUpdate(x, y, bedlevel.z_values[x][y]));
+    #endif
+
     // Restore Z fade and possibly re-enable bed leveling compensation.
     // Leveling may already be enabled due to the ENABLE_LEVELING_AFTER_G28 option.
     // TODO: Add a G28 parameter to leave leveling disabled.

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -42,6 +42,10 @@
   #include "mixing.h"
 #endif
 
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  #include "bedlevel/bedlevel.h"
+#endif
+
 #if !defined(POWER_LOSS_STATE) && PIN_EXISTS(POWER_LOSS)
   #define POWER_LOSS_STATE HIGH
 #endif
@@ -144,6 +148,12 @@ typedef struct {
       bool volumetric_enabled:1;  // M200 S D
     #endif
   } flag;
+
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    xy_pos_t grid_spacing;
+    xy_pos_t grid_start;
+    bed_mesh_t z_values;
+  #endif
 
   uint8_t valid_foot;
 

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -42,7 +42,7 @@
   #include "mixing.h"
 #endif
 
-#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+#if ENABLED(POWER_LOSS_SAVE_BILINEAR_MESH)
   #include "bedlevel/bedlevel.h"
 #endif
 
@@ -149,7 +149,7 @@ typedef struct {
     #endif
   } flag;
 
-  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  #if ENABLED(POWER_LOSS_SAVE_BILINEAR_MESH)
     xy_pos_t grid_spacing;
     xy_pos_t grid_start;
     bed_mesh_t z_values;


### PR DESCRIPTION
Could be useful when leveling is done before each print without mesh saving.