### PR TITLE
🐛  Trigger instant runout on filament jam

### DIFF
--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -51,7 +51,6 @@ bool FilamentMonitorBase::enabled = true,
   #if ENABLED(FILAMENT_MOTION_SENSOR)
     uint8_t FilamentSensorEncoder::motion_detected;
   #endif
-
   #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
     bool RunoutResponseDelayed::ignore_motion = false;
     float RunoutResponseDelayed::motion_distance_mm = FILAMENT_MOTION_DISTANCE_MM;


### PR DESCRIPTION
Fix an issue where a filament jam would fail to trigger a runout until the complete distance had been covered for a filament runout. This applies particularly to `FILAMENT_SWITCH_AND_MOTION` where the motion sensor is meant to detect jams and the runout switch is meant to detect filament running out or breaking, where it would typically be safe to keep extruding the amount of distance between the filament sensor and the extruder gears.

This PR resolves this rather straightforward bug by skipping the extra runout distance in the case of a filament jam.

Fixes #27843