### PR TITLE
Rename `BOARD_NEOPIXEL_PIX` to just `NEOPIXEL_PIN`

### DIFF
--- a/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
+++ b/Marlin/src/pins/esp32/pins_ENWI_ESPNP.h
@@ -115,5 +115,5 @@
 //
 // NeoPixel Rings
 //
-#define BOARD_NEOPIXEL_PIN                    14
+#define NEOPIXEL_PIN                          14
 #define NEOPIXEL2_PIN                         27

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -535,8 +535,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN               P1_24
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                     P1_24
 #endif
 
 /**

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -88,8 +88,8 @@
 #endif
 
 // LED driving pin
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN               P1_24
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                     P1_24
 #endif
 
 //

--- a/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
+++ b/Marlin/src/pins/native/pins_RAMPS_NATIVE.h
@@ -195,7 +195,7 @@
 //
 #define SD_SS_PIN                             53
 #define LED_PIN                               13
-#define BOARD_NEOPIXEL_PIN                    71
+#define NEOPIXEL_PIN                          71
 
 #ifndef FILWIDTH_PIN
   #define FILWIDTH_PIN                         5  // Analog Input on AUX2

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -1869,15 +1869,6 @@
 #undef _E_DIAG_EXISTS
 #undef E_DIAG_EXISTS
 
-// Get a NeoPixel pin from the LCD or board, if provided
-#ifndef NEOPIXEL_PIN
-  #if PIN_EXISTS(LCD_NEOPIXEL)
-    #define NEOPIXEL_PIN LCD_NEOPIXEL_PIN
-  #elif PIN_EXISTS(BOARD_NEOPIXEL)
-    #define NEOPIXEL_PIN BOARD_NEOPIXEL_PIN
-  #endif
-#endif
-
 // Undefine motor PWM pins for nonexistent axes since the existence of a MOTOR_CURRENT_PWM_*_PIN implies its standard use.
 // TODO: Allow remapping (e.g., E => Z2). Spec G-codes to use logical axis with index (e.g., to set Z2: Mxxx Z P1 Snnn).
 #if !HAS_X_AXIS

--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -252,7 +252,7 @@
   #define DOGLCD_A0                  LCD_PINS_DC
 
   #undef KILL_PIN
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #else
   #define BEEPER_PIN                 EXP1_01_PIN

--- a/Marlin/src/pins/sam/pins_PRINTRBOARD_G2.h
+++ b/Marlin/src/pins/sam/pins_PRINTRBOARD_G2.h
@@ -62,7 +62,7 @@
 // LED defines
 //
 //#define NEOPIXEL_TYPE                 NEO_GRBW  // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
-//#define BOARD_NEOPIXEL_PIN                  20  // LED driving pin on motherboard
+//#define NEOPIXEL_PIN                        20  // LED driving pin on motherboard
 //#define NEOPIXEL_PIXELS                      3  // Number of LEDs in the strip
 //#define SDA0                                20  // PB12 NeoPixel pin I2C data
 //#define SCL0                                21  // PB13              I2C clock

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -182,8 +182,8 @@
 //
 #define CASE_LIGHT_PIN                      PA13
 
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA8
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA8
 #endif
 
 #define SUICIDE_PIN                         PC13

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h
@@ -25,8 +25,8 @@
 
 #define BOARD_INFO_NAME "BTT SKR Mini E3 V1.2"
 
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PC7   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC7   // LED driving pin
 #endif
 
 /**

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -69,8 +69,8 @@
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG
 
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA8   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA8   // LED driving pin
 #endif
 
 #ifndef PS_ON_PIN

--- a/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
+++ b/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
@@ -121,7 +121,7 @@
 #define FAN2_PIN                            PB9   // FAN  (fan1 on board) controller cool fan
 
 // One NeoPixel onboard and a connector for other NeoPixels
-#define BOARD_NEOPIXEL_PIN                  PC7   // The NEOPIXEL LED driving pin
+#define NEOPIXEL_PIN                        PC7   // The NEOPIXEL LED driving pin
 
 /**
  *       ------

--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -238,7 +238,7 @@
 #if ENABLED(NEOPIXEL_LED)
   #define LED_PWM                           PC7   // IO1
   #ifndef NEOPIXEL_PIN
-    #define NEOPIXEL_PIN                LED_PWM   // USED WIFI IO0/IO1 PIN
+    #define NEOPIXEL_PIN                 LED_PWM  // USED WIFI IO0/IO1 PIN
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -126,7 +126,7 @@
   #define Y_SERIAL_TX_PIN                   PA9   // TXD1
   #define Z_SERIAL_TX_PIN                   PC7   // IO1
   #ifndef TMC_BAUD_RATE
-    #define TMC_BAUD_RATE                  19200
+    #define TMC_BAUD_RATE                   19200
   #endif
 #else
   // Motor current PWM pins
@@ -227,7 +227,7 @@
   #define FIL_RUNOUT2_PIN                   PE6   // MT_DET_2
 #endif
 #ifndef FIL_RUNOUT_STATE
-  #define FIL_RUNOUT_STATE                LOW
+  #define FIL_RUNOUT_STATE                  LOW
 #endif
 
 //
@@ -237,8 +237,8 @@
 
 #if ENABLED(NEOPIXEL_LED)
   #define LED_PWM                           PC7   // IO1
-  #ifndef BOARD_NEOPIXEL_PIN
-    #define BOARD_NEOPIXEL_PIN           LED_PWM  // USED WIFI IO0/IO1 PIN
+  #ifndef NEOPIXEL_PIN
+    #define NEOPIXEL_PIN                LED_PWM   // USED WIFI IO0/IO1 PIN
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -245,8 +245,8 @@
 #endif
 
 // LED driving pin
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA2
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA2
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -168,8 +168,8 @@
 //
 // Misc. Functions
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PB7   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PB7   // LED driving pin
 #endif
 
 #ifndef PS_ON_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -471,8 +471,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PB0
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PB0
 #endif
 
 #if ENABLED(WIFISUPPORT)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_MINI_E3_V3_0_1.h
@@ -92,8 +92,8 @@
   #define POWER_LOSS_PIN                    PC13  // Power Loss Detection: PWR-DET
 #endif
 
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA14  // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA14  // LED driving pin
 #endif
 
 #ifndef PS_ON_PIN

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -579,8 +579,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PE6
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PE6
 #endif
 
 #if ENABLED(WIFISUPPORT)

--- a/Marlin/src/pins/stm32f4/pins_FLY_CDY_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_FLY_CDY_V3.h
@@ -251,7 +251,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f4/pins_FLY_D8.h
+++ b/Marlin/src/pins/stm32f4/pins_FLY_D8.h
@@ -265,7 +265,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f4/pins_FLY_SUPER8.h
+++ b/Marlin/src/pins/stm32f4/pins_FLY_SUPER8.h
@@ -274,7 +274,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6_common.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6_common.h
@@ -209,7 +209,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -57,6 +57,6 @@
 #endif
 
 // The FYSETC_MINI_12864_2_1 uses one of the EXP pins
-#define BOARD_NEOPIXEL_PIN                  PC5
+#define NEOPIXEL_PIN                        PC5
 
 #include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_SKIPR_V1_0.h
@@ -312,8 +312,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PC5
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC5
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV3.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV3.h
@@ -149,7 +149,7 @@
 //
 // NeoPixel
 //
-#define BOARD_NEOPIXEL_PIN                  PC7
+#define NEOPIXEL_PIN                        PC7
 #define NEOPIXEL2_PIN                       PC8
 
 //

--- a/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
+++ b/Marlin/src/pins/stm32f4/pins_OPULO_LUMEN_REV4.h
@@ -149,7 +149,7 @@
 //
 // NeoPixel
 //
-#define BOARD_NEOPIXEL_PIN                  PC7
+#define NEOPIXEL_PIN                        PC7
 #define NEOPIXEL2_PIN                       PC8
 
 //

--- a/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
@@ -47,7 +47,7 @@
 //
 // NeoPixel
 //
-#define BOARD_NEOPIXEL_PIN                  PA8
+#define NEOPIXEL_PIN                        PA8
 
 //
 // Servos

--- a/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_EBB42_V1_1.h
@@ -134,8 +134,8 @@
 //
 // Default NEOPIXEL_PIN
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PD3   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PD3   // LED driving pin
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_E3_EZ_V1_0.h
@@ -334,6 +334,6 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PC7   // RGB
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC7   // RGB
 #endif

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
@@ -290,8 +290,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PD0
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PD0
 #endif
 
 #ifndef NEOPIXEL2_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
@@ -316,8 +316,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PC11  // RGB1
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC11  // RGB1
 #endif
 
 #ifndef NEOPIXEL2_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_0.h
@@ -68,8 +68,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PC6
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC6
 #endif
 
 #ifndef NEOPIXEL2_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_1.h
@@ -67,8 +67,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA9
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA9
 #endif
 
 #ifndef NEOPIXEL2_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
@@ -506,5 +506,5 @@
 // NeoPixel LED
 //
 #ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                       PE4  // RGB
+  #define NEOPIXEL_PIN                      PE4   // RGB
 #endif

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
@@ -505,6 +505,6 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                 PE4  // RGB
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                       PE4  // RGB
 #endif

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -453,8 +453,8 @@
 //
 // NeoPixel
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA8   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA8   // LED driving pin
 #endif
 
 // Pins for documentation and sanity checks only.

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h
@@ -382,8 +382,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PE10
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PE10
 #endif
 #ifndef NEOPIXEL2_PIN
   #define NEOPIXEL2_PIN                     PE9

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
@@ -201,7 +201,7 @@
 #define FAN1_PIN                            PA6   // FAN1
 #define FAN2_PIN                            PA7   // FAN2 / DCOT
 
-#define BOARD_NEOPIXEL_PIN                  PH3   // RGB
+#define NEOPIXEL_PIN                        PH3   // RGB
 #define NEOPIXEL2_PIN                       PB1
 
 #if HAS_LTDC_TFT

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_V3_0_common.h
@@ -602,8 +602,8 @@
 //
 // NeoPixel LED
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PE6
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PE6
 #endif
 
 #if ENABLED(WIFISUPPORT)

--- a/Marlin/src/pins/stm32h7/pins_FLY_D8_PRO.h
+++ b/Marlin/src/pins/stm32h7/pins_FLY_D8_PRO.h
@@ -205,7 +205,7 @@
 // Onboard SD support
 //
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              LCD
+  #define SDCARD_CONNECTION                 LCD
 #endif
 
 #if SD_CONNECTION_IS(LCD)
@@ -265,7 +265,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 

--- a/Marlin/src/pins/stm32h7/pins_FLY_SUPER8_PRO.h
+++ b/Marlin/src/pins/stm32h7/pins_FLY_SUPER8_PRO.h
@@ -208,7 +208,7 @@
 //#define SD_CARD_DETECT_PIN                PC13
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              LCD
+  #define SDCARD_CONNECTION                 LCD
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)
@@ -274,7 +274,7 @@
   #define FORCE_SOFT_SPI
 
   #define KILL_PIN                          -1    // NC
-  #define BOARD_NEOPIXEL_PIN         EXP1_07_PIN
+  #define NEOPIXEL_PIN               EXP1_07_PIN
 
 #elif HAS_WIRED_LCD
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
`LCD_NEOPIXEL_PIN` doesnt exist and `BOARD_NEOPIXEL_PIN` is just redundant

- Simply renames
- Adjust spacing in a couple other **pins_--.h** files
- Removes the now unnecessary check in **pins_postprocess.h**
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
