### PR TITLE
FEEDRATE_MODE_SUPPORT. Adds G93 inverse time mode and G94 units per minute feedrate mode

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2483,6 +2483,11 @@
 //#define INCH_MODE_SUPPORT
 
 //
+// G93/G94 Feedrate mode support
+//
+//#define FEEDRATE_MODE_SUPPORT
+
+//
 // M149 Set temperature units support
 //
 //#define TEMPERATURE_UNITS_SUPPORT

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -148,6 +148,7 @@
 #define STR_ERR_MATERIAL_INDEX              "M145 S<index> out of range (0-1)"
 #define STR_ERR_M421_PARAMETERS             "M421 incorrect parameter usage"
 #define STR_ERR_BAD_PLANE_MODE              "G5 requires XY plane mode"
+#define STR_ERR_BAD_FEEDRATE_MODE           "G5 currently requires units/min feedrate mode"
 #define STR_ERR_MESH_XY                     "Mesh point out of range"
 #define STR_ERR_ARC_ARGS                    "G2/G3 bad parameters"
 #define STR_ERR_PROTECTED_PIN               "Protected Pin"

--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -55,6 +55,8 @@ void GcodeSuite::G42() {
     return;
   }
 
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = true);
+
   // Move to current_position, as modified by I, J, P parameters
   destination = current_position;
 
@@ -68,8 +70,8 @@ void GcodeSuite::G42() {
     }
   #endif
 
-  const feedRate_t fval = parser.linearval('F'),
-                   fr_mm_s = MMM_TO_MMS(fval > 0 ? fval : 0.0f);
+  const feedRate_t fval = parser.feedrateval('F'),
+                   fr_mm_s = MMM_TO_MMS(fval);
 
   // SCARA kinematic has "safe" XY raw moves
   #if IS_SCARA
