### PR TITLE
include UI API in gcode.cpp

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -69,6 +69,10 @@ GcodeSuite gcode;
   #include "../feature/fancheck.h"
 #endif
 
+#if ENABLED(EXTENSIBLE_UI)
+  #include "../lcd/extui/ui_api.h"
+#endif
+
 #include "../MarlinCore.h" // for idle, kill
 
 // Inactivity shutdown

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -70,7 +70,7 @@ GcodeSuite gcode;
 #endif
 
 #if ENABLED(EXTENSIBLE_UI)
-  #include "../lcd/extui/ui_api.h"
+  #include "../lcd/extui/ui_api.h" // for ExtUI::onLevelingDone
 #endif
 
 #include "../MarlinCore.h" // for idle, kill


### PR DESCRIPTION
### Description

Was noticed in discord server

G29_RETRY_AND_RECOVER on EXTENSIBLE_UI capable displays errors with

```
Marlin/src/gcode/gcode.cpp: In static member function 'static void GcodeSuite::G29_with_retry()':
Marlin/src/gcode/gcode.cpp:318:26: error: 'ExtUI' has not been declared
     TERN_(EXTENSIBLE_UI, ExtUI::onLevelingDone());
```

The cause is 
`    TERN_(EXTENSIBLE_UI, ExtUI::onLevelingDone());
`
because ui_api.h is not included.

Added conditional incude  

### Requirements

G29_RETRY_AND_RECOVER and EXTENSIBLE_UI capable display

### Benefits

Builds as expected

### Configurations

Simple minimal example config that triggered the error
[Configuration.zip](https://github.com/user-attachments/files/21174259/Configuration.zip)
