### PR TITLE
Update/fix park, bed leveling - JyersUI/ProUI

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -1161,16 +1161,16 @@ bool unified_bed_leveling::G29_parse_parameters() {
   }
 
   if (parser.seen('P')) {
-    const uint8_t pv = parser.value_byte();
+    const uint8_t pval = parser.value_byte();
     #if !HAS_BED_PROBE
-      if (pv == 1) {
+      if (pval == 1) {
         SERIAL_ECHOLNPGM("G29 P1 requires a probe.\n");
         err_flag = true;
       }
       else
     #endif
       {
-        param.P_phase = pv;
+        param.P_phase = pval;
         if (!WITHIN(param.P_phase, 0, 6)) {
           SERIAL_ECHOLNPGM("?(P)hase value invalid (0-6).\n");
           err_flag = true;

--- a/Marlin/src/feature/bltouch.cpp
+++ b/Marlin/src/feature/bltouch.cpp
@@ -71,11 +71,9 @@ void BLTouch::init(const bool set_voltage/*=false*/) {
 
   #else
 
-    #ifdef DEBUG_OUT
-      if (DEBUGGING(LEVELING))
-        DEBUG_ECHOLN( F("BLTouch Mode: "), bltouch.od_5v_mode ? F("5V") : F("OD"),
-                      F(" (Default " TERN(BLTOUCH_SET_5V_MODE, "5V", "OD") ")"));
-    #endif
+    if (DEBUGGING(LEVELING))
+      DEBUG_ECHOLN( F("BLTouch Mode: "), bltouch.od_5v_mode ? F("5V") : F("OD"),
+                    F(" (Default " TERN(BLTOUCH_SET_5V_MODE, "5V", "OD") ")"));
 
     const bool should_set = od_5v_mode != ENABLED(BLTOUCH_SET_5V_MODE);
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -225,7 +225,7 @@ void GcodeSuite::G29() {
         }
       }
       else
-        return echo_not_entered('J');
+        return echo_not_entered('I');
 
       if (parser.seenval('J')) {
         iy = parser.value_int();

--- a/Marlin/src/gcode/feature/pause/G27.cpp
+++ b/Marlin/src/gcode/feature/pause/G27.cpp
@@ -24,6 +24,9 @@
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../../core/debug_out.h"
+
 #include "../../gcode.h"
 #include "../../../libs/nozzle.h"
 #include "../../../module/motion.h"
@@ -45,12 +48,13 @@ void GcodeSuite::G27() {
   // Don't allow nozzle parking without homing first
   if (homing_needed_error()) return;
   const uint8_t pval = parser.byteval('P');
-  if (WITHIN(pval, 0, 4)) {
-    nozzle.park(pval);
-    TERN_(SOVOL_SV06_RTS, RTS_MoveAxisHoming());
-  }
-  else
-    SERIAL_ECHOLN(F("?Invalid "), F("[P]arking style (0..4)."));
+  nozzle.park(pval);
+  TERN_(SOVOL_SV06_RTS, RTS_MoveAxisHoming());
+
+  #ifdef DEBUG_OUT
+    if (WITHIN(pval, 0, 4))
+      DEBUG_ECHOLN(F("?Invalid "), F("[P]arking style (0..4)."));
+  #endif
 }
 
 #endif // NOZZLE_PARK_FEATURE

--- a/Marlin/src/gcode/feature/pause/G27.cpp
+++ b/Marlin/src/gcode/feature/pause/G27.cpp
@@ -24,9 +24,6 @@
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
-#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
-#include "../../../core/debug_out.h"
-
 #include "../../gcode.h"
 #include "../../../libs/nozzle.h"
 #include "../../../module/motion.h"
@@ -47,14 +44,13 @@
 void GcodeSuite::G27() {
   // Don't allow nozzle parking without homing first
   if (homing_needed_error()) return;
-  const uint8_t pval = parser.byteval('P');
-  nozzle.park(pval);
-  TERN_(SOVOL_SV06_RTS, RTS_MoveAxisHoming());
-
-  #ifdef DEBUG_OUT
-    if (WITHIN(pval, 0, 4))
-      DEBUG_ECHOLN(F("?Invalid "), F("[P]arking style (0..4)."));
-  #endif
+  const int16_t pval = parser.intval('P');
+  if (WITHIN(pval, 0, 4)) {
+    nozzle.park(pval);
+    TERN_(SOVOL_SV06_RTS, RTS_MoveAxisHoming());
+  }
+  else
+    SERIAL_ECHOLN(F("?Invalid "), F("[P]arking style (0..4)."));
 }
 
 #endif // NOZZLE_PARK_FEATURE

--- a/Marlin/src/gcode/feature/pause/G27.cpp
+++ b/Marlin/src/gcode/feature/pause/G27.cpp
@@ -44,7 +44,7 @@
 void GcodeSuite::G27() {
   // Don't allow nozzle parking without homing first
   if (homing_needed_error()) return;
-  const int16_t pval = parser.intval('P');
+  const uint8_t pval = parser.byteval('P');
   if (WITHIN(pval, 0, 4)) {
     nozzle.park(pval);
     TERN_(SOVOL_SV06_RTS, RTS_MoveAxisHoming());

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -265,13 +265,6 @@ private:
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       uint8_t tilt_grid = 1;
 
-      void manualValueUpdate(bool undefined=false) {
-        queue.inject(
-          TS(F("M421I"), mesh_x, 'J', mesh_y, 'Z', p_float_t(current_position.z, 3), undefined ? "N" : "")
-        );
-        planner.synchronize();
-      }
-
       bool createPlaneFromMesh() {
         struct linear_fit_data lsf_results;
         incremental_LSF_reset(&lsf_results);
@@ -310,16 +303,15 @@ private:
         return false;
       }
 
-    #else
-
-      void manualValueUpdate() {
-        queue.inject(
-          TS(F("G29I"), mesh_x, 'J', mesh_y, 'Z', p_float_t(current_position.z, 3))
-        );
-        planner.synchronize();
-      }
-
     #endif
+
+    void manualValueUpdate(bool reset=false) {
+      float zval;
+      if (reset) { zval = 0; }
+      else { zval = current_position.z; }
+      queue.inject(TS(F("M421I"), mesh_x, F("J"), mesh_y, F("Z"), p_float_t(zval, 3)));
+      planner.synchronize();
+    }
 
     void manual_mesh_move(const bool zmove=false) {
       if (zmove) {
@@ -3515,8 +3507,8 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
         #define LEVELING_M_UP (LEVELING_M_OFFSET + 1)
         #define LEVELING_M_DOWN (LEVELING_M_UP + 1)
         #define LEVELING_M_GOTO_VALUE (LEVELING_M_DOWN + 1)
-        #define LEVELING_M_UNDEF (LEVELING_M_GOTO_VALUE + ENABLED(AUTO_BED_LEVELING_UBL))
-        #define LEVELING_M_TOTAL LEVELING_M_UNDEF
+        #define LEVELING_M_ZERO (LEVELING_M_GOTO_VALUE + 1)
+        #define LEVELING_M_TOTAL LEVELING_M_ZERO
 
         switch (item) {
           case LEVELING_M_BACK:
@@ -3606,16 +3598,14 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
               drawCheckbox(row, mesh_conf.goto_mesh_value);
             }
             break;
-          #if ENABLED(AUTO_BED_LEVELING_UBL)
-            case LEVELING_M_UNDEF:
-              if (draw)
-                drawMenuItem(row, ICON_ResetEEPROM, F("Clear Point Value"));
-              else {
-                mesh_conf.manualValueUpdate(true);
-                redrawMenu(false);
-              }
-              break;
-          #endif
+          case LEVELING_M_ZERO:
+            if (draw)
+              drawMenuItem(row, ICON_ResetEEPROM, GET_TEXT_F(MSG_ZERO_MESH_POINT));
+            else {
+              mesh_conf.manualValueUpdate(true);
+              redrawMenu(false);
+            }
+            break;
         }
         break;
     #endif // HAS_MESH

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -305,10 +305,8 @@ private:
 
     #endif
 
-    void manualValueUpdate(bool reset=false) {
-      float zval;
-      if (reset) { zval = 0; }
-      else { zval = current_position.z; }
+    void manualValueUpdate(const bool reset=false) {
+      const float zval = reset ? 0.0f : current_position.z;
       queue.inject(TS(F("M421I"), mesh_x, F("J"), mesh_y, F("Z"), p_float_t(zval, 3)));
       planner.synchronize();
     }

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -75,14 +75,6 @@ bool drawing_mesh = false;
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
 
-  void BedLevelTools::manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool undefined/*=false*/) {
-    MString<MAX_CMD_SIZE> cmd;
-    cmd.set(F("M421 I"), mesh_x, 'J', mesh_y, 'Z', p_float_t(current_position.z, 3));
-    if (undefined) cmd += F(" N");
-    gcode.process_subcommands_now(cmd);
-    planner.synchronize();
-  }
-
   bool BedLevelTools::createPlaneFromMesh() {
     struct linear_fit_data lsf_results;
     incremental_LSF_reset(&lsf_results);
@@ -122,16 +114,15 @@ bool drawing_mesh = false;
     return false;
   }
 
-#else
-
-  void BedLevelTools::manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y) {
-    gcode.process_subcommands_now(
-      TS(F("G29 I"), mesh_x, 'J', mesh_y, 'Z', p_float_t(current_position.z, 3))
-    );
-    planner.synchronize();
-  }
-
 #endif
+
+void BedLevelTools::manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool reset/*=false*/) {
+  float zval;
+  if (reset) { zval = 0; }
+  else { zval = current_position.z; }
+  queue.inject(TS(F("M421I"), mesh_x, F("J"), mesh_y, F("Z"), p_float_t(zval, 3)));
+  planner.synchronize();
+}
 
 void BedLevelTools::manualMove(const uint8_t mesh_x, const uint8_t mesh_y, bool zmove/*=false*/) {
   gcode.process_subcommands_now(F("G28O"));

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.cpp
@@ -116,10 +116,8 @@ bool drawing_mesh = false;
 
 #endif
 
-void BedLevelTools::manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool reset/*=false*/) {
-  float zval;
-  if (reset) { zval = 0; }
-  else { zval = current_position.z; }
+void BedLevelTools::manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, const bool reset/*=false*/) {
+  const float zval = reset ? 0.0f : current_position.z;
   queue.inject(TS(F("M421I"), mesh_x, F("J"), mesh_y, F("Z"), p_float_t(zval, 3)));
   planner.synchronize();
 }

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
@@ -55,11 +55,9 @@ public:
   static uint8_t tilt_grid;
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
-    static void manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool undefined=false);
     static bool createPlaneFromMesh();
-  #else
-    static void manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y);
   #endif
+  static void manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool reset=false);
   static void manualMove(const uint8_t mesh_x, const uint8_t mesh_y, bool zmove=false);
   static void moveToXYZ();
   static void moveToXY();

--- a/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
+++ b/Marlin/src/lcd/e3v2/proui/bedlevel_tools.h
@@ -57,7 +57,7 @@ public:
   #if ENABLED(AUTO_BED_LEVELING_UBL)
     static bool createPlaneFromMesh();
   #endif
-  static void manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, bool reset=false);
+  static void manualValueUpdate(const uint8_t mesh_x, const uint8_t mesh_y, const bool reset=false);
   static void manualMove(const uint8_t mesh_x, const uint8_t mesh_y, bool zmove=false);
   static void moveToXYZ();
   static void moveToXY();

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -4397,7 +4397,6 @@ void drawMaxAccelMenu() {
       #endif
       #if ENABLED(PROUI_MESH_EDIT)
         MENU_ITEM(ICON_MeshReset, MSG_MESH_RESET, onDrawMenuItem, resetMesh);
-
         MENU_ITEM(ICON_MeshEdit, MSG_EDIT_MESH, onDrawSubMenu, drawEditMeshMenu);
       #endif
       MENU_ITEM(ICON_MeshViewer, MSG_MESH_VIEW, onDrawSubMenu, dwinMeshViewer);

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -4316,6 +4316,7 @@ void drawMaxAccelMenu() {
     void applyEditMeshX() { bedLevelTools.mesh_x = menuData.value; }
     void applyEditMeshY() { bedLevelTools.mesh_y = menuData.value; }
     void resetMesh() { bedLevelTools.meshReset(); LCD_MESSAGE(MSG_MESH_RESET); }
+    void zeroPoint() { bedLevelTools.manualValueUpdate(bedLevelTools.mesh_x, bedLevelTools.mesh_y, true); editZValueItem->redraw(); LCD_MESSAGE(MSG_ZERO_MESH_POINT); }
     void setEditMeshX() { hmiValue.select = 0; setIntOnClick(0, GRID_MAX_POINTS_X - 1, bedLevelTools.mesh_x, applyEditMeshX, liveEditMesh); }
     void setEditMeshY() { hmiValue.select = 1; setIntOnClick(0, GRID_MAX_POINTS_Y - 1, bedLevelTools.mesh_y, applyEditMeshY, liveEditMesh); }
     void setEditZValue() { setPFloatOnClick(Z_OFFSET_MIN, Z_OFFSET_MAX, 3); }
@@ -4396,6 +4397,7 @@ void drawMaxAccelMenu() {
       #endif
       #if ENABLED(PROUI_MESH_EDIT)
         MENU_ITEM(ICON_MeshReset, MSG_MESH_RESET, onDrawMenuItem, resetMesh);
+
         MENU_ITEM(ICON_MeshEdit, MSG_EDIT_MESH, onDrawSubMenu, drawEditMeshMenu);
       #endif
       MENU_ITEM(ICON_MeshViewer, MSG_MESH_VIEW, onDrawSubMenu, dwinMeshViewer);
@@ -4417,6 +4419,7 @@ void drawMaxAccelMenu() {
         EDIT_ITEM(ICON_MeshEditX, MSG_MESH_X, onDrawPInt8Menu, setEditMeshX, &bedLevelTools.mesh_x);
         EDIT_ITEM(ICON_MeshEditY, MSG_MESH_Y, onDrawPInt8Menu, setEditMeshY, &bedLevelTools.mesh_y);
         editZValueItem = EDIT_ITEM(ICON_MeshEditZ, MSG_MESH_EDIT_Z, onDrawPFloat2Menu, setEditZValue, &bedlevel.z_values[bedLevelTools.mesh_x][bedLevelTools.mesh_y]);
+        MENU_ITEM(ICON_SetZOffset, MSG_ZERO_MESH_POINT, onDrawMenuItem, zeroPoint);
       }
       updateMenu(editMeshMenu);
     }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -140,6 +140,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_LEVEL_BED_WAITING              = _UxGT("Click to Begin");
   LSTR MSG_LEVEL_BED_NEXT_POINT           = _UxGT("Next Point");
   LSTR MSG_LEVEL_BED_DONE                 = _UxGT("Leveling Done!");
+  LSTR MSG_ZERO_MESH_POINT                = _UxGT("Zero Current Point");
   LSTR MSG_Z_FADE_HEIGHT                  = _UxGT("Fade Height");
   LSTR MSG_SET_HOME_OFFSETS               = _UxGT("Set Home Offsets");
   LSTR MSG_HOME_OFFSET_X                  = _UxGT("Home Offset X"); // DWIN


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Fix some mistakes:
- typo `I` instead of `J` (**mbl/G29.cpp**)
- Use unsigned byte/char for parser value in **G27.cpp** since `nozzle.park()` passes the same
- Use `pval` instead of `pv` in **ubl_G29.cpp**

Update JyersUI/ProUI
- Utilize unused `manualValueUpate()`, which basically just zeroes current mesh point
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
