### PR TITLE
🩹 Cleanup of timers

### DIFF
--- a/Marlin/src/HAL/AVR/timers.h
+++ b/Marlin/src/HAL/AVR/timers.h
@@ -111,8 +111,8 @@ FORCE_INLINE void HAL_timer_start(const uint8_t timer_num, const uint32_t) {
  * (otherwise, characters will be lost due to UART overflow).
  * Then: Stepper, Endstops, Temperature, and -finally- all others.
  */
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}
 
 #ifndef HAL_STEP_TIMER_ISR
 

--- a/Marlin/src/HAL/DUE/timers.h
+++ b/Marlin/src/HAL/DUE/timers.h
@@ -127,4 +127,4 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_SR;
 }
 
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/ESP32/timers.h
+++ b/Marlin/src/HAL/ESP32/timers.h
@@ -135,5 +135,5 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/GD32_MFL/timers.h
+++ b/Marlin/src/HAL/GD32_MFL/timers.h
@@ -141,5 +141,5 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_number, const
   }
 }
 
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/HC32/timers.cpp
+++ b/Marlin/src/HAL/HC32/timers.cpp
@@ -35,19 +35,19 @@ Timer0 temp_timer(&TIMER02A_config, &Temp_Handler);
  */
 Timer0 step_timer(&TIMER02B_config, &Step_Handler);
 
-void HAL_timer_start(const timer_channel_t timer_num, const uint32_t frequency) {
-  if (timer_num == TEMP_TIMER_NUM) {
+void HAL_timer_start(const timer_channel_t timer_ch, const uint32_t frequency) {
+  if (timer_ch == MF_TIMER_TEMP) {
     CORE_DEBUG_PRINTF("HAL_timer_start: temp timer, f=%ld\n", long(frequency));
-    timer_num->start(frequency, TEMP_TIMER_PRESCALE);
-    timer_num->setCallbackPriority(TEMP_TIMER_PRIORITY);
+    timer_ch->start(frequency, TEMP_TIMER_PRESCALE);
+    timer_ch->setCallbackPriority(TEMP_TIMER_PRIORITY);
   }
-  else if (timer_num == STEP_TIMER_NUM) {
+  else if (timer_ch == MF_TIMER_STEP) {
     CORE_DEBUG_PRINTF("HAL_timer_start: step timer, f=%ld\n", long(frequency));
-    timer_num->start(frequency, STEPPER_TIMER_PRESCALE);
-    timer_num->setCallbackPriority(STEP_TIMER_PRIORITY);
+    timer_ch->start(frequency, STEPPER_TIMER_PRESCALE);
+    timer_ch->setCallbackPriority(STEP_TIMER_PRIORITY);
   }
   else {
-    CORE_ASSERT_FAIL("HAL_timer_start: invalid timer_num")
+    CORE_ASSERT_FAIL("HAL_timer_start: invalid timer_ch")
   }
 }
 

--- a/Marlin/src/HAL/LINUX/timers.h
+++ b/Marlin/src/HAL/LINUX/timers.h
@@ -93,5 +93,5 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/LPC1768/timers.h
+++ b/Marlin/src/HAL/LPC1768/timers.h
@@ -171,4 +171,4 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/NATIVE_SIM/timers.h
+++ b/Marlin/src/HAL/NATIVE_SIM/timers.h
@@ -88,5 +88,5 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/RP2040/timers.h
+++ b/Marlin/src/HAL/RP2040/timers.h
@@ -86,10 +86,10 @@ typedef uint64_t hal_timer_t;
 //#define STEP_TIMER_PTR _HAL_TIMER(MF_TIMER_STEP)
 //#define TEMP_TIMER_PTR _HAL_TIMER(MF_TIMER_TEMP)
 
-extern alarm_pool_t* HAL_timer_pool_0;
-extern alarm_pool_t* HAL_timer_pool_1;
-extern alarm_pool_t* HAL_timer_pool_2;
-extern alarm_pool_t* HAL_timer_pool_3;
+extern alarm_pool_t *HAL_timer_pool_0;
+extern alarm_pool_t *HAL_timer_pool_1;
+extern alarm_pool_t *HAL_timer_pool_2;
+extern alarm_pool_t *HAL_timer_pool_3;
 
 extern struct repeating_timer HAL_timer_0;
 
@@ -120,28 +120,23 @@ void HAL_timer_stop(const uint8_t timer_num);
 
 FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, hal_timer_t compare) {
 
-  if (timer_num == MF_TIMER_STEP){
-    if (compare == HAL_TIMER_TYPE_MAX){
-       HAL_timer_stop(timer_num);
-       return;
-    }
+  if (timer_num == MF_TIMER_STEP && compare == HAL_TIMER_TYPE_MAX) {
+    HAL_timer_stop(timer_num);
+    return;
   }
 
- compare = compare *10; //Dirty fix, figure out a proper way
+ compare *= 10; // Dirty fix, figure out a proper way
 
   switch (timer_num) {
     case 0:
       alarm_pool_add_alarm_in_us(HAL_timer_pool_0, compare, HAL_timer_alarm_pool_0_callback, 0, false);
       break;
-
     case 1:
       alarm_pool_add_alarm_in_us(HAL_timer_pool_1, compare, HAL_timer_alarm_pool_1_callback, 0, false);
       break;
-
     case 2:
       alarm_pool_add_alarm_in_us(HAL_timer_pool_2, compare, HAL_timer_alarm_pool_2_callback, 0, false);
       break;
-
     case 3:
       alarm_pool_add_alarm_in_us(HAL_timer_pool_3, compare, HAL_timer_alarm_pool_3_callback, 0, false);
       break;
@@ -151,27 +146,20 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, hal_time
 FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return 0;
 }
-
 FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   if (timer_num == MF_TIMER_STEP) return 0ull;
   return time_us_64();
 }
 
-
 FORCE_INLINE static void HAL_timer_enable_interrupt(const uint8_t timer_num) {
   HAL_timer_irq_en[timer_num] = 1;
 }
-
 FORCE_INLINE static void HAL_timer_disable_interrupt(const uint8_t timer_num) {
   HAL_timer_irq_en[timer_num] = 0;
 }
-
 FORCE_INLINE static bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {
-  return HAL_timer_irq_en[timer_num]; //lucky coincidence that timer_num and rp2040 irq num matches
+  return HAL_timer_irq_en[timer_num]; // Lucky coincidence that timer_num and rp2040 IRQ num matches
 }
 
-FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
-  return;
-}
-
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/SAMD21/timers.h
+++ b/Marlin/src/HAL/SAMD21/timers.h
@@ -157,4 +157,4 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
-#define HAL_timer_isr_epilogue(timer_num)
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/SAMD51/timers.h
+++ b/Marlin/src/HAL/SAMD51/timers.h
@@ -145,4 +145,4 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
-#define HAL_timer_isr_epilogue(timer_num)
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -116,5 +116,5 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const ha
   }
 }
 
