### PR TITLE
fix: M20 F: list binary files without ProUI

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -209,11 +209,11 @@ inline bool extIsBIN(char *ext) {
 //
 // Return 'true' if the item is a folder, G-code file or Binary file
 //
-bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD, const bool onlyBin/*=false*/)) {
+bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD, const bool binFiles/*=false*/)) {
   //uint8_t pn0 = p.name[0];
 
   #if DISABLED(CUSTOM_FIRMWARE_UPLOAD)
-    constexpr bool onlyBin = false;
+    constexpr bool binFiles = false;
   #endif
 
   if ( (p.attributes & DIR_ATT_HIDDEN)                  // Hidden by attribute
@@ -228,9 +228,9 @@ bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD,
 
   return (
     flag.filenameIsDir                                  // All Directories are ok
-    || fileIsBinary()                                   // BIN files are accepted
-    || (!onlyBin && p.name[8] == 'G'
-                 && p.name[9] != '~')                   // Non-backup *.G* files are accepted
+    || ( binFiles && fileIsBinary())                    // BIN files are accepted
+    || (!binFiles && p.name[8] == 'G'
+                  && p.name[9] != '~')                  // Non-backup *.G* files are accepted
   );
 }
 
@@ -292,7 +292,7 @@ void CardReader::printListing(MediaFile parent, const char * const prepend, cons
     const bool includeLong = TEST(lsflags, LS_LONG_FILENAME);
   #endif
   #if ENABLED(CUSTOM_FIRMWARE_UPLOAD)
-    const bool onlyBin = TEST(lsflags, LS_ONLY_BIN);
+    const bool binFiles = TEST(lsflags, LS_ONLY_BIN);
   #endif
   UNUSED(lsflags);
   dir_t p;
@@ -328,7 +328,7 @@ void CardReader::printListing(MediaFile parent, const char * const prepend, cons
         return;
       }
     }
-    else if (is_visible_entity(p OPTARG(CUSTOM_FIRMWARE_UPLOAD, onlyBin))) {
+    else if (is_visible_entity(p OPTARG(CUSTOM_FIRMWARE_UPLOAD, binFiles))) {
       if (prepend) SERIAL_ECHO(prepend, C('/'));
       SERIAL_ECHO(createFilename(filename, p), C(' '), p.fileSize);
       if (includeTime) {

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -224,7 +224,7 @@ bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD,
   ) return false;
 
   flag.filenameIsDir = DIR_IS_SUBDIR(&p);               // We know it's a File or Folder
-  setBinFlag(extIsBIN((char *)&p.name[8]));             // List .bin files (a firmware file for flashing)
+  setBinFlag(onlyBin && extIsBIN((char *)&p.name[8]));  // List .bin files (a firmware file for flashing)
 
   return (
     flag.filenameIsDir                                  // All Directories are ok

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -224,7 +224,7 @@ bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD,
   ) return false;
 
   flag.filenameIsDir = DIR_IS_SUBDIR(&p);               // We know it's a File or Folder
-  setBinFlag(onlyBin && extIsBIN((char *)&p.name[8]));  // List .bin files (a firmware file for flashing)
+  setBinFlag(extIsBIN((char *)&p.name[8]));             // List .bin files (a firmware file for flashing)
 
   return (
     flag.filenameIsDir                                  // All Directories are ok

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -69,7 +69,7 @@ typedef struct {
        filenameIsDir:1,         // The working item is a directory
        workDirIsRoot:1,         // The working directory is / so there's no parent
        abort_sd_printing:1      // Abort by calling abortSDPrinting() at the main loop()
-       #if DO_LIST_BIN_FILES
+       #if DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD)
          , filenameIsBin:1      // The working item is a BIN file
        #endif
        #if ENABLED(BINARY_FILE_TRANSFER)
@@ -300,8 +300,8 @@ public:
   #endif
 
   // Binary flag for the current file
-  static bool fileIsBinary() { return TERN0(DO_LIST_BIN_FILES, flag.filenameIsBin); }
-  static void setBinFlag(const bool bin) { TERN(DO_LIST_BIN_FILES, flag.filenameIsBin = bin, UNUSED(bin)); }
+  static bool fileIsBinary() { return TERN0(DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD), flag.filenameIsBin); }
+  static void setBinFlag(const bool bin) { TERN(DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD), flag.filenameIsBin = bin, UNUSED(bin)); }
 
   // Current Working Dir - Set by cd, cdup, cdroot, and diveToFile(true, ...)
   static char* getWorkDirName()  { workDir.getDosName(filename); return filename; }

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -416,7 +416,7 @@ private:
   //
   // Directory items
   //
-  static bool is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD, const bool onlyBin=false));
+  static bool is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD, const bool binFiles=false));
   static int16_t countVisibleItems(MediaFile dir);
   static void selectByIndex(MediaFile dir, const int16_t index);
   static void selectByName(MediaFile dir, const char * const match);

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -60,6 +60,10 @@ extern const char M23_STR[], M24_STR[];
   #include "Sd2Card.h"
 #endif
 
