### PR TITLE
FT_MOTION : Really set moving_axis_flag for each block

### DIFF
--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -185,10 +185,7 @@ void FTMotion::loop() {
   }
 
   // Set busy status for use by planner.busy()
-  const bool oldBusy = busy;
   busy = stepping.is_busy();
-  if (oldBusy && !busy) moving_axis_flags.reset();
-
 }
 
 #if HAS_FTM_SHAPING
@@ -386,12 +383,8 @@ bool FTMotion::plan_next_block() {
 
     TERN_(FTM_HAS_LIN_ADVANCE, use_advance_lead = current_block->use_advance_lead);
 
-    #define _SET_MOVE_END(A) do{ \
-      if (moveDist.A) { \
-        moving_axis_flags.A = true; \
-        axis_move_dir.A = moveDist.A > 0; \
-      } \
-    }while(0);
+    axis_move_dir = current_block->direction_bits;
+    #define _SET_MOVE_END(A) moving_axis_flags.A = moveDist.A ? true : false;
 
     LOGICAL_AXIS_MAP(_SET_MOVE_END);
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
In `FT_MOTION`, once `moving_axis_ flag` is set to true for an axis, this  is for all the print. The probability of `if (oldBusy && !busy moving_axis_flags.reset();` is near zero in the main loop.
This PR sets this flag correctly for each block and uses `current_block->direction_bits` for setting `axis_move_dir` instead of a macro.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