-#define HAL_timer_isr_prologue(T) NOOP
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_prologue(const uint8_t) {}
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -188,7 +188,7 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}
 
 // No command is available in framework to turn off ARPE bit, which is turned on by default in libmaple.
 // Needed here to reset ARPE=0 for stepper timer

--- a/Marlin/src/HAL/TEENSY31_32/timers.h
+++ b/Marlin/src/HAL/TEENSY31_32/timers.h
@@ -74,10 +74,10 @@ typedef uint32_t hal_timer_t;
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(MF_TIMER_TEMP)
 
 #ifndef HAL_STEP_TIMER_ISR
-  #define HAL_STEP_TIMER_ISR() extern "C" void ftm0_isr() //void TC3_Handler()
+  #define HAL_STEP_TIMER_ISR() extern "C" void ftm0_isr()
 #endif
 #ifndef HAL_TEMP_TIMER_ISR
-  #define HAL_TEMP_TIMER_ISR() extern "C" void ftm1_isr() //void TC4_Handler()
+  #define HAL_TEMP_TIMER_ISR() extern "C" void ftm1_isr()
 #endif
 
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
@@ -110,4 +110,4 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/TEENSY35_36/timers.h
+++ b/Marlin/src/HAL/TEENSY35_36/timers.h
@@ -110,4 +110,4 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/HAL/TEENSY40_41/timers.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/timers.cpp
@@ -30,41 +30,74 @@
 
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
   switch (timer_num) {
+
+    //
+    // Step Timer – GPT1 - Compare Interrupt OCR1 - Reset Mode
+    //
     case MF_TIMER_STEP:
-      CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL; // turn off 24mhz mode
+      // 24MHz mode off – Use peripheral clock (150MHz)
+      CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL;
+      // Enable GPT1 clock gating
       CCM_CCGR1 |= CCM_CCGR1_GPT1_BUS(CCM_CCGR_ON);
 
-      GPT1_CR = 0;                   // disable timer
-      GPT1_SR = 0x3F;                // clear all prior status
+      // Disable timer, clear all status bits
+      GPT1_CR = 0;                      // Disable timer
+      GPT1_SR = 0x3F;                   // Clear all prior status
+
+      // Prescaler = 2 => 75MHz counting clock
       GPT1_PR = GPT1_TIMER_PRESCALE - 1;
-      GPT1_CR |= GPT_CR_CLKSRC(1);   //clock selection #1 (peripheral clock = 150 MHz)
-      GPT1_CR |= GPT_CR_ENMOD;       //reset count to zero before enabling
-      GPT1_CR |= GPT_CR_OM1(1);      // toggle mode
-      GPT1_OCR1 = (GPT1_TIMER_RATE / frequency) -1; // Initial compare value
-      GPT1_IR = GPT_IR_OF1IE;        // Compare3 value
+
+      GPT1_CR = GPT_CR_CLKSRC(1)        // Clock selection #1 (peripheral clock = 150 MHz)
+              | GPT_CR_ENMOD            // Reset count to zero before enabling
+              | GPT_CR_OM2(TERN(MARLIN_DEV_MODE, 1, 0)); // 0 = edge compare, 1 = toggle
+
+      // Compare value – the number of clocks between edges
+      GPT1_OCR1 = (GPT1_TIMER_RATE / frequency) - 1;
+
+      // Enable compare‑event interrupt
+      GPT1_IR = GPT_IR_OF2IE;           // OF2 interrupt enabled
       GPT1_CR |= GPT_CR_EN;          //enable GPT2 counting at 150 MHz
 
       OUT_WRITE(15, HIGH);
+
+      // Attach and enable Stepper IRQ
+      // Note: UART priority is 16
       attachInterruptVector(IRQ_GPT1, &stepTC_Handler);
-      NVIC_SET_PRIORITY(IRQ_GPT1, 16);
+      NVIC_SET_PRIORITY(IRQ_GPT1, 16);  // Priority 16 (higher than Temp Timer)
       break;
+
+    //
+    // Temperature Timer – GPT2 - Compare Interrupt OCR1 - Reset Mode
+    //
     case MF_TIMER_TEMP:
-      CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL; // turn off 24mhz mode
+      // 24MHz mode off – Use peripheral clock (150MHz)
+      CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL;
+      // Enable GPT2 clock gating
       CCM_CCGR0 |= CCM_CCGR0_GPT2_BUS(CCM_CCGR_ON);
 
-      GPT2_CR = 0;                   // disable timer
-      GPT2_SR = 0x3F;                // clear all prior status
+      // Disable timer, clear all status bits
+      GPT2_CR = 0;                      // Disable timer
+      GPT2_SR = 0x3F;                   // Clear all prior status
+
+      // Prescaler = 10 => 15MHz counting clock
       GPT2_PR = GPT2_TIMER_PRESCALE - 1;
-      GPT2_CR |= GPT_CR_CLKSRC(1);   //clock selection #1 (peripheral clock = 150 MHz)
-      GPT2_CR |= GPT_CR_ENMOD;       //reset count to zero before enabling
-      GPT2_CR |= GPT_CR_OM1(1);      // toggle mode
-      GPT2_OCR1 = (GPT2_TIMER_RATE / frequency) -1; // Initial compare value
-      GPT2_IR = GPT_IR_OF1IE;        // Compare3 value
+
+      GPT2_CR = GPT_CR_CLKSRC(1)        // Clock selection #1 (peripheral clock = 150 MHz)
+              | GPT_CR_ENMOD            // and reset count to zero before enabling
+              | GPT_CR_OM2(TERN(MARLIN_DEV_MODE, 1, 0)); // 0 = edge compare, 1 = toggle
+
+      // Compare value – the number of clocks between edges
+      GPT2_OCR1 = (GPT2_TIMER_RATE / frequency) - 1;
+
+      // Enable compare‑event interrupt
+      GPT2_IR = GPT_IR_OF2IE;
       GPT2_CR |= GPT_CR_EN;          //enable GPT2 counting at 150 MHz
 
       OUT_WRITE(14, HIGH);
+
+      // Attach Temperature ISR
       attachInterruptVector(IRQ_GPT2, &tempTC_Handler);
-      NVIC_SET_PRIORITY(IRQ_GPT2, 32);
+      NVIC_SET_PRIORITY(IRQ_GPT2, 32);  // Priority 32 (lower than Step Timer)
       break;
   }
 }
