### PR TITLE
revert TMC_DEBUG guard removal

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -89,7 +89,9 @@
 
   #if HAS_TMCX1X0
 
-    static uint32_t get_pwm_scale(TMC2130Stepper &st) { return st.PWM_SCALE(); }
+    #if ENABLED(TMC_DEBUG)
+      static uint32_t get_pwm_scale(TMC2130Stepper &st) { return st.PWM_SCALE(); }
+    #endif
 
     static TMC_driver_data get_driver_data(TMC2130Stepper &st) {
       constexpr uint8_t OT_bp = 25, OTPW_bp = 26;
@@ -148,7 +150,9 @@
 
   #if HAS_DRIVER(TMC2240)
 
-    static uint32_t get_pwm_scale(TMC2240Stepper &st) { return st.PWM_SCALE(); }
+    #if ENABLED(TMC_DEBUG)
+      static uint32_t get_pwm_scale(TMC2240Stepper &st) { return st.PWM_SCALE(); }
+    #endif
 
     static TMC_driver_data get_driver_data(TMC2240Stepper &st) {
       constexpr uint8_t OT_bp = 25, OTPW_bp = 26;
@@ -207,7 +211,9 @@
 
   #if HAS_TMC220x
 
-    static uint32_t get_pwm_scale(TMC2208Stepper &st) { return st.pwm_scale_sum(); }
+    #if ENABLED(TMC_DEBUG)
+      static uint32_t get_pwm_scale(TMC2208Stepper &st) { return st.pwm_scale_sum(); }
+    #endif
 
     static TMC_driver_data get_driver_data(TMC2208Stepper &st) {
       constexpr uint8_t OTPW_bp = 0, OT_bp = 1;
@@ -242,7 +248,9 @@
 
   #if HAS_DRIVER(TMC2660)
 
-    static uint32_t get_pwm_scale(TMC2660Stepper) { return 0; }
+    #if ENABLED(TMC_DEBUG)
+      static uint32_t get_pwm_scale(TMC2660Stepper) { return 0; }
+    #endif
 
     static TMC_driver_data get_driver_data(TMC2660Stepper &st) {
       constexpr uint8_t OT_bp = 1, OTPW_bp = 2;


### PR DESCRIPTION
### Description

Resolves https://github.com/MarlinFirmware/Marlin/issues/28019 

```
warning in tic_util.cpp:
'uint32_t get_pwm_scale(TMC2208Stepper&)' defined but not used 

```
In https://github.com/MarlinFirmware/Marlin/pull/27901 TMC_DEBUG guards where removed causing these warnings when TMC_DEBUG is not defined with MONITOR_DRIVER_STATUS enabled

Revered TMC_DEBUG guard removal 

### Requirements

MONITOR_DRIVER_STATUS with our without TMC_DEBUG
TMC2130, TMC2240, TMC220x or TMC2660 stepper driver

### Benefits

Warning is removed.

### Related Issues

<li>MarlinFirmware/Marlin/issues/28019
<li>MarlinFirmware/Marlin/pull/27901