+#if ANY(DO_LIST_BIN_FILES, CUSTOM_FIRMWARE_UPLOAD)
+  #define MEDIA_SUPPORT_BIN_FILES 1
+#endif
+
 typedef struct {
   bool saving:1,                // Receiving a G-code file or logging commands during a print
        logging:1,               // Log enqueued commands to the open file. See GCodeQueue::advance()
@@ -69,7 +73,7 @@ typedef struct {
        filenameIsDir:1,         // The working item is a directory
        workDirIsRoot:1,         // The working directory is / so there's no parent
        abort_sd_printing:1      // Abort by calling abortSDPrinting() at the main loop()
-       #if DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD)
+       #if MEDIA_SUPPORT_BIN_FILES
          , filenameIsBin:1      // The working item is a BIN file
        #endif
        #if ENABLED(BINARY_FILE_TRANSFER)
@@ -300,8 +304,8 @@ public:
   #endif
 
   // Binary flag for the current file
-  static bool fileIsBinary() { return TERN0(DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD), flag.filenameIsBin); }
-  static void setBinFlag(const bool bin) { TERN(DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD), flag.filenameIsBin = bin, UNUSED(bin)); }
+  static bool fileIsBinary() { return TERN0(MEDIA_SUPPORT_BIN_FILES, flag.filenameIsBin); }
+  static void setBinFlag(const bool bin) { TERN(MEDIA_SUPPORT_BIN_FILES, flag.filenameIsBin = bin, UNUSED(bin)); }
 
   // Current Working Dir - Set by cd, cdup, cdroot, and diveToFile(true, ...)
   static char* getWorkDirName()  { workDir.getDosName(filename); return filename; }


### PR DESCRIPTION
This addresses #24332.

Likely #23878 introduced a change, where M20 F listed binary only when DO_LIST_BIN_FILES was set, which in turn was only set indirectly by DWIN_LCD_PROUI.

This fix re-enables listing ".BIN"-files when CUSTOM_FIRMWARE_UPLOAD is configured, as documented for M20.

".BIN" files are only listed for M20 F, not in the UI on the printer. Which, from my interpretation of https://github.com/MarlinFirmware/Marlin/pull/23878#issuecomment-1064653601, is the desired behaviour.


### Description

`CardReader::is_visible_entity()` decides if a directory entry will be displayed/listed or not. If an entry is considered a binary file or not is stored in `card_flags_t::filenameIsBin`. However, `card_flags_t::filenameIsBin` used to exist only, if `DO_LIST_BIN_FILES` was set. At the same time `DO_LIST_BIN_FILES` also guards reading from and writing to `card_flags_t::filenameIsBin` in `CardReader::fileIsBinary()` and `CardReader::setBinFlag()`.

The documentation for M20 says that with`CUSTOM_FIRMWARE_UPLOAD` `M20 F` becomes available to list `BIN` files. This is not what the code does.
First, the preprocessor directives had to be changed to `DO_LIST_BIN_FILES || ENABLED(CUSTOM_FIRMWARE_UPLOAD)`, to enable storing of the `filenameIsBin` card flag.

Additionally, setting the flag in `is_visble_entity()` via `setBinFlag` has to depend on the parameter `onlyBin`, to list `BIN` files only for `M20 F`, but not when constructing a file list for the graphical UI.

Maybe it's a better idea to have `DWIN_LCD_PROUI` imply `CUSTOM_SOFTWARE_UPLOAD`, but I don't know the config/Marlin well enough to decide, so I went with the uglier, but safer option.

### Requirements

Reproduction:
* Requires SD support
* `CUSTOM_FIRMWARE_UPLOAD` config
* `DWIN_LCD_PROUI` config disabled/not set
* place `BIN` file on SD card
* `M20 F` will not show `BIN` file

With this patch:
* `M20 F` will list `BIN` files
* In case of graphical UI: printer will not show `BIN` files (in contrast to the solution mentioned in #24332)

### Benefits

`M20 F` behaves according to specification for all board/configs; not only when `DWIN_LCD_PROUI` is set.

### Configurations

Minimal Config (probably):
* `SD_SUPPORT`
* `BINARY_FILE_TRANSFER`
* `CUSTOM_FIRMWARE_UPLOAD`

[config.zip](https://github.com/user-attachments/files/21222609/config.zip)


### Related Issues

This aims to fix #24332