@@ -82,6 +115,7 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num) {
     case MF_TIMER_TEMP: NVIC_DISABLE_IRQ(IRQ_GPT2); break;
   }
 
+  // Ensure the CPU actually stops servicing the IRQ
   // We NEED memory barriers to ensure Interrupts are actually disabled!
   // ( https://dzone.com/articles/nvic-disabling-interrupts-on-arm-cortex-m-and-the )
   asm volatile("dsb");
@@ -97,8 +131,8 @@ bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {
 
 void HAL_timer_isr_prologue(const uint8_t timer_num) {
   switch (timer_num) {
-    case MF_TIMER_STEP: GPT1_SR = GPT_IR_OF1IE; break; // clear OF3 bit
-    case MF_TIMER_TEMP: GPT2_SR = GPT_IR_OF1IE; break; // clear OF3 bit
+    case MF_TIMER_STEP: GPT1_SR = GPT_IR_OF1IE; break;   // clear OF1
+    case MF_TIMER_TEMP: GPT2_SR = GPT_IR_OF1IE; break;
   }
   asm volatile("dsb");
 }

--- a/Marlin/src/HAL/TEENSY40_41/timers.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/timers.cpp
@@ -56,14 +56,18 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
 
       // Enable compare‑event interrupt
       GPT1_IR = GPT_IR_OF2IE;           // OF2 interrupt enabled
-      GPT1_CR |= GPT_CR_EN;          //enable GPT2 counting at 150 MHz
 
-      OUT_WRITE(15, HIGH);
+      // Pull Pin 15 HIGH (logic‑high is the “idle” state)
+      TERN_(MARLIN_DEV_MODE, OUT_WRITE(15, HIGH));
 
       // Attach and enable Stepper IRQ
       // Note: UART priority is 16
       attachInterruptVector(IRQ_GPT1, &stepTC_Handler);
       NVIC_SET_PRIORITY(IRQ_GPT1, 16);  // Priority 16 (higher than Temp Timer)
+
+      // Start GPT1 counting at 150 MHz
+      GPT1_CR |= GPT_CR_EN;
+
       break;
 
     //
@@ -91,13 +95,17 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
 
       // Enable compare‑event interrupt
       GPT2_IR = GPT_IR_OF2IE;
-      GPT2_CR |= GPT_CR_EN;          //enable GPT2 counting at 150 MHz
 
-      OUT_WRITE(14, HIGH);
+      // Pull Pin 14 HIGH (logic‑high is the “idle” state)
+      TERN_(MARLIN_DEV_MODE, OUT_WRITE(14, HIGH));
 
       // Attach Temperature ISR
       attachInterruptVector(IRQ_GPT2, &tempTC_Handler);
       NVIC_SET_PRIORITY(IRQ_GPT2, 32);  // Priority 32 (lower than Step Timer)
+
+      // Start GPT2 counting at 150 MHz
+      GPT2_CR |= GPT_CR_EN;
+
       break;
   }
 }

