### PR TITLE
Update read() (buffer boundary inclusion loops (CWE-120, CWE-20))

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -115,9 +115,8 @@ bool Preview::hasPreview() {
   uint8_t nbyte = 1;
   while (!fileprop.thumbstart && nbyte > 0 && indx < 4 * sizeof(buf)) {
     nbyte = card.read(buf, sizeof(buf) - 1);
-    if (nbyte < 0) break;
-    buf[nbyte] = '\0';
-    if (nbyte > 0) {
+    if (nbyte >= 0) {
+      buf[nbyte] = '\0';
       getValue(buf, PSTR(";TIME:"), fileprop.time);
       getValue(buf, PSTR(";Filament used:"), fileprop.filament);
       getValue(buf, PSTR(";Layer height:"), fileprop.layer);
@@ -143,6 +142,8 @@ bool Preview::hasPreview() {
         card.setIndex(indx);
       }
     }
+    else
+      break;
   }
 
   if (!fileprop.thumbstart) {

--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -83,7 +83,7 @@ fileprop_t fileprop;
 void getValue(const char * const buf, PGM_P const key, float &value) {
   if (value != 0.0f) return;
 
-  char *posptr = strstr_P(buf, key);
+  const char *posptr = strstr_P(buf, key);
   if (posptr == nullptr) return;
 
   char num[10] = "";
@@ -101,8 +101,9 @@ void getValue(const char * const buf, PGM_P const key, float &value) {
 
 bool Preview::hasPreview() {
   const char * const tbstart = PSTR("; thumbnail begin " STRINGIFY(THUMBWIDTH) "x" STRINGIFY(THUMBHEIGHT));
-  char *posptr = nullptr;
+  const char *posptr = nullptr;
   uint32_t indx = 0;
+  uint32_t prev_indx = 0;
   float tmp = 0;
 
   fileprop.clear();
@@ -114,8 +115,9 @@ bool Preview::hasPreview() {
   uint8_t nbyte = 1;
   while (!fileprop.thumbstart && nbyte > 0 && indx < 4 * sizeof(buf)) {
     nbyte = card.read(buf, sizeof(buf) - 1);
+    if (nbyte < 0) break;
+    buf[nbyte] = '\0';
     if (nbyte > 0) {
-      buf[nbyte] = '\0';
       getValue(buf, PSTR(";TIME:"), fileprop.time);
       getValue(buf, PSTR(";Filament used:"), fileprop.filament);
       getValue(buf, PSTR(";Layer height:"), fileprop.layer);
@@ -132,10 +134,12 @@ bool Preview::hasPreview() {
       fileprop.height -= tmp;
       posptr = strstr_P(buf, tbstart);
       if (posptr != nullptr) {
-        fileprop.thumbstart = indx + (posptr - &buf[0]);
+        fileprop.thumbstart = indx + (posptr - buf);
       }
       else {
         indx += _MAX(10, nbyte - (signed)strlen_P(tbstart));
+        if (indx <= prev_indx) break;
+        prev_indx = indx;
         card.setIndex(indx);
       }
     }
@@ -190,7 +194,7 @@ void Preview::drawFromSD() {
     return;
   }
 
-  MString<45> buf;
+  TString buf;
   dwinDrawRectangle(1, hmiData.colorBackground, 0, 0, DWIN_WIDTH, STATUS_Y - 1);
   if (fileprop.time) {
     buf.setf(F("Estimated time: %i:%02i"), (uint16_t)fileprop.time / 3600, ((uint16_t)fileprop.time % 3600) / 60);
@@ -210,7 +214,7 @@ void Preview::drawFromSD() {
   }
   DWINUI::drawButton(BTN_Print, 26, 290);
   DWINUI::drawButton(BTN_Cancel, 146, 290);
-  show();
+  if (fileprop.thumbsize) show();
   drawSelectHighlight(true, 290);
   dwinUpdateLCD();
 }

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -255,10 +255,12 @@ bool SdBaseFile::exists(const char *name) {
  * If no data is read, fgets() returns zero for EOF or -1 if an error occurred.
  */
 int16_t SdBaseFile::fgets(char *str, int16_t num, char *delim) {
+  if (!str || num <= 1) return -1; // Ensure space for at least '\0'
+
   char ch;
   int16_t n = 0;
   int16_t r = -1;
-  while ((n + 1) < num && (r = read(&ch, 1)) == 1) {
+  while (n < num - 1 && (r = read(&ch, 1)) == 1) {
     // delete CR
     if (ch == '\r') continue;
     str[n++] = ch;
@@ -269,10 +271,7 @@ int16_t SdBaseFile::fgets(char *str, int16_t num, char *delim) {
       if (strchr(delim, ch)) break;
     }
   }
-  if (r < 0) {
-    // read error
-    return -1;
-  }
+  if (r < 0) return -1; // read error
   str[n] = '\0';
   return n;
 }
@@ -342,7 +341,9 @@ int8_t SdBaseFile::lsPrintNext(const uint8_t flags, const uint8_t indent) {
   uint8_t w = 0;
 
   while (1) {
-    if (read(&dir, sizeof(dir)) != sizeof(dir)) return 0;
+    int16_t r = read(&dir, sizeof(dir));
+    if (r < 0) return -1;
+    if (r != sizeof(dir)) return 0;
     if (dir.name[0] == DIR_NAME_FREE) return 0;
 
     // skip deleted entry and entries for . and  ..
@@ -1277,7 +1278,8 @@ int SdBaseFile::peek() {
   filepos_t pos;
   getpos(&pos);
   int c = read();
-  if (c >= 0) setpos(&pos);
+  if (c < 0) return -1;
+  setpos(&pos);
   return c;
 }
 
@@ -1346,8 +1348,10 @@ bool SdBaseFile::printName() {
  * If an error occurs or end of file is reached -1 is returned.
  */
 int16_t SdBaseFile::read() {
-  uint8_t b;
-  return read(&b, 1) == 1 ? b : -1;
+  uint8_t b = 0;
+  int16_t r = read(&b, 1);
+  if (r != 1) return -1;
+  return static_cast<int16_t>(b);
 }
 
 /**

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -341,7 +341,7 @@ int8_t SdBaseFile::lsPrintNext(const uint8_t flags, const uint8_t indent) {
   uint8_t w = 0;
 
   while (1) {
-    int16_t r = read(&dir, sizeof(dir));
+    const int16_t r = read(&dir, sizeof(dir));
     if (r < 0) return -1;
     if (r != sizeof(dir)) return 0;
     if (dir.name[0] == DIR_NAME_FREE) return 0;
@@ -1349,7 +1349,7 @@ bool SdBaseFile::printName() {
  */
 int16_t SdBaseFile::read() {
   uint8_t b = 0;
-  int16_t r = read(&b, 1);
+  const int16_t r = read(&b, 1);
   if (r != 1) return -1;
   return static_cast<int16_t>(b);
 }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Codacy has given some warnings about `read()` in general.

>*Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20).*

Here are a couple fixes which improves on that, like explicit validation, error handling...

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
