### PR TITLE
FTMotion: Fix LA macro

### DIFF
--- a/Marlin/src/inc/Conditionals-4-adv.h
+++ b/Marlin/src/inc/Conditionals-4-adv.h
@@ -349,7 +349,7 @@
 #endif
 
 #if ALL(FT_MOTION, HAS_EXTRUDERS)
-  #define HAS_FTM_LIN_ADVANCE 1
+  #define FTM_HAS_LIN_ADVANCE 1
 #endif
 
 // Some displays can toggle Adaptive Step Smoothing.

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -539,21 +539,7 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
   endPos_prevBlock += moveDist;
 
-  #if FTM_HAS_LIN_ADVANCE
-    /**
-    * Use LIN_ADVANCE for blocks if all these are true:
-    * moveDist.e > 0                   : This is a print move.
-    * cfg.linearAdvK > 0               : There is an advance factor set.
-    * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
-                                        combined with the last print move due to min. steps per segment.
-                                        Never execute this with advance!
-                                        This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
-                                        and no one will print 100mm wide lines using 3mm filament or
-                                        35mm wide lines using 1.75mm filament.
-    */
-    use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
-                       moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
-  #endif
+  TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
 
   // Watch endstops until the move ends
   const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -539,7 +539,21 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
   endPos_prevBlock += moveDist;
 
