### PR TITLE
FTMotion Z input shaping [merged into #28055]

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1152,15 +1152,19 @@
   #define FTM_DEFAULT_DYNFREQ_MODE dynFreqMode_DISABLED // Default mode of dynamic frequency calculation. (DISABLED, Z_BASED, MASS_BASED)
   #define FTM_DEFAULT_SHAPER_X      ftMotionShaper_NONE // Default shaper mode on X axis (NONE, ZV, ZVD, ZVDD, ZVDDD, EI, 2HEI, 3HEI, MZV)
   #define FTM_DEFAULT_SHAPER_Y      ftMotionShaper_NONE // Default shaper mode on Y axis
+  #define FTM_DEFAULT_SHAPER_Z      ftMotionShaper_NONE // Default shaper mode on Z axis
   #define FTM_SHAPING_DEFAULT_FREQ_X   37.0f      // (Hz) Default peak frequency used by input shapers
   #define FTM_SHAPING_DEFAULT_FREQ_Y   37.0f      // (Hz) Default peak frequency used by input shapers
+  #define FTM_SHAPING_DEFAULT_FREQ_Z   21.0f      // (Hz) Default peak frequency used by input shapers
   #define FTM_LINEAR_ADV_DEFAULT_ENA   false      // Default linear advance enable (true) or disable (false)
   #define FTM_LINEAR_ADV_DEFAULT_K      0.0f      // Default linear advance gain. (Acceleration-based scaling factor.)
   #define FTM_SHAPING_ZETA_X            0.1f      // Zeta used by input shapers for X axis
   #define FTM_SHAPING_ZETA_Y            0.1f      // Zeta used by input shapers for Y axis
+  #define FTM_SHAPING_ZETA_Z            0.03f     // Zeta used by input shapers for Z axis
 
   #define FTM_SHAPING_V_TOL_X           0.05f     // Vibration tolerance used by EI input shapers for X axis
   #define FTM_SHAPING_V_TOL_Y           0.05f     // Vibration tolerance used by EI input shapers for Y axis
+  #define FTM_SHAPING_V_TOL_Z           0.05f     // Vibration tolerance used by EI input shapers for Z axis
 
   //#define FT_MOTION_MENU                        // Provide a MarlinUI menu to set M493 parameters
 

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -54,6 +54,11 @@ void say_shaper_type(const AxisEnum a) {
 #else
   #define AXIS_1_NAME "Y"
 #endif
+#if CORE_IS_XZ || CORE_IS_YZ
+  #define AXIS_2_NAME "C"
+#else
+  #define AXIS_2_NAME "Z"
+#endif
 
 void say_shaping() {
   // FT Enabled
@@ -72,6 +77,12 @@ void say_shaping() {
       say_shaper_type(Y_AXIS);
     }
   #endif
+  #if HAS_Z_AXIS
+    if (AXIS_HAS_SHAPER(Z)) {
+      SERIAL_ECHOPGM(" and with " AXIS_2_NAME);
+      say_shaper_type(Z_AXIS);
+    }
+  #endif
 
   SERIAL_ECHOLNPGM(".");
 
@@ -80,7 +91,7 @@ void say_shaping() {
              dynamic = z_based || g_based;
 
   // FT Dynamic Frequency Mode
-  if (AXIS_HAS_SHAPER(X) || AXIS_HAS_SHAPER(Y)) {
+  if (AXIS_HAS_SHAPER(X) || AXIS_HAS_SHAPER(Y) || AXIS_HAS_SHAPER(Z)) {
     #if HAS_DYNAMIC_FREQ
       SERIAL_ECHOPGM("Dynamic Frequency Mode ");
       switch (ftMotion.cfg.dynFreqMode) {
@@ -113,6 +124,15 @@ void say_shaping() {
       #endif
       SERIAL_EOL();
     #endif
+
+    #if HAS_Z_AXIS
+      SERIAL_ECHO_TERNARY(dynamic, AXIS_2_NAME " ", "base dynamic", "static", " shaper frequency: ");
+      SERIAL_ECHO(p_float_t(ftMotion.cfg.baseFreq.z, 2), F(" Hz"));
+      #if HAS_DYNAMIC_FREQ
+        if (dynamic) SERIAL_ECHO(F(" scaling: "), p_float_t(ftMotion.cfg.dynFreqK.z, 2), F("Hz/"), z_based ? F("mm") : F("g"));
+      #endif
+      SERIAL_EOL();
+    #endif
   }
 
   #if HAS_EXTRUDERS
@@ -135,6 +155,9 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
     #if HAS_Y_AXIS
       SERIAL_ECHOPGM(" B", c.baseFreq.y);
     #endif
+    #if HAS_Z_AXIS
+      SERIAL_ECHOPGM(" C", c.baseFreq.z);
+    #endif
   #endif
   #if HAS_DYNAMIC_FREQ
     SERIAL_ECHOPGM(" D", c.dynFreqMode);
@@ -142,6 +165,9 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
       SERIAL_ECHOPGM(" F", c.dynFreqK.x);
       #if HAS_Y_AXIS
         SERIAL_ECHOPGM(" H", c.dynFreqK.y);
+      #endif
+      #if HAS_Z_AXIS
+        SERIAL_ECHOPGM(" L", c.dynFreqK.z);
       #endif
     #endif
   #endif
@@ -188,6 +214,11 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
  *    H<Hz> Set frequency scaling for the Y axis
  *    J 0.0   Set damping ratio for the Y axis
  *    R 0.00  Set the vibration tolerance for the Y axis
+ *
+ *    C<Hz> Set static/base frequency for the Z axis
+ *    L<Hz> Set frequency scaling for the Z axis
+ *    M 0.0   Set damping ratio for the Z axis
+ *    N 0.00  Set the vibration tolerance for the Z axis
  */
 void GcodeSuite::M493() {
   struct { bool update:1, report:1; } flag = { false };
@@ -205,7 +236,7 @@ void GcodeSuite::M493() {
     }
   }
 
-  #if HAS_X_AXIS
+  #if HAS_X_AXIS || HAS_Y_AXIS || HAS_Z_AXIS
     auto set_shaper = [&](const AxisEnum axis, const char c) {
       const ftMotionShaper_t newsh = (ftMotionShaper_t)parser.value_byte();
       if (newsh != ftMotion.cfg.shaper[axis]) {
@@ -228,13 +259,19 @@ void GcodeSuite::M493() {
       return false;
     };
 
-    if (parser.seenval('X') && set_shaper(X_AXIS, 'X')) return;    // Parse 'X' mode parameter
+    #if HAS_X_AXIS
+      if (parser.seenval('X') && set_shaper(X_AXIS, 'X')) return;    // Parse 'X' mode parameter
+    #endif
 
     #if HAS_Y_AXIS
       if (parser.seenval('Y') && set_shaper(Y_AXIS, 'Y')) return;  // Parse 'Y' mode parameter
     #endif
 
-  #endif // HAS_X_AXIS
+    #if HAS_Z_AXIS
+      if (parser.seenval('Z') && set_shaper(Z_AXIS, 'Z')) return;  // Parse 'Z' mode parameter
+    #endif
+
+  #endif // HAS_X_AXIS || HAS_Y_AXIS || HAS_Z_AXIS
 
   #if HAS_EXTRUDERS
 
@@ -263,7 +300,7 @@ void GcodeSuite::M493() {
 
     // Dynamic frequency mode parameter.
     if (parser.seenval('D')) {
-      if (AXIS_HAS_SHAPER(X) || AXIS_HAS_SHAPER(Y)) {
+      if (AXIS_HAS_SHAPER(X) || AXIS_HAS_SHAPER(Y) || AXIS_HAS_SHAPER(Z)) {
         const dynFreqMode_t val = dynFreqMode_t(parser.value_byte());
         switch (val) {
           #if HAS_DYNAMIC_FREQ_MM
@@ -415,6 +452,67 @@ void GcodeSuite::M493() {
     }
 
   #endif // HAS_Y_AXIS
+
+  #if HAS_Z_AXIS
+
+    // Parse frequency parameter (Z axis).
+    if (parser.seenval('C')) {
+      if (AXIS_HAS_SHAPER(Z)) {
+        const float val = parser.value_float();
+        if (WITHIN(val, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2)) {
+          ftMotion.cfg.baseFreq.z = val;
+          flag.update = flag.report = true;
+        }
+        else // Frequency out of range.
+          SERIAL_ECHOLNPGM("Invalid frequency [", C('C'), "] value.");
+      }
+      else // Mode doesn't use frequency.
+        SERIAL_ECHOLNPGM("Wrong mode for [", C('C'), "] frequency.");
+    }
+
+    #if HAS_DYNAMIC_FREQ
+      // Parse frequency scaling parameter (Z axis).
+      if (parser.seenval('L')) {
+        if (modeUsesDynFreq) {
+          ftMotion.cfg.dynFreqK.z = parser.value_float();
+          flag.report = true;
+        }
+        else
+          SERIAL_ECHOLNPGM("Wrong mode for [", C('L'), "] frequency scaling.");
+      }
+    #endif
+
+    // Parse zeta parameter (Z axis).
+    if (parser.seenval('M')) {
+      const float val = parser.value_float();
+      if (AXIS_HAS_SHAPER(Z)) {
+        if (WITHIN(val, 0.01f, 1.0f)) {
+          ftMotion.cfg.zeta[2] = val;
+          flag.update = true;
+        }
+        else
+          SERIAL_ECHOLNPGM("Invalid Z zeta [", C('M'), "] value."); // Zeta Out of range
+      }
+      else
+        SERIAL_ECHOLNPGM("Wrong mode for zeta parameter.");
+    }
+
+    // Parse vtol parameter (Z axis).
+    if (parser.seenval('N')) {
+      const float val = parser.value_float();
+      if (AXIS_HAS_EISHAPER(Z)) {
+        if (WITHIN(val, 0.00f, 1.0f)) {
+          ftMotion.cfg.vtol[2] = val;
+          flag.update = true;
+        }
+        else
+          SERIAL_ECHOLNPGM("Invalid Z vtol [", C('N'), "] value."); // VTol out of range.
+      }
+      else
+        SERIAL_ECHOLNPGM("Wrong mode for vtol parameter.");
+    }
+
+  #endif // HAS_Z_AXIS
 
   if (flag.update) ftMotion.update_shaping_params();
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -344,59 +344,26 @@ void menu_move() {
     ui.go_back();
   }
 
-  inline void menu_ftm_shaper_x() {
-    const ftMotionShaper_t shaper = ftMotion.cfg.shaper.x;
-    START_MENU();
-    BACK_ITEM(MSG_FIXED_TIME_MOTION);
-
-    if (shaper != ftMotionShaper_NONE)   ACTION_ITEM(MSG_LCD_OFF,  []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_NONE); });
-    if (shaper != ftMotionShaper_ZV)     ACTION_ITEM(MSG_FTM_ZV,   []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_ZV); });
-    if (shaper != ftMotionShaper_ZVD)    ACTION_ITEM(MSG_FTM_ZVD,  []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_ZVD); });
-    if (shaper != ftMotionShaper_ZVDD)   ACTION_ITEM(MSG_FTM_ZVDD, []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_ZVDD); });
-    if (shaper != ftMotionShaper_ZVDDD)  ACTION_ITEM(MSG_FTM_ZVDDD,[]{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_ZVDDD); });
-    if (shaper != ftMotionShaper_EI)     ACTION_ITEM(MSG_FTM_EI,   []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_EI); });
-    if (shaper != ftMotionShaper_2HEI)   ACTION_ITEM(MSG_FTM_2HEI, []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_2HEI); });
-    if (shaper != ftMotionShaper_3HEI)   ACTION_ITEM(MSG_FTM_3HEI, []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_3HEI); });
-    if (shaper != ftMotionShaper_MZV)    ACTION_ITEM(MSG_FTM_MZV,  []{ ftm_menu_set_shaper(X_AXIS, ftMotionShaper_MZV); });
-
-    END_MENU();
-  }
-
-  inline void menu_ftm_shaper_y() {
-    const ftMotionShaper_t shaper = ftMotion.cfg.shaper.y;
-    START_MENU();
-    BACK_ITEM(MSG_FIXED_TIME_MOTION);
-
-    if (shaper != ftMotionShaper_NONE)   ACTION_ITEM(MSG_LCD_OFF,  []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_NONE); });
-    if (shaper != ftMotionShaper_ZV)     ACTION_ITEM(MSG_FTM_ZV,   []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_ZV); });
-    if (shaper != ftMotionShaper_ZVD)    ACTION_ITEM(MSG_FTM_ZVD,  []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_ZVD); });
-    if (shaper != ftMotionShaper_ZVDD)   ACTION_ITEM(MSG_FTM_ZVDD, []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_ZVDD); });
-    if (shaper != ftMotionShaper_ZVDDD)  ACTION_ITEM(MSG_FTM_ZVDDD,[]{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_ZVDDD); });
-    if (shaper != ftMotionShaper_EI)     ACTION_ITEM(MSG_FTM_EI,   []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_EI); });
-    if (shaper != ftMotionShaper_2HEI)   ACTION_ITEM(MSG_FTM_2HEI, []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_2HEI); });
-    if (shaper != ftMotionShaper_3HEI)   ACTION_ITEM(MSG_FTM_3HEI, []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_3HEI); });
-    if (shaper != ftMotionShaper_MZV)    ACTION_ITEM(MSG_FTM_MZV,  []{ ftm_menu_set_shaper(Y_AXIS, ftMotionShaper_MZV); });
-
-    END_MENU();
-  }
-
-  inline void menu_ftm_shaper_z() {
-    const ftMotionShaper_t shaper = ftMotion.cfg.shaper.z;
-    START_MENU();
-    BACK_ITEM(MSG_FIXED_TIME_MOTION);
-
-    if (shaper != ftMotionShaper_NONE)   ACTION_ITEM(MSG_LCD_OFF,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_NONE); });
-    if (shaper != ftMotionShaper_ZV)     ACTION_ITEM(MSG_FTM_ZV,   []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZV); });
-    if (shaper != ftMotionShaper_ZVD)    ACTION_ITEM(MSG_FTM_ZVD,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVD); });
-    if (shaper != ftMotionShaper_ZVDD)   ACTION_ITEM(MSG_FTM_ZVDD, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVDD); });
-    if (shaper != ftMotionShaper_ZVDDD)  ACTION_ITEM(MSG_FTM_ZVDDD,[]{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVDDD); });
-    if (shaper != ftMotionShaper_EI)     ACTION_ITEM(MSG_FTM_EI,   []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_EI); });
-    if (shaper != ftMotionShaper_2HEI)   ACTION_ITEM(MSG_FTM_2HEI, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_2HEI); });
-    if (shaper != ftMotionShaper_3HEI)   ACTION_ITEM(MSG_FTM_3HEI, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_3HEI); });
-    if (shaper != ftMotionShaper_MZV)    ACTION_ITEM(MSG_FTM_MZV,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_MZV); });
-
-    END_MENU();
-  }
+  #define MENU_FTM_SHAPER(axis, AXIS) \
+    inline void menu_ftm_shaper_##axis() { \
+      const ftMotionShaper_t shaper = ftMotion.cfg.shaper.axis; \
+      START_MENU(); \
+      BACK_ITEM(MSG_FIXED_TIME_MOTION); \
+      if (shaper != ftMotionShaper_NONE)   ACTION_ITEM(MSG_LCD_OFF,  []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_NONE); }); \
+      if (shaper != ftMotionShaper_ZV)     ACTION_ITEM(MSG_FTM_ZV,   []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_ZV); }); \
+      if (shaper != ftMotionShaper_ZVD)    ACTION_ITEM(MSG_FTM_ZVD,  []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_ZVD); }); \
+      if (shaper != ftMotionShaper_ZVDD)   ACTION_ITEM(MSG_FTM_ZVDD, []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_ZVDD); }); \
+      if (shaper != ftMotionShaper_ZVDDD)  ACTION_ITEM(MSG_FTM_ZVDDD,[]{ ftm_menu_set_shaper(AXIS, ftMotionShaper_ZVDDD); }); \
+      if (shaper != ftMotionShaper_EI)     ACTION_ITEM(MSG_FTM_EI,   []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_EI); }); \
+      if (shaper != ftMotionShaper_2HEI)   ACTION_ITEM(MSG_FTM_2HEI, []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_2HEI); }); \
+      if (shaper != ftMotionShaper_3HEI)   ACTION_ITEM(MSG_FTM_3HEI, []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_3HEI); }); \
+      if (shaper != ftMotionShaper_MZV)    ACTION_ITEM(MSG_FTM_MZV,  []{ ftm_menu_set_shaper(AXIS, ftMotionShaper_MZV); }); \
+      END_MENU(); \
+    }
+  
+  MENU_FTM_SHAPER(x, X_AXIS);
+  MENU_FTM_SHAPER(y, Y_AXIS);
+  MENU_FTM_SHAPER(z, Z_AXIS);
 
   #if HAS_DYNAMIC_FREQ
 
