### PR TITLE
FTM: Avoid layer shift on shaper parameters change

### DIFF
--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -114,7 +114,6 @@ typedef struct FTConfig {
 
   bool setAxisSync(const bool ena) {
     if (ena == axis_sync_enabled) return false;
-    prep_for_shaper_change();
     axis_sync_enabled = ena;
     update_shaping_params();
     return true;
@@ -124,7 +123,6 @@ typedef struct FTConfig {
 
     bool setShaper(const AxisEnum a, const ftMotionShaper_t s) {
       if (s == shaper[a]) return false;
-      prep_for_shaper_change();
       shaper[a] = s;
       update_shaping_params();
       return true;
@@ -135,7 +133,6 @@ typedef struct FTConfig {
     bool setZeta(const AxisEnum a, float z) {
       if (z == zeta[a]) return false;
       LIMIT(z, 0.00f, ftm_max_dampening);
-      prep_for_shaper_change();
       zeta[a] = z;
       update_shaping_params();
       return true;
@@ -148,7 +145,6 @@ typedef struct FTConfig {
       bool setVtol(const AxisEnum a, float v) {
         if (v == vtol[a]) return false;
         LIMIT(v, 0.00f, 1.0f);
-        prep_for_shaper_change();
         vtol[a] = v;
         update_shaping_params();
         return true;
@@ -165,7 +161,6 @@ typedef struct FTConfig {
           TERN_(HAS_DYNAMIC_FREQ_MM, case dynFreqMode_Z_BASED:)
           TERN_(HAS_DYNAMIC_FREQ_G, case dynFreqMode_MASS_BASED:)
           case dynFreqMode_DISABLED:
-            prep_for_shaper_change();
             dynFreqMode = dynFreqMode_t(m);
             break;
         }
@@ -181,7 +176,6 @@ typedef struct FTConfig {
       bool setDynFreqK(const AxisEnum a, const float k) {
         if (!modeUsesDynFreq()) return false;
         if (k == dynFreqK[a]) return false;
-        prep_for_shaper_change();
         dynFreqK[a] = k;
         update_shaping_params();
         return true;
@@ -196,7 +190,6 @@ typedef struct FTConfig {
   bool setBaseFreq(const AxisEnum a, float f) {
     if (f == baseFreq[a]) return false;
     LIMIT(f, FTM_MIN_SHAPE_FREQ, (FTM_FS) / 2);
-    prep_for_shaper_change();
     baseFreq[a] = f;
     update_shaping_params();
     return true;


### PR DESCRIPTION
Removed calls to prep_for_shaper_change() in various setter methods to avoid layer shift

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
<img width="1718" height="815" alt="Simulator Layer Shift" src="https://github.com/user-attachments/assets/c7afe515-096d-4533-a3e6-a9081f8c1ec2" />
Running a shaping test in the simulator with a frequency change on each layer induces a layer shift when the frequency is set above the minimum limit.

Normal behavior should be:
<img width="1346" height="616" alt="Simulator No Layer Shift" src="https://github.com/user-attachments/assets/5179d3dc-2e92-4906-9371-bafe0f9872c9" />

The layer shift is related to `prep_for_shaper_change()` call before `update_shaping_params()`.  `prep_for_shaper_change()` seems useful only for smoothing time change and perhaps for switching on or off FT_MOTION. When setting an unshaped axis to a shaper with the default frequency (37Hz), there is no layer shift.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
