### PR TITLE
add additional pins to pins_CREALITY_V425.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V425.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V425.h
@@ -72,4 +72,9 @@
 #define FAN1_PIN                            PC1   // FAN1
 #define FAN2_PIN                            PC0   // FAN2
 
+//
+// Misc. Functions
+//
+#define LED_PIN                             PC14
+
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V425.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V425.h
@@ -68,6 +68,8 @@
 //
 #define HEATER_0_PIN                        PA0   // HEATER1
 #define HEATER_BED_PIN                      PA1   // HOT BED
-#define FAN0_PIN                            PA2   // FAN
+#define FAN0_PIN                            PA2   // FAN0
+#define FAN1_PIN                            PC1   // FAN1
+#define FAN2_PIN                            PC0   // FAN2
 
 #include "pins_CREALITY_V4.h"


### PR DESCRIPTION
### Description

Th creality V4.2.5 motherboard normally found in CR-200B has additional fan mosfets and LED pin

<img width="1200" height="900" alt="v4 2 5" src="https://github.com/user-attachments/assets/118246a2-6254-44e9-9049-494b887ba1cd" />

Added them

#define FAN1_PIN                            PC1   // FAN1
#define FAN2_PIN                            PC0   // FAN2
#define LED_PIN                              PC14 

### Benefits

Fan pins are defined
LED pin is defined

### Related Issues

https://reprap.org/forum/read.php?415,897359,897371
https://github.com/Dragunovam/Klipperizing_CR-200B/blob/main/printer.cfg