### PR TITLE
FLY D5: add pins for Z probe header

### DIFF
--- a/Marlin/src/pins/stm32f0/pins_FLY_D5.h
+++ b/Marlin/src/pins/stm32f0/pins_FLY_D5.h
@@ -43,6 +43,11 @@
 #endif
 
 //
+// Servos
+//
+#define SERVO0_PIN                          PA8
+
+//
 // Timers
 //
 #define STEP_TIMER  6
@@ -54,6 +59,11 @@
 #define X_STOP_PIN                          PB4
 #define Y_STOP_PIN                          PB3
 #define Z_STOP_PIN                          PD2
+
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB5
+#endif
+
 //
 // Steppers
 //


### PR DESCRIPTION
### Description


The Fly D5 pins file is very minimal. I added the pins on the BLTouch header (Servo0 and Probe).

The pinout is documented here: https://github.com/Mellow-3D/Fly-D5/blob/main/Hardware/Fly-D5-Pinout.svg

### Requirements

Applies only to the FLY D5 board.

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Z Probe header can be used.

### Configurations

Required to compile a build without using the ZMIN Endstop. Sample Configuration attached.

[d5-probe-configs.zip](https://github.com/user-attachments/files/23486319/d5-probe-configs.zip)

### Related Issues

None.