-  TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
+  #if FTM_HAS_LIN_ADVANCE
+    /**
+    * Use LIN_ADVANCE for blocks if all these are true:
+    * moveDist.e > 0                   : This is a print move.
+    * cfg.linearAdvK > 0               : There is an advance factor set.
+    * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
+                                        combined with the last print move due to min. steps per segment.
+                                        Never execute this with advance!
+                                        This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
+                                        and no one will print 100mm wide lines using 3mm filament or
+                                        35mm wide lines using 1.75mm filament.
+    */
+    use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
+                       moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
+  #endif
 
   // Watch endstops until the move ends
   const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2380,7 +2380,7 @@ bool Planner::_populate_block(
   block->steps_per_mm = steps_per_mm;
   uint32_t accel;
   #if ANY(LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)
-    bool use_advance_lead = false;
+    bool use_adv_lead = false;
   #endif
   if (!ANY_AXIS_MOVES(block)) {                                   // Is this a retract / recover move?
     accel = CEIL(settings.retract_acceleration * steps_per_mm);   // Convert to: acceleration steps/sec^2
@@ -2416,9 +2416,11 @@ bool Planner::_populate_block(
        *
        * dm.e                         : Extruder is running forward (e.g., for "Wipe while retracting" (Slic3r) or "Combing" (Cura) moves)
        */
-      use_advance_lead = esteps && extruder_advance_K[E_INDEX_N(extruder)] && dm.e;
+      const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
+      const float advK = TERN_(FTM_HAS_LIN_ADVANCE, ftm_active ? ftMotion.cfg.linearAdvK :) extruder_advance_K[E_INDEX_N(extruder)];
+      use_adv_lead = esteps && advK && dm.e;
 
-      if (use_advance_lead) {
+      if (use_adv_lead) {
         float e_D_ratio = (target_float.e - position_float.e) /
           TERN(IS_KINEMATIC, block->millimeters,
             SQRT(sq(target_float.x - position_float.x)
@@ -2429,22 +2431,17 @@ bool Planner::_populate_block(
         // Check for unusual high e_D ratio to detect if a retract move was combined with the last print move due to min. steps per segment. Never execute this with advance!
         // This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm and no one will print 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
         if (e_D_ratio > 3.0f)
-          use_advance_lead = false;
-        else {
-          #if HAS_ROUGH_LIN_ADVANCE
-            const bool limit_accel = TERN1(FTM_HAS_LIN_ADVANCE, !ftMotion.cfg.active);
-            if (limit_accel) {
-              // Scale E acceleration so that it will be possible to jump to the advance speed.
-              const uint32_t max_accel_steps_per_s2 = MAX_E_JERK(extruder) / (extruder_advance_K[E_INDEX_N(extruder)] * e_D_ratio) * steps_per_mm;
-              if (accel > max_accel_steps_per_s2) {
-                accel = max_accel_steps_per_s2;
-                if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
-              }
-            }
-          #endif
+          use_adv_lead = false;
+        else if (TERN0(HAS_ROUGH_LIN_ADVANCE, !ftm_active)) {
+          // Scale E acceleration so that it will be possible to jump to the advance speed.
+          const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
+          if (accel > max_accel_steps_per_s2) {
+            accel = max_accel_steps_per_s2;
+            if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
+          }
         }
         #if ANY(SMOOTH_LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)
-          block->use_advance_lead = use_advance_lead;
+          block->use_advance_lead = use_adv_lead;
         #endif
       }
     #endif // LIN_ADVANCE || FTM_HAS_LIN_ADVANCE
@@ -2476,7 +2473,7 @@ bool Planner::_populate_block(
   #if HAS_ROUGH_LIN_ADVANCE
     block->la_advance_rate = 0;
     block->la_scaling = 0;
-    if (use_advance_lead) {
+    if (use_adv_lead) {
       // The Bresenham algorithm will convert this step rate into extruder steps
       block->la_advance_rate = extruder_advance_K[E_INDEX_N(extruder)] * block->acceleration_steps_per_s2;
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2432,7 +2432,7 @@ bool Planner::_populate_block(
           use_advance_lead = false;
         else {
           #if HAS_ROUGH_LIN_ADVANCE
-            const bool limit_accel = TERN1(HAS_FTM_LIN_ADVANCE, !ftMotion.cfg.active);
+            const bool limit_accel = TERN1(FTM_HAS_LIN_ADVANCE, !ftMotion.cfg.active);
             if (limit_accel) {
               // Scale E acceleration so that it will be possible to jump to the advance speed.
               const uint32_t max_accel_steps_per_s2 = MAX_E_JERK(extruder) / (extruder_advance_K[E_INDEX_N(extruder)] * e_D_ratio) * steps_per_mm;

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2408,36 +2408,38 @@ bool Planner::_populate_block(
       #define MAX_E_JERK(N) TERN(HAS_LINEAR_E_JERK, max_e_jerk[E_INDEX_N(N)], max_jerk.e)
 
       /**
-       * Use LIN_ADVANCE for blocks if all these are true:
-       *
-       * esteps                       : This is a print move, because we checked for A, B, C steps before.
-       *
-       * extruder_advance_K[extruder] : There is an advance factor set for this extruder.
-       *
-       * dm.e                         : Extruder is running forward (e.g., for "Wipe while retracting" (Slic3r) or "Combing" (Cura) moves)
+       * Apply Linear/Pressure Advance for blocks when:
+       *  !!esteps : This is a print move, because we checked for A, B, C steps before.
+       *  !!dm.e   : Extruder is running forward (e.g., for "Wipe while retracting" (Slic3r) or "Combing" (Cura) moves)
+       * ...then...
+       *  !!advanceK : There is an Advance K set so Linear/Pressure Advance is active.
+       *               Check the appropriate K value for Standard or Fixed-Time Motion.
        */
-      const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
-      const float advK = TERN_(FTM_HAS_LIN_ADVANCE, ftm_active ? ftMotion.cfg.linearAdvK :) extruder_advance_K[E_INDEX_N(extruder)];
-      use_adv_lead = esteps && advK && dm.e;
+      if (esteps && dm.e) {
+        const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
+        const float advK = TERN_(FTM_HAS_LIN_ADVANCE, ftm_active ? ftMotion.cfg.linearAdvK :) extruder_advance_K[E_INDEX_N(extruder)];
+        if (advK) {
+          float e_D_ratio = (target_float.e - position_float.e) /
+            TERN(IS_KINEMATIC, block->millimeters,
+              SQRT(sq(target_float.x - position_float.x)
+                 + sq(target_float.y - position_float.y)
+                 + sq(target_float.z - position_float.z))
+            );
 
-      if (use_adv_lead) {
-        float e_D_ratio = (target_float.e - position_float.e) /
-          TERN(IS_KINEMATIC, block->millimeters,
-            SQRT(sq(target_float.x - position_float.x)
-               + sq(target_float.y - position_float.y)
-               + sq(target_float.z - position_float.z))
-          );
-
-        // Check for unusual high e_D ratio to detect if a retract move was combined with the last print move due to min. steps per segment. Never execute this with advance!
-        // This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm and no one will print 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
-        if (e_D_ratio > 3.0f)
-          use_adv_lead = false;
-        else if (TERN0(HAS_ROUGH_LIN_ADVANCE, !ftm_active)) {
-          // Scale E acceleration so that it will be possible to jump to the advance speed.
-          const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
-          if (accel > max_accel_steps_per_s2) {
-            accel = max_accel_steps_per_s2;
-            if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
+          // Stay below an unusually high e_D ratio, a retract move combined with the last print move (due to min steps per segment).
+          //   Never execute this with advance!
+          // This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
+          //   and no one will print 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
+          use_adv_lead = e_D_ratio <= 3.0f;
+          if (use_adv_lead) {
+            if (TERN0(HAS_ROUGH_LIN_ADVANCE, !ftm_active)) {
+              // Scale E acceleration so that it will be possible to jump to the advance speed.
+              const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
+              if (accel > max_accel_steps_per_s2) {
+                accel = max_accel_steps_per_s2;
+                if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
+              }
+            }
           }
         }
         #if ANY(SMOOTH_LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -270,9 +270,8 @@ typedef struct PlannerBlock {
     xyze_pos_t dist_mm;                     // The distance traveled in mm along each axis
   #endif
 
-  // Advance extrusion
   #if ANY(SMOOTH_LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)
-    bool use_advance_lead;
+    bool use_advance_lead;                  // Linear / Pressure Advance extrusion
   #endif
 
   #if ENABLED(LIN_ADVANCE)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Had the wrong define name in 2 places after a rename, which disabled LA fully. Sorry for that

HAS_FTM_LIN_ADVANCE -> FTM_HAS_LIN_ADVANCE
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
