### PR TITLE
🧑‍💻🎨 Misc types, MMU3, style changes

### DIFF
--- a/Marlin/src/HAL/AVR/registers.h
+++ b/Marlin/src/HAL/AVR/registers.h
@@ -93,15 +93,15 @@ namespace AVRHelpers {
     typedef T type;
   };
   template <typename T>
-  struct voltype <T, 1u> {
+  struct voltype <T, 1U> {
     typedef uint8_t type;
   };
   template <typename T>
-  struct voltype <T, 2u> {
+  struct voltype <T, 2U> {
     typedef uint16_t type;
   };
   template <typename T>
-  struct voltype <T, 4u> {
+  struct voltype <T, 4U> {
     typedef uint32_t type;
   };
 
@@ -2007,7 +2007,7 @@ inline void _ATmega_resetperipherals() {
 
   #if defined(__AVR_TRM01__) || defined(__AVR_TRM02__) || defined(__AVR_TRM03__) || defined(__AVR_TRM05__)
     _EEAR._EEAR = 0;
-    dwrite(_EEDR, (uint8_t)0u);
+    dwrite(_EEDR, (uint8_t)0U);
   #endif
 
   #if defined(__AVR_TRM01__) || defined(__AVR_TRM02__) || defined(__AVR_TRM03__) || defined(__AVR_TRM04__) || defined(__AVR_TRM05__)

--- a/Marlin/src/HAL/AVR/timers.h
+++ b/Marlin/src/HAL/AVR/timers.h
@@ -28,7 +28,7 @@
 // ------------------------
 
 typedef uint16_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFU
 
 // ------------------------
 // Defines

--- a/Marlin/src/HAL/DUE/timers.h
+++ b/Marlin/src/HAL/DUE/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define HAL_TIMER_PRESCALER    2
 #define HAL_TIMER_RATE         ((F_CPU) / (HAL_TIMER_PRESCALER))  // frequency of timers peripherals

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -64,10 +64,10 @@
 #define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&hal.spinlock)
 
 #define HAL_CAN_SET_PWM_FREQ   // This HAL supports PWM Frequency adjustment
-#define PWM_FREQUENCY  1000u   // Default PWM frequency when set_pwm_duty() is called without set_pwm_frequency()
-#define PWM_RESOLUTION   10u   // Default PWM bit resolution
-#define CHANNEL_MAX_NUM  15u   // max PWM channel # to allocate (7 to only use low speed, 15 to use low & high)
-#define MAX_PWM_IOPIN    33u   // hardware pwm pins < 34
+#define PWM_FREQUENCY  1000U   // Default PWM frequency when set_pwm_duty() is called without set_pwm_frequency()
+#define PWM_RESOLUTION   10U   // Default PWM bit resolution
+#define CHANNEL_MAX_NUM  15U   // max PWM channel # to allocate (7 to only use low speed, 15 to use low & high)
+#define MAX_PWM_IOPIN    33U   // hardware pwm pins < 34
 #ifndef MAX_EXPANDER_BITS
   #define MAX_EXPANDER_BITS 32 // I2S expander bit width (max 32)
 #endif

--- a/Marlin/src/HAL/ESP32/Servo.cpp
+++ b/Marlin/src/HAL/ESP32/Servo.cpp
@@ -35,7 +35,7 @@ Servo::Servo() {}
 
 int8_t Servo::attach(const int inPin) {
   if (inPin > 0) pin = inPin;
-  channel = get_pwm_channel(pin, 50u, 16u);
+  channel = get_pwm_channel(pin, 50U, 16U);
   return channel; // -1 if no PWM avail.
 }
 

--- a/Marlin/src/HAL/ESP32/timers.h
+++ b/Marlin/src/HAL/ESP32/timers.h
@@ -30,7 +30,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint64_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFFFFFFFFFULL
+#define HAL_TIMER_TYPE_MAX 0xFFFF'FFFF'FFFF'FFFFULL
 
 #ifndef MF_TIMER_STEP
   #define MF_TIMER_STEP         0  // Timer Index for Stepper
@@ -52,12 +52,12 @@ typedef uint64_t hal_timer_t;
 
 #if ENABLED(I2S_STEPPER_STREAM)
   #define STEPPER_TIMER_PRESCALE     1
-  #define STEPPER_TIMER_RATE         250000                           // 250khz, 4µs pulses of i2s word clock
+  #define STEPPER_TIMER_RATE         250'000                          // 250khz, 4µs pulses of i2s word clock
 #else
   #define STEPPER_TIMER_PRESCALE     40
   #define STEPPER_TIMER_RATE         ((HAL_TIMER_RATE) / (STEPPER_TIMER_PRESCALE)) // frequency of stepper timer, 2MHz
 #endif
-#define STEPPER_TIMER_TICKS_PER_US   ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
+#define STEPPER_TIMER_TICKS_PER_US   ((STEPPER_TIMER_RATE) / 1'000'000) // stepper timer ticks per µs
 
 #define STEP_TIMER_MIN_INTERVAL   8 // minimum time in µs between stepper interrupts
 

--- a/Marlin/src/HAL/HC32/timers.h
+++ b/Marlin/src/HAL/HC32/timers.h
@@ -27,7 +27,7 @@
 //
 typedef Timer0 *timer_channel_t;
 typedef uint16_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFU
 
 //
 // Timer instances

--- a/Marlin/src/HAL/LINUX/timers.h
+++ b/Marlin/src/HAL/LINUX/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define HAL_TIMER_RATE         ((SystemCoreClock) / 4)  // frequency of timers peripherals
 

--- a/Marlin/src/HAL/LPC1768/timers.h
+++ b/Marlin/src/HAL/LPC1768/timers.h
@@ -57,7 +57,7 @@
 #define _HAL_TIMER_ISR(T)  __HAL_TIMER_ISR(T)
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define HAL_TIMER_RATE         ((F_CPU) / 4)  // frequency of timers peripherals
 

--- a/Marlin/src/HAL/NATIVE_SIM/timers.h
+++ b/Marlin/src/HAL/NATIVE_SIM/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint64_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFF'FFFF'FFFF'FFFFULL
 
 #define HAL_TIMER_RATE         ((SystemCoreClock) / 4)  // frequency of timers peripherals
 
@@ -52,11 +52,11 @@ typedef uint64_t hal_timer_t;
 #endif
 #define SYSTICK_TIMER_FREQUENCY 1000
 
-#define TEMP_TIMER_RATE        1000000
-#define TEMP_TIMER_FREQUENCY   1000 // temperature interrupt frequency
+#define TEMP_TIMER_RATE        1'000'000
+#define TEMP_TIMER_FREQUENCY        1000 // temperature interrupt frequency
 
 #define STEPPER_TIMER_RATE     HAL_TIMER_RATE   // frequency of stepper timer (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)
-#define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
+#define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1'000'000) // stepper timer ticks per µs
 #define STEPPER_TIMER_PRESCALE (CYCLES_PER_MICROSECOND / STEPPER_TIMER_TICKS_PER_US)
 
 #define PULSE_TIMER_RATE       STEPPER_TIMER_RATE   // frequency of pulse timer

--- a/Marlin/src/HAL/RP2040/timers.h
+++ b/Marlin/src/HAL/RP2040/timers.h
@@ -41,9 +41,9 @@
 #define _HAL_TIMER_ISR(T)  __HAL_TIMER_ISR(T)
 
 typedef uint64_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFF'FFFF'FFFF'FFFFULL
 
-#define HAL_TIMER_RATE         (1000000ull)  // fixed value as we use a microsecond timesource
+#define HAL_TIMER_RATE         (1'000'000ULL)  // fixed value as we use a microsecond timesource
 #ifndef MF_TIMER_STEP
   #define MF_TIMER_STEP        0  // Timer Index for Stepper
 #endif

--- a/Marlin/src/HAL/SAMD21/timers.h
+++ b/Marlin/src/HAL/SAMD21/timers.h
@@ -33,7 +33,7 @@
 // --------------------------------------------------------------------------
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define HAL_TIMER_RATE      F_CPU   // frequency of timers peripherals
 

--- a/Marlin/src/HAL/SAMD51/timers.h
+++ b/Marlin/src/HAL/SAMD51/timers.h
@@ -32,7 +32,7 @@
 // --------------------------------------------------------------------------
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define HAL_TIMER_RATE      F_CPU   // frequency of timers peripherals
 

--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -40,7 +40,7 @@
  */
 
 typedef uint16_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFU
 
 #define HAL_TIMER_RATE uint32_t(F_CPU)  // frequency of timers peripherals
 

--- a/Marlin/src/HAL/TEENSY31_32/timers.h
+++ b/Marlin/src/HAL/TEENSY31_32/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define FTM0_TIMER_PRESCALE 8
 #define FTM1_TIMER_PRESCALE 4

--- a/Marlin/src/HAL/TEENSY35_36/timers.h
+++ b/Marlin/src/HAL/TEENSY35_36/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFFUL
 
 #define FTM0_TIMER_PRESCALE 8
 #define FTM1_TIMER_PRESCALE 4

--- a/Marlin/src/HAL/TEENSY40_41/timers.h
+++ b/Marlin/src/HAL/TEENSY40_41/timers.h
@@ -34,7 +34,7 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 typedef uint32_t hal_timer_t;
-#define HAL_TIMER_TYPE_MAX 0xFFFFFFFE
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFEUL
 
 #define GPT_TIMER_RATE (F_CPU / 4) // 150MHz (Can't use F_BUS_ACTUAL because it's extern volatile)
 

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -549,11 +549,20 @@ struct XYval {
   // Explicit copy and copies with conversion
   FI constexpr XYval<T>           copy() const { return *this; }
   FI constexpr XYval<T>            ABS() const { return { T(_ABS(x)), T(_ABS(y)) }; }
-  FI constexpr XYval<int16_t>  asInt16() const { return { int16_t(x), int16_t(y) }; }
-  FI constexpr XYval<int32_t>  asInt32() const { return { int32_t(x), int32_t(y) }; }
   FI constexpr XYval<int32_t>   ROUNDL() const { return { int32_t(LROUND(x)), int32_t(LROUND(y)) }; }
-  FI constexpr XYval<float>    asFloat() const { return { static_cast<float>(x), static_cast<float>(y) }; }
   FI constexpr XYval<float> reciprocal() const { return { _RECIP(x), _RECIP(y) }; }
+
+  // Conversion to other types
+  template <class Q>
+  constexpr XYval as() const {
+    return XYval{ static_cast<Q>(x), static_cast<Q>(y) };
+  }
+  FI constexpr XYval asInt16()  const { return as<int16_t>(); }
+  FI constexpr XYval asInt32()  const { return as<int32_t>(); }
+  FI constexpr XYval asUInt32() const { return as<uint32_t>(); }
+  FI constexpr XYval asInt64()  const { return as<int64_t>(); }
+  FI constexpr XYval asUInt64() const { return as<uint64_t>(); }
+  FI constexpr XYval asFloat()  const { return as<float>(); }
 
   // Marlin workspace shifting is done with G92 and M206
   FI XYval<float> asLogical() const { XYval<float> o = asFloat(); toLogical(o); return o; }
@@ -706,11 +715,26 @@ struct XYZval {
   // Explicit copy and copies with conversion
   FI constexpr XYZval<T>           copy() const { XYZval<T> o = *this; return o; }
   FI constexpr XYZval<T>            ABS() const { return NUM_AXIS_ARRAY(T(_ABS(x)), T(_ABS(y)), T(_ABS(z)), T(_ABS(i)), T(_ABS(j)), T(_ABS(k)), T(_ABS(u)), T(_ABS(v)), T(_ABS(w))); }
-  FI constexpr XYZval<int16_t>  asInt16() const { return NUM_AXIS_ARRAY(int16_t(x), int16_t(y), int16_t(z), int16_t(i), int16_t(j), int16_t(k), int16_t(u), int16_t(v), int16_t(w)); }
-  FI constexpr XYZval<int32_t>  asInt32() const { return NUM_AXIS_ARRAY(int32_t(x), int32_t(y), int32_t(z), int32_t(i), int32_t(j), int32_t(k), int32_t(u), int32_t(v), int32_t(w)); }
   FI constexpr XYZval<int32_t>   ROUNDL() const { return NUM_AXIS_ARRAY(int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)), int32_t(LROUND(i)), int32_t(LROUND(j)), int32_t(LROUND(k)), int32_t(LROUND(u)), int32_t(LROUND(v)), int32_t(LROUND(w))); }
-  FI constexpr XYZval<float>    asFloat() const { return NUM_AXIS_ARRAY(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(i), static_cast<float>(j), static_cast<float>(k), static_cast<float>(u), static_cast<float>(v), static_cast<float>(w)); }
   FI constexpr XYZval<float> reciprocal() const { return NUM_AXIS_ARRAY(_RECIP(x),  _RECIP(y),  _RECIP(z),  _RECIP(i),  _RECIP(j),  _RECIP(k),  _RECIP(u),  _RECIP(v),  _RECIP(w)); }
+
+  // Conversion to other types
+  template <class Q>
+  constexpr XYZval as() const {
+    return XYZval{
+      NUM_AXIS_LIST(
+        static_cast<Q>(x), static_cast<Q>(y), static_cast<Q>(z),
+        static_cast<Q>(i), static_cast<Q>(j), static_cast<Q>(k),
+        static_cast<Q>(u), static_cast<Q>(v), static_cast<Q>(w)
+      )
+    };
+  }
+  FI constexpr XYZval asInt16()  const { return as<int16_t>(); }
+  FI constexpr XYZval asInt32()  const { return as<int32_t>(); }
+  FI constexpr XYZval asUInt32() const { return as<uint32_t>(); }
+  FI constexpr XYZval asInt64()  const { return as<int64_t>(); }
+  FI constexpr XYZval asUInt64() const { return as<uint64_t>(); }
+  FI constexpr XYZval asFloat()  const { return as<float>(); }
 
   // Marlin workspace shifting is done with G92 and M206
   FI XYZval<float> asLogical() const { XYZval<float> o = asFloat(); toLogical(o); return o; }
@@ -861,14 +885,27 @@ struct XYZEval {
   // Explicit copy and copies with conversion
   FI constexpr XYZEval<T>            copy() const { XYZEval<T> v = *this; return v; }
   FI constexpr XYZEval<T>             ABS() const { return LOGICAL_AXIS_ARRAY(T(_ABS(e)), T(_ABS(x)), T(_ABS(y)), T(_ABS(z)), T(_ABS(i)), T(_ABS(j)), T(_ABS(k)), T(_ABS(u)), T(_ABS(v)), T(_ABS(w))); }
-  FI constexpr XYZEval<int16_t>   asInt16() const { return LOGICAL_AXIS_ARRAY(int16_t(e), int16_t(x), int16_t(y), int16_t(z), int16_t(i), int16_t(j), int16_t(k), int16_t(u), int16_t(v), int16_t(w)); }
-  FI constexpr XYZEval<int32_t>   asInt32() const { return LOGICAL_AXIS_ARRAY(int32_t(e), int32_t(x), int32_t(y), int32_t(z), int32_t(i), int32_t(j), int32_t(k), int32_t(u), int32_t(v), int32_t(w)); }
-  FI constexpr XYZEval<uint32_t> asUInt32() const { return LOGICAL_AXIS_ARRAY(uint32_t(e), uint32_t(x), uint32_t(y), uint32_t(z), uint32_t(i), uint32_t(j), uint32_t(k), uint32_t(u), uint32_t(v), uint32_t(w)); }
-  FI constexpr XYZEval<int64_t>   asInt64() const { return LOGICAL_AXIS_ARRAY(int64_t(e), int64_t(x), int64_t(y), int64_t(z), int64_t(i), int64_t(j), int64_t(k), int64_t(u), int64_t(v), int64_t(w)); }
-  FI constexpr XYZEval<uint64_t> asUInt64() const { return LOGICAL_AXIS_ARRAY(uint64_t(e), uint64_t(x), uint64_t(y), uint64_t(z), uint64_t(i), uint64_t(j), uint64_t(k), uint64_t(u), uint64_t(v), uint64_t(w)); }
   FI constexpr XYZEval<int32_t>    ROUNDL() const { return LOGICAL_AXIS_ARRAY(int32_t(LROUND(e)), int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)), int32_t(LROUND(i)), int32_t(LROUND(j)), int32_t(LROUND(k)), int32_t(LROUND(u)), int32_t(LROUND(v)), int32_t(LROUND(w))); }
-  FI constexpr XYZEval<float>     asFloat() const { return LOGICAL_AXIS_ARRAY(static_cast<float>(e), static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(i), static_cast<float>(j), static_cast<float>(k), static_cast<float>(u), static_cast<float>(v), static_cast<float>(w)); }
   FI constexpr XYZEval<float>  reciprocal() const { return LOGICAL_AXIS_ARRAY(_RECIP(e), _RECIP(x), _RECIP(y), _RECIP(z), _RECIP(i), _RECIP(j), _RECIP(k), _RECIP(u), _RECIP(v), _RECIP(w)); }
+
+  // Conversion to other types
+  template <class Q>
+  constexpr XYZEval as() const {
+    return XYZEval{
+      LOGICAL_AXIS_LIST(
+        static_cast<Q>(e),
+        static_cast<Q>(x), static_cast<Q>(y), static_cast<Q>(z),
+        static_cast<Q>(i), static_cast<Q>(j), static_cast<Q>(k),
+        static_cast<Q>(u), static_cast<Q>(v), static_cast<Q>(w)
+      )
+    };
+  }
+  FI constexpr XYZEval asInt16()  const { return as<int16_t>(); }
+  FI constexpr XYZEval asInt32()  const { return as<int32_t>(); }
+  FI constexpr XYZEval asUInt32() const { return as<uint32_t>(); }
+  FI constexpr XYZEval asInt64()  const { return as<int64_t>(); }
+  FI constexpr XYZEval asUInt64() const { return as<uint64_t>(); }
+  FI constexpr XYZEval asFloat()  const { return as<float>(); }
 
   // Marlin workspace shifting is done with G92 and M206
   FI XYZEval<float> asLogical() const { XYZEval<float> o = asFloat(); toLogical(o); return o; }

--- a/Marlin/src/feature/mmu3/mmu3.cpp
+++ b/Marlin/src/feature/mmu3/mmu3.cpp
@@ -867,7 +867,7 @@ namespace MMU3 {
           nozzle_timer.start();
           LogEchoEvent(F("Cooling Timeout started"));
         }
-        else if (nozzle_timer.duration() > (PAUSE_PARK_NOZZLE_TIMEOUT * 1000ul)) { // mins->msec.
+        else if (nozzle_timer.duration() > (PAUSE_PARK_NOZZLE_TIMEOUT * 1000UL)) { // mins->msec.
           mmu_print_saved &= ~(SavedState::CooldownPending);
           mmu_print_saved |= SavedState::Cooldown;
           thermal_setTargetHotend(0);

--- a/Marlin/src/feature/mmu3/mmu3_protocol_logic.cpp
+++ b/Marlin/src/feature/mmu3/mmu3_protocol_logic.cpp
@@ -707,7 +707,7 @@ namespace MMU3 {
   }
 
   bool ProtocolLogic::Elapsed(uint32_t timeout) const {
-    return _millis() >= (lastUARTActivityMs + timeout);
+    return ELAPSED(_millis(), lastUARTActivityMs + timeout);
   }
 
   void ProtocolLogic::RecordUARTActivity() {
@@ -716,7 +716,7 @@ namespace MMU3 {
 
   void ProtocolLogic::RecordReceivedByte(uint8_t c) {
     lastReceivedBytes[lrb] = c;
-    lrb = (lrb + 1) % lastReceivedBytes.size();
+    lrb = (lrb + 1) % COUNT(lastReceivedBytes);
   }
 
   constexpr char NibbleToChar(uint8_t c) {
@@ -728,13 +728,13 @@ namespace MMU3 {
   }
 
   void ProtocolLogic::FormatLastReceivedBytes(char *dst) {
-    for (uint8_t i = 0; i < lastReceivedBytes.size(); ++i) {
-      uint8_t b = lastReceivedBytes[(lrb - i - 1) % lastReceivedBytes.size()];
+    for (uint8_t i = 0; i < COUNT(lastReceivedBytes); ++i) {
+      uint8_t b = lastReceivedBytes[(COUNT(lastReceivedBytes) - 1 + (lrb - i)) % COUNT(lastReceivedBytes)];
       dst[i * 3] = NibbleToChar(b >> 4);
       dst[i * 3 + 1] = NibbleToChar(b & 0xf);
       dst[i * 3 + 2] = ' ';
     }
-    dst[(lastReceivedBytes.size() - 1) * 3 + 2] = 0; // terminate properly
+    dst[(COUNT(lastReceivedBytes) - 1) * 3 + 2] = 0; // terminate properly
   }
 
   void ProtocolLogic::FormatLastResponseMsgAndClearLRB(char *dst) {
@@ -777,18 +777,18 @@ namespace MMU3 {
   }
 
   void ProtocolLogic::LogError(const char *reason_P) {
-    char lrb[lastReceivedBytes.size() * 3];
-    FormatLastReceivedBytes(lrb);
+    char _lrb[COUNT(lastReceivedBytes) * 3];
+    FormatLastReceivedBytes(_lrb);
 
     MMU2_ERROR_MSGRPGM(reason_P);
     SERIAL_ECHOPGM(", last bytes: ");
-    SERIAL_ECHOLN(lrb);
+    SERIAL_ECHOLN(_lrb);
   }
 
   void ProtocolLogic::LogResponse() {
-    char lrb[lastReceivedBytes.size()];
-    FormatLastResponseMsgAndClearLRB(lrb);
-    MMU2_ECHO_MSGLN(lrb);
+    char _lrb[COUNT(lastReceivedBytes)];
+    FormatLastResponseMsgAndClearLRB(_lrb);
+    MMU2_ECHO_MSGLN(_lrb);
   }
 
   StepStatus ProtocolLogic::SuppressShortDropOuts(const char *msg_P, StepStatus ss) {

--- a/Marlin/src/feature/mmu3/mmu3_protocol_logic.h
+++ b/Marlin/src/feature/mmu3/mmu3_protocol_logic.h
@@ -36,24 +36,8 @@
   #include "mmu_hw/buttons.h"
   #include "mmu_hw/registers.h"
   #include "mmu3_protocol.h"
-
-  // #include <array> std array is not available on AVR ... we need to "fake" it
-  namespace std {
-    template <typename T, uint8_t N>
-    class array {
-      T data[N];
-      public:
-      array() = default;
-      inline constexpr T *begin() const { return data; }
-      inline constexpr T *end() const { return data + N; }
-      static constexpr uint8_t size() { return N; }
-      inline T &operator[](uint8_t i) { return data[i]; }
-    };
-  } // std
-
 #else // !__AVR__
 
-  #include <array>
   #include "mmu_hw/error_codes.h"
   #include "mmu_hw/progress_codes.h"
 
@@ -351,8 +335,7 @@ namespace MMU3 {
 
     Protocol protocol;                       //!< protocol codec
 
-    std::array<uint8_t, 16> lastReceivedBytes; //!< remembers the last few bytes of incoming communication for diagnostic purposes
-    uint8_t lrb;
+    uint8_t lrb, lastReceivedBytes[16];      //!< keep the last few bytes of incoming communication for diagnostic purposes
 
     ErrorCode errorCode;        //!< last received error code from the MMU
     ProgressCode progressCode;  //!< last received progress code from the MMU

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -40,6 +40,9 @@
   #error "Marlin requires C++11 support (gcc >= 4.7, Arduino IDE >= 1.6.8). Please upgrade your toolchain."
 #endif
 
+// Emit the GCC version
+//static_assert(false, "GCC version: " STRINGIFY(__GNUC__) "." STRINGIFY(__GNUC_MINOR__) "." STRINGIFY(__GNUC_PATCHLEVEL__));
+
 // Strings for sanity check messages
 #define _NUM_AXES_STR NUM_AXIS_GANG("X ", "Y ", "Z ", "I ", "J ", "K ", "U ", "V ", "W ")
 #define _LOGICAL_AXES_STR LOGICAL_AXIS_GANG("E ", "X ", "Y ", "Z ", "I ", "J ", "K ", "U ", "V ", "W ")

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2699,7 +2699,7 @@ hal_timer_t Stepper::block_phase_isr() {
       TERN_(HAS_ROUGH_LIN_ADVANCE, la_delta_error = delta_error);
 
       // Calculate Bresenham dividends and divisors
-      advance_dividend = (current_block->steps << 1).asInt32();
+      advance_dividend = current_block->steps << 1; // narrowing conversion
       advance_divisor = step_event_count << 1;
 
       #if ENABLED(INPUT_SHAPING_X)

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -42,22 +42,22 @@
 
 #if DISABLED(SD_NO_DEFAULT_TIMEOUT)
   #ifndef SD_INIT_TIMEOUT
-    #define SD_INIT_TIMEOUT 2000u   // (ms) Init timeout
+    #define SD_INIT_TIMEOUT 2000U   // (ms) Init timeout
   #elif SD_INIT_TIMEOUT < 0
     #error "SD_INIT_TIMEOUT must be greater than or equal to 0."
   #endif
   #ifndef SD_ERASE_TIMEOUT
-    #define SD_ERASE_TIMEOUT 10000u // (ms) Erase timeout
+    #define SD_ERASE_TIMEOUT 10000U // (ms) Erase timeout
   #elif SD_ERASE_TIMEOUT < 0
     #error "SD_ERASE_TIMEOUT must be greater than or equal to 0."
   #endif
   #ifndef SD_READ_TIMEOUT
-    #define SD_READ_TIMEOUT 300u    // (ms) Read timeout
+    #define SD_READ_TIMEOUT 300U    // (ms) Read timeout
   #elif SD_READ_TIMEOUT < 0
     #error "SD_READ_TIMEOUT must be greater than or equal to 0."
   #endif
   #ifndef SD_WRITE_TIMEOUT
-    #define SD_WRITE_TIMEOUT 600u   // (ms) Write timeout
+    #define SD_WRITE_TIMEOUT 600U   // (ms) Write timeout
   #elif SD_WRITE_TIMEOUT < 0
     #error "SD_WRITE_TIMEOUT must be greater than or equal to 0."
   #endif

--- a/Marlin/tests/core/test_macros.cpp
+++ b/Marlin/tests/core/test_macros.cpp
@@ -251,14 +251,14 @@ MARLIN_TEST(macros_numeric, NOLESS_int) {
 
 MARLIN_TEST(macros_numeric, NOLESS_uint) {
   // Scenario 1: Input was already acceptable
-  unsigned int b = 8u;
-  NOLESS(b, 5u);
-  TEST_ASSERT_EQUAL(8u, b);
+  unsigned int b = 8U;
+  NOLESS(b, 5U);
+  TEST_ASSERT_EQUAL(8U, b);
 
   // Original scenario: Input was less than the limit
-  b = 5u;
-  NOLESS(b, 10u);
-  TEST_ASSERT_EQUAL(10u, b);
+  b = 5U;
+  NOLESS(b, 10U);
+  TEST_ASSERT_EQUAL(10U, b);
 }
 
 MARLIN_TEST(macros_numeric, NOLESS_float) {
@@ -310,14 +310,14 @@ MARLIN_TEST(macros_numeric, NOMORE_int) {
 
 MARLIN_TEST(macros_numeric, NOMORE_uint) {
   // Scenario 1: Input was already acceptable
-  unsigned int b = 8u;
-  NOMORE(b, 10u);
-  TEST_ASSERT_EQUAL(8u, b);
+  unsigned int b = 8U;
+  NOMORE(b, 10U);
+  TEST_ASSERT_EQUAL(8U, b);
 
   // Original scenario: Input was more than the limit
-  b = 15u;
-  NOMORE(b, 10u);
-  TEST_ASSERT_EQUAL(10u, b);
+  b = 15U;
+  NOMORE(b, 10U);
+  TEST_ASSERT_EQUAL(10U, b);
 }
 
 MARLIN_TEST(macros_numeric, NOMORE_float) {
@@ -383,17 +383,17 @@ MARLIN_TEST(macros_numeric, LIMIT_int) {
 }
 
 MARLIN_TEST(macros_numeric, LIMIT_uint) {
-  unsigned int b = 15u;
-  LIMIT(b, 10u, 20u);
-  TEST_ASSERT_EQUAL(15u, b);
+  unsigned int b = 15U;
+  LIMIT(b, 10U, 20U);
+  TEST_ASSERT_EQUAL(15U, b);
 
-  b = 5u;
-  LIMIT(b, 10u, 20u);
-  TEST_ASSERT_EQUAL(10u, b);
+  b = 5U;
+  LIMIT(b, 10U, 20U);
+  TEST_ASSERT_EQUAL(10U, b);
 
-  b = 25u;
-  LIMIT(b, 10u, 20u);
-  TEST_ASSERT_EQUAL(20u, b);
+  b = 25U;
+  LIMIT(b, 10U, 20U);
+  TEST_ASSERT_EQUAL(20U, b);
 }
 
 MARLIN_TEST(macros_numeric, LIMIT_float) {

--- a/Marlin/tests/feature/test_runout.cpp
+++ b/Marlin/tests/feature/test_runout.cpp
@@ -29,7 +29,7 @@
 MARLIN_TEST(runout, poll_runout_states) {
   FilamentSensorBase sensor;
   // Expected default value is one bit set for each extruder
-  uint8_t expected = static_cast<uint8_t>(~(~0u << NUM_RUNOUT_SENSORS));
+  uint8_t expected = static_cast<uint8_t>(~(~0U << NUM_RUNOUT_SENSORS));
   TEST_ASSERT_EQUAL(expected, sensor.poll_runout_states());
 }
 

--- a/ini/due.ini
+++ b/ini/due.ini
@@ -16,10 +16,11 @@
 #  - RADDS
 #
 [env:DUE]
-platform         = atmelsam
-board            = due
-build_src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
-build_flags      = -DWATCHDOG_PIO_RESET
+platform          = atmelsam
+#platform_packages = toolchain-gccarmnoneeabi@1.120301.0   # Otherwise it's GCC 7.2.1
+board             = due
+build_src_filter  = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
+build_flags       = -DWATCHDOG_PIO_RESET
 
 [env:DUE_USB]
 extends  = env:DUE

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -10,14 +10,15 @@
 ####################################
 
 [common_stm32]
-platform         = ststm32@~12.1
-board_build.core = stm32
-build_flags      = ${common.build_flags} -std=gnu++14
+platform          = ststm32@~12.1
+#platform_packages = toolchain-gccarmnoneeabi@1.100301.220327   # Otherwise it's GCC 9.2.1
+board_build.core  = stm32
+build_flags       = ${common.build_flags} -std=gnu++14
                    -DHAL_STM32 -DPLATFORM_M997_SUPPORT
                    -DUSBCON -DUSBD_USE_CDC -DTIM_IRQ_PRIO=13 -DADC_RESOLUTION=12
-build_unflags    = -std=gnu++11
-build_src_filter = ${common.default_src_filter} +<src/HAL/STM32> -<src/HAL/STM32/tft> +<src/HAL/shared/backtrace>
-extra_scripts    = ${common.extra_scripts}
+build_unflags     = -std=gnu++11
+build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32> -<src/HAL/STM32/tft> +<src/HAL/shared/backtrace>
+extra_scripts     = ${common.extra_scripts}
                    pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
 custom_marlin.HAS_LTDC_TFT           = build_src_filter=+<src/HAL/STM32/tft/tft_ltdc.cpp>
 custom_marlin.HAS_FSMC_TFT           = build_src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp>

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -33,7 +33,7 @@ lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
                     SoftwareSerialM
 platform_packages = tool-stm32duino
-                    toolchain-gccarmnoneeabi@1.100301.220327
+                    toolchain-gccarmnoneeabi@1.120301.0   # Otherwise it's GCC 7.2.1
 extra_scripts     = ${common.extra_scripts}
                     pre:buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
                     pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -65,7 +65,8 @@ monitor_speed = 115200
 [env:STM32F103RC_meeb_maple]
 extends              = env:STM32F103RC_maple
 board                = marlin_maple_MEEB_3DP
-platform_packages    = platformio/tool-dfuutil@~1.11.0
+platform_packages    = ${env:STM32F103RC_maple.platform_packages}
+                       platformio/tool-dfuutil@~1.11.0
 build_flags          = ${env:STM32F103RC_maple.build_flags}
                        -DDEBUG_LEVEL=0
                        -DSS_TIMER=4
@@ -93,7 +94,6 @@ extends           = env:STM32F103RC_maple
 extra_scripts     = ${env:STM32F103RC_maple.extra_scripts}
                     buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = ${env:STM32F103RC_maple.build_flags} -DDEBUG_LEVEL=0
-platform_packages = toolchain-gccarmnoneeabi@1.90301.200702
 lib_ldf_mode      = chain
 debug_tool        = stlink
 upload_protocol   = serial
@@ -109,7 +109,6 @@ extends              = env:STM32F103RC_maple
 board_build.address  = 0x08007000
 board_build.ldscript = STM32F103RC_SKR_MINI_256K.ld
 build_flags          = ${env:STM32F103RC_maple.build_flags} -DDEBUG_LEVEL=0 -DSS_TIMER=4
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 monitor_speed        = 115200
 
 [env:STM32F103RC_btt_USB_maple]
@@ -136,7 +135,6 @@ upload_protocol      = jlink
 [env:STM32F103RC_creality_maple]
 extends              = env:STM32F103RC_maple
 build_flags          = ${env:STM32F103RC_maple.build_flags} -DTEMP_TIMER_CHAN=4
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 board_build.address  = 0x08007000
 board_build.ldscript = creality256k.ld
 board_build.rename   = firmware-{date}-{time}.bin
@@ -160,7 +158,6 @@ board_build.ldscript = crealityPro.ld
 [env:GD32F103RC_voxelab_maple]
 extends              = env:STM32F103RC_maple
 build_flags          = ${env:STM32F103RC_maple.build_flags} -DTEMP_TIMER_CHAN=4
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 board_build.address  = 0x08007000
 board_build.ldscript = creality256k.ld
 debug_tool           = jlink
@@ -170,7 +167,6 @@ upload_protocol      = jlink
 extends              = env:STM32F103RE_maple
 build_flags          = ${env:STM32F103RE_maple.build_flags} -DTEMP_TIMER_CHAN=4
                        -DVOXELAB_N32 -DSDCARD_FLASH_LIMIT_256K
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 board_build.address  = 0x08007000
 board_build.ldscript = creality.ld
 debug_tool           = jlink
@@ -393,13 +389,11 @@ lib_ignore                = Adafruit NeoPixel, SPI, SailfishLCD, SailfishRGB_LED
 
 [env:STM32F103RC_ZM3E2_USB_maple]
 extends              = ZONESTAR_ZM3E_maple
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 board                = genericSTM32F103RC
 board_build.ldscript = ZONESTAR_ZM3E_256K.ld
 
 [env:STM32F103VC_ZM3E4_USB_maple]
 extends              = ZONESTAR_ZM3E_maple
-platform_packages    = toolchain-gccarmnoneeabi@1.90301.200702
 board                = genericSTM32F103VC
 board_build.ldscript = ZONESTAR_ZM3E_256K.ld
 build_flags          = ${ZONESTAR_ZM3E_maple.build_flags} -DTONE_TIMER=1 -DTONE_CHANNEL=2


### PR DESCRIPTION
- One less file with STL include. (We will embrace STL for Marlin 3.x.)
- Easier-to-extend type conversion for `XYval`, `XYZval`, `XYZEval`.
  - Suppress an ugly "narrowing conversion" warning.
- Use ammocs to clarify some big numbers, and make timer scale unsigned.
