### PR TITLE
PLR: G code before kill

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,3 +1,4 @@
+
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
@@ -1806,6 +1807,7 @@
     //#define BACKUP_POWER_SUPPLY           // Backup power / UPS to move the steppers on power-loss
     #if ENABLED(BACKUP_POWER_SUPPLY)
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
+      //#define EVENT_GCODE_BEFORE_KILL "G27P4\nM400" // Executed as last thing before kill. E.g. park nozzle to prevent leakage on print
     #endif
 
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -339,6 +339,9 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=POW
       quickstop_stepper();
       // With backup power a retract and raise can be done now
       retract_and_lift(zraise);
+      #ifdef EVENT_GCODE_BEFORE_KILL
+        PROCESS_SUBCOMMANDS_NOW(F(EVENT_GCODE_BEFORE_KILL));
+      #endif
     #endif
 
     if (TERN0(DEBUG_POWER_LOSS_RECOVERY, simulated)) {


### PR DESCRIPTION
Add last custom g-code to be executed as last command before kill. For example "G27P4" to move nozzle out of print to prevent leakage and blob formation.