### PR TITLE
FT_MOTION : Remove Warning when FT_MOTION and FTM_HOME_AND_PROBE are enabled

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -314,7 +314,7 @@ void unified_bed_leveling::G29() {
   const bool may_move = p_val == 1 || p_val == 2 || p_val == 4 || parser.seen_test('J');
 
   // Potentially disable Fixed-Time Motion for probing
-  TERN_(FT_MOTION, FTMotionDisableInScope FT_Disabler);
+  TERN_(FT_MOTION, IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler));
 
   // Check for commands that require the printer to be homed
   if (may_move) {

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -277,7 +277,7 @@ G29_TYPE GcodeSuite::G29() {
 
   #if DISABLED(PROBE_MANUALLY) && ENABLED(FT_MOTION)
     // Potentially disable Fixed-Time Motion for probing
-    FTMotionDisableInScope FT_Disabler;
+    IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler);
   #endif
 
   /**

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -68,7 +68,7 @@ inline void echo_not_entered(const char c) { SERIAL_CHAR(c); SERIAL_ECHOLNPGM(" 
 void GcodeSuite::G29() {
 
   // Potentially disable Fixed-Time Motion for probing
-  TERN_(FT_MOTION, FTMotionDisableInScope FT_Disabler);
+  TERN_(FT_MOTION, IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler));
 
   DEBUG_SECTION(log_G29, "G29", true);
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -131,7 +131,7 @@
   inline void home_z_safely() {
 
     // Potentially disable Fixed-Time Motion for homing
-    TERN_(FT_MOTION, FTMotionDisableInScope FT_Disabler);
+    TERN_(FT_MOTION, IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler));
 
     DEBUG_SECTION(log_G28, "home_z_safely", DEBUGGING(LEVELING));
 
@@ -290,7 +290,7 @@ void GcodeSuite::G28() {
     #endif
 
     // Potentially disable Fixed-Time Motion for homing
-    TERN_(FT_MOTION, FTMotionDisableInScope FT_Disabler);
+    TERN_(FT_MOTION, IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler));
 
     // Always home with tool 0 active
     #if HAS_MULTI_HOTEND

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -81,7 +81,7 @@ void GcodeSuite::G30() {
     TERN_(HAS_PTC, ptc.set_enabled(parser.boolval('C', true)));
 
     // Potentially disable Fixed-Time Motion for probing
-    TERN_(FT_MOTION, FTMotionDisableInScope FT_Disabler);
+    TERN_(FT_MOTION, IF_DISABLED(FTM_HOME_AND_PROBE, FTMotionDisableInScope FT_Disabler));
 
     // Probe the bed, optionally raise, and return the measured height
     const float measured_z = probe.probe_at_point(probepos, raise_after);

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -271,8 +271,8 @@ class FTMotion {
 
 extern FTMotion ftMotion;
 
-typedef struct FTMotionDisableInScope {
-  #if DISABLED(FTM_HOME_AND_PROBE)
+#if DISABLED(FTM_HOME_AND_PROBE)
+  typedef struct FTMotionDisableInScope {
     bool isactive;
     FTMotionDisableInScope() {
       isactive = ftMotion.cfg.active;
@@ -282,5 +282,5 @@ typedef struct FTMotionDisableInScope {
       ftMotion.cfg.active = isactive;
       if (isactive) ftMotion.init();
     }
-  #endif
-} FTMotionDisableInScope_t;
+  } FTMotionDisableInScope_t;
+#endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Currently, when `FT_MOTION` and `FTM_HOME_AND_PROBE` are enabled, there is a warning during compilation for the unused variable `FTMotionDisableInScope FT_Disabler`. I just changed the preprocessor macros to get rid of this warning.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Suppress a warning during compilation
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
None
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
