### PR TITLE
refix LA

### DIFF
--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -50,28 +50,32 @@ void say_shaping() {
   SERIAL_ECHO_TERNARY(ftMotion.cfg.active, "Fixed-Time Motion ", "en", "dis", "abled");
 
   // FT Shaping
+  const bool is_shaping = AXIS_IS_SHAPING(X) || AXIS_IS_SHAPING(Y) || AXIS_IS_SHAPING(Z) || AXIS_IS_SHAPING(E);
   bool sep = false;
-  SERIAL_ECHOPGM(" (");
-  #if HAS_X_AXIS
-    if (AXIS_IS_SHAPING(X)) say_shaper_type(X_AXIS, sep, STEPPER_A_NAME);
-  #endif
-  #if HAS_Y_AXIS
-    if (AXIS_IS_SHAPING(Y)) say_shaper_type(Y_AXIS, sep, STEPPER_B_NAME);
-  #endif
-  #if ENABLED(FTM_SHAPER_Z)
-    if (AXIS_IS_SHAPING(Z)) say_shaper_type(Z_AXIS, sep, STEPPER_C_NAME);
-  #endif
-  #if ENABLED(FTM_SHAPER_E)
-    if (AXIS_IS_SHAPING(E)) say_shaper_type(E_AXIS, sep, 'E');
-  #endif
-  SERIAL_ECHOLNPGM(")");
+  if (is_shaping) {
+    SERIAL_ECHOPGM(" (");
+    #if HAS_X_AXIS
+      if (AXIS_IS_SHAPING(X)) say_shaper_type(X_AXIS, sep, STEPPER_A_NAME);
+    #endif
+    #if HAS_Y_AXIS
+      if (AXIS_IS_SHAPING(Y)) say_shaper_type(Y_AXIS, sep, STEPPER_B_NAME);
+    #endif
+    #if ENABLED(FTM_SHAPER_Z)
+      if (AXIS_IS_SHAPING(Z)) say_shaper_type(Z_AXIS, sep, STEPPER_C_NAME);
+    #endif
+    #if ENABLED(FTM_SHAPER_E)
+      if (AXIS_IS_SHAPING(E)) say_shaper_type(E_AXIS, sep, 'E');
+    #endif
+    SERIAL_CHAR(')');
+  }
+  SERIAL_EOL();
 
   const bool z_based = TERN0(HAS_DYNAMIC_FREQ_MM, ftMotion.cfg.dynFreqMode == dynFreqMode_Z_BASED),
              g_based = TERN0(HAS_DYNAMIC_FREQ_G,  ftMotion.cfg.dynFreqMode == dynFreqMode_MASS_BASED),
              dynamic = z_based || g_based;
 
   // FT Dynamic Frequency Mode
-  if (AXIS_IS_SHAPING(X) || AXIS_IS_SHAPING(Y) || AXIS_IS_SHAPING(Z) || AXIS_IS_SHAPING(E)) {
+  if (is_shaping) {
     #if HAS_DYNAMIC_FREQ
       SERIAL_ECHOPGM("Dynamic Frequency Mode ");
       switch (ftMotion.cfg.dynFreqMode) {
@@ -119,11 +123,10 @@ void say_shaping() {
   }
 
   #if HAS_EXTRUDERS
-    SERIAL_ECHO_TERNARY(ftMotion.cfg.linearAdvEna, "Linear Advance ", "en", "dis", "abled");
-    if (ftMotion.cfg.linearAdvEna)
+    if (ftMotion.cfg.active) {
+      SERIAL_ECHO_TERNARY(ftMotion.cfg.linearAdvEna, "Linear Advance ", "en", "dis", "abled");
       SERIAL_ECHOLNPGM(". Gain: ", ftMotion.cfg.linearAdvK);
-    else
-      SERIAL_EOL();
+    }
   #endif
 }
 
@@ -287,7 +290,6 @@ void GcodeSuite::M493() {
       const bool val = parser.value_bool();
       ftMotion.cfg.linearAdvEna = val;
       flag.report = true;
-      SERIAL_ECHO_TERNARY(val, "Linear Advance ", "en", "dis", "abled.\n");
     }
 
     // Pressure control (linear advance) gain parameter.

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -625,8 +625,12 @@ void FTMotion::loadBlockData(block_t * const current_block) {
      *                                   and no one will print 100mm wide lines using 3mm filament or
      *                                   35mm wide lines using 1.75mm filament.
      */
-    use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
-                       moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
+    if (!current_block->use_advance_lead) {
+      use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
+                         moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
+      if (use_advance_lead)
+        SERIAL_ECHOLNPGM("The block code is totally lame.");
+    }
   #endif
 
   // Watch endstops until the move ends

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -613,25 +613,7 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
   endPos_prevBlock += moveDist;
 
-   #if FTM_HAS_LIN_ADVANCE
-    /**
-     * Use LIN_ADVANCE for blocks if all these are true:
-     * moveDist.e > 0                   : This is a print move.
-     * cfg.linearAdvK > 0               : There is an advance factor set.
-     * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
-     *                                   combined with the last print move due to min. steps per segment.
-     *                                   Never execute this with advance!
-     *                                   This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
-     *                                   and no one will print 100mm wide lines using 3mm filament or
-     *                                   35mm wide lines using 1.75mm filament.
-     */
-    if (!current_block->use_advance_lead) {
-      use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
-                         moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
-      if (use_advance_lead)
-        SERIAL_ECHOLNPGM("The block code is totally lame.");
-    }
-  #endif
+  TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
 
   // Watch endstops until the move ends
   const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -613,7 +613,21 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
   endPos_prevBlock += moveDist;
 
-  TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
+   #if FTM_HAS_LIN_ADVANCE
+    /**
+    * Use LIN_ADVANCE for blocks if all these are true:
+    * moveDist.e > 0                   : This is a print move.
+    * cfg.linearAdvK > 0               : There is an advance factor set.
+    * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
+                                        combined with the last print move due to min. steps per segment.
+                                        Never execute this with advance!
+                                        This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
+                                        and no one will print 100mm wide lines using 3mm filament or
+                                        35mm wide lines using 1.75mm filament.
+    */
+    use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
+                       moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
+  #endif
 
   // Watch endstops until the move ends
   const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -615,16 +615,16 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
    #if FTM_HAS_LIN_ADVANCE
     /**
-    * Use LIN_ADVANCE for blocks if all these are true:
-    * moveDist.e > 0                   : This is a print move.
-    * cfg.linearAdvK > 0               : There is an advance factor set.
-    * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
-                                        combined with the last print move due to min. steps per segment.
-                                        Never execute this with advance!
-                                        This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
-                                        and no one will print 100mm wide lines using 3mm filament or
-                                        35mm wide lines using 1.75mm filament.
-    */
+     * Use LIN_ADVANCE for blocks if all these are true:
+     * moveDist.e > 0                   : This is a print move.
+     * cfg.linearAdvK > 0               : There is an advance factor set.
+     * moveDist.e / totalLength < 3.0f  : Check for unusual high e_D ratio to detect if a retract move was
+     *                                   combined with the last print move due to min. steps per segment.
+     *                                   Never execute this with advance!
+     *                                   This assumes no one will use a retract length of 0mm < retr_length < ~0.2mm
+     *                                   and no one will print 100mm wide lines using 3mm filament or
+     *                                   35mm wide lines using 1.75mm filament.
+     */
     use_advance_lead = moveDist.e > 0 && cfg.linearAdvK > 0 &&
                        moveDist.e / (SQRT(sq(moveDist.x) + sq(moveDist.y) + sq(moveDist.z))) < 3.0f;
   #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2442,9 +2442,6 @@ bool Planner::_populate_block(
             }
           }
         }
-        #if ANY(SMOOTH_LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)
-          block->use_advance_lead = use_adv_lead;
-        #endif
       }
     #endif // LIN_ADVANCE || FTM_HAS_LIN_ADVANCE
 
@@ -2496,6 +2493,10 @@ bool Planner::_populate_block(
       const uint32_t xy_steps = TERN0(INPUT_SHAPING_X, block->steps.x) + TERN0(INPUT_SHAPING_Y, block->steps.y);
       block->xy_length_inv_q30 = xy_steps ? (_BV32(30) / xy_steps) : 0;
     #endif
+  #endif
+
+  #if ANY(SMOOTH_LIN_ADVANCE, FTM_HAS_LIN_ADVANCE)
+    block->use_advance_lead = use_adv_lead;
   #endif
 
   // Formula for the average speed over a 1 step worth of distance if starting from zero and


### PR DESCRIPTION

### Description

Linear advance is still broken in ftmotion.
I do not know why using `use_advance_lead` from the block does not work, but computing it inside ftmotion does.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
