### PR TITLE
Option to disable M303 and save flash

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -922,8 +922,8 @@
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
 
   //#define PID_EDIT_MENU         // Add PID editing to the "Advanced Settings" menu. (~700 bytes of flash)
-  //#define PID_AUTOTUNE_MENU       // Add PID auto-tuning to the "Advanced Settings" menu. (~250 bytes of flash)
-  //#define DISABLE_M303_AUTOTUNE   // Disable the M303 PID autotune command to save ~2.7K bytes of flash.
+  //#define PID_AUTOTUNE_MENU     // Add PID auto-tuning to the "Advanced Settings" menu. (~250 bytes of flash)
+  //#define DISABLE_M303_AUTOTUNE // Disable the M303 PID autotune command to save ~2.7K bytes of flash.
 #endif
 
 // @section safety

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -922,7 +922,8 @@
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
 
   //#define PID_EDIT_MENU         // Add PID editing to the "Advanced Settings" menu. (~700 bytes of flash)
-  //#define PID_AUTOTUNE_MENU     // Add PID auto-tuning to the "Advanced Settings" menu. (~250 bytes of flash)
+  //#define PID_AUTOTUNE_MENU       // Add PID auto-tuning to the "Advanced Settings" menu. (~250 bytes of flash)
+  //#define DISABLE_M303_AUTOTUNE   // Disable the M303 PID autotune command to save ~2.7K bytes of flash.
 #endif
 
 // @section safety

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -832,7 +832,7 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
         case 302: M302(); break;                                  // M302: Allow cold extrudes (set the minimum extrude temperature)
       #endif
 
-      #if HAS_PID_HEATING
+      #if HAS_PID_AUTOTUNE
         case 303: M303(); break;                                  // M303: PID autotune
       #endif
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1014,7 +1014,7 @@ private:
     static void M302();
   #endif
 
-  #if HAS_PID_HEATING
+  #if HAS_PID_AUTOTUNE
     static void M303();
   #endif
 

--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if HAS_PID_HEATING
+#if HAS_PID_AUTOTUNE
 
 #include "../gcode.h"
 #include "../queue.h" // for flush_tx
@@ -85,4 +85,4 @@ void GcodeSuite::M303() {
   queue.flush_rx();
 }
 
-#endif // HAS_PID_HEATING
+#endif // HAS_PID_AUTOTUNE

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -2731,6 +2731,11 @@
   #define HAS_PID_HEATING 1
 #endif
 
+// PID autotune (M303 command)
+#if HAS_PID_HEATING && DISABLED(DISABLE_M303_AUTOTUNE)
+  #define HAS_PID_AUTOTUNE 1
+#endif
+
 // Thermal protection
 #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
   #define WATCH_HOTENDS 1

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1051,6 +1051,12 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   #endif
 #endif
 
+
+/* PID autotune (M303 command) */
+#if PID_AUTOTUNE_MENU && DISABLE_M303_AUTOTUNE
+  #error "Can't enable PID_AUTOTUNE_MENU and DISABLE_M303_AUTOTUNE at the same time."
+#endif
+
 /**
  * Bed Heating Options - PID vs Limit Switching
  */

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1053,7 +1053,7 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
 
 
 /* PID autotune (M303 command) */
-#if PID_AUTOTUNE_MENU && DISABLE_M303_AUTOTUNE
+#if ALL(PID_AUTOTUNE_MENU, DISABLE_M303_AUTOTUNE)
   #error "Can't enable PID_AUTOTUNE_MENU and DISABLE_M303_AUTOTUNE at the same time."
 #endif
 

