### PR TITLE
Fix ftmotion unstable step rate

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1192,7 +1192,6 @@
   #endif
 
   #define FTM_STEPS_PER_UNIT_TIME (FTM_STEPPER_FS / FTM_FS)       // Interpolated stepper commands per unit time
-  #define FTM_CTS_COMPARE_VAL (FTM_STEPS_PER_UNIT_TIME / 2)       // Comparison value used in interpolation algorithm
   #define FTM_MIN_TICKS ((STEPPER_TIMER_RATE) / (FTM_STEPPER_FS)) // Minimum stepper ticks between steps
 
   #define FTM_MIN_SHAPE_FREQ           10         // Minimum shaping frequency

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -53,15 +53,14 @@ AxisBits FTMotion::axis_move_dir;
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
 
-bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM, ...
-                                                // ... and reset when block is completely converted to FTM trajectory.
-bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory...
-                                                // ... has been generated, is now available in the upper -
-                                                // batch of traj.x[], y, z ... e vectors, and is ready to be
-                                                // post processed, if applicable, then interpolated. Reset when the
-                                                // data has been shifted out.
-bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed...
-                                                // ... if applicable, and is ready to be converted to step commands.
+bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM,
+                                                //  and reset when block is completely converted to FTM trajectory.
+bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory has been
+                                                //  generated, is now available in the upper-batch of traj.A[], and
+                                                //  is ready to be post-processed (if applicable) and interpolated.
+                                                //  Reset once the data has been shifted out.
+bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed
+                                                //  (if applicable) and is ready to be converted to step commands.
 
 // Trapezoid data variables.
 xyze_pos_t   FTMotion::startPos,                    // (mm) Start position of block
@@ -687,7 +686,7 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
  * Add up to one stepper command to the buffer with STEP/DIR bits for all axes.
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
-  constexpr float INV_FTM_STEPS_PER_UNIT_TIME = (1.0 / FTM_STEPS_PER_UNIT_TIME);
+  constexpr float INV_FTM_STEPS_PER_UNIT_TIME = 1.0f / (FTM_STEPS_PER_UNIT_TIME);
 
   // q10 per-stepper-slot increment toward this sample’s target step count.
   // (traj*spm - steps) = steps still due by the end of this UNIT_TIME.
@@ -695,9 +694,8 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
   // Over FTM_STEPS_PER_UNIT_TIME stepper-slots this sums to the exact target (no drift).
   // Any fraction of a step that may remain will be accounted for by the next UNIT_TIME
   #define TOSTEPS_q10(A, B) int32_t( \
-      (trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] - steps.A) * _BV(10) - \
-      step_error_q10.A * INV_FTM_STEPS_PER_UNIT_TIME \
-    )
+    (trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] - steps.A) * _BV(10) \
+     - step_error_q10.A * INV_FTM_STEPS_PER_UNIT_TIME )
 
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -681,16 +681,17 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
 } // generateTrajectoryPointsFromBlock
 
 /**
- * Interpolate a single trajectory data point into stepper commands.
+ * @brief Interpolate a single trajectory data point into stepper commands.
  * @param idx The index of the trajectory point to convert.
- * This function calculates the required stepper movements for each axis
- * based on the difference between the current and previous trajectory points,
- * and fills the stepper command buffer with the appropriate step and direction bits.
+ *
+ * Calculate the required stepper movements for each axis based on the
+ * difference between the current and previous trajectory points.
+ * Add up to one stepper command to the buffer with STEP/DIR bits for all axes.
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
   #define TOSTEPS_q10(A, B) \
     int32_t((trajMod.A[idx] - prev_traj_point.A) * \
-            planner.settings.axis_steps_per_mm[B] * (1 << 10))
+            planner.settings.axis_steps_per_mm[B] * _BV(10))
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),
     TOSTEPS_q10(x, X_AXIS), TOSTEPS_q10(y, Y_AXIS), TOSTEPS_q10(z, Z_AXIS),
@@ -700,32 +701,39 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
 
   // Remember this trajectory point for the next call
   #define SET_PREV(A) prev_traj_point.A = trajMod.A[idx];
-  LOGICAL_AXIS_MAP(SET_PREV)
+  LOGICAL_AXIS_MAP(SET_PREV);
 
-  const int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;
+  // Fixed-point denominator for step accumulation
+  constexpr int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;
 
+  // 1. Subtract one whole step from the accumulated distance
+  // 2. Accumulate one positive or negative step
+  // 3. Set the step and direction bits for the stepper command
   #define RUN_AXIS(A)                                       \
     do {                                                    \
       if (step_error_q10.A >= denom_q10) {                  \
+        step_error_q10.A -= denom_q10;                      \
         steps.A++;                                          \
         cmd |= _BV(FT_BIT_DIR_##A) | _BV(FT_BIT_STEP_##A);  \
-        step_error_q10.A -= denom_q10;                      \
       }                                                     \
       if (step_error_q10.A <= -denom_q10) {                 \
+        step_error_q10.A += denom_q10;                      \
         steps.A--;                                          \
         cmd |= _BV(FT_BIT_STEP_##A); /* neg dir implicit */ \
-        step_error_q10.A += denom_q10;                      \
       }                                                     \
     } while (0);
 
