### PR TITLE
add additional obsolete files to preflight test.   

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -136,7 +136,7 @@ if pioutil.is_pio_build():
         #
         mixedin = []
         p = project_dir / "Marlin/src/lcd/dogm"
-        for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
+        for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h","u8g_dev_ssd1306_sh1106_128x64_I2C.cpp", "u8g_dev_ssd1309_12864.cpp", "u8g_dev_st7565_64128n_HAL.cpp", "u8g_dev_st7920_128x64_HAL.cpp", "u8g_dev_tft_upscale_from_128x64.cpp", "u8g_dev_uc1701_mini12864_HAL.cpp", "ultralcd_st7920_u8glib_rrd_AVR.cpp" ]:
             if (p / f).is_file():
                 mixedin += [ f ]
         p = project_dir / "Marlin/src/feature/bedlevel/abl"


### PR DESCRIPTION
### Description

A user decided to extract bugfix 2.1.x over Marlin 2.1.2.5 creating many code conflicts.

These are part of bugfix 2.1.x (note the u8g subdirectory)

\src\lcd\dogm\u8g\u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
\src\lcd\dogm\u8g\u8g_dev_ssd1306_sh1106_128x64_SWSPI.cpp
\src\lcd\dogm\u8g\u8g_dev_ssd1309_12864.cpp
\src\lcd\dogm\u8g\u8g_dev_st7565_64128n_HAL.cpp
\src\lcd\dogm\u8g\u8g_dev_st7920_128x64_HAL.cpp
\src\lcd\dogm\u8g\u8g_dev_tft_upscale_from_128x64.cpp
\src\lcd\dogm\u8g\u8g_dev_uc1701_mini12864_HAL.cpp
\src\lcd\dogm\u8g\ultralcd_st7920_u8glib_rrd_AVR.cpp

These are part of 2.1.2.5
\src\lcd\dogm\u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
\src\lcd\dogm\u8g_dev_ssd1309_12864.cpp
\src\lcd\dogm\u8g_dev_st7565_64128n_HAL.cpp
\src\lcd\dogm\u8g_dev_st7920_128x64_HAL.cpp
\src\lcd\dogm\u8g_dev_tft_upscale_from_128x64.cpp
\src\lcd\dogm\u8g_dev_uc1701_mini12864_HAL.cpp
\src\lcd\dogm\ultralcd_st7920_u8glib_rrd_AVR.cpp

the 2.1.2.5 files should not be part of bugfix 

Added the  2.1.2.5  files to the existing preflight-checks.py to make sure the user deletes them from newer versions of Marlin.  

### Benefits

Code has a chance of building

### Related Issues

<li>MarlinFirmware/Marlin/issues/27989