### PR TITLE
always have to check Tool parameter of gcodes

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -126,16 +126,14 @@ void GcodeSuite::say_units() {
  * Return -1 if the T parameter is out of range
  */
 int8_t GcodeSuite::get_target_extruder_from_command() {
-  #if HAS_TOOLCHANGE
-    if (parser.seenval('T')) {
-      const int8_t e = parser.value_byte();
-      if (e < EXTRUDERS) return e;
-      SERIAL_ECHO_START();
-      SERIAL_CHAR('M'); SERIAL_ECHO(parser.codenum);
-      SERIAL_ECHOLNPGM(" " STR_INVALID_EXTRUDER " ", e);
-      return -1;
-    }
-  #endif
+  if (parser.seenval('T')) {
+    const int8_t e = parser.value_byte();
+    if (e < EXTRUDERS) return e;
+    SERIAL_ECHO_START();
+    SERIAL_CHAR('M'); SERIAL_ECHO(parser.codenum);
+    SERIAL_ECHOLNPGM(" " STR_INVALID_EXTRUDER " ", e);
+    return -1;
+  }
   return active_extruder;
 }
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -130,8 +130,7 @@ int8_t GcodeSuite::get_target_extruder_from_command() {
     const int8_t e = parser.value_byte();
     if (e < EXTRUDERS) return e;
     SERIAL_ECHO_START();
-    SERIAL_CHAR('M'); SERIAL_ECHO(parser.codenum);
-    SERIAL_ECHOLNPGM(" " STR_INVALID_EXTRUDER " ", e);
+    SERIAL_ECHOLN(C('M'), parser.codenum, F(" " STR_INVALID_EXTRUDER " "), e);
     return -1;
   }
   return active_extruder;
@@ -149,7 +148,7 @@ int8_t GcodeSuite::get_target_e_stepper_from_command(const int8_t dval/*=-1*/) {
   if (dval == -2) return dval;
 
   SERIAL_ECHO_START();
-  SERIAL_CHAR('M'); SERIAL_ECHO(parser.codenum);
+  SERIAL_ECHO(C('M'), parser.codenum);
   if (e == -1)
     SERIAL_ECHOLNPGM(" " STR_E_STEPPER_NOT_SPECIFIED);
   else


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/issues/28081 noticed that gcodes with a tool parameter behave incorrectly when passed a gcode with an invalid tool.  
Instead of producing an error  on the gcode It applies the gcode to the primary tool.

eg gcode

M104 S240 T0
M104 S0 T1

With only a e0 extruder results in the extruder e0 being turned off not e1 or an error 

### Requirements

None

### Benefits

gcodes M92, M104, M105, M109, M200, M201, M203, M218, M221, M600, M603, M701 and M702 test the tool parameter and error if tool is not valid

### Related Issues

<li>MarlinFirmware/Marlin/issues/28081
<li>MarlinFirmware/Marlin/pull/26615