-  for (uint32_t i = 0; i < (uint32_t)FTM_STEPS_PER_UNIT_TIME; i++) {
+  for (uint32_t i = 0; i < uint32_t(FTM_STEPS_PER_UNIT_TIME); i++) {
+    // Reference the next stepper command in the circular buffer
     ft_command_t& cmd = stepperCmdBuff[stepperCmdBuff_produceIdx];
+
+    // Init the command to no STEP (Reverse DIR)
     cmd = 0;
 
-    // Accumulate the errors for all axes
+    // Accumulate the "error" for all axes according the fixed-point distance
     step_error_q10 += delta_q10;
 
-    // Set up step/dir bits for all axes
+    // Where the error has accumulated whole axis steps, add them to the command
     LOGICAL_AXIS_MAP(RUN_AXIS);
 
     // Next circular buffer index

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -689,7 +689,7 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
   constexpr float INV_FTM_STEPS_PER_UNIT_TIME = 1.0f / (FTM_STEPS_PER_UNIT_TIME);
 
   // q10 per-stepper-slot increment toward this sample’s target step count.
-  // (traj*spm - steps) = steps still due by the end of this UNIT_TIME.
+  // (traj * steps_per_mm - steps) = steps still due at the start of this UNIT_TIME.
   // Convert to q10 (×2^10), then subtract the current accumulator error: step_error_q10 / FTM_STEPS_PER_UNIT_TIME.
   // Over FTM_STEPS_PER_UNIT_TIME stepper-slots this sums to the exact target (no drift).
   // Any fraction of a step that may remain will be accounted for by the next UNIT_TIME

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -53,15 +53,15 @@ AxisBits FTMotion::axis_move_dir;
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
 
-bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM,
-                                                // and reset when block is completely converted to FTM trajectory.
-bool FTMotion::isTrajBufferFull = false;        // Indicates a batch of the fixed time trajectory
-                                                // has been generated, is now available in the upper -
+bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM, ...
+                                                // ... and reset when block is completely converted to FTM trajectory.
+bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory...
+                                                // ... has been generated, is now available in the upper -
                                                 // batch of traj.x[], y, z ... e vectors, and is ready to be
                                                 // post processed, if applicable, then interpolated. Reset when the
                                                 // data has been shifted out.
-bool FTMotion::isTrajBufferPostProcessed = false;   // Indicates the batch is done being post processed
-                                                    // and is ready to be converted to step commands.
+bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed...
+                                                // ... if applicable, and is ready to be converted to step commands.
 
 // Trapezoid data variables.
 xyze_pos_t   FTMotion::startPos,                    // (mm) Start position of block
@@ -171,18 +171,21 @@ void FTMotion::loop() {
   }
 
   if (blockProcRdy) {
-    if (!isTrajBufferFull) generateTrajectoryPointsFromBlock(); // may clear blockProcRdy
+
+    if (!batchRdy) generateTrajectoryPointsFromBlock(); // may clear blockProcRdy
+
+    // Check if the block has been completely converted:
     if (!blockProcRdy) {
       discard_planner_block_protected();
-      if (!isTrajBufferFull && !planner.has_blocks_queued()) {
+      if (!batchRdy && !planner.has_blocks_queued()) {
         runoutBlock();
-        generateTrajectoryPointsFromBlock(); // Additional call to guarantee isTrajBufferFull is set this loop.
+        generateTrajectoryPointsFromBlock(); // Additional call to guarantee batchRdy is set this loop.
       }
     }
   }
 
   // FBS / post processing.
-  if (isTrajBufferFull && !isTrajBufferPostProcessed) {
+  if (batchRdy && !batchRdyForInterp) {
 
     // Call Ulendo FBS here.
 
@@ -199,23 +202,23 @@ void FTMotion::loop() {
     #endif
 
     // ... data is ready in trajMod.
-    isTrajBufferPostProcessed = true;
+    batchRdyForInterp = true;
 
-    isTrajBufferFull = false; // Clear so generateTrajectoryPointsFromBlock() can resume generating points.
+    batchRdy = false; // Clear so generateTrajectoryPointsFromBlock() can resume generating points.
   }
 
   // Interpolation (generation of step commands from fixed time trajectory).
-  while (isTrajBufferPostProcessed
+  while (batchRdyForInterp
     && (stepperCmdBuffItems() < (FTM_STEPPERCMD_BUFF_SIZE) - (FTM_STEPS_PER_UNIT_TIME))) {
     generateStepsFromTrajectory(interpIdx);
     if (++interpIdx == FTM_BATCH_SIZE) {
-      isTrajBufferPostProcessed = false;
+      batchRdyForInterp = false;
       interpIdx = 0;
     }
   }
 
   // Report busy status to planner.
-  busy = (stepperCmdBuffHasData || blockProcRdy || isTrajBufferFull || isTrajBufferPostProcessed);
+  busy = (stepperCmdBuffHasData || blockProcRdy || batchRdy || batchRdyForInterp);
 
 }
 
@@ -379,7 +382,7 @@ void FTMotion::reset() {
 
   traj.reset();
 
-  blockProcRdy = isTrajBufferFull = isTrajBufferPostProcessed = false;
+  blockProcRdy = batchRdy = batchRdyForInterp = false;
 
   endPos_prevBlock.reset();
 
@@ -467,11 +470,11 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   const xyze_pos_t& moveDist = current_block->dist_mm;
   ratio = moveDist * oneOverLength;
 
-  const float steps_per_mm = totalLength / current_block->step_event_count;  // (steps/mm) Distance for each step
+  const float spm = totalLength / current_block->step_event_count;  // (steps/mm) Distance for each step
 
-  f_s = steps_per_mm * current_block->initial_rate;              // (steps/s) Start feedrate
+  f_s = spm * current_block->initial_rate;              // (steps/s) Start feedrate
 
-  const float f_e = steps_per_mm * current_block->final_rate;    // (steps/s) End feedrate
+  const float f_e = spm * current_block->final_rate;    // (steps/s) End feedrate
 
   /* Keep for comprehension
   const float a = current_block->acceleration,          // (mm/s^2) Same magnitude for acceleration or deceleration
@@ -668,14 +671,14 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
     // Filled up the queue with regular and shaped steps
     if (++traj_produceIdx == FTM_WINDOW_SIZE) {
       traj_produceIdx = BATCH_SIDX_IN_WINDOW;
-      isTrajBufferFull = true;
+      batchRdy = true;
     }
 
     if (++traj_consumeIdx == max_intervals) {
       blockProcRdy = false;
       traj_consumeIdx = 0;
     }
-  } while (blockProcRdy && !isTrajBufferFull);
+  } while (blockProcRdy && !batchRdy);
 } // generateTrajectoryPointsFromBlock
 
 /**

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -80,8 +80,8 @@ uint32_t FTMotion::N1,                          // Number of data points in the 
 uint32_t FTMotion::max_intervals;               // Total number of data points that will be generated from block.
 
 // Make vector variables.
-uint32_t FTMotion::traj_consumeIdx = 0,         // Index of fixed time trajectory generation of the overall block.
-         FTMotion::traj_produceIdx = 0;         // Index of fixed time trajectory generation within the batch.
+uint32_t FTMotion::traj_idx_get = 0,            // Index of fixed time trajectory generation of the overall block.
+         FTMotion::traj_idx_set = 0;            // Index of fixed time trajectory generation within the batch.
 
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
@@ -384,8 +384,8 @@ void FTMotion::reset() {
 
   endPos_prevBlock.reset();
 
-  traj_consumeIdx = 0;
-  traj_produceIdx = TERN(FTM_UNIFIED_BWS, 0, _MIN(BATCH_SIDX_IN_WINDOW, FTM_BATCH_SIZE));
+  traj_idx_get = 0;
+  traj_idx_set = TERN(FTM_UNIFIED_BWS, 0, _MIN(BATCH_SIDX_IN_WINDOW, FTM_BATCH_SIZE));
 
   steps.reset();
   step_error_q10.reset();
@@ -430,7 +430,7 @@ void FTMotion::runoutBlock() {
   startPos = endPos_prevBlock;
   ratio.reset();
 
-  const int32_t n_to_fill_batch = (FTM_WINDOW_SIZE) - traj_produceIdx;
+  const int32_t n_to_fill_batch = (FTM_WINDOW_SIZE) - traj_idx_set;
 
   // This line or function is to be modified for FBS use; do not optimize out.
   const int32_t n_to_settle_shaper = num_samples_shaper_settle();
@@ -564,18 +564,18 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 // Generate data points of the trajectory.
 void FTMotion::generateTrajectoryPointsFromBlock() {
   do {
-    float tau = (traj_consumeIdx + 1) * (FTM_TS);         // (s) Time since start of block
+    float tau = (traj_idx_get + 1) * (FTM_TS);            // (s) Time since start of block
     float dist = 0.0f;                                    // (mm) Distance traveled
     #if HAS_EXTRUDERS
       float accel_k = 0.0f;                               // (mm/s^2) Acceleration K factor
     #endif
 
-    if (traj_consumeIdx < N1) {
+    if (traj_idx_get < N1) {
       // Acceleration phase
       dist = (f_s * tau) + (0.5f * accel_P * sq(tau));    // (mm) Distance traveled for acceleration phase since start of block
       TERN_(HAS_EXTRUDERS, accel_k = accel_P);            // (mm/s^2) Acceleration K factor from Accel phase
     }
-    else if (traj_consumeIdx < (N1 + N2)) {
+    else if (traj_idx_get < (N1 + N2)) {
       // Coasting phase
       dist = s_1e + F_P * (tau - N1 * (FTM_TS));          // (mm) Distance traveled for coasting phase since start of block
       //TERN_(HAS_EXTRUDERS, accel_k = 0.0f);
@@ -587,17 +587,17 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
       TERN_(HAS_EXTRUDERS, accel_k = decel_P);            // (mm/s^2) Acceleration K factor from Decel phase
     }
 
-    #define _SET_TRAJ(q) traj.q[traj_produceIdx] = startPos.q + ratio.q * dist;
+    #define _SET_TRAJ(q) traj.q[traj_idx_set] = startPos.q + ratio.q * dist;
     LOGICAL_AXIS_MAP_LC(_SET_TRAJ);
 
     #if HAS_EXTRUDERS
       if (cfg.linearAdvEna) {
-        float dedt_adj = (traj.e[traj_produceIdx] - e_raw_z1) * (FTM_FS);
+        float dedt_adj = (traj.e[traj_idx_set] - e_raw_z1) * (FTM_FS);
         if (ratio.e > 0.0f) dedt_adj += accel_k * cfg.linearAdvK * 0.0001f;
 
-        e_raw_z1 = traj.e[traj_produceIdx];
+        e_raw_z1 = traj.e[traj_idx_set];
         e_advanced_z1 += dedt_adj * (FTM_TS);
-        traj.e[traj_produceIdx] = e_advanced_z1;
+        traj.e[traj_idx_set] = e_advanced_z1;
       }
     #endif
 
@@ -608,7 +608,7 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
       #if HAS_DYNAMIC_FREQ_MM
         case dynFreqMode_Z_BASED: {
           static float oldz = 0.0f;
-          const float z = traj.z[traj_produceIdx];
+          const float z = traj.z[traj_idx_set];
           if (z != oldz) { // Only update if Z changed.
             oldz = z;
             #if HAS_X_AXIS
@@ -628,10 +628,10 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
           // Update constantly. The optimization done for Z value makes
           // less sense for E, as E is expected to constantly change.
           #if HAS_X_AXIS
-            shaping.x.set_axis_shaping_N(cfg.shaper.x, cfg.baseFreq.x + cfg.dynFreqK.x * traj.e[traj_produceIdx], cfg.zeta.x);
+            shaping.x.set_axis_shaping_N(cfg.shaper.x, cfg.baseFreq.x + cfg.dynFreqK.x * traj.e[traj_idx_set], cfg.zeta.x);
           #endif
           #if HAS_Y_AXIS
-            shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y + cfg.dynFreqK.y * traj.e[traj_produceIdx], cfg.zeta.y);
+            shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y + cfg.dynFreqK.y * traj.e[traj_idx_set], cfg.zeta.y);
           #endif
           break;
       #endif
@@ -643,22 +643,22 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
     #if HAS_FTM_SHAPING
       #if HAS_X_AXIS
         if (shaping.x.ena) {
-          shaping.x.d_zi[shaping.zi_idx] = traj.x[traj_produceIdx];
-          traj.x[traj_produceIdx] *= shaping.x.Ai[0];
+          shaping.x.d_zi[shaping.zi_idx] = traj.x[traj_idx_set];
+          traj.x[traj_idx_set] *= shaping.x.Ai[0];
           for (uint32_t i = 1U; i <= shaping.x.max_i; i++) {
             const uint32_t udiffx = shaping.zi_idx - shaping.x.Ni[i];
-            traj.x[traj_produceIdx] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
+            traj.x[traj_idx_set] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
           }
         }
       #endif
 
       #if HAS_Y_AXIS
         if (shaping.y.ena) {
-          shaping.y.d_zi[shaping.zi_idx] = traj.y[traj_produceIdx];
-          traj.y[traj_produceIdx] *= shaping.y.Ai[0];
+          shaping.y.d_zi[shaping.zi_idx] = traj.y[traj_idx_set];
+          traj.y[traj_idx_set] *= shaping.y.Ai[0];
           for (uint32_t i = 1U; i <= shaping.y.max_i; i++) {
             const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
-            traj.y[traj_produceIdx] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
+            traj.y[traj_idx_set] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
           }
         }
       #endif
@@ -666,13 +666,13 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
     #endif // HAS_FTM_SHAPING
 
     // Filled up the queue with regular and shaped steps
-    if (++traj_produceIdx == FTM_WINDOW_SIZE) {
-      traj_produceIdx = BATCH_SIDX_IN_WINDOW;
+    if (++traj_idx_set == FTM_WINDOW_SIZE) {
+      traj_idx_set = BATCH_SIDX_IN_WINDOW;
       batchRdy = true;
     }
-    if (++traj_consumeIdx == max_intervals) {
+    if (++traj_idx_get == max_intervals) {
       blockProcRdy = false;
-      traj_consumeIdx = 0;
+      traj_idx_get = 0;
     }
   } while (blockProcRdy && !batchRdy);
 } // generateTrajectoryPointsFromBlock

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -86,8 +86,8 @@ uint32_t FTMotion::traj_consumeIdx = 0,         // Index of fixed time trajector
 
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
-xyze_long_t FTMotion::step_error_q10 = { 0 };   // fractional remainder in q10.21 format
-xyze_float_t FTMotion::last_consumed_traj_point = { 0 };  // The last point before current (i.e., traj[traj_consumeIdx - 1])
+xyze_long_t FTMotion::step_error_q10 = { 0 };   // Fractional remainder in q10.21 format
+xyze_float_t FTMotion::prev_traj_point = { 0 }; // Last-added trajectory point (i.e., traj[traj_consumeIdx - 1])
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
@@ -391,7 +391,7 @@ void FTMotion::reset() {
 
   steps.reset();
   step_error_q10.reset();
-  last_consumed_traj_point.reset();
+  prev_traj_point.reset();
   interpIdx = 0;
 
   #if HAS_FTM_SHAPING
@@ -673,7 +673,6 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
       traj_produceIdx = BATCH_SIDX_IN_WINDOW;
       batchRdy = true;
     }
-
     if (++traj_consumeIdx == max_intervals) {
       blockProcRdy = false;
       traj_consumeIdx = 0;
@@ -690,7 +689,7 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
   #define TOSTEPS_q10(A, B) \
-    int32_t((trajMod.A[idx] - last_consumed_traj_point.A) *  \
+    int32_t((trajMod.A[idx] - prev_traj_point.A) * \
             planner.settings.axis_steps_per_mm[B] * (1 << 10))
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),
@@ -698,8 +697,10 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
     TOSTEPS_q10(i, I_AXIS), TOSTEPS_q10(j, J_AXIS), TOSTEPS_q10(k, K_AXIS),
     TOSTEPS_q10(u, U_AXIS), TOSTEPS_q10(v, V_AXIS), TOSTEPS_q10(w, W_AXIS)
   );
-  #define SET_LAST(A) last_consumed_traj_point.A = trajMod.A[idx];
-  LOGICAL_AXIS_MAP(SET_LAST)
+
+  // Remember this trajectory point for the next call
+  #define SET_PREV(A) prev_traj_point.A = trajMod.A[idx];
+  LOGICAL_AXIS_MAP(SET_PREV)
 
   const int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;
 
@@ -720,8 +721,14 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
   for (uint32_t i = 0; i < (uint32_t)FTM_STEPS_PER_UNIT_TIME; i++) {
     ft_command_t& cmd = stepperCmdBuff[stepperCmdBuff_produceIdx];
     cmd = 0;
+
+    // Accumulate the errors for all axes
     step_error_q10 += delta_q10;
+
+    // Set up step/dir bits for all axes
     LOGICAL_AXIS_MAP(RUN_AXIS);
+
+    // Next circular buffer index
     if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE))
       stepperCmdBuff_produceIdx = 0;
   }

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -689,11 +689,11 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
  * Add up to one stepper command to the buffer with STEP/DIR bits for all axes.
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
-  // Round to nearest (lrintf) to avoid truncation’s sign bias.
-  // Truncating toward zero drops the first small increment after a direction flip,
+  // Round to nearest to avoid truncation’s sign bias.
+  // Merely truncating drops the first small increment after a direction flip,
   // which shows up as a missing step. Rounding prevents that.
   #define TOSTEPS_q10(A, B) \
-    lrintf((trajMod.A[idx] - prev_traj_point.A) * \
+    LROUND((trajMod.A[idx] - prev_traj_point.A) * \
             planner.settings.axis_steps_per_mm[B] * _BV(10))
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -689,8 +689,11 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
  * Add up to one stepper command to the buffer with STEP/DIR bits for all axes.
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
+  // Round to nearest (lrintf) to avoid truncation’s sign bias.
+  // Truncating toward zero drops the first small increment after a direction flip,
+  // which shows up as a missing step. Rounding prevents that.
   #define TOSTEPS_q10(A, B) \
-    int32_t((trajMod.A[idx] - prev_traj_point.A) * \
+    lrintf((trajMod.A[idx] - prev_traj_point.A) * \
             planner.settings.axis_steps_per_mm[B] * _BV(10))
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -53,15 +53,15 @@ AxisBits FTMotion::axis_move_dir;
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
 
-bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM, ...
-                                                // ... and reset when block is completely converted to FTM trajectory.
-bool FTMotion::batchRdy = false;                // Indicates a batch of the fixed time trajectory...
-                                                // ... has been generated, is now available in the upper -
+bool FTMotion::isBlockInProgress = false;       // Set when new block data is loaded from stepper module into FTM,
+                                                // and reset when block is completely converted to FTM trajectory.
+bool FTMotion::isTrajBufferFull = false;        // Indicates a batch of the fixed time trajectory
+                                                // has been generated, is now available in the upper -
                                                 // batch of traj.x[], y, z ... e vectors, and is ready to be
                                                 // post processed, if applicable, then interpolated. Reset when the
                                                 // data has been shifted out.
-bool FTMotion::batchRdyForInterp = false;       // Indicates the batch is done being post processed...
-                                                // ... if applicable, and is ready to be converted to step commands.
+bool FTMotion::isTrajBufferPostProcessed = false;   // Indicates the batch is done being post processed
+                                                    // and is ready to be converted to step commands.
 
 // Trapezoid data variables.
 xyze_pos_t   FTMotion::startPos,                    // (mm) Start position of block
@@ -81,11 +81,14 @@ uint32_t FTMotion::N1,                          // Number of data points in the 
 uint32_t FTMotion::max_intervals;               // Total number of data points that will be generated from block.
 
 // Make vector variables.
-uint32_t FTMotion::makeVector_idx = 0,          // Index of fixed time trajectory generation of the overall block.
-         FTMotion::makeVector_batchIdx = 0;     // Index of fixed time trajectory generation within the batch.
+uint32_t FTMotion::traj_consumeIdx = 0,         // Index of fixed time trajectory generation of the overall block.
+         FTMotion::traj_produceIdx = 0;         // Index of fixed time trajectory generation within the batch.
 
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
+xyze_long_t FTMotion::step_error_q10 = { 0 };   // fractional remainder in q10.21 format
+xyze_float_t FTMotion::last_consumed_traj_point = { 0 };  // The last point before current (i.e traj[traj_consumeIdx - 1])
+
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
@@ -141,7 +144,7 @@ void FTMotion::loop() {
     stepper.abort_current_block = false;  // Abort finished.
   }
 
-  while (!blockProcRdy && (stepper.current_block = planner.get_current_block())) {
+  while (!isBlockInProgress && (stepper.current_block = planner.get_current_block())) {
     if (stepper.current_block->is_sync()) {     // Sync block?
       if (stepper.current_block->is_sync_pos()) // Position sync? Set the position.
         stepper._set_position(stepper.current_block->position);
@@ -156,6 +159,7 @@ void FTMotion::loop() {
     // triggered endstop, which shortly marks the block for discard.
     endstops.update();
 
+    isBlockInProgress = true;
     // Some kinematics track axis motion in HX, HY, HZ
     #if ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)
       stepper.last_direction_bits.hx = stepper.current_block->direction_bits.hx;
@@ -168,22 +172,19 @@ void FTMotion::loop() {
     #endif
   }
 
-  if (blockProcRdy) {
-
-    if (!batchRdy) makeVector(); // may clear blockProcRdy
-
-    // Check if the block has been completely converted:
-    if (!blockProcRdy) {
+  if (isBlockInProgress) {
+    if (!isTrajBufferFull) generateTrajectoryPointsFromBlock(); 
+    if (!isBlockInProgress) {
       discard_planner_block_protected();
-      if (!batchRdy && !planner.has_blocks_queued()) {
+      if (!isTrajBufferFull && !planner.has_blocks_queued()) {
         runoutBlock();
-        makeVector(); // Additional call to guarantee batchRdy is set this loop.
+        generateTrajectoryPointsFromBlock(); // Additional call to guarantee isTrajBufferFull is set this loop.
       }
     }
   }
 
   // FBS / post processing.
-  if (batchRdy && !batchRdyForInterp) {
+  if (isTrajBufferFull && !isTrajBufferPostProcessed) {
 
     // Call Ulendo FBS here.
 
@@ -200,23 +201,23 @@ void FTMotion::loop() {
     #endif
 
     // ... data is ready in trajMod.
-    batchRdyForInterp = true;
+    isTrajBufferPostProcessed = true;
 
-    batchRdy = false; // Clear so makeVector() can resume generating points.
+    isTrajBufferFull = false; // Clear so generateTrajectoryPointsFromBlock() can resume generating points.
   }
 
   // Interpolation (generation of step commands from fixed time trajectory).
-  while (batchRdyForInterp
+  while (isTrajBufferPostProcessed
     && (stepperCmdBuffItems() < (FTM_STEPPERCMD_BUFF_SIZE) - (FTM_STEPS_PER_UNIT_TIME))) {
-    convertToSteps(interpIdx);
+    generateStepsFromTrajectory(interpIdx);
     if (++interpIdx == FTM_BATCH_SIZE) {
-      batchRdyForInterp = false;
+      isTrajBufferPostProcessed = false;
       interpIdx = 0;
     }
   }
 
   // Report busy status to planner.
-  busy = (stepperCmdBuffHasData || blockProcRdy || batchRdy || batchRdyForInterp);
+  busy = (stepperCmdBuffHasData || isBlockInProgress || isTrajBufferFull || isTrajBufferPostProcessed);
 
 }
 
@@ -380,14 +381,16 @@ void FTMotion::reset() {
 
   traj.reset();
 
-  blockProcRdy = batchRdy = batchRdyForInterp = false;
+  isBlockInProgress = isTrajBufferFull = isTrajBufferPostProcessed = false;
 
   endPos_prevBlock.reset();
 
-  makeVector_idx = 0;
-  makeVector_batchIdx = TERN(FTM_UNIFIED_BWS, 0, _MIN(BATCH_SIDX_IN_WINDOW, FTM_BATCH_SIZE));
+  traj_consumeIdx = 0;
+  traj_produceIdx = TERN(FTM_UNIFIED_BWS, 0, _MIN(BATCH_SIDX_IN_WINDOW, FTM_BATCH_SIZE));
 
   steps.reset();
+  step_error_q10.reset();
+  last_consumed_traj_point.reset();
   interpIdx = 0;
 
   #if HAS_FTM_SHAPING
@@ -429,7 +432,7 @@ void FTMotion::runoutBlock() {
   startPos = endPos_prevBlock;
   ratio.reset();
 
-  const int32_t n_to_fill_batch = (FTM_WINDOW_SIZE) - makeVector_batchIdx;
+  const int32_t n_to_fill_batch = (FTM_WINDOW_SIZE) - traj_produceIdx;
 
   // This line or function is to be modified for FBS use; do not optimize out.
   const int32_t n_to_settle_shaper = num_samples_shaper_settle();
@@ -439,7 +442,7 @@ void FTMotion::runoutBlock() {
 
   max_intervals =  PROP_BATCHES * (FTM_BATCH_SIZE) + n_to_settle_shaper + n_to_fill_batch_after_settling;
 
-  blockProcRdy = true;
+  isBlockInProgress = true;
 }
 
 // Auxiliary function to get number of step commands in the buffer.
@@ -463,16 +466,14 @@ void FTMotion::loadBlockData(block_t * const current_block) {
               oneOverLength = 1.0f / totalLength;
 
   startPos = endPos_prevBlock;
-
   const xyze_pos_t& moveDist = current_block->dist_mm;
-
   ratio = moveDist * oneOverLength;
 
-  const float spm = totalLength / current_block->step_event_count;  // (steps/mm) Distance for each step
+  const float steps_per_mm = totalLength / current_block->step_event_count;  // (steps/mm) Distance for each step
 
-  f_s = spm * current_block->initial_rate;              // (steps/s) Start feedrate
+  f_s = steps_per_mm * current_block->initial_rate;              // (steps/s) Start feedrate
 
-  const float f_e = spm * current_block->final_rate;    // (steps/s) End feedrate
+  const float f_e = steps_per_mm * current_block->final_rate;    // (steps/s) End feedrate
 
   /* Keep for comprehension
   const float a = current_block->acceleration,          // (mm/s^2) Same magnitude for acceleration or deceleration
@@ -563,20 +564,20 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 }
 
 // Generate data points of the trajectory.
-void FTMotion::makeVector() {
+void FTMotion::generateTrajectoryPointsFromBlock() {
   do {
-    float tau = (makeVector_idx + 1) * (FTM_TS);          // (s) Time since start of block
+    float tau = (traj_consumeIdx + 1) * (FTM_TS);          // (s) Time since start of block
     float dist = 0.0f;                                    // (mm) Distance traveled
     #if HAS_EXTRUDERS
       float accel_k = 0.0f;                               // (mm/s^2) Acceleration K factor
     #endif
 
-    if (makeVector_idx < N1) {
+    if (traj_consumeIdx < N1) {
       // Acceleration phase
       dist = (f_s * tau) + (0.5f * accel_P * sq(tau));    // (mm) Distance traveled for acceleration phase since start of block
       TERN_(HAS_EXTRUDERS, accel_k = accel_P);            // (mm/s^2) Acceleration K factor from Accel phase
     }
-    else if (makeVector_idx < (N1 + N2)) {
+    else if (traj_consumeIdx < (N1 + N2)) {
       // Coasting phase
       dist = s_1e + F_P * (tau - N1 * (FTM_TS));          // (mm) Distance traveled for coasting phase since start of block
       //TERN_(HAS_EXTRUDERS, accel_k = 0.0f);
@@ -588,17 +589,17 @@ void FTMotion::makeVector() {
       TERN_(HAS_EXTRUDERS, accel_k = decel_P);            // (mm/s^2) Acceleration K factor from Decel phase
     }
 
-    #define _SET_TRAJ(q) traj.q[makeVector_batchIdx] = startPos.q + ratio.q * dist;
+    #define _SET_TRAJ(q) traj.q[traj_produceIdx] = startPos.q + ratio.q * dist;
     LOGICAL_AXIS_MAP_LC(_SET_TRAJ);
 
     #if HAS_EXTRUDERS
       if (cfg.linearAdvEna) {
-        float dedt_adj = (traj.e[makeVector_batchIdx] - e_raw_z1) * (FTM_FS);
+        float dedt_adj = (traj.e[traj_produceIdx] - e_raw_z1) * (FTM_FS);
         if (ratio.e > 0.0f) dedt_adj += accel_k * cfg.linearAdvK * 0.0001f;
 
-        e_raw_z1 = traj.e[makeVector_batchIdx];
+        e_raw_z1 = traj.e[traj_produceIdx];
         e_advanced_z1 += dedt_adj * (FTM_TS);
-        traj.e[makeVector_batchIdx] = e_advanced_z1;
+        traj.e[traj_produceIdx] = e_advanced_z1;
       }
     #endif
 
@@ -609,7 +610,7 @@ void FTMotion::makeVector() {
       #if HAS_DYNAMIC_FREQ_MM
         case dynFreqMode_Z_BASED: {
           static float oldz = 0.0f;
-          const float z = traj.z[makeVector_batchIdx];
+          const float z = traj.z[traj_produceIdx];
           if (z != oldz) { // Only update if Z changed.
             oldz = z;
             #if HAS_X_AXIS
@@ -629,10 +630,10 @@ void FTMotion::makeVector() {
           // Update constantly. The optimization done for Z value makes
           // less sense for E, as E is expected to constantly change.
           #if HAS_X_AXIS
-            shaping.x.set_axis_shaping_N(cfg.shaper.x, cfg.baseFreq.x + cfg.dynFreqK.x * traj.e[makeVector_batchIdx], cfg.zeta.x);
+            shaping.x.set_axis_shaping_N(cfg.shaper.x, cfg.baseFreq.x + cfg.dynFreqK.x * traj.e[traj_produceIdx], cfg.zeta.x);
           #endif
           #if HAS_Y_AXIS
-            shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y + cfg.dynFreqK.y * traj.e[makeVector_batchIdx], cfg.zeta.y);
+            shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y + cfg.dynFreqK.y * traj.e[traj_produceIdx], cfg.zeta.y);
           #endif
           break;
       #endif
@@ -644,22 +645,22 @@ void FTMotion::makeVector() {
     #if HAS_FTM_SHAPING
       #if HAS_X_AXIS
         if (shaping.x.ena) {
-          shaping.x.d_zi[shaping.zi_idx] = traj.x[makeVector_batchIdx];
-          traj.x[makeVector_batchIdx] *= shaping.x.Ai[0];
+          shaping.x.d_zi[shaping.zi_idx] = traj.x[traj_produceIdx];
+          traj.x[traj_produceIdx] *= shaping.x.Ai[0];
           for (uint32_t i = 1U; i <= shaping.x.max_i; i++) {
             const uint32_t udiffx = shaping.zi_idx - shaping.x.Ni[i];
-            traj.x[makeVector_batchIdx] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
+            traj.x[traj_produceIdx] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
           }
         }
       #endif
 
       #if HAS_Y_AXIS
         if (shaping.y.ena) {
-          shaping.y.d_zi[shaping.zi_idx] = traj.y[makeVector_batchIdx];
-          traj.y[makeVector_batchIdx] *= shaping.y.Ai[0];
+          shaping.y.d_zi[shaping.zi_idx] = traj.y[traj_produceIdx];
+          traj.y[traj_produceIdx] *= shaping.y.Ai[0];
           for (uint32_t i = 1U; i <= shaping.y.max_i; i++) {
             const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
-            traj.y[makeVector_batchIdx] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
+            traj.y[traj_produceIdx] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
           }
         }
       #endif
@@ -667,86 +668,59 @@ void FTMotion::makeVector() {
     #endif // HAS_FTM_SHAPING
 
     // Filled up the queue with regular and shaped steps
-    if (++makeVector_batchIdx == FTM_WINDOW_SIZE) {
-      makeVector_batchIdx = BATCH_SIDX_IN_WINDOW;
-      batchRdy = true;
+    if (++traj_produceIdx == FTM_WINDOW_SIZE) {
+      traj_produceIdx = BATCH_SIDX_IN_WINDOW;
+      isTrajBufferFull = true;
     }
 
-    if (++makeVector_idx == max_intervals) {
-      blockProcRdy = false;
-      makeVector_idx = 0;
+    if (++traj_consumeIdx == max_intervals) {
+      isBlockInProgress = false;
+      traj_consumeIdx = 0;
     }
-  } while (blockProcRdy && !batchRdy);
+  } while (isBlockInProgress && !isTrajBufferFull);
 }
 
-/**
- * Convert to steps
- * - Commands are written in a bitmask with step and dir as single bits.
- * - Tests for delta are moved outside the loop.
- * - Two functions are used for command computation with an array of function pointers.
- */
-static void (*command_set[LOGICAL_AXES])(int32_t&, int32_t&, ft_command_t&, int32_t, int32_t);
+// Interpolates a single trajectory data point into stepper commands.
+void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
+  #define TOSTEPS_q10(A, B)                                                    \
+    int32_t((trajMod.A[idx] - last_consumed_traj_point.A) *                       \
+            planner.settings.axis_steps_per_mm[B] * (1 << 10))
+  xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
+    TOSTEPS_q10(e, block_extruder_axis),
+    TOSTEPS_q10(x, X_AXIS), TOSTEPS_q10(y, Y_AXIS), TOSTEPS_q10(z, Z_AXIS),
+    TOSTEPS_q10(i, I_AXIS), TOSTEPS_q10(j, J_AXIS), TOSTEPS_q10(k, K_AXIS),
+    TOSTEPS_q10(u, U_AXIS), TOSTEPS_q10(v, V_AXIS), TOSTEPS_q10(w, W_AXIS)
+  );
+  #define SET_LAST(A) last_consumed_traj_point.A = trajMod.A[idx];
+  LOGICAL_AXIS_MAP(SET_LAST)
 
-static void command_set_pos(int32_t &e, int32_t &s, ft_command_t &b, int32_t bd, int32_t bs) {
-  if (e < FTM_CTS_COMPARE_VAL) return;
-  s++;
-  b |= bd | bs;
-  e -= FTM_STEPS_PER_UNIT_TIME;
-}
+  const int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;
 
-static void command_set_neg(int32_t &e, int32_t &s, ft_command_t &b, int32_t bd, int32_t bs) {
-  if (e > -(FTM_CTS_COMPARE_VAL)) return;
-  s--;
-  b |= bs;
-  e += FTM_STEPS_PER_UNIT_TIME;
-}
-
-// Interpolates single data point to stepper commands.
-void FTMotion::convertToSteps(const uint32_t idx) {
-  xyze_long_t err_P = { 0 };
-
-  //#define STEPS_ROUNDING
-  #if ENABLED(STEPS_ROUNDING)
-    #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] + (trajMod.A[idx] < 0.0f ? -0.5f : 0.5f))
-    const xyze_long_t steps_tar = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, block_extruder_axis), // May be eliminated if guaranteed positive.
-      TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
-      TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
-      TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)
-    );
-    xyze_long_t delta = steps_tar - steps;
-  #else
-    #define TOSTEPS(A,B) int32_t(trajMod.A[idx] * planner.settings.axis_steps_per_mm[B]) - steps.A
-    xyze_long_t delta = LOGICAL_AXIS_ARRAY(
-      TOSTEPS(e, block_extruder_axis),
-      TOSTEPS(x, X_AXIS), TOSTEPS(y, Y_AXIS), TOSTEPS(z, Z_AXIS),
-      TOSTEPS(i, I_AXIS), TOSTEPS(j, J_AXIS), TOSTEPS(k, K_AXIS),
-      TOSTEPS(u, U_AXIS), TOSTEPS(v, V_AXIS), TOSTEPS(w, W_AXIS)
-    );
-  #endif
-
-  #define _COMMAND_SET(AXIS) command_set[_AXIS(AXIS)] = delta[_AXIS(AXIS)] >= 0 ? command_set_pos : command_set_neg;
-  LOGICAL_AXIS_MAP(_COMMAND_SET);
-
-  for (uint32_t i = 0U; i < (FTM_STEPS_PER_UNIT_TIME); i++) {
-
-    ft_command_t &cmd = stepperCmdBuff[stepperCmdBuff_produceIdx];
-
-    // Init all step/dir bits to 0 (defaulting to reverse/negative motion)
+  for (uint32_t i = 0; i < (uint32_t)FTM_STEPS_PER_UNIT_TIME; i++) {
+    ft_command_t& cmd = stepperCmdBuff[stepperCmdBuff_produceIdx];
     cmd = 0;
+    step_error_q10 += delta_q10;
 
-    // Accumulate the errors for all axes
-    err_P += delta;
+  #define RUN_AXIS(A)                                                          \
+    do {                                                                       \
+      if (step_error_q10.A >= denom_q10) {                                     \
+        steps.A++;                                                             \
+        cmd |= _BV(FT_BIT_DIR_##A) | _BV(FT_BIT_STEP_##A);                     \
+        step_error_q10.A -= denom_q10;                                         \
+      }                                                                        \
+      if (step_error_q10.A <= -denom_q10) {                                    \
+        steps.A--;                                                             \
+        cmd |= _BV(FT_BIT_STEP_##A); /* neg dir implicit */                    \
+        step_error_q10.A += denom_q10;                                         \
+      }                                                                        \
+    } while (0);
 
-    // Set up step/dir bits for all axes
-    #define _COMMAND_RUN(A) command_set[_AXIS(A)](err_P.A, steps.A, cmd, _BV(FT_BIT_DIR_##A), _BV(FT_BIT_STEP_##A));
-    LOGICAL_AXIS_MAP(_COMMAND_RUN);
+    LOGICAL_AXIS_MAP(RUN_AXIS)
 
-    // Next circular buffer index
-    if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE))
+    if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE)) {
       stepperCmdBuff_produceIdx = 0;
-
-  } // FTM_STEPS_PER_UNIT_TIME loop
+    }
+  }
 }
 
 #endif // FT_MOTION

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -53,7 +53,7 @@ AxisBits FTMotion::axis_move_dir;
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
 
