### PR TITLE
add LIB_MAX31855

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -29,6 +29,7 @@ SR_LCD_3W_NL                           = SailfishLCD=https://github.com/mikeshub
 HAS_MOTOR_CURRENT_(I2C|DAC|SPI|PWM)    = build_src_filter=+<src/gcode/feature/digipot>
 HAS_MOTOR_CURRENT_I2C                  = SlowSoftI2CMaster
                                          build_src_filter=+<src/feature/digipot>
+LIB_MAX31855                           = GadgetAngel MAX31855=https://github.com/GadgetAngel/Adafruit-MAX31855-V1.0.3-Mod-M/archive/refs/heads/master.zip
 LIB_INTERNAL_MAX31865                  = build_src_filter=+<src/libs/MAX31865.cpp>
 NEOPIXEL_LED                           = adafruit/Adafruit NeoPixel@~1.12.3
                                          build_src_filter=+<src/feature/leds/neopixel.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -29,7 +29,7 @@ SR_LCD_3W_NL                           = SailfishLCD=https://github.com/mikeshub
 HAS_MOTOR_CURRENT_(I2C|DAC|SPI|PWM)    = build_src_filter=+<src/gcode/feature/digipot>
 HAS_MOTOR_CURRENT_I2C                  = SlowSoftI2CMaster
                                          build_src_filter=+<src/feature/digipot>
-LIB_MAX31855                           = GadgetAngel MAX31855=https://github.com/GadgetAngel/Adafruit-MAX31855-V1.0.3-Mod-M/archive/refs/heads/master.zip
+LIB_MAX31855                           = GadgetAngel MAX31855=https://github.com/GadgetAngel/Adafruit-MAX31855-V1.0.3-Mod-M/archive/dc9cc10ac2.zip
 LIB_INTERNAL_MAX31865                  = build_src_filter=+<src/libs/MAX31865.cpp>
 NEOPIXEL_LED                           = adafruit/Adafruit NeoPixel@~1.12.3
                                          build_src_filter=+<src/feature/leds/neopixel.cpp>


### PR DESCRIPTION
### Description

A user on discord was attempting to use and obscure bit of marlin code  based around define LIB_MAX31855

As mentioned in the code "LIB_MAX31855 can be added to the build_flags in platformio.ini to use a user-defined library"

But it looks like its referring to stock  Adafruit MAX31855 library but when you try this you run into

```
error: Marlin\src\module\temperature.cpp:3578:33: error: 'MAX31855' {aka 'class Adafruit_MAX31855'} has no member named 'readRaw32'
 3578 |         max_tc_temp = max855ref.readRaw32();

```

Stock Adafruit  MAX31855 does not have readRaw32()

This code is meant to use specific fork https://github.com/GadgetAngel/Adafruit-MAX31855-V1.0.3-Mod-M 

So I added the correct  fork of  Adafruit MAX31855 library to features.ini 

### Requirements

Add LIB_MAX31855 to build_flags and set a Thermsitor to -3

### Benefits

Builds as expected

### Related 

<li>MarlinFirmware/Marlin/pull/20447
