### PR TITLE
followup to Refactor AUTOTEMP

### DIFF
--- a/Marlin/src/gcode/temp/M104_M109.cpp
+++ b/Marlin/src/gcode/temp/M104_M109.cpp
@@ -141,11 +141,8 @@ void GcodeSuite::M104_M109(const bool isM109) {
   void GcodeSuite::M104_report(const bool forReplay/*=true*/) {
     TERN_(MARLIN_SMALL_BUILD, return);
     report_heading_etc(forReplay, F(STR_AUTOTEMP));
-    SERIAL_ECHOLNPGM("  M104"
-      " S", thermalManager.autotemp.cfg.min,
-      " B", thermalManager.autotemp.cfg.max,
-      " F", thermalManager.autotemp.cfg.factor
-    );
+    const autotemp_cfg_t &c = thermalManager.autotemp.cfg;
+    SERIAL_ECHOLNPGM("  M104 S", c.min, " B", c.max, " F", c.factor);
   }
 #endif
 

--- a/Marlin/src/gcode/temp/M104_M109.cpp
+++ b/Marlin/src/gcode/temp/M104_M109.cpp
@@ -140,12 +140,12 @@ void GcodeSuite::M104_M109(const bool isM109) {
   //
   void GcodeSuite::M104_report(const bool forReplay/*=true*/) {
     TERN_(MARLIN_SMALL_BUILD, return);
-      report_heading_etc(forReplay, F(STR_AUTOTEMP));
-      SERIAL_ECHOLNPGM("  M104"
-        " S", thermalManager.autotemp.cfg.min,
-        " B", thermalManager.autotemp.cfg.max,
-        " F", thermalManager.autotemp.cfg.factor
-      );
+    report_heading_etc(forReplay, F(STR_AUTOTEMP));
+    SERIAL_ECHOLNPGM("  M104"
+      " S", thermalManager.autotemp.cfg.min,
+      " B", thermalManager.autotemp.cfg.max,
+      " F", thermalManager.autotemp.cfg.factor
+    );
   }
 #endif
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -325,9 +325,14 @@ void menu_backlash();
     // Autotemp, Min, Max, Fact
     //
     #if ALL(AUTOTEMP, HAS_TEMP_HOTEND)
-      EDIT_ITEM(int3, MSG_MIN, &thermalManager.autotemp.cfg.min, 0, thermalManager.hotend_max_target(0));
-      EDIT_ITEM(int3, MSG_MAX, &thermalManager.autotemp.cfg.max, 0, thermalManager.hotend_max_target(0));
-      EDIT_ITEM(float42_52, MSG_FACTOR, &thermalManager.autotemp.cfg.factor, 0, 10);
+      autotemp_cfg_t &c = thermalManager.autotemp.cfg;
+      EDIT_ITEM(int3, MSG_MIN, &c.min, 0, thermalManager.hotend_max_target(0), []{
+        NOLESS(thermalManager.autotemp.cfg.max, thermalManager.autotemp.cfg.min);
+      });
+      EDIT_ITEM(int3, MSG_MAX, &c.max, 0, thermalManager.hotend_max_target(0), []{
+        NOMORE(thermalManager.autotemp.cfg.min, thermalManager.autotemp.cfg.max);
+      });
+      EDIT_ITEM(float42_52, MSG_FACTOR, &c.factor, 0, 10);
     #endif
 
     //
@@ -340,13 +345,15 @@ void menu_backlash();
     //
 
     #if ALL(PIDTEMP, PID_EDIT_MENU)
-      #define __PID_HOTEND_MENU_ITEMS(N) \
+
+      #define __PID_HOTEND_MENU_ITEMS(N) do{ \
         raw_Kp = thermalManager.temp_hotend[N].pid.p(); \
         raw_Ki = thermalManager.temp_hotend[N].pid.i(); \
         raw_Kd = thermalManager.temp_hotend[N].pid.d(); \
-        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_P_E, &raw_Kp, 1, 9990, []{ apply_PID_p(N); }); \
+        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_P_E, &raw_Kp, 1.00f, 9990, []{ apply_PID_p(N); }); \
         EDIT_ITEM_FAST_N(float52sign, N, MSG_PID_I_E, &raw_Ki, 0.01f, 9990, []{ apply_PID_i(N); }); \
-        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_D_E, &raw_Kd, 1, 9990, []{ apply_PID_d(N); })
+        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_D_E, &raw_Kd, 1.00f, 9990, []{ apply_PID_d(N); }); \
+      }while(0)
 
       #if ENABLED(PID_EXTRUSION_SCALING)
         #define _PID_HOTEND_MENU_ITEMS(N) \
@@ -377,9 +384,9 @@ void menu_backlash();
         raw_Kp = T.pid.p(); \
         raw_Ki = T.pid.i(); \
         raw_Kd = T.pid.d(); \
-        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_P_E, &raw_Kp, 1, 9990, []{ apply_PID_p(N); }); \
+        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_P_E, &raw_Kp, 1.00f, 9990, []{ apply_PID_p(N); }); \
         EDIT_ITEM_FAST_N(float52sign, N, MSG_PID_I_E, &raw_Ki, 0.01f, 9990, []{ apply_PID_i(N); }); \
-        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_D_E, &raw_Kd, 1, 9990, []{ apply_PID_d(N); })
+        EDIT_ITEM_FAST_N(float41sign, N, MSG_PID_D_E, &raw_Kd, 1.00f, 9990, []{ apply_PID_d(N); })
     #endif
 
     #if ENABLED(PIDTEMP)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3875,7 +3875,7 @@ void MarlinSettings::reset() {
     //
     // M104 settings for AUTOTEMP
     //
-    TERN_(AUTOTEMP, gcode.M104_report());
+    TERN_(AUTOTEMP, gcode.M104_report(forReplay));
 
     //
     // M149 Temperature units


### PR DESCRIPTION
### Description

Since https://github.com/MarlinFirmware/Marlin/pull/28155 M503 reports M104 settings formatted incorrectly  

Eg
```
echo:; Linear Units:
echo:  G21 ; (mm)
  M104 S210 B250 F0.10
echo:; Temperature Units:
echo:  M149 C ; Units in Celsius
```

It should report 
```
echo:; Linear Units:
echo:  G21 ; (mm)
echo:; Auto Temp Control:
echo:  M104 S210 B250 F0.10
echo:; Temperature Units:
echo:  M149 C ; Units in Celsius
```

Missed forReplay parameter in M104_report call in Marlin/src/module/settings.cpp caused the incorrect formatting.

I also corrected indenting in Marlin/src/gcode/temp/M104_M109.cpp
As existing indenting made it look like the code was part of the TERN_ when it is not.

### Requirements

#define AUTOTEMP

### Benefits

M104_report works as expected

### Related Issues

<li>MarlinFirmware/Marlin/pull/28155