### PR TITLE
re order pins.h to match boards.h

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -177,6 +177,8 @@
   #include "ramps/pins_RAMPS_ENDER_4.h"             // ATmega2560                           env:mega2560
 #elif MB(RAMPS_CREALITY)
   #include "ramps/pins_RAMPS_CREALITY.h"            // ATmega2560                           env:mega2560
+#elif MB(CREALITY_V252)
+  #include "ramps/pins_CREALITY_V252.h"             // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_F5)
   #include "ramps/pins_DAGOMA_F5.h"                 // ATmega2560                           env:mega2560
 #elif MB(DAGOMA_D6)
@@ -225,8 +227,6 @@
   #include "ramps/pins_XTLW_MFF_V2.h"               // ATmega2560                           env:mega2560
 #elif MB(RUMBA_E3D)
   #include "ramps/pins_RUMBA_E3D.h"                 // ATmega2560                           env:mega2560
-#elif MB(CREALITY_V252)
-  #include "ramps/pins_CREALITY_V252.h"             // ATmega2560                           env:mega2560
 
 //
 // RAMBo and derivatives


### PR DESCRIPTION
### Description

PR https://github.com/MarlinFirmware/Marlin/pull/27996 added  BOARD_CREALITY_V252 
but before it got merged the boards.h was re-orded to put BOARD_CREALITY_V252 after BOARD_RAMPS_CREALITY but pins.h did not get re-ordered.
This breaks  Validate boards

Re-orders pins.h to match the order in boards.h

### Benefits

Validate boards CI tet passes, and pins and boards have the same ordering.
