### PR TITLE
 Fix: Prevent double counting of probe Z-offset in Bilinear leveling (Planner.cpp)

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1480,7 +1480,7 @@ void Planner::check_axes_activity() {
         raw.z += bedlevel.get_z_correction(raw);
       #endif
 
-      TERN_(MESH_BED_LEVELING, raw.z += bedlevel.get_z_offset());
+      TERN_(MESH_BED_LEVELING, raw.z += 0);
 
     #endif
   }


### PR DESCRIPTION
#  Fix: Prevent double counting of probe Z-offset in Bilinear leveling (Planner.cpp)

## Description:

This PR fixes a regression in Marlin 2.1.1 where Z_PROBE_OFFSET (M851) is applied twice during Bilinear Bed Leveling in Planner.cpp. The result is nozzle height errors and repeated babystepping corrections. The fix neutralizes the redundant addition and restores expected behavior from 2.0.7.2.

## Version / Setup
- Marlin 2.1.1
- Printer: Prusa Clone M2.5S
- E3DV6 extruder
- Mega2560 + RAMPS1.4
- small oled and custom controller but as in Prusa printers
- Mechanical switch Z-endstop + servo with mechanical switch-probe configured
- Bilinear Bed Leveling enabled
- Endstop and probe pins defined in configuration

## Problem

When using `Z_PROBE_OFFSET` with G29:
- Offset values are transferred into the mesh points.
- At print start, the nozzle is too high.
- Correcting with babystepping during the first layer updates the Z-offset value.
- Running G29 again adds this new offset into the mesh, causing to have to use babystepping to re-calibrate the z-offset.
- This repeats continuously when using the default `Z_PROBE_OFFSET`.

Although this is an older printer, the configuration allows mechanical endstops and a servo probe, so it should still work. Current behavior forces the user to disable the probe after one measurement and manually calculate a new Z-offset into `M206 Z`, which is not desirable. G29 should be usable before each print without manual recalculation.

## Root Cause
In `planner.cpp`, the probe offset is added again during Bilinear mesh leveling:

```planner.cpp
// Original code planner.cpp
TERN_(MESH_BED_LEVELING, raw.z += bedlevel.get_z_offset());
```
This results in the Z offset (M851) being applied twice.

### Fix
Neutralize the addition:

```planner.cpp
// Fixed line planner.cpp
TERN_(MESH_BED_LEVELING, raw.z += 0);
```

### Requirements

Main way to repeat is to use printer with mechanical endstop switches, mechanical probe switch and bilinear bed leveling. 

### Benefits

This helps to solve issues which are linked below. And this also returns the offset adjustment to controller device and is usable as Z height calibration. 

### Configurations

Just change the planner.cpp setting as proposed in code settings

### Related Issues

This problem has been reported multiple times in different contexts:
- [BUG: z probe offset isn't working (#22322)](https://github.com/MarlinFirmware/Marlin/issues/22322)
- [Probe offsets being ignored (#23850)](https://github.com/MarlinFirmware/Marlin/issues/23850)
- [Z-Offset Not Working Properly After Upgrading (#27581)](https://github.com/MarlinFirmware/Marlin/issues/27581)
- [Z-probe offset vs. endstop logic (#27680)](https://github.com/MarlinFirmware/Marlin/issues/27680)

### Earlier offset issue fix
- [Proposed Z offset fix #27714](https://github.com/MarlinFirmware/Marlin/pull/27714)

These reports highlight the same underlying issue: probe offset (`M851`) is applied incorrectly or inconsistently, especially when Bilinear Bed Leveling is active and using  `#define BABYSTEP_ZPROBE_OFFSET`

## Request for further Marlin Revisions

I hope this somehow helps to isolate the problem as it seems to be an issue. I think that this issue stems from transitioning to current day bedlevel measuring devices that are used as endstops also. That's why you probably changed to the `Z_PROBE_OFFSET` and `BABYSTEP_ZPROBE_OFFSET`. But when also adding `#define BABYSTEP_HOTEND_Z_OFFSET` for multiple hotends, which is confusing for users as do you really have to have more than 1 hotend to have Babystep relative to hotend. Also you could point to configuration.h `#define Z_MIN_PROBE_PIN` as it is still a feature and hopefully for some time in the future. You have this `//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN` which might also add to the mix why offsets are off.

