### PR TITLE
FT_MOTION : Refactor TICKS_BITS definition for simulated board

### DIFF
--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -30,17 +30,16 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
   const uint32_t hi = a >> 16, lo = a & 0x0000FFFF;
   return (hi * b) + ((lo * b) >> 16);
 }
-#define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
-constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-#if (MOTHERBOARD == BOARD_SIMULATED)
-  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#else
-  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#endif
-constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
-                                                                     // "clz" counts leading zeroes.
-constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.
-                                                                     // Intervals buffer has fixed point numbers with the point on this position
+constexpr int CLZ32(const uint32_t v, const int c=0) {
+  return v ? (TEST32(v, 31)) ? c : CLZ32(v << 1, c + 1) : 32;
+}
+#define FTM_NEVER uint32_t(UINT16_MAX)                        // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
+constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS; // Timer ticks per frame (by default, 1kHz)
+constexpr uint32_t TICKS_BITS = CLZ32(FRAME_TICKS + 1U);      // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;              // Bits remaining
+                                                              // "clz" counts leading zeroes.
+constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                   // uint16 interval fractional bits.
+                                                              // Intervals buffer has fixed point numbers with the point on this position
 
 static_assert(FRAME_TICKS < FTM_NEVER, "(STEPPER_TIMER_RATE / FTM_FS) must be < " STRINGIFY(FTM_NEVER) " to fit 16-bit fixed-point numbers.");
 static_assert(FRAME_TICKS !=  2000 || FTM_Q_INT == 11, "FTM_Q_INT should be 11");

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -32,7 +32,11 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
 }
 #define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
 constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#if (MOTHERBOARD == BOARD_SIMULATED)
+  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#else
+  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#endif
 constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
                                                                      // "clz" counts leading zeroes.
 constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -32,7 +32,11 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
 }
 #define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
 constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#if (MOTHERBOARD == BOARD_SIMULATED)
+  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#else
+  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#endif
 constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
                                                                      // "clz" counts leading zeroes.
 constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -32,7 +32,11 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
 }
 #define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
 constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1UL);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#if (MOTHERBOARD == BOARD_SIMULATED)
+  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#else
+  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
+#endif
 constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
                                                                      // "clz" counts leading zeroes.
 constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -32,11 +32,7 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
 }
 #define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
 constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-#if (MOTHERBOARD == BOARD_SIMULATED)
-  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#else
-  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#endif
+constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1UL);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
 constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
                                                                      // "clz" counts leading zeroes.
 constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -32,11 +32,7 @@ FORCE_INLINE constexpr uint32_t a_times_b_shift_16(const uint32_t a, const uint3
 }
 #define FTM_NEVER uint32_t(UINT16_MAX)                               // Reserved number to indicate "no ticks in this frame" (FRAME_TICKS_FP+1 would work too)
 constexpr uint32_t FRAME_TICKS = STEPPER_TIMER_RATE / FTM_FS;        // Timer ticks per frame (by default, 1kHz)
-#if (MOTHERBOARD == BOARD_SIMULATED)
-  constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1U);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#else
-  constexpr uint32_t TICKS_BITS = __builtin_clzl(FRAME_TICKS + 1UL); // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
-#endif
+constexpr uint32_t TICKS_BITS = __builtin_clz(FRAME_TICKS + 1);   // Bits to represent the max value (duration of a frame, +1 one for FTM_NEVER).
 constexpr uint32_t FTM_Q_INT = 32u - TICKS_BITS;                     // Bits remaining
                                                                      // "clz" counts leading zeroes.
 constexpr uint32_t FTM_Q = 16u - FTM_Q_INT;                          // uint16 interval fractional bits.


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
With `FT_MOTION` enabled, the simulator can't be built anymore as some  asserts fail in `stepping.h.`. Fix the build for the simulated board.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Simulator is working again
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
