### PR TITLE
Warn about disabling FTM_SHAPER_E and FTM_SMOOTHING

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -947,11 +947,11 @@
   #if ENABLED(LIN_ADVANCE)
     #warning "Be aware that FT_MOTION K factor is now set with M900 K (same as LIN_ADVANCE)."
     #if DISABLED(FTM_SMOOTHING)
-      #warning "Be aware that enabling FTM_SMOOTHING and setting FTM_SMOOTHING_TIME_E tames extruder accelerations due to linear advance and results in higher print quality."
+      #warning "For higher print quality enable FTM_SMOOTHING with FTM_SMOOTHING_TIME_E to tame Linear Advance accelerations."
     #endif
   #endif
   #if DISABLED(FTM_SHAPER_E)
-    #warning "Be aware that enabling FTM_SHAPER_E (even if you let the shaper to NONE) allows synchronising all axes and results in higher print quality."
+    #warning "For higher print quality enable FTM_SHAPER_E (even if shaper is NONE) to allow axis synchronization."
   #endif
 #endif
 #if ENABLED(FTM_HOME_AND_PROBE)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -947,7 +947,7 @@
   #if ENABLED(LIN_ADVANCE)
     #warning "Be aware that FT_MOTION K factor is now set with M900 K (same as LIN_ADVANCE)."
     #if DISABLED(FTM_SMOOTHING)
-      #warning "Be aware that enabling FTM_SMOOTHING and setting FTM_SMOOTHING_TIME_E tames extruder acceleations due to linear advance and results in higher print quality."
+      #warning "Be aware that enabling FTM_SMOOTHING and setting FTM_SMOOTHING_TIME_E tames extruder accelerations due to linear advance and results in higher print quality."
     #endif
   #endif
   #if DISABLED(FTM_SHAPER_E)

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -946,6 +946,12 @@
   #endif
   #if ENABLED(LIN_ADVANCE)
     #warning "Be aware that FT_MOTION K factor is now set with M900 K (same as LIN_ADVANCE)."
+    #if DISABLED(FTM_SMOOTHING)
+      #warning "Be aware that enabling FTM_SMOOTHING and setting FTM_SMOOTHING_TIME_E tames extruder acceleations due to linear advance and results in higher print quality."
+    #endif
+  #endif
+  #if DISABLED(FTM_SHAPER_E)
+    #warning "Be aware that enabling FTM_SHAPER_E (even if you let the shaper to NONE) allows synchronising all axes and results in higher print quality."
   #endif
 #endif
 #if ENABLED(FTM_HOME_AND_PROBE)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

> Be aware that enabling FTM_SMOOTHING and setting FTM_SMOOTHING_TIME_E tames extruder acceleations due to linear advance and results in higher print quality.
> Be aware that enabling FTM_SHAPER_E (even if you let the shaper to NONE) allows synchronising all axes and results in higher print quality.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
