### PR TITLE
Fix leds compile error

### DIFF
--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -105,9 +105,11 @@ void menu_led_custom() {
   #if ENABLED(NEOPIXEL2_SEPARATE)
     STATIC_ITEM_N(1, MSG_LED_CHANNEL_N, SS_DEFAULT|SS_INVERT);
   #endif
-  EDIT_ITEM(uint8, MSG_INTENSITY_R, &leds.color.r, 0, 255, leds.update, true);
-  EDIT_ITEM(uint8, MSG_INTENSITY_G, &leds.color.g, 0, 255, leds.update, true);
-  EDIT_ITEM(uint8, MSG_INTENSITY_B, &leds.color.b, 0, 255, leds.update, true);
+  #if ENABLED(LED_CONTROL_MENU)
+    EDIT_ITEM(uint8, MSG_INTENSITY_R, &leds.color.r, 0, 255, leds.update, true);
+    EDIT_ITEM(uint8, MSG_INTENSITY_G, &leds.color.g, 0, 255, leds.update, true);
+    EDIT_ITEM(uint8, MSG_INTENSITY_B, &leds.color.b, 0, 255, leds.update, true);
+  #endif
   #if HAS_WHITE_LED
     EDIT_ITEM(uint8, MSG_INTENSITY_W, &leds.color.w, 0, 255, leds.update, true);
   #endif


### PR DESCRIPTION
Compile error because of #28143
I used LED_CONTROL because led include is added by it.
Previously code was compiled by LED_COLOR_PRESETS  not sure which is best