@@ -77,6 +79,8 @@ void GcodeSuite::G42() {
   #else
     prepare_internal_move_to_destination(fr_mm_s);
   #endif
+
+  TERN_(FEEDRATE_MODE_SUPPORT, print_move = false);
 }
 
 #endif // HAS_MESH

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -138,12 +138,12 @@ void GcodeSuite::M240() {
 
     #ifdef PHOTO_RETRACT_MM
       const float rval = parser.linearval('R', _PHOTO_RETRACT_MM);
-      const feedRate_t sval = parser.feedrateval('S', TERN(ADVANCED_PAUSE_FEATURE, PAUSE_PARK_RETRACT_FEEDRATE, TERN(FWRETRACT, RETRACT_FEEDRATE, 45)));
+      const feedRate_t sval = MMM_TO_MMS(parser.feedrateval('S', TERN(ADVANCED_PAUSE_FEATURE, PAUSE_PARK_RETRACT_FEEDRATE, TERN(FWRETRACT, RETRACT_FEEDRATE, 45))));
       e_move_m240(-rval, sval);
     #endif
 
-    feedRate_t fr_mm_s = parser.feedrateval('F');
-    if (fr_mm_s) NOLESS(fr_mm_s, 10.0f);
+    feedRate_t fr_mm_s = MMM_TO_MMS(parser.feedrateval('F'));
+    if (fr_mm_s && TERN1(FEEDRATE_MODE_SUPPORT, parser.inverse_time_enabled)) NOLESS(fr_mm_s, 10.0f);
 
     constexpr xyz_pos_t photo_position = PHOTO_POSITION;
     xyz_pos_t raw = {

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -202,7 +202,7 @@ void GcodeSuite::get_destination_from_command() {
   #endif
 
   if (parser.floatval('F') > 0) {
-    const float fr_mm_min = parser.value_linear_units();
+    const float fr_mm_min = parser.value_feedrate();
     feedrate_mm_s = MMM_TO_MMS(fr_mm_min);
     // Update the cutter feed rate for use by M4 I set inline moves.
     TERN_(LASER_FEATURE, cutter.feedrate_mm_m = fr_mm_min);
@@ -463,6 +463,11 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
       case 91: G91(); break;                                      // G91: Relative Mode
 
       case 92: G92(); break;                                      // G92: Set current axis position(s)
+
+      #if ENABLED(FEEDRATE_MODE_SUPPORT)
+        case 93: G93(); break;                                  // G93: Set feedrate mode to inverse time
+        case 94: G94(); break;                                  // G94: Set feedrate mode to length units per minute
+      #endif
 
       #if ENABLED(CALIBRATION_GCODE)
         case 425: G425(); break;                                  // G425: Perform calibration with calibration cube

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -637,6 +637,12 @@ private:
 
   static void G92();
 
+
+  #if ENABLED(FEEDRATE_MODE_SUPPORT)
+    static void G93();
+    static void G94();
+  #endif
+
   #if ENABLED(CALIBRATION_GCODE)
     static void G425();
   #endif

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -56,11 +56,21 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
   #ifdef G0_FEEDRATE
     feedRate_t old_feedrate;
     #if ENABLED(VARIABLE_G0_FEEDRATE)
+      TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = true);
       if (fast_move) {
         old_feedrate = feedrate_mm_s;             // Back up the (old) motion mode feedrate
         feedrate_mm_s = fast_move_feedrate;       // Get G0 feedrate from last usage
       }
+    #elif defined(FEEDRATE_MODE_SUPPORT)
+      if (fast_move) {
+        parser.print_move = false;
+      }
+      else {
+        parser.print_move = true;
+      }
     #endif
+  #elif ENABLED(FEEDRATE_MODE_SUPPORT)
+    parser.print_move = true;
   #endif
 
   get_destination_from_command();                 // Get X Y [Z[I[J[K]]]] [E] F (and set cutter power)
@@ -106,6 +116,8 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
     // Restore the motion mode feedrate
     if (fast_move) feedrate_mm_s = old_feedrate;
   #endif
+
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = false);
 
   #if ENABLED(NANODLP_Z_SYNC)
     #if ENABLED(NANODLP_ALL_AXIS)

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -212,12 +212,17 @@ void plan_arc(
   }
 
   // Feedrate for the move, scaled by the feedrate multiplier
-  const feedRate_t scaled_fr_mm_s = MMS_SCALED(feedrate_mm_s);
+  #if ENABLED(FEEDRATE_MODE_SUPPORT)
+    const feedRate_t scaled_fr = MMS_SCALED(feedrate_mm_s);
+    const feedRate_t scaled_fr_mm_s = parser.inverse_time_enabled ? scaled_fr * flat_mm : scaled_fr;
+  #else
+    const feedRate_t scaled_fr_mm_s = MMS_SCALED(feedrate_mm_s);
+  #endif
 
   // Get the ideal segment length for the move based on settings
   const float ideal_segment_mm = (
     #if ARC_SEGMENTS_PER_SEC  // Length based on segments per second and feedrate
-      constrain(scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC), MIN_ARC_SEGMENT_MM, MAX_ARC_SEGMENT_MM)
+      constrain(scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC, MIN_ARC_SEGMENT_MM, MAX_ARC_SEGMENT_MM))
     #else
       MAX_ARC_SEGMENT_MM      // Length using the maximum segment size
     #endif
@@ -236,7 +241,11 @@ void plan_arc(
   // Add hints to help optimize the move
   PlannerHints hints;
   #if ENABLED(FEEDRATE_SCALING)
-    hints.inv_duration = (scaled_fr_mm_s / flat_mm) * segments;
+    #if ENABLED(FEEDRATE_MODE_SUPPORT)
+      hints.inv_duration = segments * (parser.inverse_time_enabled ? scaled_fr : (scaled_fr_mm_s / flat_mm));
+    #else
+      hints.inv_duration = segments * (scaled_fr_mm_s / flat_mm);
+    #endif
   #endif
 
   /**
@@ -427,6 +436,8 @@ void GcodeSuite::G2_G3(const bool clockwise) {
 
   TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_RUNNING));
 
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = true);
+
   #if ENABLED(SF_ARC_FIX)
     const bool relative_mode_backup = relative_mode;
     relative_mode = true;
@@ -485,6 +496,8 @@ void GcodeSuite::G2_G3(const bool clockwise) {
   }
   else
     SERIAL_ERROR_MSG(STR_ERR_ARC_ARGS);
+
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = false);
 
   TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
 }

--- a/Marlin/src/gcode/motion/G5.cpp
+++ b/Marlin/src/gcode/motion/G5.cpp
@@ -54,6 +54,13 @@ void GcodeSuite::G5() {
     }
   #endif
 
+  #if ENABLED(FEEDRATE_MODE_SUPPORT)
+    if (parser.inverse_time_enabled) {
+      SERIAL_ERROR_MSG(STR_ERR_BAD_FEEDRATE_MODE);
+      return;
+    }
+  #endif
+
   get_destination_from_command();
 
   const xy_pos_t offsets[2] = {

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -37,6 +37,11 @@ bool GCodeParser::volumetric_enabled;
   float GCodeParser::linear_unit_factor, GCodeParser::volumetric_unit_factor;
 #endif
 
+#if ENABLED(FEEDRATE_MODE_SUPPORT)
+  bool GCodeParser::inverse_time_enabled;
+  bool GCodeParser::print_move;
+#endif
+
 #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   TempUnit GCodeParser::input_temp_units = TEMPUNIT_C;
 #endif

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -76,6 +76,11 @@ public:
     static float linear_unit_factor, volumetric_unit_factor;
   #endif
 
+  #if ENABLED(FEEDRATE_MODE_SUPPORT)
+    static bool inverse_time_enabled;
+    static bool print_move;
+  #endif
+
   #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
     static TempUnit input_temp_units;
   #endif
@@ -415,7 +420,13 @@ public:
 
   #endif // !TEMPERATURE_UNITS_SUPPORT
 
-  static feedRate_t value_feedrate() { return MMM_TO_MMS(value_linear_units()); }
+  static feedRate_t value_feedrate() { 
+    #if ENABLED(FEEDRATE_MODE_SUPPORT)
+      return (inverse_time_enabled && print_move) ? value_float() : value_linear_units();
+    #else
+      return value_linear_units();
+    #endif
+  }
 
   void unknown_command_warning();
 

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -45,12 +45,17 @@ inline void G38_single_probe(const uint8_t move_value) {
 inline bool G38_run_probe() {
 
   bool G38_pass_fail = false;
-
+  if (probe.offset.x || probe.offset.y || probe.offset.z) {
+    const xyze_pos_t npos_start = current_position - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+    const xyze_pos_t npos_destination = destination - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+    do_blocking_move_to(npos_start);
+    destination = npos_destination;
+  }
   #if MULTIPLE_PROBING > 1
     // Get direction of move and retract
     xyz_float_t retract_mm;
     LOOP_NUM_AXES(i) {
-      const float dist = destination[i] - current_position[i];
+      const float dist = npos_destination[i] - npos_start[i];
       retract_mm[i] = ABS(dist) < G38_MINIMUM_MOVE ? 0 : home_bump_mm((AxisEnum)i) * (dist > 0 ? -1 : 1);
     }
   #endif
@@ -79,7 +84,11 @@ inline bool G38_run_probe() {
       endstops.enable(false);
       prepare_line_to_destination();
       planner.synchronize();
-
+      #if ENABLED(SOLENOID_PROBE)
+        probe.stow();
+        safe_delay(1000);
+        probe.deploy();
+      #endif
       REMEMBER(fr, feedrate_mm_s, feedrate_mm_s * 0.25);
 
       // Bump the target more slowly
@@ -88,8 +97,13 @@ inline bool G38_run_probe() {
       G38_single_probe(move_value);
     #endif
   }
-
-  endstops.not_homing();
+  if (probe.offset.x || probe.offset.y || probe.offset.z) {
+    endstops.enable(false);
+    TERN_(SOLENOID_PROBE, probe.stow());
+    destination += DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+    do_blocking_move_to(destination);
+    planner.synchronize();
+  }
   return G38_pass_fail;
 }
 
@@ -105,24 +119,29 @@ inline bool G38_run_probe() {
  *  G38.5 - Probe away from workpiece, stop on contact break
  */
 void GcodeSuite::G38(const int8_t subcode) {
-
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = true);
   // Get X Y Z E F
   get_destination_from_command();
 
   remember_feedrate_scaling_off();
-
+  probe.use_probing_tool();
   const bool error_on_fail = TERN(G38_PROBE_AWAY, !TEST(subcode, 0), subcode == 2);
 
   // If any axis has enough movement, do the move
-  LOOP_NUM_AXES(i)
+  LOOP_NUM_AXES(i) {
     if (ABS(destination[i] - current_position[i]) >= G38_MINIMUM_MOVE) {
-      if (!parser.seenval('F')) feedrate_mm_s = homing_feedrate((AxisEnum)i);
+      if (!parser.seenval('F')) {
+        TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = false);
+        feedrate_mm_s = homing_feedrate((AxisEnum)i);
+      }
       // If G38.2 fails throw an error
       if (!G38_run_probe() && error_on_fail) SERIAL_ERROR_MSG("Failed to reach target");
       break;
     }
-
+  }
+  probe.use_probing_tool(false);
   restore_feedrate_and_scaling();
+  TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = false);
 }
 
 #endif // G38_PROBE_TARGET

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -45,12 +45,21 @@ inline void G38_single_probe(const uint8_t move_value) {
 inline bool G38_run_probe() {
 
   bool G38_pass_fail = false;
-  if (probe.offset.x || probe.offset.y || probe.offset.z) {
-    const xyze_pos_t npos_start = current_position - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
-    const xyze_pos_t npos_destination = destination - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
-    do_blocking_move_to(npos_start);
-    destination = npos_destination;
+  const xyze_pos_t start_pos = current_position;
+  const xyze_pos_t old_destination = destination;
+  probe.use_probing_tool();
+  if (probe.deploy()) {
+    SERIAL_ERROR_MSG("Failed to deploy probe");
+    endstops.not_homing();
+    probe.use_probing_tool(false);
+    return false;
   }
+  const xyze_pos_t npos_start = start_pos - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+  const xyze_pos_t npos_destination = old_destination - DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+  do_blocking_move_to(npos_start);
+  destination = npos_destination;
+
+
   #if MULTIPLE_PROBING > 1
     // Get direction of move and retract
     xyz_float_t retract_mm;
@@ -87,7 +96,11 @@ inline bool G38_run_probe() {
       #if ENABLED(SOLENOID_PROBE)
         probe.stow();
         safe_delay(1000);
-        probe.deploy();
+        if (probe.deploy()) {
+          endstops.not_homing();
+          probe.use_probing_tool(false);
+          return false;
+        }
       #endif
       REMEMBER(fr, feedrate_mm_s, feedrate_mm_s * 0.25);
 
@@ -97,13 +110,14 @@ inline bool G38_run_probe() {
       G38_single_probe(move_value);
     #endif
   }
-  if (probe.offset.x || probe.offset.y || probe.offset.z) {
-    endstops.enable(false);
-    TERN_(SOLENOID_PROBE, probe.stow());
-    destination += DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
-    do_blocking_move_to(destination);
-    planner.synchronize();
-  }
+  endstops.enable(false);
+  TERN_(SOLENOID_PROBE, probe.stow());
+  const xyze_pos_t probed_pos = current_position + DIFF_TERN(HAS_HOTEND_OFFSET, probe.offset, hotend_offset[active_extruder]);
+  probe.use_probing_tool(false);
+  destination = probed_pos;
+  do_blocking_move_to(destination);
+  planner.synchronize();
+  endstops.not_homing();
   return G38_pass_fail;
 }
 
@@ -124,7 +138,6 @@ void GcodeSuite::G38(const int8_t subcode) {
   get_destination_from_command();
 
   remember_feedrate_scaling_off();
-  probe.use_probing_tool();
   const bool error_on_fail = TERN(G38_PROBE_AWAY, !TEST(subcode, 0), subcode == 2);
 
   // If any axis has enough movement, do the move
@@ -139,7 +152,6 @@ void GcodeSuite::G38(const int8_t subcode) {
       break;
     }
   }
-  probe.use_probing_tool(false);
   restore_feedrate_and_scaling();
   TERN_(FEEDRATE_MODE_SUPPORT, parser.print_move = false);
 }

--- a/Marlin/src/gcode/units/G93_G94.cpp
+++ b/Marlin/src/gcode/units/G93_G94.cpp
@@ -1,0 +1,47 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2025 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file G93_G94.cpp
+ * @author DerAndere
+ * @brief G93 (inverse time mode) and G94 (units per minute feedrate mode).
+ *
+ * Copyright 2025 DerAndere
+ */
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(FEEDRATE_MODE_SUPPORT)
+
+#include "../gcode.h"
+
+/**
+ * G93: Set feedrate mode to inverse time
+ */
+void GcodeSuite::G93() { parser.inverse_time_enabled = true; }
+
+/**
+ * G94: Set feedrate mode to length units per minute
+ */
+void GcodeSuite::G94() { parser.inverse_time_enabled = false; }
+
+#endif // FEEDRATE_MODE_SUPPORT

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -145,6 +145,7 @@ xyze_pos_t destination; // {0}
   #define DEFAULT_FEEDRATE_MM_M 4000
 #endif
 feedRate_t feedrate_mm_s = MMM_TO_MMS(DEFAULT_FEEDRATE_MM_M);
+//bool print_move = false;
 int16_t feedrate_percentage = 100;
 #if ENABLED(EDITABLE_HOMING_FEEDRATE)
   xyz_feedrate_t homing_feedrate_mm_m = HOMING_FEEDRATE_MM_M;

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -113,6 +113,8 @@ feedRate_t get_homing_bump_feedrate(const AxisEnum axis);
  */
 extern feedRate_t feedrate_mm_s;
 
+//extern bool print_move;
+
 /**
  * Feedrate scaling is applied to all G0/G1, G2/G3, and G5 moves
  */

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2226,17 +2226,30 @@ bool Planner::_populate_block(
    * EXAMPLE: At 120mm/s a 60mm move involving XYZ axes takes 0.5s. So this will give 2.0.
    * EXAMPLE: At 120°/s a 60° move involving only rotational axes takes 0.5s. So this will give 2.0.
    */
-  float inverse_secs = inverse_millimeters * (
-    #if ALL(HAS_ROTATIONAL_AXES, INCH_MODE_SUPPORT)
-      /**
-       * Workaround for premature feedrate conversion
-       * from in/s to mm/s by get_distance_from_command.
-       */
-      cartesian_move ? fr_mm_s : LINEAR_UNIT(fr_mm_s)
-    #else
-      fr_mm_s
-    #endif
-  );
+
+  float inverse_secs;
+  if (TERN0(FEEDRATE_MODE_SUPPORT, parser.inverse_time_enabled && parser.print_move)) {
+    inverse_secs = fr_mm_s;
+    float min_inverse_secs;
+    if (esteps)
+      min_inverse_secs = settings.min_feedrate_mm_s * inverse_millimeters;
+    else
+      min_inverse_secs = settings.min_travel_feedrate_mm_s * inverse_millimeters;
+    NOLESS(inverse_secs, min_inverse_secs);
+  }
+  else {
+    inverse_secs  = inverse_millimeters * (
+      #if ALL(HAS_ROTATIONAL_AXES, INCH_MODE_SUPPORT)
+        /**
+         * Workaround for premature feedrate conversion
+         * from in/s to mm/s by get_distance_from_command.
+         */
+        cartesian_move ? fr_mm_s : LINEAR_UNIT(fr_mm_s)
+      #else
+        fr_mm_s
+      #endif
+    );
+  }
 
   // Get the number of non busy movements in queue (non busy means that they can be altered)
   const uint8_t moves_queued = nonbusy_movesplanned();

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -362,6 +362,7 @@ HAS_TEMP_PROBE                         = build_src_filter=+<src/gcode/temp/M192.
 HAS_PID_HEATING                        = build_src_filter=+<src/gcode/temp/M303.cpp>
 MPCTEMP                                = build_src_filter=+<src/gcode/temp/M306.cpp>
 INCH_MODE_SUPPORT                      = build_src_filter=+<src/gcode/units/G20_G21.cpp>
+FEEDRATE_MODE_SUPPORT                  = build_src_filter=+<src/gcode/units/G93_G94.cpp>
 TEMPERATURE_UNITS_SUPPORT              = build_src_filter=+<src/gcode/units/M149.cpp>
 NEED_HEX_PRINT                         = build_src_filter=+<src/libs/hex_print.cpp>
 NEED_LSF                               = build_src_filter=+<src/libs/least_squares_fit.cpp>


### PR DESCRIPTION
### Description

Add option `FEEDRATE_MODE_SUPPORT`. When this option is enabled, the following G-codes are supported:
- G93 (inverse time mode): Feedrate (Value of the F word) is specified in strokes per minute. 
- G94 (units per minute feedrate mode (default)

Background:

So far, Marlin only supported feedrate specified in units per minute (G94). Marlin uses the LinuxCNC definition of feedrate (https://github.com/MarlinFirmware/Marlin/blob/a506701a8b3db72316c0914919c0da706341b807/Marlin/src/module/motion.cpp#L1444-L1465). Feedrate in units per minute is not very intuitive if more than 3 axes are involved. Thus,  G93 inverse time mode is usually preferred for multi-axis machining.

Example: 

```
G90 ; absolute positioning
G1 X0 Y0 ; move to X0 Y0
G93 ; inverse time mode
G1 X10 F60 ; this move takes 1/60 minutes, i.e. 1 second
G1 X5 F60 ; this move takes in 1/60 minutes, i.e. 1 second
G1 X10 F10 ; this move takes 1/10 minutes, i.e.  6 seconds
```

Caveats:

- Currently, fixed time motion (`FT_MOTION`) will probably not work correctly when G93 inverse time mode is active. 
- Currently, in G93 mode, each move will be completed in ((1/F) minutes + time for acceleration + time for deceleration). It would be a further improvement if each move (including acceleration and deceleration) completes in (1/F) minutes.

### Requirements

`#define FEEDRATE_MODE_SUPPORT`

### Benefits

Support for G93 inverse time feedrate mode. This mode is preferred in multi-axis machining. 

### Configurations

Enable this new option in the default Configuration.h:
`#define FEEDRATE_MODE_SUPPORT`

### Related Issues

- This feature was requested via Email
- https://github.com/MarlinFirmware/Marlin/issues/8290
- https://github.com/MarlinFirmware/Marlin/pull/8311
