### PR TITLE
PLR: custom gcodes

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1806,6 +1806,7 @@
     //#define BACKUP_POWER_SUPPLY           // Backup power / UPS to move the steppers on power-loss
     #if ENABLED(BACKUP_POWER_SUPPLY)
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
+      //#define EVENT_GCODE_BEFORE_KILL "G27P4\nM400" // Executed as last thing before kill. E.g. park bozzle to prevent blob on print
     #endif
 
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!
@@ -1813,6 +1814,8 @@
     #if ENABLED(POWER_LOSS_RECOVER_ZHOME)
       //#define POWER_LOSS_ZHOME_POS { 0, 0 } // Safe XY position to home Z while avoiding objects on the bed
     #endif
+
+    //#define EVENT_GCODE_ON_RESUME "M600"  //G-code run just before print resumed. E.g. "change filament" to ensure proper filament load.
   #endif
 
   /**

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -339,6 +339,9 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
       quickstop_stepper();
       // With backup power a retract and raise can be done now
       retract_and_lift(zraise);
+      #ifdef EVENT_GCODE_BEFORE_KILL
+        PROCESS_SUBCOMMANDS_NOW(F(EVENT_GCODE_BEFORE_KILL));
+      #endif
     #endif
 
     if (TERN0(DEBUG_POWER_LOSS_RECOVERY, simulated)) {
@@ -601,6 +604,10 @@ void PrintJobRecovery::resume() {
   #if ENABLED(SOVOL_SV06_RTS)
     if (rts.print_state) rts.refreshTime();
     rts.start_print_flag = false;
+  #endif
+
+  #ifdef EVENT_GCODE_ON_RESUME
+    PROCESS_SUBCOMMANDS_NOW(F(EVENT_GCODE_ON_RESUME));
   #endif
 }
 


### PR DESCRIPTION
Add two custom G-codes:

- just before kill, for example to park nozzle outside of print area to prevent leakage and blobs
- just before print resume after power loss, for instance "M600" to ensure properly filament load and purge