--- a/Marlin/src/HAL/TEENSY40_41/timers.h
+++ b/Marlin/src/HAL/TEENSY40_41/timers.h
@@ -60,7 +60,7 @@ typedef uint32_t hal_timer_t;
 #define HAL_TIMER_RATE         GPT1_TIMER_RATE
 #define STEPPER_TIMER_RATE     HAL_TIMER_RATE
 #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000)
-#define STEPPER_TIMER_PRESCALE ((GPT_TIMER_RATE / 1000000) / STEPPER_TIMER_TICKS_PER_US)
+#define STEPPER_TIMER_PRESCALE (GPT_TIMER_RATE / STEPPER_TIMER_RATE)
 
 #define PULSE_TIMER_RATE       STEPPER_TIMER_RATE   // frequency of pulse timer
 #define PULSE_TIMER_PRESCALE   STEPPER_TIMER_PRESCALE
@@ -115,5 +115,4 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
-//void HAL_timer_isr_epilogue(const uint8_t timer_num) {}
-#define HAL_timer_isr_epilogue(T) NOOP
+inline void HAL_timer_isr_epilogue(const uint8_t) {}

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1513,11 +1513,7 @@ HAL_STEP_TIMER_ISR() {
   HAL_timer_isr_epilogue(MF_TIMER_STEP);
 }
 
-#ifdef CPU_32_BIT
-  #define STEP_MULTIPLY(A,B) MultiU32X24toH32(A, B)
-#else
-  #define STEP_MULTIPLY(A,B) MultiU24X32toH16(A, B)
-#endif
+#define STEP_MULTIPLY(A,B) TERN(CPU_32_BIT, MultiU32X24toH32, MultiU24X32toH16)(A, B)
 
 #if ENABLED(SMOOTH_LIN_ADVANCE)
   FORCE_INLINE static constexpr int32_t MULT_Q(uint8_t q, int32_t x, int32_t y) { return (int64_t(x) * y) >> q; }


### PR DESCRIPTION
Fixing #28167.

- Use inlines in place of macros for empty timer functions.
- Enable the timer as the last step on Teensy 4.x.
- Don't use "toggle" mode on Teensy 4.x unless doing a dev build