@@ -472,36 +439,18 @@ void menu_move() {
 
     // Show only when FT Motion is active (or optionally always show)
     if (c.active || ENABLED(FT_MOTION_NO_MENU_TOGGLE)) {
-      #if HAS_X_AXIS
-        SUBMENU_N_S(X_AXIS, _shaper_name(X_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_x);
-
-        if (AXIS_HAS_SHAPER(X)) {
-          EDIT_ITEM_FAST_N(float42_52, X_AXIS, MSG_FTM_BASE_FREQ_N, &c.baseFreq.x, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2, ftMotion.update_shaping_params);
-          EDIT_ITEM_FAST_N(float42_52, X_AXIS, MSG_FTM_ZETA_N, &c.zeta.x, 0.0f, 1.0f, ftMotion.update_shaping_params);
-          if (AXIS_HAS_EISHAPER(X))
-            EDIT_ITEM_FAST_N(float42_52, X_AXIS, MSG_FTM_VTOL_N, &c.vtol.x, 0.0f, 1.0f, ftMotion.update_shaping_params);
-        }
-      #endif
-      #if HAS_Y_AXIS
-        SUBMENU_N_S(Y_AXIS, _shaper_name(Y_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_y);
-
-        if (AXIS_HAS_SHAPER(Y)) {
-          EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_BASE_FREQ_N, &c.baseFreq.y, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2, ftMotion.update_shaping_params);
-          EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_ZETA_N, &c.zeta.y, 0.0f, 1.0f, ftMotion.update_shaping_params);
-          if (AXIS_HAS_EISHAPER(Y))
-            EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_VTOL_N, &c.vtol.y, 0.0f, 1.0f, ftMotion.update_shaping_params);
-          }
-      #endif
-      #if HAS_Z_AXIS
-        SUBMENU_N_S(Z_AXIS, _shaper_name(Z_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_z);
-
-        if (AXIS_HAS_SHAPER(Z)) {
-          EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_BASE_FREQ_N, &c.baseFreq.z, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2, ftMotion.update_shaping_params);
-          EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_ZETA_N, &c.zeta.z, 0.0f, 1.0f, ftMotion.update_shaping_params);
-          if (AXIS_HAS_EISHAPER(Z))
-            EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_VTOL_N, &c.vtol.z, 0.0f, 1.0f, ftMotion.update_shaping_params);
-        }
-      #endif
+      #define SHAPER_MENU_ITEM(axis, AXIS) \
+        SUBMENU_N_S(AXIS, _shaper_name(AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_##axis); \
+        if (AXIS_HAS_SHAPER(A)) { \
+          EDIT_ITEM_FAST_N(float42_52, AXIS, MSG_FTM_BASE_FREQ_N, &c.baseFreq.axis, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2, ftMotion.update_shaping_params); \
+          EDIT_ITEM_FAST_N(float42_52, AXIS, MSG_FTM_ZETA_N, &c.zeta.axis, 0.0f, 1.0f, ftMotion.update_shaping_params); \
+          if (AXIS_HAS_EISHAPER(A)) \
+            EDIT_ITEM_FAST_N(float42_52, AXIS, MSG_FTM_VTOL_N, &c.vtol.axis, 0.0f, 1.0f, ftMotion.update_shaping_params); \
+        } 
+      
+      TERN_(HAS_X_AXIS, SHAPER_MENU_ITEM(x, X_AXIS));
+      TERN_(HAS_Y_AXIS, SHAPER_MENU_ITEM(y, Y_AXIS));
+      TERN_(HAS_Z_AXIS, SHAPER_MENU_ITEM(z, Z_AXIS));
 
       #if HAS_DYNAMIC_FREQ
         SUBMENU_S(_dmode(), MSG_FTM_DYN_MODE, menu_ftm_dyn_mode);

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -380,6 +380,24 @@ void menu_move() {
     END_MENU();
   }
 
+  inline void menu_ftm_shaper_z() {
+    const ftMotionShaper_t shaper = ftMotion.cfg.shaper.z;
+    START_MENU();
+    BACK_ITEM(MSG_FIXED_TIME_MOTION);
+
+    if (shaper != ftMotionShaper_NONE)   ACTION_ITEM(MSG_LCD_OFF,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_NONE); });
+    if (shaper != ftMotionShaper_ZV)     ACTION_ITEM(MSG_FTM_ZV,   []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZV); });
+    if (shaper != ftMotionShaper_ZVD)    ACTION_ITEM(MSG_FTM_ZVD,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVD); });
+    if (shaper != ftMotionShaper_ZVDD)   ACTION_ITEM(MSG_FTM_ZVDD, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVDD); });
+    if (shaper != ftMotionShaper_ZVDDD)  ACTION_ITEM(MSG_FTM_ZVDDD,[]{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_ZVDDD); });
+    if (shaper != ftMotionShaper_EI)     ACTION_ITEM(MSG_FTM_EI,   []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_EI); });
+    if (shaper != ftMotionShaper_2HEI)   ACTION_ITEM(MSG_FTM_2HEI, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_2HEI); });
+    if (shaper != ftMotionShaper_3HEI)   ACTION_ITEM(MSG_FTM_3HEI, []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_3HEI); });
+    if (shaper != ftMotionShaper_MZV)    ACTION_ITEM(MSG_FTM_MZV,  []{ ftm_menu_set_shaper(Z_AXIS, ftMotionShaper_MZV); });
+
+    END_MENU();
+  }
+
   #if HAS_DYNAMIC_FREQ
 
     void menu_ftm_dyn_mode() {
@@ -472,6 +490,16 @@ void menu_move() {
           EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_ZETA_N, &c.zeta.y, 0.0f, 1.0f, ftMotion.update_shaping_params);
           if (AXIS_HAS_EISHAPER(Y))
             EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_VTOL_N, &c.vtol.y, 0.0f, 1.0f, ftMotion.update_shaping_params);
