### PR TITLE
🔨 STM32 build with -std=gnu++17

### DIFF
--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -13,10 +13,10 @@
 platform          = ststm32@~12.1
 #platform_packages = toolchain-gccarmnoneeabi@1.100301.220327   # Otherwise it's GCC 9.2.1
 board_build.core  = stm32
-build_flags       = ${common.build_flags} -std=gnu++14
+build_flags       = ${common.build_flags} -std=gnu++17
                    -DHAL_STM32 -DPLATFORM_M997_SUPPORT
                    -DUSBCON -DUSBD_USE_CDC -DTIM_IRQ_PRIO=13 -DADC_RESOLUTION=12
-build_unflags     = -std=gnu++11
+build_unflags     = -std=gnu++11 -std=gnu++14
 build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32> -<src/HAL/STM32/tft> +<src/HAL/shared/backtrace>
 extra_scripts     = ${common.extra_scripts}
                    pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py


### PR DESCRIPTION
Add `-std=gnu++17` as the default for all STM32 (non-Maple) builds, aiming for a C++17 baseline for available language features.

---
Note: For c++17 the Teensy targets require an appropriate `libarm_cortexM7lfsp_math.a`. Maybe one of these?
```
.../CMSIS/DSP/Lib/GCC/libarm_cortexM7lfsp_math.a
.../CMSIS/Lib/GCC/libarm_cortexM7lfsp_math.a
packages/toolchain-gccarmnoneeabi@1.50401.190816/arm-none-eabi/lib/libarm_cortexM7lfsp_math.a
```