--- a/Marlin/src/lcd/dwin/proui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/proui/dwin.cpp
@@ -1695,21 +1695,23 @@ void dwinLevelingDone() {
 
 #if HAS_PID_HEATING
 
-  void dwinStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-    hmiData.pidCycles = count;
-    switch (hid) {
-      #if ENABLED(PIDTEMP)
-        case 0 ... HOTENDS - 1: hmiData.hotendPIDT = temp; break;
-      #endif
-      #if ENABLED(PIDTEMPBED)
-        case H_BED: hmiData.bedPIDT = temp; break;
-      #endif
-      #if ENABLED(PIDTEMPCHAMBER)
-        case H_CHAMBER: hmiData.chamberPIDT = temp; break;
-      #endif
-      default: break;
+  #if HAS_PID_AUTOTUNE
+    void dwinStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+      hmiData.pidCycles = count;
+      switch (hid) {
+        #if ENABLED(PIDTEMP)
+          case 0 ... HOTENDS - 1: hmiData.hotendPIDT = temp; break;
+        #endif
+        #if ENABLED(PIDTEMPBED)
+          case H_BED: hmiData.bedPIDT = temp; break;
+        #endif
+        #if ENABLED(PIDTEMPCHAMBER)
+          case H_CHAMBER: hmiData.chamberPIDT = temp; break;
+        #endif
+        default: break;
+      }
     }
-  }
+  #endif
 
   void dwinPIDTuning(tempcontrol_t result) {
     hmiValue.tempControl = result;

--- a/Marlin/src/lcd/dwin/proui/dwin.h
+++ b/Marlin/src/lcd/dwin/proui/dwin.h
@@ -398,7 +398,9 @@ void drawMaxAccelMenu();
 // PID
 #if HAS_PID_HEATING
   #include "../../../module/temperature.h"
-  void dwinStartM303(const int count, const heater_id_t hid, const celsius_t temp);
+  #if HAS_PID_AUTOTUNE
+    void dwinStartM303(const int count, const heater_id_t hid, const celsius_t temp);
+  #endif
   void dwinPIDTuning(tempcontrol_t result);
   #if ANY(PID_AUTOTUNE_MENU, PID_EDIT_MENU)
     #if ENABLED(PIDTEMP)

--- a/Marlin/src/lcd/dwin/proui/proui_extui.cpp
+++ b/Marlin/src/lcd/dwin/proui/proui_extui.cpp
@@ -213,9 +213,11 @@ namespace ExtUI {
       }
     }
 
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      dwinStartM303(count, hid, temp);
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        dwinStartM303(count, hid, temp);
+      }
+    #endif
 
   #endif
 

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
@@ -167,9 +167,11 @@ namespace ExtUI {
     void onPIDTuning(const pidresult_t rst) {
       // Called for temperature PID tuning result
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
@@ -156,9 +156,11 @@ namespace ExtUI {
     void onPIDTuning(const pidresult_t rst) {
       // Called for temperature PID tuning result
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/vyper_extui.cpp
@@ -168,9 +168,11 @@ namespace ExtUI {
     void onPIDTuning(const pidresult_t rst) {
       // Called for temperature PID tuning result
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus/dgus_extui.cpp
@@ -203,9 +203,11 @@ namespace ExtUI {
       }
       screen.gotoScreen(DGUS_SCREEN_MAIN);
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
@@ -176,9 +176,11 @@ namespace ExtUI {
       // Called for temperature PID tuning result
       screen.pidTuning(rst);
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/dgus_reloaded_extui.cpp
@@ -172,9 +172,11 @@ namespace ExtUI {
       // Called for temperature PID tuning result
       screen.pidTuning(rst);
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/example/example.cpp
+++ b/Marlin/src/lcd/extui/example/example.cpp
@@ -170,9 +170,11 @@ namespace ExtUI {
         case PID_DONE:            break;
       }
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
@@ -208,9 +208,11 @@ namespace ExtUI {
       }
       GOTO_SCREEN(StatusScreen);
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif // HAS_PID_HEATING
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/ia_creality_extui.cpp
@@ -419,9 +419,11 @@ void onPostprocessSettings() {}
     #endif
     onStatusChanged(F("PID Tune Finished"));
   }
-  void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-    // Called by M303 to update the UI
-  }
+  #if HAS_PID_AUTOTUNE
+    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+      // Called by M303 to update the UI
+    }
+  #endif
 #endif
 
 #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
@@ -128,9 +128,11 @@ namespace ExtUI {
       }
     }
 
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
 
   #endif
 

--- a/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
@@ -155,9 +155,11 @@ namespace ExtUI {
       // Called for temperature PID tuning result
       nextion.panelInfo(37);
     }
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
-      // Called by M303 to update the UI
-    }
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp) {
+        // Called by M303 to update the UI
+      }
+    #endif
   #endif
 
   #if ENABLED(MPC_AUTOTUNE)

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -935,9 +935,11 @@ namespace ExtUI {
       thermalManager.setPID(uint8_t(tool), p, i, d);
     }
 
-    void startPIDTune(const celsius_t temp, extruder_t tool) {
-      thermalManager.PID_autotune(temp, heater_id_t(tool), 8, true);
-    }
+    #if HAS_PID_AUTOTUNE
+      void startPIDTune(const celsius_t temp, extruder_t tool) {
+        thermalManager.PID_autotune(temp, heater_id_t(tool), 8, true);
+      }
+    #endif
   #endif
 
   #if ENABLED(PIDTEMPBED)
@@ -949,9 +951,11 @@ namespace ExtUI {
       thermalManager.temp_bed.pid.set(p, i, d);
     }
 
-    void startBedPIDTune(const celsius_t temp) {
-      thermalManager.PID_autotune(temp, H_BED, 4, true);
-    }
+    #if HAS_PID_AUTOTUNE
+      void startBedPIDTune(const celsius_t temp) {
+        thermalManager.PID_autotune(temp, H_BED, 4, true);
+      }
+    #endif
   #endif
 
   void injectCommands_P(PGM_P const gcode) { queue.inject_P(gcode); }

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -567,7 +567,9 @@ namespace ExtUI {
   #endif
   #if HAS_PID_HEATING
     void onPIDTuning(const pidresult_t rst);
-    void onStartM303(const int count, const heater_id_t hid, const celsius_t temp);
+    #if HAS_PID_AUTOTUNE
+      void onStartM303(const int count, const heater_id_t hid, const celsius_t temp);
+    #endif
   #endif
   #if ENABLED(MPC_AUTOTUNE)
     void onMPCTuning(const mpcresult_t rst);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -772,7 +772,7 @@ void Temperature::factory_reset() {
 
 } // factory_reset
 
-#if HAS_PID_HEATING
+#if HAS_PID_AUTOTUNE
 
   inline void say_default_() { SERIAL_ECHOPGM("#define DEFAULT_"); }
 
@@ -1031,7 +1031,7 @@ void Temperature::factory_reset() {
       return;
   }
 
-#endif // HAS_PID_HEATING
+#endif // HAS_PID_AUTOTUNE
 
 #if ENABLED(MPC_AUTOTUNE)
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -1257,16 +1257,18 @@ class Temperature {
 
     static bool tuning_idle(const millis_t &ms);
 
-    /**
-     * M303 PID auto-tuning for hotends or bed
-     */
     #if HAS_PID_HEATING
 
       #if HAS_PID_DEBUG
         static bool pid_debug_flag;
       #endif
 
-      static void PID_autotune(const celsius_t target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result=false);
+      /**
+       * M303 PID auto-tuning for hotends or bed
+       */
+      #if HAS_PID_AUTOTUNE
+        static void PID_autotune(const celsius_t target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result=false);
+      #endif // HAS_PID_AUTOTUNE
 
       // Update the temp manager when PID values change
       #if ENABLED(PIDTEMP)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Add option to disable M303 in order to save flash, the autoune is usefull just when calibrating the sensor, but has no use in the long term, in contrast, Model Predictive Control for hotend has an option to disable autotune, but classic PID does not
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
No special req
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Keep PID control but add option to disable M303 in order to save flash, this saves 2.7K bytes in a Mega1280
The option keeps the M303 enabled by default, uncomment  #define DISABLE_M303_AUTOTUNE to disable and save space
<!-- What does this PR fix or improve? -->

### Configurations
Just uncomment   #define DISABLE_M303_AUTOTUNE in Configuration.h
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
Contributes to save space for better support of Atmega1280 leaving memory for other options that are used more often or have a major impact
https://github.com/MarlinFirmware/Marlin/pull/28089
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