-bool FTMotion::isBlockInProgress = false;       // Set when new block data is loaded from stepper module into FTM,
+bool FTMotion::blockProcRdy = false;            // Set when new block data is loaded from stepper module into FTM,
                                                 // and reset when block is completely converted to FTM trajectory.
 bool FTMotion::isTrajBufferFull = false;        // Indicates a batch of the fixed time trajectory
                                                 // has been generated, is now available in the upper -
@@ -87,8 +87,7 @@ uint32_t FTMotion::traj_consumeIdx = 0,         // Index of fixed time trajector
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
 xyze_long_t FTMotion::step_error_q10 = { 0 };   // fractional remainder in q10.21 format
-xyze_float_t FTMotion::last_consumed_traj_point = { 0 };  // The last point before current (i.e traj[traj_consumeIdx - 1])
-
+xyze_float_t FTMotion::last_consumed_traj_point = { 0 };  // The last point before current (i.e., traj[traj_consumeIdx - 1])
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
@@ -144,7 +143,7 @@ void FTMotion::loop() {
     stepper.abort_current_block = false;  // Abort finished.
   }
 
-  while (!isBlockInProgress && (stepper.current_block = planner.get_current_block())) {
+  while (!blockProcRdy && (stepper.current_block = planner.get_current_block())) {
     if (stepper.current_block->is_sync()) {     // Sync block?
       if (stepper.current_block->is_sync_pos()) // Position sync? Set the position.
         stepper._set_position(stepper.current_block->position);
@@ -159,7 +158,6 @@ void FTMotion::loop() {
     // triggered endstop, which shortly marks the block for discard.
     endstops.update();
 
-    isBlockInProgress = true;
     // Some kinematics track axis motion in HX, HY, HZ
     #if ANY(CORE_IS_XY, CORE_IS_XZ, MARKFORGED_XY, MARKFORGED_YX)
       stepper.last_direction_bits.hx = stepper.current_block->direction_bits.hx;
@@ -172,9 +170,9 @@ void FTMotion::loop() {
     #endif
   }
 
-  if (isBlockInProgress) {
-    if (!isTrajBufferFull) generateTrajectoryPointsFromBlock(); 
-    if (!isBlockInProgress) {
+  if (blockProcRdy) {
+    if (!isTrajBufferFull) generateTrajectoryPointsFromBlock(); // may clear blockProcRdy
+    if (!blockProcRdy) {
       discard_planner_block_protected();
       if (!isTrajBufferFull && !planner.has_blocks_queued()) {
         runoutBlock();
@@ -217,7 +215,7 @@ void FTMotion::loop() {
   }
 
   // Report busy status to planner.
-  busy = (stepperCmdBuffHasData || isBlockInProgress || isTrajBufferFull || isTrajBufferPostProcessed);
+  busy = (stepperCmdBuffHasData || blockProcRdy || isTrajBufferFull || isTrajBufferPostProcessed);
 
 }
 
@@ -381,7 +379,7 @@ void FTMotion::reset() {
 
   traj.reset();
 
-  isBlockInProgress = isTrajBufferFull = isTrajBufferPostProcessed = false;
+  blockProcRdy = isTrajBufferFull = isTrajBufferPostProcessed = false;
 
   endPos_prevBlock.reset();
 
@@ -442,7 +440,7 @@ void FTMotion::runoutBlock() {
 
   max_intervals =  PROP_BATCHES * (FTM_BATCH_SIZE) + n_to_settle_shaper + n_to_fill_batch_after_settling;
 
-  isBlockInProgress = true;
+  blockProcRdy = true;
 }
 
 // Auxiliary function to get number of step commands in the buffer.
@@ -566,7 +564,7 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 // Generate data points of the trajectory.
 void FTMotion::generateTrajectoryPointsFromBlock() {
   do {
-    float tau = (traj_consumeIdx + 1) * (FTM_TS);          // (s) Time since start of block
+    float tau = (traj_consumeIdx + 1) * (FTM_TS);         // (s) Time since start of block
     float dist = 0.0f;                                    // (mm) Distance traveled
     #if HAS_EXTRUDERS
       float accel_k = 0.0f;                               // (mm/s^2) Acceleration K factor
@@ -674,16 +672,22 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
     }
 
     if (++traj_consumeIdx == max_intervals) {
-      isBlockInProgress = false;
+      blockProcRdy = false;
       traj_consumeIdx = 0;
     }
-  } while (isBlockInProgress && !isTrajBufferFull);
-}
+  } while (blockProcRdy && !isTrajBufferFull);
+} // generateTrajectoryPointsFromBlock
 
-// Interpolates a single trajectory data point into stepper commands.
+/**
+ * Interpolate a single trajectory data point into stepper commands.
+ * @param idx The index of the trajectory point to convert.
+ * This function calculates the required stepper movements for each axis
+ * based on the difference between the current and previous trajectory points,
+ * and fills the stepper command buffer with the appropriate step and direction bits.
+ */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
-  #define TOSTEPS_q10(A, B)                                                    \
-    int32_t((trajMod.A[idx] - last_consumed_traj_point.A) *                       \
+  #define TOSTEPS_q10(A, B) \
+    int32_t((trajMod.A[idx] - last_consumed_traj_point.A) *  \
             planner.settings.axis_steps_per_mm[B] * (1 << 10))
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),
@@ -696,30 +700,27 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
 
   const int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;
 
+  #define RUN_AXIS(A)                                       \
+    do {                                                    \
+      if (step_error_q10.A >= denom_q10) {                  \
+        steps.A++;                                          \
+        cmd |= _BV(FT_BIT_DIR_##A) | _BV(FT_BIT_STEP_##A);  \
+        step_error_q10.A -= denom_q10;                      \
+      }                                                     \
+      if (step_error_q10.A <= -denom_q10) {                 \
+        steps.A--;                                          \
+        cmd |= _BV(FT_BIT_STEP_##A); /* neg dir implicit */ \
+        step_error_q10.A += denom_q10;                      \
+      }                                                     \
+    } while (0);
+
   for (uint32_t i = 0; i < (uint32_t)FTM_STEPS_PER_UNIT_TIME; i++) {
     ft_command_t& cmd = stepperCmdBuff[stepperCmdBuff_produceIdx];
     cmd = 0;
     step_error_q10 += delta_q10;
-
-  #define RUN_AXIS(A)                                                          \
-    do {                                                                       \
-      if (step_error_q10.A >= denom_q10) {                                     \
-        steps.A++;                                                             \
-        cmd |= _BV(FT_BIT_DIR_##A) | _BV(FT_BIT_STEP_##A);                     \
-        step_error_q10.A -= denom_q10;                                         \
-      }                                                                        \
-      if (step_error_q10.A <= -denom_q10) {                                    \
-        steps.A--;                                                             \
-        cmd |= _BV(FT_BIT_STEP_##A); /* neg dir implicit */                    \
-        step_error_q10.A += denom_q10;                                         \
-      }                                                                        \
-    } while (0);
-
-    LOGICAL_AXIS_MAP(RUN_AXIS)
-
-    if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE)) {
+    LOGICAL_AXIS_MAP(RUN_AXIS);
+    if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE))
       stepperCmdBuff_produceIdx = 0;
-    }
   }
 }
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -87,7 +87,6 @@ uint32_t FTMotion::traj_consumeIdx = 0,         // Index of fixed time trajector
 // Interpolation variables.
 xyze_long_t FTMotion::steps = { 0 };            // Step count accumulator.
 xyze_long_t FTMotion::step_error_q10 = { 0 };   // Fractional remainder in q10.21 format
-xyze_float_t FTMotion::prev_traj_point = { 0 }; // Last-added trajectory point (i.e., traj[traj_consumeIdx - 1])
 
 uint32_t FTMotion::interpIdx = 0;               // Index of current data point being interpolated.
 
@@ -391,7 +390,6 @@ void FTMotion::reset() {
 
   steps.reset();
   step_error_q10.reset();
-  prev_traj_point.reset();
   interpIdx = 0;
 
   #if HAS_FTM_SHAPING
@@ -689,22 +687,24 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
  * Add up to one stepper command to the buffer with STEP/DIR bits for all axes.
  */
 void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
-  // Round to nearest to avoid truncation’s sign bias.
-  // Merely truncating drops the first small increment after a direction flip,
-  // which shows up as a missing step. Rounding prevents that.
-  #define TOSTEPS_q10(A, B) \
-    LROUND((trajMod.A[idx] - prev_traj_point.A) * \
-            planner.settings.axis_steps_per_mm[B] * _BV(10))
+  constexpr float INV_FTM_STEPS_PER_UNIT_TIME = (1.0 / FTM_STEPS_PER_UNIT_TIME);
+
+  // q10 per-stepper-slot increment toward this sample’s target step count.
+  // (traj*spm - steps) = steps still due by the end of this UNIT_TIME.
+  // Convert to q10 (×2^10), then subtract the current accumulator error: step_error_q10 / FTM_STEPS_PER_UNIT_TIME.
+  // Over FTM_STEPS_PER_UNIT_TIME stepper-slots this sums to the exact target (no drift).
+  // Any fraction of a step that may remain will be accounted for by the next UNIT_TIME
+  #define TOSTEPS_q10(A, B) int32_t( \
+      (trajMod.A[idx] * planner.settings.axis_steps_per_mm[B] - steps.A) * _BV(10) - \
+      step_error_q10.A * INV_FTM_STEPS_PER_UNIT_TIME \
+    )
+
   xyze_long_t delta_q10 = LOGICAL_AXIS_ARRAY(
     TOSTEPS_q10(e, block_extruder_axis),
     TOSTEPS_q10(x, X_AXIS), TOSTEPS_q10(y, Y_AXIS), TOSTEPS_q10(z, Z_AXIS),
     TOSTEPS_q10(i, I_AXIS), TOSTEPS_q10(j, J_AXIS), TOSTEPS_q10(k, K_AXIS),
     TOSTEPS_q10(u, U_AXIS), TOSTEPS_q10(v, V_AXIS), TOSTEPS_q10(w, W_AXIS)
   );
-
-  // Remember this trajectory point for the next call
-  #define SET_PREV(A) prev_traj_point.A = trajMod.A[idx];
-  LOGICAL_AXIS_MAP(SET_PREV);
 
   // Fixed-point denominator for step accumulation
   constexpr int32_t denom_q10 = (FTM_STEPS_PER_UNIT_TIME) << 10;

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -141,8 +141,8 @@ class FTMotion {
     static xyze_trajectory_t traj;
     static xyze_trajectoryMod_t trajMod;
 
-    static bool blockProcRdy;
-    static bool batchRdy, batchRdyForInterp;
+    static bool isBlockInProgress;
+    static bool isTrajBufferFull, isTrajBufferPostProcessed;
 
     // Trapezoid data variables.
     static xyze_pos_t   startPos,         // (mm) Start position of block
@@ -160,14 +160,16 @@ class FTMotion {
     // Number of batches needed to propagate the current trajectory to the stepper.
     static constexpr uint32_t PROP_BATCHES = CEIL((FTM_WINDOW_SIZE) / (FTM_BATCH_SIZE)) - 1;
 
-    // Make vector variables.
-    static uint32_t makeVector_idx,
-                    makeVector_batchIdx;
+    // generateTrajectoryPointsFromBlock variables.
+    static uint32_t traj_consumeIdx,
+                    traj_produceIdx;
 
     // Interpolation variables.
     static uint32_t interpIdx;
 
     static xyze_long_t steps;
+    static xyze_long_t step_error_q10; 
+    static xyze_float_t last_consumed_traj_point; 
 
     #if ENABLED(DISTINCT_E_FACTORS)
       static uint8_t block_extruder_axis;  // Cached extruder axis index
@@ -214,8 +216,8 @@ class FTMotion {
     static void runoutBlock();
     static int32_t stepperCmdBuffItems();
     static void loadBlockData(block_t *const current_block);
-    static void makeVector();
-    static void convertToSteps(const uint32_t idx);
+    static void generateTrajectoryPointsFromBlock();
+    static void generateStepsFromTrajectory(const uint32_t idx);
 
     FORCE_INLINE static int32_t num_samples_shaper_settle() { return ( shaping.x.ena || shaping.y.ena ) ? FTM_ZMAX : 0; }
 

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -161,8 +161,8 @@ class FTMotion {
     static constexpr uint32_t PROP_BATCHES = CEIL((FTM_WINDOW_SIZE) / (FTM_BATCH_SIZE)) - 1;
 
     // generateTrajectoryPointsFromBlock variables.
-    static uint32_t traj_consumeIdx,
-                    traj_produceIdx;
+    static uint32_t traj_idx_get,
+                    traj_idx_set;
 
     // Interpolation variables.
     static uint32_t interpIdx;

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -169,7 +169,6 @@ class FTMotion {
 
     static xyze_long_t steps;
     static xyze_long_t step_error_q10;
-    static xyze_float_t prev_traj_point;
 
     #if ENABLED(DISTINCT_E_FACTORS)
       static uint8_t block_extruder_axis;  // Cached extruder axis index

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -141,7 +141,7 @@ class FTMotion {
     static xyze_trajectory_t traj;
     static xyze_trajectoryMod_t trajMod;
 
-    static bool isBlockInProgress;
+    static bool blockProcRdy;
     static bool isTrajBufferFull, isTrajBufferPostProcessed;
 
     // Trapezoid data variables.

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -168,8 +168,8 @@ class FTMotion {
     static uint32_t interpIdx;
 
     static xyze_long_t steps;
-    static xyze_long_t step_error_q10; 
-    static xyze_float_t last_consumed_traj_point; 
+    static xyze_long_t step_error_q10;
+    static xyze_float_t prev_traj_point;
 
     #if ENABLED(DISTINCT_E_FACTORS)
       static uint8_t block_extruder_axis;  // Cached extruder axis index

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -142,7 +142,7 @@ class FTMotion {
     static xyze_trajectoryMod_t trajMod;
 
     static bool blockProcRdy;
-    static bool isTrajBufferFull, isTrajBufferPostProcessed;
+    static bool batchRdy, batchRdyForInterp;
 
     // Trapezoid data variables.
     static xyze_pos_t   startPos,         // (mm) Start position of block


### PR DESCRIPTION
### Description

FTMotion is very noisy, and a logic analyser shows very clearly how it fails to generate a constant pulse rate:
<img width="2615" height="1283" alt="image" src="https://github.com/user-attachments/assets/9606b142-bf03-425b-a5a0-e5a76bff9608" />

It's expected that it generates two rate bands since it can only produce rates which are an integer fraction of FTM_STEPPER_FS, but it shouldn't generate half a dozen.

There were 3 main problems:

1. Bresenham error is reset between slices (i.e trajectory points). This changes the phase of the pulse train on every FTM_TS seconds (default setting is 1 millisecond). This is somewhat hidden by stepping only when the error crosses FTM_CTS_COMPARE_VAL (so it steps at half a denominator), but that still makes uneven rates.
2. The bresenham nominator (delta) is calculated as `traj[idx]*steps_per_mm - steps`, so any error accumulated in one slice is compensated by going faster in the next one. The correct way is to rely on a persistent (static) fractional error variable.
3. The bresenham nominator (delta) is calculated per slice (1 ms) as an integer, so at low speeds it has awful resolution. This accumulates error across the whole slice (goes too slow) which is then also corrected in the next one by going too fast. For example, if at slow speeds, an axis travels at 2.5 steps per slice, it will do only 2 in the first one, and then it will do 3 in the next one and so on.


This PR fixes them like this:
1. Keep bresenham error vector across slices (static variable)
2. Calculate delta as `(traj[idx] - traj[idx-1]) * steps_per_mm`, this way rates are consistent across slices. Step error doesn't accumulate since it is kept across slices. ~~The only disadvantage is that after any move we may be ±1 step away from the target, but that only happens once per direction change so it doesn't accumulate.~~ **FIXED**
3. Use a scaler for the  bresenham nominator and denominator to increase resolution (1<<10)

As a bonus I also:
1. Renamed variables and functions to be more representative. This also makes many comments unnecessary. I would have let them as they were, but I was having a hard time understanding the code.
2. Also refactored the macros in the function that generates the stepper commands, which were very hard to follow. They should be slightly more efficient too since there's no function call indirections anymore.


### Result

<img width="1636" height="1590" alt="image" src="https://github.com/user-attachments/assets/29165790-1c98-42f3-ad79-3709ff429e99" />
<img width="860" height="854" alt="image" src="https://github.com/user-attachments/assets/5884480f-f3fc-4578-a6a2-cac8c116eff4" />

Rates are constant (only the expected 2 bands) and steppers are silent.

Note: The fact that each band jumps a tiny bit is just quantisation error in my logic analyzer. It goes away if I use higher acquisition rate. All pulse trains show very good consistency on each of the (maximum) two bands.

### Requirements

Enable FTMotioon

### Benefits

Silent steppers that don't resonate and cause layer shifts

### Configurations

#define FT_MOTION

### Related Issues

Solves [#ft_motion](https://github.com/MarlinFirmware/Marlin/issues/27344)
