### PR TITLE
update HAS_MARLINUI_U8GLIB to point to latest U8glib-HAL

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -39,7 +39,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_LCDPRINT                           = build_src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = build_src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = U8glib-HAL=https://github.com/marlinfirmware/U8glib-HAL/archive/96a554280d.zip
+HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@v0.5.5
                                          build_src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = build_src_filter=+<src/lcd/tft_io>
 I2C_EEPROM                             = build_src_filter=+<src/HAL/shared/eeprom_if_i2c.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -39,7 +39,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_LCDPRINT                           = build_src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = build_src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@0.5.4
+HAS_MARLINUI_U8GLIB                    = U8glib-HAL=https://github.com/marlinfirmware/U8glib-HAL/archive/96a554280d.zip
                                          build_src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = build_src_filter=+<src/lcd/tft_io>
 I2C_EEPROM                             = build_src_filter=+<src/HAL/shared/eeprom_if_i2c.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -39,7 +39,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_LCDPRINT                           = build_src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = build_src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@v0.5.5
+HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@0.5.5
                                          build_src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = build_src_filter=+<src/lcd/tft_io>
 I2C_EEPROM                             = build_src_filter=+<src/HAL/shared/eeprom_if_i2c.cpp>


### PR DESCRIPTION
### Description

MFL GD32 support was added to U8glib-HAL some time ago, but Marlin was not updated to use it.

Since no version numbers changed I have switched to using commit hash vs version number.

addresses issue https://github.com/MarlinFirmware/Marlin/issues/27775

### Requirements

MFL GD32 

### Benefits

MFL GD32  with U8GLIB-HAL builds

### Related Issues

<li>MarlinFirmware/U8glib-HAL/pull/35
<li>MarlinFirmware/Marlin/issues/27775
<li>MarlinFirmware/Marlin/issues/28010
