### PR TITLE
Fix `linux_native_test`

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -29,11 +29,11 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/LINUX>
 extends          = env:linux_native
 extra_scripts    = ${common.extra_scripts}
                    post:buildroot/share/PlatformIO/scripts/collect-code-tests.py
-build_src_filter = ${env:linux_native.build_src_filter} +<tests>
-lib_deps         = throwtheswitch/Unity@^2.5.2
+build_src_filter = ${env:linux_native.build_src_filter} +<test>
+lib_deps         = throwtheswitch/Unity@^2.6.0
 test_build_src   = true
 build_unflags    =
-build_flags      = ${env:linux_native.build_flags} -Werror
+build_flags      = ${env:linux_native.build_flags} -Werror -DNO_USER_FEEDBACK_WARNING
 
 #
 # Native Simulation

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -29,7 +29,7 @@
 
 static std::list<MarlinTest*> all_marlin_tests;
 
-MarlinTest::MarlinTest(const std::string _name, const void(*_test)(), const char *_file, const int _line)
+MarlinTest::MarlinTest(const std::string& _name, const void(*_test)(), const char *_file, const int _line)
 : name(_name), test(_test), file(_file), line(_line) {
   all_marlin_tests.push_back(this);
 }

--- a/test/unit_tests.h
+++ b/test/unit_tests.h
@@ -33,7 +33,7 @@
  */
 class MarlinTest {
 public:
-    MarlinTest(const std::string name, const void(*test)(), const char *_file, const int line);
+    MarlinTest(const std::string& name, const void(*test)(), const char *_file, const int line);
     /**
      * Run the test via Unity
      */


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Building `linux_native_test` results in errors.

the following fixes/improves on it:
- update *throwtheswitch/Unity*
- use correct **test** directory
- add `NO_USER_FEEDBACK_WARNING`, which automatically resulted in error
- use reference for `const std::string`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
