### PR TITLE
add PID_MAX and MAX_BED_POWER sanity checks

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1028,6 +1028,9 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   #undef MPC_AUTOTUNE_MENU
   #undef MPC_PTC
 #endif
+#ifdef PID_MAX
+  static_assert(PID_MAX >= 0 && PID_MAX < 256, "PID_MAX must be >= 0 and < 256.");
+#endif
 
 #if ENABLED(MPC_INCLUDE_FAN)
   #if !HAS_FAN
@@ -1047,6 +1050,9 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
  */
 #if ALL(PIDTEMPBED, BED_LIMIT_SWITCHING)
   #error "To use BED_LIMIT_SWITCHING you must disable PIDTEMPBED."
+#endif
+#ifdef MAX_BED_POWER
+  static_assert(MAX_BED_POWER >= 0 && MAX_BED_POWER < 256, "MAX_BED_POWER must be >= 0 and < 256.");
 #endif
 
 // Fan Kickstart power

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1028,8 +1028,8 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   #undef MPC_AUTOTUNE_MENU
   #undef MPC_PTC
 #endif
-#ifdef PID_MAX
-  static_assert(PID_MAX >= 0 && PID_MAX < 256, "PID_MAX must be >= 0 and < 256.");
+#if !WITHIN(PID_MAX, 0, 255)
+  #error "PID_MAX must be an integer from 0 to 255."
 #endif
 
 #if ENABLED(MPC_INCLUDE_FAN)
@@ -1051,8 +1051,8 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
 #if ALL(PIDTEMPBED, BED_LIMIT_SWITCHING)
   #error "To use BED_LIMIT_SWITCHING you must disable PIDTEMPBED."
 #endif
-#ifdef MAX_BED_POWER
-  static_assert(MAX_BED_POWER >= 0 && MAX_BED_POWER < 256, "MAX_BED_POWER must be >= 0 and < 256.");
+#if !WITHIN(MAX_BED_POWER, 0, 255)
+  #error "MAX_BED_POWER must be an integer from 0 to 255."
 #endif
 
 // Fan Kickstart power


### PR DESCRIPTION
### Description

Add checks that PID_MAX and MAX_BED_POWER is >=0 and < 256

Found Configs in the wild with this incorrectly set to 315

### Requirements

PIDTEMP and or PIDTEMPBED

### Benefits

Correct values are enforced 

