### PR TITLE
FT_MOTION :  fix build when FTM_HOME_AND_PROBE  is enabled

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -277,7 +277,7 @@ G29_TYPE GcodeSuite::G29() {
 
   #if DISABLED(PROBE_MANUALLY) && ENABLED(FT_MOTION)
     // Potentially disable Fixed-Time Motion for probing
-    FTMotionDisableInScope FT_Disabler;
+    FTM_DISABLE_IN_SCOPE();
   #endif
 
   /**


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Replace last  `FTMotionDisableInScope FT_Disabler` in `bedlevel/abl/G29.cpp` by `FTM_DISABLE_IN_SCOPE()`. Fix compilation error when `FTM_HOME_AND_PROBE` is enabled
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
