### PR TITLE
Update genallfont.sh, add support for includes and a minor edit

### DIFF
--- a/Marlin/src/lcd/dogm/fontdata/fontdata_ISO10646_1.h
+++ b/Marlin/src/lcd/dogm/fontdata/fontdata_ISO10646_1.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/lcd/dogm/fontdata/fontdata_ISO10646_1.h
+++ b/Marlin/src/lcd/dogm/fontdata/fontdata_ISO10646_1.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2023 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/buildroot/share/fonts/genallfont.sh
+++ b/buildroot/share/fonts/genallfont.sh
@@ -77,6 +77,13 @@ for ALANG in ${LANG_ARG:=$LANGS_DEFAULT} ; do
   DN_WORK=$(mktemp -d)
   cp Configuration.h ${DN_WORK}/
   cp src/lcd/language/language_${ALANG}.h ${DN_WORK}/
+  # Find and copy included language files
+  included_files=$(grep -o '#include "language_[^"]*\.h"' src/lcd/language/language_${ALANG}.h | sed 's/#include "\(.*\)"/\1/')
+  for inc_file in $included_files; do
+    if [ -f "src/lcd/language/$inc_file" ]; then
+      cp "src/lcd/language/$inc_file" ${DN_WORK}/
+    fi
+  done
   cd "${DN_WORK}"
   ${DN_EXEC}/uxggenpages.sh "${FONTFILE}" $ALANG
   sed -i fontutf8-data.h -e 's|fonts//|fonts/|g' -e 's|fonts//|fonts/|g' -e 's|[/0-9a-zA-Z_\-]*buildroot/share/fonts|buildroot/share/fonts|' 2>/dev/null
@@ -126,7 +133,7 @@ if [ 1 = 1 ]; then
 
 #include <U8glib-HAL.h>
 
-#if defined(__AVR__) && ENABLED(NOT_EXTENDED_ISO10646_1_5X7)
+#if ALL(__AVR__, NOT_EXTENDED_ISO10646_1_5X7)
   // reduced font (only symbols 1 - 127) - saves about 1278 bytes of FLASH
 
 $TMP1

--- a/buildroot/share/fonts/genallfont.sh
+++ b/buildroot/share/fonts/genallfont.sh
@@ -78,12 +78,11 @@ for ALANG in ${LANG_ARG:=$LANGS_DEFAULT} ; do
   cp Configuration.h ${DN_WORK}/
   cp src/lcd/language/language_${ALANG}.h ${DN_WORK}/
   # Find and copy included language files
-  included_files=$(grep -o '#include "language_[^"]*\.h"' src/lcd/language/language_${ALANG}.h | sed 's/#include "\(.*\)"/\1/')
-  for inc_file in $included_files; do
-    if [ -f "src/lcd/language/$inc_file" ]; then
-      cp "src/lcd/language/$inc_file" ${DN_WORK}/
-    fi
-  done
+  sed -n 's/^#include "\(language_[^"]*\.h\)".*/\1/p' "src/lcd/language/language_${ALANG}.h" |
+    while IFS= read -r f; do
+      src="src/lcd/language/$f"
+      [ -f "$src" ] && cp "$src" "$DN_WORK/"
+    done
   cd "${DN_WORK}"
   ${DN_EXEC}/uxggenpages.sh "${FONTFILE}" $ALANG
   sed -i fontutf8-data.h -e 's|fonts//|fonts/|g' -e 's|fonts//|fonts/|g' -e 's|[/0-9a-zA-Z_\-]*buildroot/share/fonts|buildroot/share/fonts|' 2>/dev/null

--- a/buildroot/share/fonts/genallfont.sh
+++ b/buildroot/share/fonts/genallfont.sh
@@ -64,6 +64,9 @@ fi
 #
 LANGS_DEFAULT="an bg ca cz da de el el_CY en es eu fi fr fr_na gl hr hu it jp_kana ko_KR nl pl pt pt_br ro ru sk sv tr uk vi zh_CN zh_TW test"
 
+DN_WORK=$(mktemp -d)
+open "$DN_WORK"
+
 #
 # Generate data for language list MARLIN_LANGS or all if not provided
 #
@@ -74,7 +77,6 @@ for ALANG in ${LANG_ARG:=$LANGS_DEFAULT} ; do
      ko_* ) FONTFILE="${DN_EXEC}/NanumGothic.bdf" ;;
         * ) FONTFILE="${DN_EXEC}/marlin-6x12-3.bdf" ;;
   esac
-  DN_WORK=$(mktemp -d)
   cp Configuration.h ${DN_WORK}/
   cp src/lcd/language/language_${ALANG}.h ${DN_WORK}/
   # Find and copy included language files
@@ -88,8 +90,10 @@ for ALANG in ${LANG_ARG:=$LANGS_DEFAULT} ; do
   sed -i fontutf8-data.h -e 's|fonts//|fonts/|g' -e 's|fonts//|fonts/|g' -e 's|[/0-9a-zA-Z_\-]*buildroot/share/fonts|buildroot/share/fonts|' 2>/dev/null
   cd - >/dev/null
   mv ${DN_WORK}/fontutf8-data.h src/lcd/dogm/fontdata/langdata_${ALANG}.h
-  rm -rf ${DN_WORK}
+  rm -rf ${DN_WORK}/*
 done
+
+rm -rf ${DN_WORK}
 
 #
 # Generate default ASCII font (char range 0-255):


### PR DESCRIPTION
### Description

While looking into lcd fonts I noticed that executing  genallfont.sh did not results in identical data being created in Marlin/src/lcd/dogm/fontdata file compared to what was already there.

Tracked it down to several changes: 

language_el_CY.h  added in https://github.com/MarlinFirmware/Marlin/pull/22799 uses an include "#include "language_el.h""   Script did not support this so generates a "empty" langdata_el_CY.h 
 
fontdata_ISO10646_1.h was directly edited in https://github.com/MarlinFirmware/Marlin/pull/28055
The current script reverts this directly committed change.

Updated so correct data is generated when using the  genallfont.sh script

Also in https://github.com/marlinfirmware/Marlin/commit/6a8ebddaf66fbe12d6d6b266d99080d66e618876 the copyright date for fontdata_ISO10646_1.h was updated.  but this is not in the provided file. So I have updated the provided file to match.  


### Requirements

genallfont.sh

### Benefits

Correct data is generated