+          }
+      #endif
+      #if HAS_Z_AXIS
+        SUBMENU_N_S(Z_AXIS, _shaper_name(Z_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_z);
+
+        if (AXIS_HAS_SHAPER(Z)) {
+          EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_BASE_FREQ_N, &c.baseFreq.z, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2, ftMotion.update_shaping_params);
+          EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_ZETA_N, &c.zeta.z, 0.0f, 1.0f, ftMotion.update_shaping_params);
+          if (AXIS_HAS_EISHAPER(Z))
+            EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_VTOL_N, &c.vtol.z, 0.0f, 1.0f, ftMotion.update_shaping_params);
         }
       #endif
 
@@ -483,6 +511,9 @@ void menu_move() {
           #endif
           #if HAS_Y_AXIS
             EDIT_ITEM_FAST_N(float42_52, Y_AXIS, MSG_FTM_DFREQ_K_N, &c.dynFreqK.y, 0.0f, 20.0f);
+          #endif
+          #if HAS_Z_AXIS
+            EDIT_ITEM_FAST_N(float42_52, Z_AXIS, MSG_FTM_DFREQ_K_N, &c.dynFreqK.z, 0.0f, 20.0f);
           #endif
         }
       #endif
@@ -540,6 +571,9 @@ void menu_move() {
     #endif
     #if HAS_Y_AXIS
       SUBMENU_N_S(Y_AXIS, _shaper_name(Y_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_y);
+    #endif
+    #if HAS_Z_AXIS
+      SUBMENU_N_S(Z_AXIS, _shaper_name(Z_AXIS), MSG_FTM_CMPN_MODE, menu_ftm_shaper_z);
     #endif
     #if HAS_DYNAMIC_FREQ
       SUBMENU_S(_dmode(), MSG_FTM_DYN_MODE, menu_ftm_dyn_mode);

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -105,6 +105,9 @@ uint32_t FTMotion::interpIdx = 0;               // Index of current data point b
     #if HAS_Y_AXIS
       , y:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 } // ena, d_zi[], Ai[], Ni[], max_i
     #endif
+    #if HAS_Z_AXIS
+      , z:{ false, { 0.0f }, { 0.0f }, { 0 }, 0 } // ena, d_zi[], Ai[], Ni[], max_i
+    #endif
   };
 #endif
 
