### PR TITLE
add missing comma in  u8g_dev_ssd13xx_HAL_sleep_on

### DIFF
--- a/Marlin/src/lcd/dogm/u8g/u8g_dev_ssd1306_sh1106_128x64_SWSPI.cpp
+++ b/Marlin/src/lcd/dogm/u8g/u8g_dev_ssd1306_sh1106_128x64_SWSPI.cpp
@@ -87,7 +87,7 @@
 static const uint8_t u8g_dev_ssd13xx_HAL_sleep_on[] PROGMEM = {
   U8G_ESC_ADR(0),   // Instruction mode
   U8G_ESC_CS(1),    // Enable chip
-  SH1106_ON(0)      // Display off
+  SH1106_ON(0),     // Display off
   U8G_ESC_CS(0),    // Disable chip
   U8G_ESC_END       // End of sequence
 };


### PR DESCRIPTION
### Description

Missing comma in 

```cpp
static const uint8_t u8g_dev_ssd13xx_HAL_sleep_on[] PROGMEM = {
  U8G_ESC_ADR(0),   // Instruction mode
  U8G_ESC_CS(1),    // Enable chip
  SH1106_ON(0)      // Display off
  U8G_ESC_CS(0),    // Disable chip
  U8G_ESC_END       // End of sequence
};
```
Added missing comma after SH1106_ON(0)

### Requirements

A display that uses this code  eg ZONESTAR_12864OLED

### Benefits

Code builds

