### PR TITLE
add BOARD_ATOMSTACK_FB5_V2

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -419,6 +419,7 @@
 #define BOARD_MD_D301                 5068  // Mingda D2 DZ301 V1.0 (STM32F103ZE)
 #define BOARD_VOXELAB_AQUILA          5069  // Voxelab Aquila V1.0.0/V1.0.1 (GD32F103RC / N32G455RE / STM32F103RE)
 #define BOARD_SPRINGER_CONTROLLER     5070  // ORCA 3D SPRINGER Modular Controller (STM32F103VC)
+#define BOARD_ATOMSTACK_FB5_V2        5071  // Atomstack FB5 V2.0 (STM32F103RCT6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -686,6 +686,8 @@
   #include "gd32f1/pins_VOXELAB_AQUILA.h"           // GD32F1, N32G4, STM32F1               env:GD32F103RC_voxelab_maple env:N32G455RE_voxelab_maple env:STM32F103RE_creality_maple env:STM32F103RE_creality
 #elif MB(SPRINGER_CONTROLLER)
   #include "stm32f1/pins_ORCA_3D_SPRINGER.h"        // STM32F1                              env:STM32F103VC_orca3d
+#elif MB(ATOMSTACK_FB5_V2)
+  #include "stm32f1/pins_ATOMSTACK_FB5_V2.h"        // STM32F1                              env:STM32F103RC_atomstack
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32f1/pins_ATOMSTACK_FB5_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_ATOMSTACK_FB5_V2.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2026 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -22,13 +22,13 @@
 #pragma once
 
 /**
- * AtomStrack FB5 V2.0 (STM32F103RCT6) common board pin assignments
+ * AtomStack FB5 V2.0 (STM32F103RCT6) common board pin assignments
  */
 
 #include "env_validate.h"
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME      "AtomStrack FB5 V2.0"
+  #define BOARD_INFO_NAME      "AtomStack FB5 V2.0"
 #endif
 #ifndef DEFAULT_MACHINE_NAME
   #define DEFAULT_MACHINE_NAME "ATOMSTACK Cambrian"
@@ -106,16 +106,9 @@
   //#define E0_HARDWARE_SERIAL MSerial1
 
   #define X_SERIAL_TX_PIN                   PC7
-  #define X_SERIAL_RX_PIN                   PC7
-
   #define Y_SERIAL_TX_PIN                   PD2
-  #define Y_SERIAL_RX_PIN                   PD2
-
   #define Z_SERIAL_TX_PIN                   PC12
-  #define Z_SERIAL_RX_PIN                   PC12
-
   #define E0_SERIAL_TX_PIN                  PC11
-  #define E0_SERIAL_RX_PIN                  PC11
 
   // Reduce baud rate to improve software serial reliability
   #ifndef TMC_BAUD_RATE
@@ -125,17 +118,18 @@
 #endif // HAS_TMC_UART
 
 //
-// Heaters 0,1 / Fans / Bed
+// Heaters / Fans
 //
 #define HEATER_0_PIN                        PC9
-#define FAN0_PIN                            PA8
 #define HEATER_BED_PIN                      PC8
+
+#define FAN0_PIN                            PA8
 
 //
 // Temperature Sensors
 //
-#define TEMP_BED_PIN                        PA1   // TB
 #define TEMP_0_PIN                          PA0   // TH1
+#define TEMP_BED_PIN                        PA1   // TB
 
 //
 // Filament Runout Sensor
