### PR TITLE
followup to add more CONTROLLER fans, _TEMP is not _PIN

### DIFF
--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -94,10 +94,10 @@ void ControllerFan::update() {
       #if ALL(HAS_HEATED_BED, CONTROLLER_FAN_BED_HEATING)
         || thermalManager.temp_bed.soft_pwm_amount > 0
       #endif
-      #if PIN_EXISTS(CONTROLLER_FAN_MIN_BOARD_)
+      #ifdef CONTROLLER_FAN_MIN_BOARD_TEMP
         || thermalManager.wholeDegBoard() >= CONTROLLER_FAN_MIN_BOARD_TEMP
       #endif
-      #if PIN_EXISTS(CONTROLLER_FAN_MIN_SOC_)
+      #ifdef CONTROLLER_FAN_MIN_SOC_TEMP
         || thermalManager.wholeDegSoc() >= CONTROLLER_FAN_MIN_SOC_TEMP
       #endif
     ) lastComponentOn = ms; //... set time to NOW so the fan will turn on


### PR DESCRIPTION
### Description

Followup to https://github.com/MarlinFirmware/Marlin/pull/27961

      #ifdef CONTROLLER_FAN_MIN_BOARD_TEMP
      #ifdef CONTROLLER_FAN_MIN_SOC_TEMP

where incorrectly converted to 

     #if PIN_EXISTS(CONTROLLER_FAN_MIN_BOARD_)
     #if PIN_EXISTS(CONTROLLER_FAN_MIN_SOC_)

This PR reverts these 

### Requirements

USE_CONTROLLER_FAN
with either or both of 
CONTROLLER_FAN_MIN_BOARD_TEMP
CONTROLLER_FAN_MIN_SOC_TEMP

### Benefits

Works as expected

### Related 
https://github.com/MarlinFirmware/Marlin/commit/081458a3c880582c2c41915fc5c830adc81a98de#r163973048
https://github.com/MarlinFirmware/Marlin/commit/081458a3c880582c2c41915fc5c830adc81a98de#r163973247
