### PR TITLE
reduce small enum to uint8_t 

### DIFF
--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -209,7 +209,7 @@
       static ring_buffer_pos_t get_tx_buffer_free();
     #endif
 
-    enum { HasEmergencyParser = Cfg::EMERGENCYPARSER };
+    enum : uint8_t { HasEmergencyParser = Cfg::EMERGENCYPARSER };
     static bool emergency_parser_enabled() { return Cfg::EMERGENCYPARSER; }
 
     FORCE_INLINE static uint8_t dropped() { return Cfg::DROPPED_RX ? rx_dropped_bytes : 0; }

--- a/Marlin/src/HAL/AVR/ServoTimers.h
+++ b/Marlin/src/HAL/AVR/ServoTimers.h
@@ -76,7 +76,7 @@
   // everything else
 #endif
 
-typedef enum {
+typedef enum : uint8_t {
   #ifdef _useTimer1
     _timer1,
   #endif

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -446,22 +446,22 @@
 
     // test if type is integral
     template<typename>  struct _is_integral { enum { value = false }; };
-    template<>          struct _is_integral<unsigned char> { enum { value = true }; };
-    template<>          struct _is_integral<unsigned short> { enum { value = true }; };
-    template<>          struct _is_integral<unsigned int> { enum { value = true }; };
-    template<>          struct _is_integral<unsigned long> { enum { value = true }; };
-    template<>          struct _is_integral<unsigned long long> { enum { value = true }; };
-    template<>          struct _is_integral<char> { enum { value = true }; };
-    template<>          struct _is_integral<short> { enum { value = true }; };
-    template<>          struct _is_integral<int> { enum { value = true }; };
-    template<>          struct _is_integral<long> { enum { value = true }; };
-    template<>          struct _is_integral<long long> { enum { value = true }; };
+    template<>          struct _is_integral<unsigned char> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<unsigned short> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<unsigned int> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<unsigned long> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<unsigned long long> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<char> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<short> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<int> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<long> { enum : uint8_t { value = true }; };
+    template<>          struct _is_integral<long long> { enum : uint8_t { value = true }; };
     template<typename T> struct is_integral : public _is_integral<typename remove_cv<T>::type> {};
   }
 
   // enum type check and regression to its underlying integral.
   namespace Private {
-    template<typename T> struct is_enum { enum { value = __is_enum(T) }; };
+    template<typename T> struct is_enum { enum : uint8_t { value = __is_enum(T) }; };
 
     template<typename T, bool = is_enum<T>::value>  struct _underlying_type { using type = __underlying_type(T); };
     template<typename T>                            struct _underlying_type<T, false> { };
@@ -476,7 +476,7 @@
       template <typename Type, typename Yes=char, typename No=long> struct HasMember_ ## Member { \
         template <typename C> static Yes& test( decltype(&C::Member) ) ; \
         template <typename C> static No& test(...); \
-        enum { value = sizeof(test<Type>(0)) == sizeof(Yes) }; }; \
+        enum : uint8_t { value = sizeof(test<Type>(0)) == sizeof(Yes) }; }; \
     }
 
   // Call the method if it exists, but do nothing if it does not. The method is detected at compile time.

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -50,7 +50,7 @@ struct serial_index_t {
 // In order to catch usage errors in code, we make the base to encode number explicit
 // If given a number (and not this enum), the compiler will reject the overload, falling back to the (double, digit) version
 // We don't want hidden conversion of the first parameter to double, so it has to be as hard to do for the compiler as creating this enum
-enum class PrintBase {
+enum class PrintBase : uint8_t {
   Dec = 10,
   Hex = 16,
   Oct = 8,
@@ -58,7 +58,7 @@ enum class PrintBase {
 };
 
 // A simple feature list enumeration
-enum class SerialFeature {
+enum class SerialFeature : uint8_t {
   None                = 0x00,
   MeatPack            = 0x01,   //!< Enabled when Meatpack is present
   BinaryFileTransfer  = 0x02,   //!< Enabled for BinaryFile transfer support (in the future)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -110,7 +110,7 @@
 /**
  * Planner block flags as boolean bit fields
  */
-enum BlockFlagBit {
+enum BlockFlagBit : uint8_t {
   // Recalculate trapezoids on entry junction. For optimization.
   BLOCK_BIT_RECALCULATE,
 


### PR DESCRIPTION
### Description

Having a play with Clang-Tidy, It really does not like marlin code..
But one thing it did advise is the size reduction of some enums

```
Marlin/src/feature/adc/../../inc/../HAL/../HAL/AVR/../../core/serial_base.h:53:12: warning: enum 'PrintBase' uses a larger base type ('int', size: 2 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size]
   53 | enum class PrintBase {
      |            ^
Marlin/src/feature/adc/../../inc/../HAL/../HAL/AVR/../../core/serial_base.h:61:12: warning: enum 'SerialFeature' uses a larger base type ('int', size: 2 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size]
   61 | enum class SerialFeature {
   
Marlin/src/sd/../module/planner.h:113:6: warning: enum 'BlockFlagBit' uses a larger base type ('unsigned int', size: 2 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size]
  113 | enum BlockFlagBit {

Marlin/src/core/../inc/../HAL/../HAL/AVR/../../core/serial_base.h:71:1: warning: enum '(unnamed enum at Marlin/src/core/../inc/../HAL/../HAL/AVR/../../core/serial_base.h:71:1)' uses a larger base type ('unsigned int', size: 2 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size]

```

So I have added these, as I cannot see any negatives. 

### Benefits

Slightly smaller firmware. Way less warnings in Clang-Tidy. 

