### PR TITLE
Allow override of Z_STOP_PIN in pins_CHITU3D_V6.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -27,7 +27,11 @@
 #define Z2_STEP_PIN                         PF5
 #define Z2_DIR_PIN                          PF1
 
-#define Z_STOP_PIN                          PA14
+// Some Chitu v6 boards use PA14 and some use PG9, so allow overriding this definition in configuration.h
+// The CXY-V6-191017 in the early Tronxy X5SA Pro printers seem to use PG9
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                          PA14
+#endif
 
 #ifndef FIL_RUNOUT2_PIN
   #define FIL_RUNOUT2_PIN                   PF13

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -27,10 +27,10 @@
 #define Z2_STEP_PIN                         PF5
 #define Z2_DIR_PIN                          PF1
 
-// Some Chitu v6 boards use PA14 and some use PG9, so allow overriding this definition in configuration.h
-// The CXY-V6-191017 in the early Tronxy X5SA Pro printers seem to use PG9
+// Some Chitu v6 boards use PA14 and some use PG9.
+// The CXY-V6-191017 in early Tronxy X5SA Pro printers apparently use PG9.
 #ifndef Z_STOP_PIN
-  #define Z_STOP_PIN                          PA14
+  #define Z_STOP_PIN                        PA14
 #endif
 
 #ifndef FIL_RUNOUT2_PIN


### PR DESCRIPTION
### Description
Surrounded #define of Z_STOP_PIN with an #ifndef so it can be overridden in configuration.h for the Tronxy boards that actually use PG9 instead of PA14 for this pin.

### Requirements
No changes required for the rest of the existing tree

### Benefits
[Fix] Allows boards such as the Tronxy X5SA Pro boards with board version CXY-V6-191017 to succesfully do Z homing

### Configurations
Can now use
  #define Z_STOP_PIN PG9
in configuration.h

### Related Issues
probably helps to fix the Z homing bug of many chitu3d v6 boards, as Tronxy was not consistent with its implementation and documentation. Such as https://github.com/MarlinFirmware/Marlin/issues/24532 and https://github.com/MarlinFirmware/Marlin/issues/25547
