### PR TITLE
PLR: configurable UNRETRACT

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1806,6 +1806,7 @@
     //#define BACKUP_POWER_SUPPLY           // Backup power / UPS to move the steppers on power-loss
     #if ENABLED(BACKUP_POWER_SUPPLY)
       //#define POWER_LOSS_RETRACT_LEN   10 // (mm) Length of filament to retract on fail
+      #define POWER_LOSS_UNRETRACT_LEN   POWER_LOSS_RETRACT_LEN // (mm) Length of filament to unretract on resume
     #endif
 
     // Enable if Z homing is needed for proper recovery. 99.9% of the time this should be disabled!

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -83,7 +83,8 @@ PrintJobRecovery recovery;
   #undef POWER_LOSS_RETRACT_LEN   // No retract at outage without backup power
 #endif
 #ifndef POWER_LOSS_RETRACT_LEN
-  #define POWER_LOSS_RETRACT_LEN 0
+  #define POWER_LOSS_RETRACT_LEN   0
+  #define POWER_LOSS_UNRETRACT_LEN 0
 #endif
 #ifndef POWER_LOSS_PURGE_LEN
   #define POWER_LOSS_PURGE_LEN 0
@@ -548,13 +549,13 @@ void PrintJobRecovery::resume() {
   #endif
 
   // Un-retract if there was a retract at outage
-  #if ENABLED(BACKUP_POWER_SUPPLY) && POWER_LOSS_RETRACT_LEN > 0
-    PROCESS_SUBCOMMANDS_NOW(F("G1F3000E" STRINGIFY(POWER_LOSS_RETRACT_LEN)));
+  #if ENABLED(BACKUP_POWER_SUPPLY) && POWER_LOSS_UNRETRACT_LEN > 0
+    PROCESS_SUBCOMMANDS_NOW(F("G1F3000E" STRINGIFY(POWER_LOSS_UNRETRACT_LEN)));
   #endif
 
   // Additional purge on resume if configured
   #if POWER_LOSS_PURGE_LEN
-    PROCESS_SUBCOMMANDS_NOW(TS(F("G1F3000E"), (POWER_LOSS_PURGE_LEN) + (POWER_LOSS_RETRACT_LEN)));
+    PROCESS_SUBCOMMANDS_NOW(TS(F("G1F3000E"), (POWER_LOSS_PURGE_LEN) + (POWER_LOSS_UNRETRACT_LEN)));
   #endif
 
   #if ENABLED(NOZZLE_CLEAN_FEATURE)


### PR DESCRIPTION
Configure UNRETRACT separately on power loss resume. Setting it less than POWER_LOSS_RETRACT_LEN could reduce blobs. I set it to zero and use `M600 `before resume. (see  **PLR: custom gcodes #27966**)

Question: why there is additional `POWER_LOSS_RETRACT_LEN` unretract  in purge? It was already untertracted just before

```
  // Un-retract if there was a retract at outage
  #if ENABLED(BACKUP_POWER_SUPPLY) && POWER_LOSS_RETRACT_LEN > 0
    PROCESS_SUBCOMMANDS_NOW(F("G1F3000E" STRINGIFY(POWER_LOSS_RETRACT_LEN)));
  #endif

  // Additional purge on resume if configured
  #if POWER_LOSS_PURGE_LEN
    PROCESS_SUBCOMMANDS_NOW(TS(F("G1F3000E"), (POWER_LOSS_PURGE_LEN) + (POWER_LOSS_RETRACT_LEN)));
  #endif
```


