### PR TITLE
fix advK if ftm is disabled but la is enabled

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2416,7 +2416,10 @@ bool Planner::_populate_block(
        *               Check the appropriate K value for Standard or Fixed-Time Motion.
        */
       if (esteps && dm.e) {
-        const float advK = TERN(FTM_HAS_LIN_ADVANCE, (ftMotion.cfg.active ? ftMotion.cfg.linearAdvK : extruder_advance_K[E_INDEX_N(extruder)]), extruder_advance_K[E_INDEX_N(extruder)]);
+        const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
+        const float advK = ftm_active
+          ? TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.linearAdvK)
+          : TERN0(HAS_ROUGH_LIN_ADVANCE, extruder_advance_K[E_INDEX_N(extruder)]);
         if (advK) {
           float e_D_ratio = (target_float.e - position_float.e) /
             TERN(IS_KINEMATIC, block->millimeters,
@@ -2430,14 +2433,12 @@ bool Planner::_populate_block(
           // This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
           //   and no one will print 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
           use_adv_lead = e_D_ratio <= 3.0f;
-          if (use_adv_lead) {
-            if (TERN0(HAS_ROUGH_LIN_ADVANCE, !TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active))) {
-              // Scale E acceleration so that it will be possible to jump to the advance speed.
-              const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
-              if (accel > max_accel_steps_per_s2) {
-                accel = max_accel_steps_per_s2;
-                if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
-              }
+          if (use_adv_lead && TERN0(HAS_ROUGH_LIN_ADVANCE, !ftm_active)) {
+            // For Standard Motion LA: Scale E acceleration so it'll be possible to jump to the advance speed
+            const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
+            if (accel > max_accel_steps_per_s2) {
+              accel = max_accel_steps_per_s2;
+              if (TERN0(LA_DEBUG, DEBUGGING(INFO))) SERIAL_ECHOLNPGM("Acceleration limited.");
             }
           }
         }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2416,8 +2416,7 @@ bool Planner::_populate_block(
        *               Check the appropriate K value for Standard or Fixed-Time Motion.
        */
       if (esteps && dm.e) {
-        const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
-        const float advK = TERN_(FTM_HAS_LIN_ADVANCE, ftm_active ? ftMotion.cfg.linearAdvK :) TERN0(LIN_ADVANCE, extruder_advance_K[E_INDEX_N(extruder)]);
+        const float advK = TERN(FTM_HAS_LIN_ADVANCE, (ftMotion.cfg.active ? ftMotion.cfg.linearAdvK : extruder_advance_K[E_INDEX_N(extruder)]), extruder_advance_K[E_INDEX_N(extruder)]);
         if (advK) {
           float e_D_ratio = (target_float.e - position_float.e) /
             TERN(IS_KINEMATIC, block->millimeters,
@@ -2432,7 +2431,7 @@ bool Planner::_populate_block(
           //   and no one will print 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
           use_adv_lead = e_D_ratio <= 3.0f;
           if (use_adv_lead) {
-            if (TERN0(HAS_ROUGH_LIN_ADVANCE, !ftm_active)) {
+            if (TERN0(HAS_ROUGH_LIN_ADVANCE, !TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active))) {
               // Scale E acceleration so that it will be possible to jump to the advance speed.
               const uint32_t max_accel_steps_per_s2 = (MAX_E_JERK(extruder) / (advK * e_D_ratio)) * steps_per_mm;
               if (accel > max_accel_steps_per_s2) {


### PR DESCRIPTION
fix advK if ftm is disabled but la enabled
### Description

ftm_active is not propperly guarded to not kick in when LA is enabled but FTM is disabled.
its a helper variable only used in this function and can be removed and its functionality done inline.

introduced in 

https://github.com/MarlinFirmware/Marlin/pull/28065

also the fix in 

https://github.com/MarlinFirmware/Marlin/commit/e228a222a375668f11817be619d8b411b1ab34cb

is not right

### Requirements

Enable LA while FTM is disabled

### Benefits

no error like:

```
PS C:\Users\master\Documents\GitHub\Marlin> platformio run --silent -e STM32F401RC_creality_e3s1pro_abl
Marlin\src\module\planner.cpp: In static member function 'static bool Planner::_populate_block(block_t*, const abce_long_t&, const xyze_pos_t&, feedRate_t, uint8_t, const PlannerHints&, float&)':
Marlin\src\module\planner.cpp:2429:20: warning: unused variable 'ftm_active' [-Wunused-variable]
 2429 |         const bool ftm_active = TERN0(FTM_HAS_LIN_ADVANCE, ftMotion.cfg.active);
```
my line 2429 is line 2419 upstream.

### Configurations

not needed

### Related Issues

none.