@@ -159,7 +153,7 @@
 #endif
 
 /**
- *   AtomStrack FB5 V2.0
+ *   AtomStack FB5 V2.0
  *        ------
  *    5V | 1  2 | 5V
  *   GND | 3  4 | GND

--- a/Marlin/src/pins/stm32f1/pins_ATOMSTACK_FB5_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_ATOMSTACK_FB5_V2.h
@@ -1,0 +1,204 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * AtomStrack FB5 V2.0 (STM32F103RCT6) common board pin assignments
+ */
+
+#include "env_validate.h"
+
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME      "AtomStrack FB5 V2.0"
+#endif
+#ifndef DEFAULT_MACHINE_NAME
+  #define DEFAULT_MACHINE_NAME "ATOMSTACK Cambrian"
+#endif
+
+//
+// EEPROM
+//
+#if ANY(NO_EEPROM_SELECTED, FLASH_EEPROM_EMULATION)
+  #define FLASH_EEPROM_EMULATION
+  #define EEPROM_PAGE_SIZE     (0x800U)           // 2K
+  #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
+  #define MARLIN_EEPROM_SIZE    EEPROM_PAGE_SIZE  // 2K
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PA3
+
+//
+// Limit Switches
+//
+#define X_STOP_PIN                          PA4
+#define Y_STOP_PIN                          PA5
+#define Z_STOP_PIN                          PC6
+
+//
+// Z Probe
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB1
+#endif
+
+//
+// Probe enable
+//
+#if ENABLED(PROBE_ENABLE_DISABLE) && !defined(PROBE_ENABLE_PIN)
+  #define PROBE_ENABLE_PIN            SERVO0_PIN
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PC0
+#define X_DIR_PIN                           PB2
+#define X_ENABLE_PIN                        PC13
+
+#define Y_STEP_PIN                          PC2
+#define Y_DIR_PIN                           PB9
+#define Y_ENABLE_PIN                        PB12
+
+#ifndef Z_STEP_PIN
+  #define Z_STEP_PIN                        PB7
+#endif
+#ifndef Z_DIR_PIN
+  #define Z_DIR_PIN                         PB6
+#endif
+#define Z_ENABLE_PIN                        PB8
+
+#define E0_STEP_PIN                         PB4
+#define E0_DIR_PIN                          PB3
+#define E0_ENABLE_PIN                       PB5
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  MSerial1
+  //#define Y_HARDWARE_SERIAL  MSerial1
+  //#define Z_HARDWARE_SERIAL  MSerial1
+  //#define E0_HARDWARE_SERIAL MSerial1
+
+  #define X_SERIAL_TX_PIN                   PC7
+  #define X_SERIAL_RX_PIN                   PC7
+
+  #define Y_SERIAL_TX_PIN                   PD2
+  #define Y_SERIAL_RX_PIN                   PD2
+
+  #define Z_SERIAL_TX_PIN                   PC12
+  #define Z_SERIAL_RX_PIN                   PC12
+
+  #define E0_SERIAL_TX_PIN                  PC11
+  #define E0_SERIAL_RX_PIN                  PC11
+
+  // Reduce baud rate to improve software serial reliability
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200
+  #endif
+
+#endif // HAS_TMC_UART
+
+//
+// Heaters 0,1 / Fans / Bed
+//
+#define HEATER_0_PIN                        PC9
+#define FAN0_PIN                            PA8
+#define HEATER_BED_PIN                      PC8
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN                        PA1   // TB
+#define TEMP_0_PIN                          PA0   // TH1
+
+//
+// Filament Runout Sensor
+//
+//#define FIL_RUNOUT_PIN                    PB10  // MT_DET (Mechanical Limit Detector)
+#define FIL_RUNOUT_PIN                      PC15  // E0-STOP
+
+//
+// Power-loss Detection
+//
+#ifndef POWER_LOSS_PIN
+  //#define POWER_LOSS_PIN                  PC12  // Power Loss Detection: PWR-DET
+#endif
+
+//
+// USB connect control
+//
+#ifndef USB_CONNECT_PIN
+  #define USB_CONNECT_PIN                   PB11
+  #define USB_CONNECT_INVERTING             false
+#endif
+
+/**
+ *   AtomStrack FB5 V2.0
+ *        ------
+ *    5V | 1  2 | 5V
+ *   GND | 3  4 | GND
+ *    NC | 5  6 | PA9  (TX1)
+ *    NC | 7  8 | PA10 (RX1)
+ *        ------
+ *         AUX1
+ */
+
+/**
+  * DWG80480C043_02WTCZ12 4.3 Inch Smart LCD [800x480] pinout
+  *            ---
+  *        5V | 1 |
+  *        NC | 2 |
+  * (TX1) PA9 | 3 |
+  * (RX1)PA10 | 4 |
+  *        NC | 5 |
+  *       GND | 6 |
+  *            ---
+  *        DWIN (plug)
+  */
+
+// LED driving pin
+#ifndef BOARD_NEOPIXEL_PIN
+  #define BOARD_NEOPIXEL_PIN                PA2
+#endif
+
+//
+// SD Card
+//
+#define SDCARD_CONNECTION                ONBOARD
+#define ONBOARD_SPI_DEVICE                     2  // Maple
+#define ONBOARD_SD_CS_PIN              SD_SS_PIN
+#define SD_DETECT_PIN                       PC10
+#define NO_SD_HOST_DRIVE
+
+// TODO: This is the only way to set SPI for SD on STM32 (for now)
+#define ENABLE_SPI2
+#define SD_SCK_PIN                          PB13
+#define SD_MISO_PIN                         PB14
+#define SD_MOSI_PIN                         PB15
+#define SD_SS_PIN                           PA15

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -116,6 +116,23 @@ build_unflags               = ${common_STM32F103RC_variant.build_unflags}
 debug_tool                  = stlink
 
 #
+# AtomStack FB5 V2.0 (STM32F103RCT6 ARM Cortex-M3)
+#
+[env:STM32F103RC_atomstack]
+extends                     = common_STM32F103RC_variant
+board_build.encrypt_mks     = Robin_e3.bin
+board_build.offset          = 0x5000
+board_upload.offset_address = 0x08005000
+build_flags                 = ${common_STM32F103RC_variant.build_flags}
+                              -DTIMER_SERVO=TIM5
+                              -DUSE_USB_FS
+                              -DUSBD_IRQ_PRIO=5
+                              -DUSBD_IRQ_SUBPRIO=6
+                              -DUSBD_USE_CDC_MSC
+; upload_protocol             = stlink
+
+
+#
 # Creality (STM32F103Rx)
 #
 [STM32F103Rx_creality]

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -129,8 +129,7 @@ build_flags                 = ${common_STM32F103RC_variant.build_flags}
                               -DUSBD_IRQ_PRIO=5
                               -DUSBD_IRQ_SUBPRIO=6
                               -DUSBD_USE_CDC_MSC
-; upload_protocol             = stlink
-
+;upload_protocol             = stlink
 
 #
 # Creality (STM32F103Rx)


### PR DESCRIPTION
### Description

Add BOARD_ATOMSTACK_FB5_V2 as found in Atomstack Cambrian Max/Pro

![Atomstack FB5 v2 0](https://github.com/user-attachments/assets/a82af930-ad3f-4815-88a3-116dc12496de)

Found in https://github.com/samiulbasher/Atomstack_Cambrian-PRO/tree/main

### Benefits

Board is in Marlin

### Related Issues
https://reprap.org/forum/read.php?415,897378,897380
https://www.facebook.com/groups/marlinfirmware/posts/4236668943102739/

