### PR TITLE
add M401_report so BLTOUCH_HS_MODE state is reported in M503

### DIFF
--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1050,6 +1050,7 @@ private:
 
   #if HAS_BED_PROBE
     static void M401();
+    static void M401_report(const bool forReplay=true);
     static void M402();
   #endif
 

--- a/Marlin/src/gcode/probe/M401_M402.cpp
+++ b/Marlin/src/gcode/probe/M401_M402.cpp
@@ -57,6 +57,19 @@ void GcodeSuite::M401() {
   report_current_position();
 }
 
+void GcodeSuite::M401_report(const bool forReplay/*=true*/) {
+  #if HAS_BLTOUCH_HS_MODE
+  if (!forReplay) {
+    report_heading_etc(forReplay, F("BLTouch HS mode"));
+    SERIAL_ECHOPGM_P(
+      PSTR("  M401 S"), bltouch.high_speed_mode,
+      PSTR("; "), ON_OFF(bltouch.high_speed_mode)
+    );
+    SERIAL_EOL();
+  }
+  #endif
+}
+
 /**
  * M402: Deactivate and stow the Z probe
  *  R<bool> Remain in place after stowing (and before deactivating) the probe

--- a/Marlin/src/gcode/probe/M401_M402.cpp
+++ b/Marlin/src/gcode/probe/M401_M402.cpp
@@ -58,15 +58,13 @@ void GcodeSuite::M401() {
 }
 
 void GcodeSuite::M401_report(const bool forReplay/*=true*/) {
+  TERN_(MARLIN_SMALL_BUILD, return);
+
   #if HAS_BLTOUCH_HS_MODE
-  if (!forReplay) {
-    report_heading_etc(forReplay, F("BLTouch HS mode"));
-    SERIAL_ECHOPGM_P(
-      PSTR("  M401 S"), bltouch.high_speed_mode,
-      PSTR("; "), ON_OFF(bltouch.high_speed_mode)
-    );
-    SERIAL_EOL();
-  }
+    if (!forReplay) {
+      report_heading_etc(forReplay, F("BLTouch HS mode"));
+      SERIAL_ECHOLNPGM("  M401 S", bltouch.high_speed_mode, " ; ", ON_OFF(bltouch.high_speed_mode));
+    }
   #endif
 }
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3961,6 +3961,11 @@ void MarlinSettings::reset() {
     TERN_(EDITABLE_SERVO_ANGLES, gcode.M281_report(forReplay));
 
     //
+    // BLTOUCH_HS_MODE ENABLED/DISABLED
+    //
+    TERN_(BLTOUCH_HS_MODE, gcode.M401_report(forReplay));
+
+    //
     // Kinematic Settings
     //
     TERN_(IS_KINEMATIC, gcode.M665_report(forReplay));

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3961,7 +3961,7 @@ void MarlinSettings::reset() {
     TERN_(EDITABLE_SERVO_ANGLES, gcode.M281_report(forReplay));
 
     //
-    // BLTOUCH_HS_MODE ENABLED/DISABLED
+    // BLTouch High Speed Mode
     //
     TERN_(BLTOUCH_HS_MODE, gcode.M401_report(forReplay));
 


### PR DESCRIPTION
### Description

As requested in https://github.com/MarlinFirmware/Marlin/issues/28071
Added the status of BLTouch High Speed (HS) Mode to M503

M503 eg when off
echo:; BLTouch HS mode:
echo:  M401 S0; OFF

M503 eg when on
echo:; BLTouch HS mode:
echo:  M401 S1; ON

### Requirements

BLTOUCH
BLTOUCH_HS_MODE

### Benefits

M503 has these details. (it was already visible with M401 H)

### Related Issues
<li>MarlinFirmware/Marlin/issues/28071