@@ -369,6 +372,12 @@ void FTMotion::loop() {
         shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y, cfg.zeta.y);
       }
     #endif
+    #if HAS_Z_AXIS
+      if ((shaping.z.ena = AXIS_HAS_SHAPER(Z))) {
+        shaping.z.set_axis_shaping_A(cfg.shaper.z, cfg.zeta.z, cfg.vtol.z);
+        shaping.z.set_axis_shaping_N(cfg.shaper.z, cfg.baseFreq.z, cfg.zeta.z);
+      }
+    #endif
   }
 
 #endif // HAS_FTM_SHAPING
@@ -394,6 +403,7 @@ void FTMotion::reset() {
   #if HAS_FTM_SHAPING
     TERN_(HAS_X_AXIS, ZERO(shaping.x.d_zi));
     TERN_(HAS_Y_AXIS, ZERO(shaping.y.d_zi));
+    TERN_(HAS_Z_AXIS, ZERO(shaping.z.d_zi));
     shaping.zi_idx = 0;
   #endif
 
@@ -659,6 +669,16 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
           for (uint32_t i = 1U; i <= shaping.y.max_i; i++) {
             const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
             traj.y[traj_idx_set] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
+          }
+        }
+      #endif
+      #if HAS_Z_AXIS
+        if (shaping.z.ena) {
+          shaping.z.d_zi[shaping.zi_idx] = traj.z[traj_idx_set];
+          traj.z[traj_idx_set] *= shaping.z.Ai[0];
+          for (uint32_t i = 1U; i <= shaping.z.max_i; i++) {
+            const uint32_t udiffz = shaping.zi_idx - shaping.z.Ni[i];
+            traj.z[traj_idx_set] += shaping.z.Ai[i] * shaping.z.d_zi[shaping.z.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffz : udiffz];
           }
         }
       #endif

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -360,24 +360,14 @@ void FTMotion::loop() {
   }
 
   void FTMotion::update_shaping_params() {
-    #if HAS_X_AXIS
-      if ((shaping.x.ena = AXIS_HAS_SHAPER(X))) {
-        shaping.x.set_axis_shaping_A(cfg.shaper.x, cfg.zeta.x, cfg.vtol.x);
-        shaping.x.set_axis_shaping_N(cfg.shaper.x, cfg.baseFreq.x, cfg.zeta.x);
-      }
-    #endif
-    #if HAS_Y_AXIS
-      if ((shaping.y.ena = AXIS_HAS_SHAPER(Y))) {
-        shaping.y.set_axis_shaping_A(cfg.shaper.y, cfg.zeta.y, cfg.vtol.y);
-        shaping.y.set_axis_shaping_N(cfg.shaper.y, cfg.baseFreq.y, cfg.zeta.y);
-      }
-    #endif
-    #if HAS_Z_AXIS
-      if ((shaping.z.ena = AXIS_HAS_SHAPER(Z))) {
-        shaping.z.set_axis_shaping_A(cfg.shaper.z, cfg.zeta.z, cfg.vtol.z);
-        shaping.z.set_axis_shaping_N(cfg.shaper.z, cfg.baseFreq.z, cfg.zeta.z);
-      }
-    #endif
+    #define UPDATE_SHAPER(axis) \
+      shaping.axis.ena = ftMotion.cfg.shaper.axis != ftMotionShaper_NONE; \
+      shaping.axis.set_axis_shaping_A(cfg.shaper.axis, cfg.zeta.axis, cfg.vtol.axis); \
+      shaping.axis.set_axis_shaping_N(cfg.shaper.axis, cfg.baseFreq.axis, cfg.zeta.axis);
+    
+    TERN_(HAS_X_AXIS, UPDATE_SHAPER(x));
+    TERN_(HAS_Y_AXIS, UPDATE_SHAPER(y));
+    TERN_(HAS_Z_AXIS, UPDATE_SHAPER(z));
   }
 
 #endif // HAS_FTM_SHAPING
