### PR TITLE
Fix trajectory resetting on init and reference to pointer

### DIFF
--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -73,7 +73,7 @@ typedef struct FTConfig {
     float linearAdvK = FTM_LINEAR_ADV_DEFAULT_K;          // Linear advance gain.
   #endif
 
-  TrajectoryType trajectory_type = TrajectoryType::TRAPEZOIDAL; // Trajectory generator type
+  TrajectoryType trajectory_type = TrajectoryType::FTM_TRAJECTORY_TYPE; // Trajectory generator type
   float poly6_acceleration_overshoot; // Overshoot factor for Poly6 (1.25 to 2.0)
 } ft_config_t;
 
@@ -186,7 +186,7 @@ class FTMotion {
     static TrapezoidalTrajectoryGenerator trapezoidalGenerator;
     static Poly5TrajectoryGenerator poly5Generator;
     static Poly6TrajectoryGenerator poly6Generator;
-    static TrajectoryGenerator& currentGenerator;
+    static TrajectoryGenerator* currentGenerator;
     static TrajectoryType trajectoryType;
 
     // Number of batches needed to propagate the current trajectory to the stepper.


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
A small pre-merge refactoring in #28082 broke runtime trajectory selection.
Furthermore trajectory type was being reset on each ftmotion init (which happens each time ftmotion is enabled, eg after homing)

Changing references back to pointers makes s_curves functional again. (see https://en.cppreference.com/w/cpp/language/reference_initialization.html#:~:text=A%20reference%20to%20T%20can%20be%20initialized%20with%20an%20object%20of%20type%20T%2C%20a%20function%20of%20type%20T%2C%20or%20an%20object%20implicitly%20convertible%20to%20T.%20Once%20initialized%2C%20a%20reference%20cannot%20be%20reseated%20(changed)%20to%20refer%20to%20another%20object.)

Changing init to use cfg.trajectory_type fixes the second bug.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
