### PR TITLE
fix typo AUX2_08_PIN -> AUX2_08 in pins_RAMPS.h

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -864,7 +864,7 @@
     #elif ENABLED(MINIPANEL)
 
       #ifndef BEEPER_PIN
-        #define BEEPER_PIN           AUX2_08_PIN
+        #define BEEPER_PIN               AUX2_08
       #endif
       #define LCD_BACKLIGHT_PIN          AUX2_10
 


### PR DESCRIPTION
### Description

When selecting MINIPANEL lcd on ramps marlin failed to build due to typo

In https://github.com/MarlinFirmware/Marlin/pull/26719 all the RAMPS AUX pins lost their _PIN  suffix, I don't know why, but regardless one AUX2_08_PIN was missed.

Updated AUX2_08_PIN to AUX2_08 to match the rest. 

### Requirements

A motherboard that uses pins_RAMPS and a lcd that uses MINIPANEL 

### Benefits

Builds as expected

### Related Issues

<li>MarlinFirmware/Marlin/issues/28032</li>

### NOTE
Is also in 2.1.2.5 