@@ -651,37 +641,19 @@ void FTMotion::generateTrajectoryPointsFromBlock() {
 
     // Apply shaping if active on each axis
     #if HAS_FTM_SHAPING
-      #if HAS_X_AXIS
-        if (shaping.x.ena) {
-          shaping.x.d_zi[shaping.zi_idx] = traj.x[traj_idx_set];
-          traj.x[traj_idx_set] *= shaping.x.Ai[0];
-          for (uint32_t i = 1U; i <= shaping.x.max_i; i++) {
-            const uint32_t udiffx = shaping.zi_idx - shaping.x.Ni[i];
-            traj.x[traj_idx_set] += shaping.x.Ai[i] * shaping.x.d_zi[shaping.x.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffx : udiffx];
-          }
-        }
-      #endif
+      #define SHAPE(AXIS) \
+        if (shaping.AXIS.ena) { \
+          shaping.AXIS.d_zi[shaping.zi_idx] = traj.AXIS[traj_idx_set]; \
+          traj.AXIS[traj_idx_set] *= shaping.AXIS.Ai[0]; \
+          for (uint32_t i = 1U; i <= shaping.AXIS.max_i; i++) { \
+            const uint32_t udiff = shaping.zi_idx - shaping.AXIS.Ni[i]; \
+            traj.AXIS[traj_idx_set] += shaping.AXIS.Ai[i] * shaping.AXIS.d_zi[shaping.AXIS.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiff : udiff]; \
+          } \
+        } 
+      TERN_(HAS_X_AXIS, SHAPE(x));
+      TERN_(HAS_Y_AXIS, SHAPE(y));
+      TERN_(HAS_Z_AXIS, SHAPE(z));
 
-      #if HAS_Y_AXIS
-        if (shaping.y.ena) {
-          shaping.y.d_zi[shaping.zi_idx] = traj.y[traj_idx_set];
-          traj.y[traj_idx_set] *= shaping.y.Ai[0];
-          for (uint32_t i = 1U; i <= shaping.y.max_i; i++) {
-            const uint32_t udiffy = shaping.zi_idx - shaping.y.Ni[i];
-            traj.y[traj_idx_set] += shaping.y.Ai[i] * shaping.y.d_zi[shaping.y.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffy : udiffy];
-          }
-        }
-      #endif
-      #if HAS_Z_AXIS
-        if (shaping.z.ena) {
-          shaping.z.d_zi[shaping.zi_idx] = traj.z[traj_idx_set];
-          traj.z[traj_idx_set] *= shaping.z.Ai[0];
-          for (uint32_t i = 1U; i <= shaping.z.max_i; i++) {
-            const uint32_t udiffz = shaping.zi_idx - shaping.z.Ni[i];
-            traj.z[traj_idx_set] += shaping.z.Ai[i] * shaping.z.d_zi[shaping.z.Ni[i] > shaping.zi_idx ? (FTM_ZMAX) + udiffz : udiffz];
-          }
-        }
-      #endif
       if (++shaping.zi_idx == (FTM_ZMAX)) shaping.zi_idx = 0;
     #endif // HAS_FTM_SHAPING
 

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -42,13 +42,13 @@ typedef struct FTConfig {
 
   #if HAS_FTM_SHAPING
     ft_shaped_shaper_t shaper =                           // Shaper type
-      { SHAPED_ELEM(FTM_DEFAULT_SHAPER_X, FTM_DEFAULT_SHAPER_Y) };
+      { SHAPED_ELEM(FTM_DEFAULT_SHAPER_X, FTM_DEFAULT_SHAPER_Y, FTM_DEFAULT_SHAPER_Z) };
     ft_shaped_float_t baseFreq =                          // Base frequency. [Hz]
-      { SHAPED_ELEM(FTM_SHAPING_DEFAULT_FREQ_X, FTM_SHAPING_DEFAULT_FREQ_Y) };
+      { SHAPED_ELEM(FTM_SHAPING_DEFAULT_FREQ_X, FTM_SHAPING_DEFAULT_FREQ_Y, FTM_SHAPING_DEFAULT_FREQ_Z) };
     ft_shaped_float_t zeta =                              // Damping factor
-      { SHAPED_ELEM(FTM_SHAPING_ZETA_X, FTM_SHAPING_ZETA_Y) };
+      { SHAPED_ELEM(FTM_SHAPING_ZETA_X, FTM_SHAPING_ZETA_Y, FTM_SHAPING_ZETA_Z) };
     ft_shaped_float_t vtol =                              // Vibration Level
-      { SHAPED_ELEM(FTM_SHAPING_V_TOL_X, FTM_SHAPING_V_TOL_Y) };
+      { SHAPED_ELEM(FTM_SHAPING_V_TOL_X, FTM_SHAPING_V_TOL_Y, FTM_SHAPING_V_TOL_Z) };
 
     #if HAS_DYNAMIC_FREQ
       dynFreqMode_t dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE; // Dynamic frequency mode configuration.
@@ -91,10 +91,18 @@ class FTMotion {
           cfg.vtol.y = FTM_SHAPING_V_TOL_Y;
         #endif
 
+        #if HAS_Z_AXIS
+          cfg.shaper.z = FTM_DEFAULT_SHAPER_Z;
+          cfg.baseFreq.z = FTM_SHAPING_DEFAULT_FREQ_Z;
+          cfg.zeta.z = FTM_SHAPING_ZETA_Z;
+          cfg.vtol.z = FTM_SHAPING_V_TOL_Z;
+        #endif
+
         #if HAS_DYNAMIC_FREQ
           cfg.dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE;
           TERN_(HAS_X_AXIS, cfg.dynFreqK.x = 0.0f);
           TERN_(HAS_Y_AXIS, cfg.dynFreqK.y = 0.0f);
+          TERN_(HAS_Z_AXIS, cfg.dynFreqK.z = 0.0f);
         #endif
 
         update_shaping_params();
@@ -193,12 +201,9 @@ class FTMotion {
 
       typedef struct Shaping {
         uint32_t zi_idx;           // Index of storage in the data point delay vectors.
-        #if HAS_X_AXIS
-          axis_shaping_t x;
-        #endif
-        #if HAS_Y_AXIS
-          axis_shaping_t y;
-        #endif
+        TERN_(HAS_X_AXIS, axis_shaping_t x);
+        TERN_(HAS_Y_AXIS, axis_shaping_t y);
+        TERN_(HAS_Z_AXIS, axis_shaping_t z);
       } shaping_t;
 
       static shaping_t shaping; // Shaping data
@@ -218,7 +223,7 @@ class FTMotion {
     static void generateTrajectoryPointsFromBlock();
     static void generateStepsFromTrajectory(const uint32_t idx);
 
-    FORCE_INLINE static int32_t num_samples_shaper_settle() { return ( shaping.x.ena || shaping.y.ena ) ? FTM_ZMAX : 0; }
+    FORCE_INLINE static int32_t num_samples_shaper_settle() { return ( shaping.x.ena || shaping.y.ena || shaping.z.ena ) ? FTM_ZMAX : 0; }
 
 }; // class FTMotion
 

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -77,26 +77,15 @@ class FTMotion {
 
       #if HAS_FTM_SHAPING
 
-        #if HAS_X_AXIS
-          cfg.shaper.x = FTM_DEFAULT_SHAPER_X;
-          cfg.baseFreq.x = FTM_SHAPING_DEFAULT_FREQ_X;
-          cfg.zeta.x = FTM_SHAPING_ZETA_X;
-          cfg.vtol.x = FTM_SHAPING_V_TOL_X;
-        #endif
+        #define SET_CGF_DEFAULTS(axis, AXIS) \
+          cfg.shaper.axis = FTM_DEFAULT_SHAPER_##AXIS; \
+          cfg.baseFreq.axis = FTM_SHAPING_DEFAULT_FREQ_##AXIS; \
+          cfg.zeta.axis = FTM_SHAPING_ZETA_##AXIS; \
+          cfg.vtol.axis = FTM_SHAPING_V_TOL_##AXIS;
 
-        #if HAS_Y_AXIS
-          cfg.shaper.y = FTM_DEFAULT_SHAPER_Y;
-          cfg.baseFreq.y = FTM_SHAPING_DEFAULT_FREQ_Y;
-          cfg.zeta.y = FTM_SHAPING_ZETA_Y;
-          cfg.vtol.y = FTM_SHAPING_V_TOL_Y;
-        #endif
-
-        #if HAS_Z_AXIS
-          cfg.shaper.z = FTM_DEFAULT_SHAPER_Z;
-          cfg.baseFreq.z = FTM_SHAPING_DEFAULT_FREQ_Z;
-          cfg.zeta.z = FTM_SHAPING_ZETA_Z;
-          cfg.vtol.z = FTM_SHAPING_V_TOL_Z;
-        #endif
+        TERN_(HAS_X_AXIS, SET_CGF_DEFAULTS(x, X));
+        TERN_(HAS_Y_AXIS, SET_CGF_DEFAULTS(y, Y));
+        TERN_(HAS_Z_AXIS, SET_CGF_DEFAULTS(z, Z));
 
         #if HAS_DYNAMIC_FREQ
           cfg.dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE;

--- a/Marlin/src/module/ft_types.h
+++ b/Marlin/src/module/ft_types.h
@@ -59,18 +59,18 @@ enum {
 };
 
 #if HAS_FTM_SHAPING
-  #define NUM_AXES_SHAPED TERN(HAS_Y_AXIS, 2, 1)
-  #define SHAPED_ELEM(A, B) A OPTARG(HAS_Y_AXIS, B)
+  #define NUM_AXES_SHAPED TERN(HAS_Z_AXIS, 3, TERN(HAS_Y_AXIS, 2, 1))
+  #define SHAPED_ELEM(A, B, C) A OPTARG(HAS_Y_AXIS, B) OPTARG(HAS_Z_AXIS, C)
 #else
   #define NUM_AXES_SHAPED 0
-  #define SHAPED_ELEM(A, B)
+  #define SHAPED_ELEM(A, B, C)
 #endif
 
 template<typename T>
 struct FTShapedAxes {
   union {
-    struct { T SHAPED_ELEM(X, Y); };
-    struct { T SHAPED_ELEM(x, y); };
+    struct { T SHAPED_ELEM(X, Y, Z); };
+    struct { T SHAPED_ELEM(x, y, z); };
     T val[NUM_AXES_SHAPED];
   };
   T& operator[](int i) { return val[i]; }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -36,7 +36,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V90"
+#define EEPROM_VERSION "V91"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.


### PR DESCRIPTION
### Description

Adds Z axis input shaping to FTMotion

Note that this commit [SHAPE and UPDATE_SHAPER macros to simplify code](https://github.com/MarlinFirmware/Marlin/pull/28045/commits/caf20ccba620b5d04051d12f44e0a10ffea51345) replaces a lot of repeated code per axis with macros. This is also in preparation for axis synchronisation, which also adds the extruder to list of shapeable axes (so it can be synchronised).

# Unshaped
https://github.com/user-attachments/assets/214bc75e-9dfd-42ae-bec7-345d69dc6746

# Shaped

https://github.com/user-attachments/assets/c1a3da61-0c4a-4cfd-8d0d-5230785e6622




### Requirements

FTMotion

### Benefits

Stable bed bed

### Configurations

```cpp
  #define FTM_DEFAULT_SHAPER_Z      ftMotionShaper_NONE // Default shaper mode on Z axis
  #define FTM_SHAPING_DEFAULT_FREQ_Z   21.0f      // (Hz) Default peak frequency used by input shapers
  #define FTM_SHAPING_ZETA_Y            0.1f      // Zeta used by input shapers for Y axis
  #define FTM_SHAPING_V_TOL_Z           0.05f     // Vibration tolerance used by EI input shapers for Z axis

```

### Related Issues

ZV Input shaping for the Z axis was added in #27073 but for the classic motion. 
