### PR TITLE
FT_MOTION: fix PLR bug #28102

### DIFF
--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -31,6 +31,10 @@
 #include "stepper.h" // Access stepper block queue function and abort status.
 #include "endstops.h"
 
+#if ENABLED(POWER_LOSS_RECOVERY)
+  #include "../feature/powerloss.h"
+#endif
+
 FTMotion ftMotion;
 
 //-----------------------------------------------------------------
@@ -170,6 +174,12 @@ void FTMotion::loop() {
       continue;
     }
     loadBlockData(stepper.current_block);
+    
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      recovery.info.sdpos = stepper.current_block->sdpos;
+      recovery.info.current_position = stepper.current_block->start_position;
+    #endif
+
     blockProcRdy = true;
 
     // Some kinematics track axis motion in HX, HY, HZ


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
As reported by @vovodroid, power loss recovery is broken when FT_MOTION is active. In this case, SD card  and  print head positions are not saved. Now the positions are saved just after `loadblock()` in the `FT_MOTION` loop as in the standard motion system. Thanks to @ThomasToka for the advice.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
PLR enabled in `Configuration_adv.h`

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Fix bug #28102
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
