### PR TITLE
Fix decrease feed rate in lcd mks ui.

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_change_speed.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_change_speed.cpp
@@ -62,7 +62,7 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       break;
     case ID_C_DEC:
       if (!editingFlowrate)
-        feedrate_percentage = _MAX(MIN_EXT_SPEED_PERCENT, feedrate_percentage + uiCfg.stepPrintSpeed);
+        feedrate_percentage = _MAX(MIN_EXT_SPEED_PERCENT, feedrate_percentage - uiCfg.stepPrintSpeed);
       else {
         const int16_t new_flow = _MAX(MIN_EXT_SPEED_PERCENT, planner.flow_percentage[0] - uiCfg.stepPrintSpeed);
         planner.set_flow(0, new_flow);


### PR DESCRIPTION
### Description

I ran into a problem with my MKS TS35 printer. When printing, the extruder speed decreased and then increased. Only one letter in one file was replaced. I fixed the problem and tested it out. It works!

### Requirements

MKS TS35 Screen

### Benefits

You can reduce the extrusion speed.

### Configurations

Just turn on the 
#define TFT_LVGL_UI
and 
#define TOUCH_SCREEN

### Related
<li>MarlinFirmware/Marlin/issues/28108
