### PR TITLE
FT_MOTION : Use direction_bits and axis_did_move

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -877,11 +877,10 @@ void Endstops::update() {
 
   // Signal, after validation, if an endstop limit is pressed or not
 
-  #define AXIS_IS_MOVING(A) stepper.axis_is_moving(_AXIS(A))
   #define AXIS_DIR_REV(A)  !TERN(FT_MOTION, ftMotion, stepper).motor_direction(A)
 
   #if HAS_X_AXIS
-    if (AXIS_IS_MOVING(X)) {
+    if (stepper.axis_is_moving(X_AXIS)) {
       const AxisEnum x_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? X_AXIS : X_AXIS_HEAD;
       if (AXIS_DIR_REV(x_head)) {
         #if HAS_X_MIN_STATE
@@ -915,7 +914,7 @@ void Endstops::update() {
   #endif // HAS_X_AXIS
 
   #if HAS_Y_AXIS
-    if (AXIS_IS_MOVING(Y)) {
+    if (stepper.axis_is_moving(Y_AXIS)) {
       const AxisEnum y_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? Y_AXIS : Y_AXIS_HEAD;
       if (AXIS_DIR_REV(y_head)) {
         #if HAS_Y_MIN_STATE
@@ -949,7 +948,7 @@ void Endstops::update() {
   #endif // HAS_Y_AXIS
 
   #if HAS_Z_AXIS
-    if (AXIS_IS_MOVING(Z)) {
+    if (stepper.axis_is_moving(Z_AXIS)) {
       const AxisEnum z_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? Z_AXIS : Z_AXIS_HEAD;
       if (AXIS_DIR_REV(z_head)) {
         // Z- : Gantry down, bed up
@@ -997,7 +996,7 @@ void Endstops::update() {
   #endif // HAS_Z_AXIS
 
   #if HAS_I_AXIS && HAS_I_STATE
-    if (AXIS_IS_MOVING(I)) {
+    if (stepper.axis_is_moving(I_AXIS)) {
       if (AXIS_DIR_REV(I_AXIS_HEAD)) {
         #if HAS_I_MIN_STATE
           PROCESS_ENDSTOP(I, MIN);
@@ -1012,7 +1011,7 @@ void Endstops::update() {
   #endif // HAS_I_AXIS
 
   #if HAS_J_AXIS && HAS_J_STATE
-    if (AXIS_IS_MOVING(J)) {
+    if (stepper.axis_is_moving(J_AXIS)) {
       if (AXIS_DIR_REV(J_AXIS_HEAD)) {
         #if HAS_J_MIN_STATE
           PROCESS_ENDSTOP(J, MIN);
@@ -1027,7 +1026,7 @@ void Endstops::update() {
   #endif // HAS_J_AXIS
 
   #if HAS_K_AXIS && HAS_K_STATE
-    if (AXIS_IS_MOVING(K)) {
+    if (stepper.axis_is_moving(K_AXIS)) {
       if (AXIS_DIR_REV(K_AXIS_HEAD)) {
         #if HAS_K_MIN_STATE
           PROCESS_ENDSTOP(K, MIN);
@@ -1042,7 +1041,7 @@ void Endstops::update() {
   #endif // HAS_K_AXIS
 
   #if HAS_U_AXIS && HAS_U_STATE
-    if (AXIS_IS_MOVING(U)) {
+    if (stepper.axis_is_moving(U_AXIS)) {
       if (AXIS_DIR_REV(U_AXIS_HEAD)) {
         #if HAS_U_MIN_STATE
           PROCESS_ENDSTOP(U, MIN);
@@ -1057,7 +1056,7 @@ void Endstops::update() {
   #endif // HAS_U_AXIS
 
   #if HAS_V_AXIS && HAS_V_STATE
-    if (AXIS_IS_MOVING(V)) {
+    if (stepper.axis_is_moving(V_AXIS)) {
       if (AXIS_DIR_REV(V_AXIS_HEAD)) {
         #if HAS_V_MIN_STATE
           PROCESS_ENDSTOP(V, MIN);
@@ -1072,7 +1071,7 @@ void Endstops::update() {
   #endif // HAS_V_AXIS
 
   #if HAS_W_AXIS && HAS_W_STATE
-    if (AXIS_IS_MOVING(W)) {
+    if (stepper.axis_is_moving(W_AXIS)) {
       if (AXIS_DIR_REV(W_AXIS_HEAD)) {
         #if HAS_W_MIN_STATE
           PROCESS_ENDSTOP(W, MIN);

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -877,12 +877,10 @@ void Endstops::update() {
 
   // Signal, after validation, if an endstop limit is pressed or not
 
-  #define AXIS_DIR_REV(A)  !TERN(FT_MOTION, ftMotion, stepper).motor_direction(A)
-
   #if HAS_X_AXIS
     if (stepper.axis_is_moving(X_AXIS)) {
       const AxisEnum x_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? X_AXIS : X_AXIS_HEAD;
-      if (AXIS_DIR_REV(x_head)) {
+      if (!stepper.motor_direction(x_head)) {
         #if HAS_X_MIN_STATE
           PROCESS_ENDSTOP_X(MIN);
           #if   CORE_DIAG(XY, Y, MIN)
@@ -916,7 +914,7 @@ void Endstops::update() {
   #if HAS_Y_AXIS
     if (stepper.axis_is_moving(Y_AXIS)) {
       const AxisEnum y_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? Y_AXIS : Y_AXIS_HEAD;
-      if (AXIS_DIR_REV(y_head)) {
+      if (!stepper.motor_direction(y_head)) {
         #if HAS_Y_MIN_STATE
           PROCESS_ENDSTOP_Y(MIN);
           #if   CORE_DIAG(XY, X, MIN)
@@ -950,7 +948,7 @@ void Endstops::update() {
   #if HAS_Z_AXIS
     if (stepper.axis_is_moving(Z_AXIS)) {
       const AxisEnum z_head = TERN0(FT_MOTION, ftMotion.cfg.active) ? Z_AXIS : Z_AXIS_HEAD;
-      if (AXIS_DIR_REV(z_head)) {
+      if (!stepper.motor_direction(z_head)) {
         // Z- : Gantry down, bed up
         #if HAS_Z_MIN_STATE
           // If the Z_MIN_PIN is being used for the probe there's no
@@ -997,7 +995,7 @@ void Endstops::update() {
 
   #if HAS_I_AXIS && HAS_I_STATE
     if (stepper.axis_is_moving(I_AXIS)) {
-      if (AXIS_DIR_REV(I_AXIS_HEAD)) {
+      if (!stepper.motor_direction(I_AXIS_HEAD)) {
         #if HAS_I_MIN_STATE
           PROCESS_ENDSTOP(I, MIN);
         #endif
@@ -1012,7 +1010,7 @@ void Endstops::update() {
 
   #if HAS_J_AXIS && HAS_J_STATE
     if (stepper.axis_is_moving(J_AXIS)) {
-      if (AXIS_DIR_REV(J_AXIS_HEAD)) {
+      if (!stepper.motor_direction(J_AXIS_HEAD)) {
         #if HAS_J_MIN_STATE
           PROCESS_ENDSTOP(J, MIN);
         #endif
@@ -1027,7 +1025,7 @@ void Endstops::update() {
 
   #if HAS_K_AXIS && HAS_K_STATE
     if (stepper.axis_is_moving(K_AXIS)) {
-      if (AXIS_DIR_REV(K_AXIS_HEAD)) {
+      if (!stepper.motor_direction(K_AXIS_HEAD)) {
         #if HAS_K_MIN_STATE
           PROCESS_ENDSTOP(K, MIN);
         #endif
@@ -1042,7 +1040,7 @@ void Endstops::update() {
 
   #if HAS_U_AXIS && HAS_U_STATE
     if (stepper.axis_is_moving(U_AXIS)) {
-      if (AXIS_DIR_REV(U_AXIS_HEAD)) {
+      if (!stepper.motor_direction(U_AXIS_HEAD)) {
         #if HAS_U_MIN_STATE
           PROCESS_ENDSTOP(U, MIN);
         #endif
@@ -1057,7 +1055,7 @@ void Endstops::update() {
 
   #if HAS_V_AXIS && HAS_V_STATE
     if (stepper.axis_is_moving(V_AXIS)) {
-      if (AXIS_DIR_REV(V_AXIS_HEAD)) {
+      if (!stepper.motor_direction(V_AXIS_HEAD)) {
         #if HAS_V_MIN_STATE
           PROCESS_ENDSTOP(V, MIN);
         #endif
@@ -1072,7 +1070,7 @@ void Endstops::update() {
 
   #if HAS_W_AXIS && HAS_W_STATE
     if (stepper.axis_is_moving(W_AXIS)) {
-      if (AXIS_DIR_REV(W_AXIS_HEAD)) {
+      if (!stepper.motor_direction(W_AXIS_HEAD)) {
         #if HAS_W_MIN_STATE
           PROCESS_ENDSTOP(W, MIN);
         #endif

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -877,7 +877,7 @@ void Endstops::update() {
 
   // Signal, after validation, if an endstop limit is pressed or not
 
-  #define AXIS_IS_MOVING(A) TERN(FT_MOTION, ftMotion, stepper).axis_is_moving(_AXIS(A))
+  #define AXIS_IS_MOVING(A) stepper.axis_is_moving(_AXIS(A))
   #define AXIS_DIR_REV(A)  !TERN(FT_MOTION, ftMotion, stepper).motor_direction(A)
 
   #if HAS_X_AXIS

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -53,6 +53,8 @@ bool FTMotion::stepperCmdBuffHasData = false;   // The stepper buffer has items 
 
 // Private variables.
 
+bool FTMotion:: block_start = false;            // Will be set to true when a new block is loaded
+
 // NOTE: These are sized for Ulendo FBS use.
 xyze_trajectory_t    FTMotion::traj;            // = {0.0f} Storage for fixed-time-based trajectory.
 xyze_trajectoryMod_t FTMotion::trajMod;         // = {0.0f} Storage for fixed time trajectory window.
@@ -438,6 +440,8 @@ void FTMotion::reset() {
 
   traj.reset();
 
+  block_start = false;
+
   blockProcRdy = batchRdy = batchRdyForInterp = false;
 
   endPos_prevBlock.reset();
@@ -535,6 +539,7 @@ void FTMotion::setTrajectoryType(const TrajectoryType type) {
 // Load / convert block data from planner to fixed-time control variables.
 // Called from FTMotion::loop() at the fetch of the next planner block.
 void FTMotion::loadBlockData(block_t * const current_block) {
+  block_start = true; // Mark a new block
   // Cache the extruder index for this block
   TERN_(DISTINCT_E_FACTORS, block_extruder_axis = E_AXIS_N(current_block->extruder));
 
@@ -756,11 +761,15 @@ void FTMotion::generateStepsFromTrajectory(const uint32_t idx) {
     // Init the command to no STEP (Reverse DIR)
     cmd = 0;
 
-    // Accumulate the "error" for all axes according the fixed-point distance
-    step_error_q10 += delta_q10;
+   if(block_start)
+      block_start = false;
+    else {
+          // Accumulate the "error" for all axes according the fixed-point distance
+          step_error_q10 += delta_q10;
 
-    // Where the error has accumulated whole axis steps, add them to the command
-    LOGICAL_AXIS_MAP(RUN_AXIS);
+          // Where the error has accumulated whole axis steps, add them to the command
+          LOGICAL_AXIS_MAP(RUN_AXIS);
+    }
 
     // Next circular buffer index
     if (++stepperCmdBuff_produceIdx == (FTM_STEPPERCMD_BUFF_SIZE))

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -557,9 +557,6 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   // Plan the trajectory using the trajectory generator
   currentGenerator->plan(initial_speed, final_speed, current_block->acceleration, current_block->nominal_speed, totalLength);
 
-  // Accel + Coasting + Decel + datapoints
-  const float reminder_from_last_block = - tau;
-
   endPos_prevBlock += moveDist;
 
   TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -51,8 +51,6 @@ int32_t FTMotion::stepperCmdBuff_produceIdx = 0, // Index of next stepper comman
 
 bool FTMotion::stepperCmdBuffHasData = false;   // The stepper buffer has items and is in use.
 
-AxisBits FTMotion::axis_move_dir;
-
 // Private variables.
 
 // NOTE: These are sized for Ulendo FBS use.
@@ -439,7 +437,6 @@ void FTMotion::reset() {
   stepperCmdBuff_produceIdx = stepperCmdBuff_consumeIdx = 0;
 
   traj.reset();
-  stepper.axis_did_move.reset();
 
   blockProcRdy = batchRdy = batchRdyForInterp = false;
 
@@ -558,10 +555,6 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   endPos_prevBlock += moveDist;
 
   TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
-
-  // Set direction and moving bits for a new block
-  stepper.set_axis_moved_for_current_block();
-  axis_move_dir = current_block->direction_bits;
 
 }
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -51,7 +51,6 @@ int32_t FTMotion::stepperCmdBuff_produceIdx = 0, // Index of next stepper comman
 
 bool FTMotion::stepperCmdBuffHasData = false;   // The stepper buffer has items and is in use.
 
-XYZEval<millis_t> FTMotion::axis_move_end_ti = { 0 };
 AxisBits FTMotion::axis_move_dir;
 
 // Private variables.
@@ -440,6 +439,7 @@ void FTMotion::reset() {
   stepperCmdBuff_produceIdx = stepperCmdBuff_consumeIdx = 0;
 
   traj.reset();
+  stepper.axis_did_move.reset();
 
   blockProcRdy = batchRdy = batchRdyForInterp = false;
 
@@ -564,20 +564,10 @@ void FTMotion::loadBlockData(block_t * const current_block) {
 
   TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
 
-  // Watch endstops until the move ends
-  const float total_duration = currentGenerator->getTotalDuration();
-  uint32_t max_intervals = ceil((total_duration + reminder_from_last_block) * FTM_FS);
-  const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));
-
+  // Set direction and moving bits for a new block
+  stepper.set_axis_moved_for_current_block();
   axis_move_dir = current_block->direction_bits;
 
-  #define _SET_MOVE_END(A) do{ \
-    if (moveDist.A) { \
-      axis_move_end_ti.A = move_end_ti; \
-    } \
-  }while(0);
-
-  LOGICAL_AXIS_MAP(_SET_MOVE_END);
 }
 
 // Generate data points of the trajectory.

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -461,8 +461,6 @@ void FTMotion::reset() {
   TERN_(HAS_EXTRUDERS, prev_traj_e = 0.0f);  // Reset linear advance variables.
   TERN_(DISTINCT_E_FACTORS, block_extruder_axis = E_AXIS);
 
-  axis_move_end_ti.reset();
-
   if (did_suspend) stepper.wake_up();
 }
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -569,10 +569,11 @@ void FTMotion::loadBlockData(block_t * const current_block) {
   uint32_t max_intervals = ceil((total_duration + reminder_from_last_block) * FTM_FS);
   const millis_t move_end_ti = millis() + SEC_TO_MS((FTM_TS) * float(max_intervals + num_samples_shaper_settle() + ((PROP_BATCHES) + 1) * (FTM_BATCH_SIZE)) + (float(FTM_STEPPERCMD_BUFF_SIZE) / float(FTM_STEPPER_FS)));
 
+  axis_move_dir = current_block->direction_bits;
+
   #define _SET_MOVE_END(A) do{ \
     if (moveDist.A) { \
       axis_move_end_ti.A = move_end_ti; \
-      axis_move_dir.A = moveDist.A > 0; \
     } \
   }while(0);
 

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -158,7 +158,11 @@ class FTMotion {
     static void setTrajectoryType(const TrajectoryType type);
     static TrajectoryType getTrajectoryType() { return trajectoryType; }
 
+    static int32_t stepperCmdBuffItems();
+
   private:
+
+    static bool block_start; // Flag to mark block start
 
     static xyze_trajectory_t traj;
     static xyze_trajectoryMod_t trajMod;
@@ -246,7 +250,6 @@ class FTMotion {
     // Private methods
     static void discard_planner_block_protected();
     static void runoutBlock();
-    static int32_t stepperCmdBuffItems();
     static void loadBlockData(block_t *const current_block);
     static void generateTrajectoryPointsFromBlock();
     static void generateStepsFromTrajectory(const uint32_t idx);

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -161,7 +161,7 @@ class FTMotion {
     static TrajectoryType getTrajectoryType() { return trajectoryType; }
 
     FORCE_INLINE static bool motor_direction(const AxisEnum axis) {
-      return cfg.active ? axis_move_dir[axis] : stepper.last_direction_bits[axis];
+      return cfg.active ? axis_move_dir[axis] : stepper.motor_direction(axis);
     }
 
   private:

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -136,8 +136,6 @@ class FTMotion {
 
     static bool stepperCmdBuffHasData;                    // The stepper buffer has items and is in use.
 
-    static AxisBits axis_move_dir;
-
     // Public methods
     static void init();
     static void loop();                                   // Controller main, to be invoked from non-isr task.
@@ -159,10 +157,6 @@ class FTMotion {
     // Trajectory generator selection
     static void setTrajectoryType(const TrajectoryType type);
     static TrajectoryType getTrajectoryType() { return trajectoryType; }
-
-    FORCE_INLINE static bool motor_direction(const AxisEnum axis) {
-      return cfg.active ? axis_move_dir[axis] : stepper.motor_direction(axis);
-    }
 
   private:
 

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -136,7 +136,6 @@ class FTMotion {
 
     static bool stepperCmdBuffHasData;                    // The stepper buffer has items and is in use.
 
-    static XYZEval<millis_t> axis_move_end_ti;
     static AxisBits axis_move_dir;
 
     // Public methods
@@ -161,9 +160,6 @@ class FTMotion {
     static void setTrajectoryType(const TrajectoryType type);
     static TrajectoryType getTrajectoryType() { return trajectoryType; }
 
-    FORCE_INLINE static bool axis_is_moving(const AxisEnum axis) {
-      return cfg.active ? PENDING(millis(), axis_move_end_ti[axis]) : stepper.axis_is_moving(axis);
-    }
     FORCE_INLINE static bool motor_direction(const AxisEnum axis) {
       return cfg.active ? axis_move_dir[axis] : stepper.last_direction_bits[axis];
     }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3573,24 +3573,31 @@ void Stepper::report_positions() {
     if (++ftMotion.stepperCmdBuff_consumeIdx == (FTM_STEPPERCMD_BUFF_SIZE))
       ftMotion.stepperCmdBuff_consumeIdx = 0;
 
-    USING_TIMED_PULSE();
+        #define _FTM_SET_MOVE(AXIS) axis_did_move.bset(_AXIS(AXIS), _FTM_STEP(AXIS));
 
-    // Get FT Motion command flags for axis STEP / DIR
-    #define _FTM_STEP(AXIS) TEST(command, FT_BIT_STEP_##AXIS)
-    #define _FTM_DIR(AXIS) TEST(command, FT_BIT_DIR_##AXIS)
+    #define _FTM_SET_DIR(AXIS) if (_FTM_STEP(AXIS)) last_direction_bits.bset(_AXIS(AXIS), _FTM_DIR(AXIS));
+    
+    // Pop one command from the buffer
+    const ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
+    if (++ftMotion.stepperCmdBuff_consumeIdx == (FTM_STEPPERCMD_BUFF_SIZE))
+      ftMotion.stepperCmdBuff_consumeIdx = 0;
+    
+    // Test command for a block start
+    if((command == 0) && ftMotion.stepperCmdBuffItems()){
+      // Start of a block, pick the next buffer command and just set MOVE and DIR bits
+      const ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
+      LOGICAL_AXIS_MAP(_FTM_SET_MOVE);
+      LOGICAL_AXIS_MAP(_FTM_SET_DIR);
+      return;
+    }
+
+    USING_TIMED_PULSE();
 
     /**
      * Update direction bits for steppers that were stepped by this command.
      * HX, HY, HZ direction bits were set for Core kinematics
      * when the block was fetched and are not overwritten here.
      */
-
-    axis_did_move.reset();
-
-    #define _FTM_SET_MOVE_DIR(AXIS) if (_FTM_STEP(AXIS))  { last_direction_bits.bset(_AXIS(AXIS), _FTM_DIR(AXIS));\
-                                                            axis_did_move.bset(_AXIS(AXIS), true);\
-                                                          } 
-    LOGICAL_AXIS_MAP(_FTM_SET_MOVE_DIR);
 
     if (last_set_direction != last_direction_bits) {
       // Apply directions (generally applying to the entire linear move)

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3568,24 +3568,23 @@ void Stepper::report_positions() {
     ftMotion.stepperCmdBuffHasData = (ftMotion.stepperCmdBuff_produceIdx != ftMotion.stepperCmdBuff_consumeIdx);
     if (!ftMotion.stepperCmdBuffHasData) return;
 
-    // "Pop" one command from current motion buffer
-    const ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
-    if (++ftMotion.stepperCmdBuff_consumeIdx == (FTM_STEPPERCMD_BUFF_SIZE))
-      ftMotion.stepperCmdBuff_consumeIdx = 0;
+    // Get FT Motion command flags for axis STEP / DIR
+    #define _FTM_STEP(AXIS) TEST(command, FT_BIT_STEP_##AXIS)
+    #define _FTM_DIR(AXIS) TEST(command, FT_BIT_DIR_##AXIS)
 
-        #define _FTM_SET_MOVE(AXIS) axis_did_move.bset(_AXIS(AXIS), _FTM_STEP(AXIS));
+    #define _FTM_SET_MOVE(AXIS) axis_did_move.bset(_AXIS(AXIS), _FTM_STEP(AXIS));
 
     #define _FTM_SET_DIR(AXIS) if (_FTM_STEP(AXIS)) last_direction_bits.bset(_AXIS(AXIS), _FTM_DIR(AXIS));
-    
-    // Pop one command from the buffer
-    const ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
+
+    // "Pop" one command from current motion buffer
+    ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
     if (++ftMotion.stepperCmdBuff_consumeIdx == (FTM_STEPPERCMD_BUFF_SIZE))
       ftMotion.stepperCmdBuff_consumeIdx = 0;
     
     // Test command for a block start
     if((command == 0) && ftMotion.stepperCmdBuffItems()){
       // Start of a block, pick the next buffer command and just set MOVE and DIR bits
-      const ft_command_t command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
+      command = ftMotion.stepperCmdBuff[ftMotion.stepperCmdBuff_consumeIdx];
       LOGICAL_AXIS_MAP(_FTM_SET_MOVE);
       LOGICAL_AXIS_MAP(_FTM_SET_DIR);
       return;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3585,8 +3585,12 @@ void Stepper::report_positions() {
      * when the block was fetched and are not overwritten here.
      */
 
-    #define _FTM_SET_DIR(AXIS) if (_FTM_STEP(AXIS)) last_direction_bits.bset(_AXIS(AXIS), _FTM_DIR(AXIS));
-    LOGICAL_AXIS_MAP(_FTM_SET_DIR);
+    axis_did_move.reset();
+
+    #define _FTM_SET_MOVE_DIR(AXIS) if (_FTM_STEP(AXIS))  { last_direction_bits.bset(_AXIS(AXIS), _FTM_DIR(AXIS));\
+                                                            axis_did_move.bset(_AXIS(AXIS), true);\
+                                                          } 
+    LOGICAL_AXIS_MAP(_FTM_SET_MOVE_DIR);
 
     if (last_set_direction != last_direction_bits) {
       // Apply directions (generally applying to the entire linear move)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

In `loadblock(...)` function (`ft_motion.cpp`), axis directions are computed when a new block is loaded. These directions are already computed by the planner, so use them instead of setting axis_move_dir in a macro.And also fall back to previous settings for `endstops.update()` by using `axis_did_move` and `directions_bits`. The code is much simpler; the global behavior is not modified; it also uses less flash memory.
I think that @dbuezas has the same idea and feeling about current endstops handling.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
