### PR TITLE
Test Scripts Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ marlin:
 .PHONY: marlin
 
 clean:
-	rm -r .pio/build
+	rm -rf .pio/build*
 
 tests-single-ci:
 	export GIT_RESET_HARD=true

--- a/buildroot/bin/ci_src_filter
+++ b/buildroot/bin/ci_src_filter
@@ -6,7 +6,9 @@ set -e
 FN="platformio.ini"
 
 if [[ $1 == "-n" ]]; then
-  awk '/default_src_filter/ { sub("default_src_filter", "org_src_filter"); print "default_src_filter = +<src/*>"; } 1' $FN > $FN~ && mv $FN~ $FN
+  if ! grep -q "org_src_filter" "$FN"; then
+    awk '/default_src_filter/ { sub("default_src_filter", "org_src_filter"); print "default_src_filter = +<src/*>"; } 1' $FN > $FN~ && mv $FN~ $FN
+  fi
 else
   git checkout $FN 2>/dev/null
 fi

--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, sys, subprocess
+import os, subprocess
 
 files_to_remove = [
   "Marlin/_Bootscreen.h",
@@ -13,21 +13,11 @@ for file in files_to_remove:
   if os.path.exists(file):
     os.remove(file)
 
-def use_example_configs():
-  try:
-    subprocess.run(['use_example_configs'], check=True)
-  except FileNotFoundError:
-    print("use_example_configs not found, skipping.")
-  pass
-
-if len(sys.argv) > 1 and sys.argv[1] in ['-d', '--default']:
-  use_example_configs()
-else:
-  files_to_checkout = [
-    "Marlin/Configuration.h",
-    "Marlin/Configuration_adv.h",
-    "Marlin/config.ini",
-    "Marlin/src/pins/*/pins_*.h"
-  ]
-  for file in files_to_checkout:
-    subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)
+files_to_checkout = [
+  "Marlin/Configuration.h",
+  "Marlin/Configuration_adv.h",
+  "Marlin/config.ini",
+  "Marlin/src/pins/*/pins_*.h"
+]
+for file in files_to_checkout:
+  subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)

--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -3,31 +3,31 @@
 import os, sys, subprocess
 
 files_to_remove = [
-  "Marlin/_Bootscreen.h",
-  "Marlin/_Statusscreen.h",
-  "marlin_config.json",
-  ".pio/build/mc.zip"
+    "Marlin/_Bootscreen.h",
+    "Marlin/_Statusscreen.h",
+    "marlin_config.json",
+    ".pio/build/mc.zip"
 ]
 
 for file in files_to_remove:
-  if os.path.exists(file):
-    os.remove(file)
+    if os.path.exists(file):
+        os.remove(file)
 
 def use_example_configs():
-  try:
-    subprocess.run(['use_example_configs'], check=True)
-  except FileNotFoundError:
-    print("use_example_configs not found, skipping.")
-  pass
+    try:
+        subprocess.run(['use_example_configs'], check=True)
+    except FileNotFoundError:
+        print("use_example_configs not found, skipping.")
+    pass
 
 if len(sys.argv) > 1 and sys.argv[1] in ['-d', '--default']:
-  use_example_configs()
+    use_example_configs()
 else:
-  files_to_checkout = [
-    "Marlin/Configuration.h",
-    "Marlin/Configuration_adv.h",
-    "Marlin/config.ini",
-    "Marlin/src/pins/*/pins_*.h"
-  ]
-  for file in files_to_checkout:
-    subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)
+    files_to_checkout = [
+        "Marlin/Configuration.h",
+        "Marlin/Configuration_adv.h",
+        "Marlin/config.ini",
+        "Marlin/src/pins/*/pins_*.h"
+    ]
+    for file in files_to_checkout:
+        subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)

--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -17,7 +17,10 @@ def use_example_configs():
     try:
         subprocess.run(['use_example_configs'], check=True)
     except FileNotFoundError:
-        print("use_example_configs not found, skipping.")
+        try:
+            subprocess.run(['./buildroot/bin/use_example_configs'], check=True)
+        except FileNotFoundError:
+            print("use_example_configs not found, skipping.")
     pass
 
 if len(sys.argv) > 1 and sys.argv[1] in ['-d', '--default']:

--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, subprocess
+import os, sys, subprocess
 
 files_to_remove = [
   "Marlin/_Bootscreen.h",
@@ -13,11 +13,21 @@ for file in files_to_remove:
   if os.path.exists(file):
     os.remove(file)
 
-files_to_checkout = [
-  "Marlin/Configuration.h",
-  "Marlin/Configuration_adv.h",
-  "Marlin/config.ini",
-  "Marlin/src/pins/*/pins_*.h"
-]
-for file in files_to_checkout:
-  subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)
+def use_example_configs():
+  try:
+    subprocess.run(['use_example_configs'], check=True)
+  except FileNotFoundError:
+    print("use_example_configs not found, skipping.")
+  pass
+
+if len(sys.argv) > 1 and sys.argv[1] in ['-d', '--default']:
+  use_example_configs()
+else:
+  files_to_checkout = [
+    "Marlin/Configuration.h",
+    "Marlin/Configuration_adv.h",
+    "Marlin/config.ini",
+    "Marlin/src/pins/*/pins_*.h"
+  ]
+  for file in files_to_checkout:
+    subprocess.run(["git", "checkout", file], stderr=subprocess.DEVNULL)

--- a/buildroot/bin/use_example_configs
+++ b/buildroot/bin/use_example_configs
@@ -124,6 +124,11 @@ def main():
   else:
     config_path = "default"
 
+  try:
+    subprocess.run(['restore_configs'], check=True)
+  except FileNotFoundError:
+    print("restore_configs not found, skipping.")
+
   fetch_configs(branch, config_path)
 
 if __name__ == "__main__":

--- a/buildroot/bin/use_example_configs
+++ b/buildroot/bin/use_example_configs
@@ -124,11 +124,6 @@ def main():
   else:
     config_path = "default"
 
-  try:
-    subprocess.run(['restore_configs'], check=True)
-  except FileNotFoundError:
-    print("restore_configs not found, skipping.")
-
   fetch_configs(branch, config_path)
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Sometimes when building tests, it shows up as `.pio/build-<repo>` if you are like using a different name for the repo.

- Changed in **Makefile** to rm `build*`
- - Follow up to [🧑‍💻 Add 'make clean'](https://github.com/MarlinFirmware/Marlin/commit/4349f4ab0cde4f7c0e28e52661f8f9fada20a8b8)
---

When running a default test multiple times, it causes an issue with `org_src_filter` in **platformio.ini** by repeatedly adding it.
- Add a check to **ci_src_filter** 
- - query: is this change from default to org even needed, could it just be omitted?
---

Removed some code that just isn't needed  
(i.e. works the same [as far as I know] without it)
- **restore_configs**, **use_example_configs** <br>
its like they call eachother so it becomes redundant.  
no need to *restore* configs when you're going to *use example* configs.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
---

#### I cannot get `mftest` to work whatsoever.
```
#
# Test STM32F103RE_creality (4): 
#
use_example_configs "Creality/Ender-3 S1/STM32F1"
./buildroot/bin/mftest: line 335: use_example_configs: command not found
line 335: opt_set: command not found
line 335: opt_enabled: command not found
line 335: opt_disable: command not found
```

No idea how this could work. it is supposed to pull an example configuration like when using `make tests-all-local` or something. it should pull a single configuration of your choice, but this does not do that.
Its almost like the bash script of **mftest** is having trouble executing the python script
---<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
