### PR TITLE
Fix typo in "Allow Nozzle Wipe odd linear count"

### DIFF
--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -65,9 +65,9 @@ Nozzle nozzle;
             do_blocking_move_to_x(start.x);
         #else
           if (i & 1)
-            do_blocking_move_to_x(end);
+            do_blocking_move_to_xy(end);
           else
-            do_blocking_move_to_x(start);
+            do_blocking_move_to_xy(start);
         #endif
       }
 


### PR DESCRIPTION
This fixes the code that was merged from pr https://github.com/MarlinFirmware/Marlin/pull/27952

    commit 02e5225e10bd74404aaad8d374b905d9db76b2f9
    Author: Darsey Litzenberger <dlitz@dlitz.net>
    Commit: GitHub <noreply@github.com>

        🩹 Allow Nozzle Wipe odd linear count (#27952)

