### PR TITLE
Build scripts: Use subprocess to fetch URLs to avoid problems with shell quoting

### DIFF
--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -3,7 +3,7 @@
 # configuration.py
 # Apply options from config.ini to the existing Configuration headers
 #
-import re, os, shutil, configparser, datetime
+import re, os, shutil, subprocess, configparser, datetime
 from pathlib import Path
 
 verbose = 0
@@ -149,9 +149,9 @@ def fetch_example(url):
 
     # Find a suitable fetch command
     if shutil.which("curl") is not None:
-        fetch = "curl -L -s -S -f -o"
+        fetch = ["curl", "-L", "-s", "-S", "-f", "-o"]
     elif shutil.which("wget") is not None:
-        fetch = "wget -q -O"
+        fetch = ["wget", "-q", "-O"]
     else:
         blab("Couldn't find curl or wget", -1)
         #blab("Couldn't find curl or wget", 0)
@@ -165,7 +165,7 @@ def fetch_example(url):
     # Try to fetch the remote files
     gotfile = False
     for fn in ("Configuration.h", "Configuration_adv.h", "_Bootscreen.h", "_Statusscreen.h"):
-        if os.system(f"{fetch} wgot {url}/{fn} >/dev/null 2>&1") == 0:
+        if subprocess.call(fetch + ["wgot", f"{url}/{fn}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
             shutil.move('wgot', config_path(fn))
             gotfile = True
             blab(f"Fetched {fn}", 2)

--- a/buildroot/share/PlatformIO/scripts/configuration.py
+++ b/buildroot/share/PlatformIO/scripts/configuration.py
@@ -149,9 +149,9 @@ def fetch_example(url):
 
     # Find a suitable fetch command
     if shutil.which("curl") is not None:
-        fetch = ["curl", "-L", "-s", "-S", "-f", "-o"]
+        fetch = [ "curl", "-L", "-s", "-S", "-f", "-o" ]
     elif shutil.which("wget") is not None:
-        fetch = ["wget", "-q", "-O"]
+        fetch = [ "wget", "-q", "-O" ]
     else:
         blab("Couldn't find curl or wget", -1)
         #blab("Couldn't find curl or wget", 0)
@@ -165,7 +165,7 @@ def fetch_example(url):
     # Try to fetch the remote files
     gotfile = False
     for fn in ("Configuration.h", "Configuration_adv.h", "_Bootscreen.h", "_Statusscreen.h"):
-        if subprocess.call(fetch + ["wgot", f"{url}/{fn}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
+        if subprocess.call(fetch + [ "wgot", f"{url}/{fn}" ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
             shutil.move('wgot', config_path(fn))
             gotfile = True
             blab(f"Fetched {fn}", 2)


### PR DESCRIPTION

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Use `subprocess.call` instead of `os.sytem` when downloading URLs to avoid shell quoting problems with special characters.
I ran into this using `example/Tevo/Tornado/V2 (MKS GEN-L)`:
```
sh: 1: Syntax error: "(" unexpected
sh: 1: Syntax error: "(" unexpected
sh: 1: Syntax error: "(" unexpected
sh: 1: Syntax error: "(" unexpected
```
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
