### PR TITLE
followup for GCODE_MACROS_IN_EEPROM

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -708,7 +708,7 @@ typedef struct SettingsDataStruct {
   //
   // GCODE_MACROS
   //
-  #if ENABLED(GCODE_MACROS_EEPROM)
+  #if ENABLED(GCODE_MACROS_IN_EEPROM)
     char gcode_macros[GCODE_MACROS_SLOTS][GCODE_MACROS_SLOT_SIZE + 1];
   #endif
 
@@ -1833,7 +1833,7 @@ void MarlinSettings::postprocess() {
     //
     // GCODE_MACROS
     //
-    #if ENABLED(GCODE_MACROS_EEPROM)
+    #if ENABLED(GCODE_MACROS_IN_EEPROM)
       _FIELD_TEST(gcode_macros);
       EEPROM_WRITE(gcode.macros);
     #endif
@@ -2999,7 +2999,7 @@ void MarlinSettings::postprocess() {
       //
       // GCODE_MACROS
       //
-      #if ENABLED(GCODE_MACROS_EEPROM)
+      #if ENABLED(GCODE_MACROS_IN_EEPROM)
         EEPROM_READ(gcode.macros);
       #endif
 
@@ -3825,7 +3825,7 @@ void MarlinSettings::reset() {
   //
   // G-code Macros
   //
-  TERN_(GCODE_MACROS_EEPROM, gcode.reset_macros());
+  TERN_(GCODE_MACROS_IN_EEPROM, gcode.reset_macros());
 
   //
   // Hotend Idle Timeout


### PR DESCRIPTION
### Description

As reported in https://github.com/MarlinFirmware/Marlin/issues/28173
code used  GCODE_MACROS_EEPROM while config used GCODE_MACROS_IN_EEPROM
Updated code to also use GCODE_MACROS_IN_EEPROM

### Requirements

#define GCODE_MACROS
#define EEPROM_SETTINGS)
#define GCODE_MACROS_IN_EEPROM  

### Benefits

Feature actually gets enabled. 

### Related Issues

<li>MarlinFirmware/Marlin/issues/28173
<li>MarlinFirmware/Marlin/pull/28114