### PR TITLE
Adds DRILL_CYCLE feature

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4439,7 +4439,7 @@
 /**
  * Adds canned drilling cycle G Codes: 
  * G73: Shallow peck drill cycle
- * G80: Cancel drill cycle
+ * G80: End drill cycle
  * G81: Basic drill cycle
  * G82: Normal drill cycle (Basic with dwell)
  * G83: Deep drill cycle (Normal with peck)
@@ -4447,7 +4447,7 @@
  * G99: Start drill - retract to specified
  *   or when DRILL_USE_81_ONLY is specified:
  * G81.4: Shallow peck drill cycle
- * G81.0: Cancel drill cycle
+ * G81.0: End drill cycle
  * G81.1: Basic drill cycle
  * G81.2: Normal drill cycle (Basic with dwell)
  * G81.3: Deep drill cycle (Normal with peck)
@@ -4456,12 +4456,12 @@
  */
 #define DRILL_CYCLES
 #if ENABLED(DRILL_CYCLES)
-  //#define DRILL_USE_81_ONLY
-  #define DRILL_CYCLES_XY_FEEDRATE      1600
-  #define DRILL_CYCLES_RETRACT_FEEDRATE 1200
-  #define DRILL_CYCLES_DEFAULT_FEEDRATE 300
-  #define DRILL_CYCLES_DEFAULT_PECK     2.0
-  #define DRILL_CYCLES_DEFAULT_DWELL    0
+  //#define DRILL_USE_81_ONLY                   //Uses G81.x sub commands
+  #define DRILL_CYCLES_XY_FEEDRATE      1600    //Feedrate for xy operations
+  #define DRILL_CYCLES_RETRACT_FEEDRATE 1200    //Feedrate while retracting
+  #define DRILL_CYCLES_DEFAULT_FEEDRATE 300     //Default drilling freedrate if one is not specified
+  #define DRILL_CYCLES_DEFAULT_PECK     2.0     //Default pecking distance if one is not specified
+  #define DRILL_CYCLES_DEFAULT_DWELL    0       //Default dwell distance if one is not specified
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4454,7 +4454,7 @@
  * G81.18: Start drill - retract to initial
  * G81.19: Start drill - retract to specified
  */
-#define DRILL_CYCLES
+//#define DRILL_CYCLES
 #if ENABLED(DRILL_CYCLES)
   //#define DRILL_USE_81_ONLY                   //Uses G81.x sub commands
   #define DRILL_CYCLES_XY_FEEDRATE      1600    //Feedrate for xy operations

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4454,7 +4454,7 @@
  * G81.18: Start drill - retract to initial
  * G81.19: Start drill - retract to specified
  */
-//#define DRILL_CYCLES
+#define DRILL_CYCLES
 #if ENABLED(DRILL_CYCLES)
   //#define DRILL_USE_81_ONLY                   //Uses G81.x sub commands
   #define DRILL_CYCLES_XY_FEEDRATE      1600    //Feedrate for xy operations

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4437,6 +4437,34 @@
 #endif
 
 /**
+ * Adds canned drilling cycle G Codes: 
+ * G73: Shallow peck drill cycle
+ * G80: Cancel drill cycle
+ * G81: Basic drill cycle
+ * G82: Normal drill cycle (Basic with dwell)
+ * G83: Deep drill cycle (Normal with peck)
+ * G98: Start drill - retract to initial
+ * G99: Start drill - retract to specified
+ *   or when DRILL_USE_81_ONLY is specified:
+ * G81.4: Shallow peck drill cycle
+ * G81.0: Cancel drill cycle
+ * G81.1: Basic drill cycle
+ * G81.2: Normal drill cycle (Basic with dwell)
+ * G81.3: Deep drill cycle (Normal with peck)
+ * G81.18: Start drill - retract to initial
+ * G81.19: Start drill - retract to specified
+ */
+#define DRILL_CYCLES
+#if ENABLED(DRILL_CYCLES)
+  //#define DRILL_USE_81_ONLY
+  #define DRILL_CYCLES_XY_FEEDRATE      1600
+  #define DRILL_CYCLES_RETRACT_FEEDRATE 1200
+  #define DRILL_CYCLES_DEFAULT_FEEDRATE 300
+  #define DRILL_CYCLES_DEFAULT_PECK     2.0
+  #define DRILL_CYCLES_DEFAULT_DWELL    0
+#endif
+
+/**
  * MAX7219 Debug Matrix
  *
  * Add support for a low-cost 8x8 LED Matrix based on the Max7219 chip as a realtime status display.

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -463,6 +463,20 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
         case 80: G80(); break;                                    // G80: Reset the current motion mode
       #endif
 
+      #if ENABLED(DRILL_CYCLES)
+        #if ENABLED(DRILL_USE_81_ONLY) || ENABLED(GCODE_MOTION_MODES)
+          case 81: G81(parser.subcode); break;                    // G81: Drill cycle  G81: Cancel, G81.18 G81.19 Start, G81.1 G81.2 G81.3 G81.4 Cycles
+        #else
+          case 73: G81(4); break;                                 // G73: Shallow peck drill cycle
+          case 80: G81(0); break;                                 // G80: Cancel drill cycle
+          case 81: G81(1); break;                                 // G81: Basic drill cycle
+          case 82: G81(2); break;                                 // G82: Normal drill cycle (Basic with dwell)
+          case 83: G81(3); break;                                 // G83: Deep drill cycle (Normal with peck)
+          case 98: G81(18); break;                                // G98: Retract to initial
+          case 99: G81(19); break;                                // G99: Retract to specified
+        #endif
+      #endif
+
       case 90: G90(); break;                                      // G90: Absolute Mode
       case 91: G91(); break;                                      // G91: Relative Mode
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -465,10 +465,10 @@ void GcodeSuite::process_parsed_command(bool no_ok/*=false*/) {
 
       #if ENABLED(DRILL_CYCLES)
         #if ENABLED(DRILL_USE_81_ONLY) || ENABLED(GCODE_MOTION_MODES)
-          case 81: G81(parser.subcode); break;                    // G81: Drill cycle  G81: Cancel, G81.18 G81.19 Start, G81.1 G81.2 G81.3 G81.4 Cycles
+          case 81: G81(parser.subcode); break;                    // G81: Drill cycle  G81: End, G81.18 G81.19 Start, G81.1 G81.2 G81.3 G81.4 Cycles
         #else
           case 73: G81(4); break;                                 // G73: Shallow peck drill cycle
-          case 80: G81(0); break;                                 // G80: Cancel drill cycle
+          case 80: G81(0); break;                                 // G80: End drill cycle
           case 81: G81(1); break;                                 // G81: Basic drill cycle
           case 82: G81(2); break;                                 // G82: Normal drill cycle (Basic with dwell)
           case 83: G81(3); break;                                 // G83: Deep drill cycle (Normal with peck)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -66,11 +66,18 @@
  * G42  - Coordinated move to a mesh point (Requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BLINEAR, or AUTO_BED_LEVELING_UBL)
  * G60  - Save current position. (Requires SAVED_POSITIONS)
  * G61  - Apply/Restore saved coordinates. (Requires SAVED_POSITIONS)
+ * G73  - Shallow peck drill cycle
  * G76  - Calibrate first layer temperature offsets. (Requires PTC_PROBE and PTC_BED)
  * G80  - Cancel current motion mode (Requires GCODE_MOTION_MODES)
+ * G80  - Cancel drill cancel
+ * G81  - Basic drill cycle
+ * G82  - Normal drill cycle
+ * G83  - Deep drill cycle
  * G90  - Use Absolute Coordinates
  * G91  - Use Relative Coordinates
  * G92  - Set current position to coordinates given
+ * G98  - Start drill - retract to initial
+ * G99  - Start drill - retract to specified
  *
  * "M" Codes
  *
@@ -642,6 +649,10 @@ private:
 
   #if ENABLED(GCODE_MOTION_MODES)
     static void G80();
+  #endif
+
+  #if ENABLED(DRILL_CYCLES)
+    static void G81(uint8_t mode);
   #endif
 
   static void G90() { set_relative_mode(false); }

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -226,6 +226,9 @@ void GcodeSuite::M115() {
     // MOTION_MODES (M80-M89)
     cap_line(F("MOTION_MODES"), ENABLED(GCODE_MOTION_MODES));
 
+    // DRILL CYCLES (G73-99)
+    cap_line(F("DRILL_CYCLES"), ENABLED(DRILL_CYCLES));
+
     // ARC_SUPPORT (G2-G3)
     cap_line(F("ARCS"), ENABLED(ARC_SUPPORT));
 

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -1,0 +1,174 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(DRILL_CYCLES)
+
+#include "../gcode.h"
+#include "../../module/motion.h"
+
+/**
+ * G73: Shallow peck drill cycle
+ * G80: Cancel drill cycle
+ * G81: Basic drill cycle
+ * G82: Normal drill cycle (Basic with dwell)
+ * G83: Deep drill cycle (Normal with peck)
+ * G98: Start drill - retract to initial
+ * G99: Start drill - retract to specified
+ */
+
+ //#define DRILL_CYCLE_DEBUG
+
+bool  retract_to_initial  = true;
+bool  drill_cycle_started = false;
+
+void move_to_XYZF(float x, float y, float z, uint16_t f) {
+  char gcode_str[50], x_str[10], y_str[10], z_str[10];
+  dtostrf(x, 1, 3, x_str);
+  dtostrf(y, 1, 3, y_str);
+  dtostrf(z, 1, 3, z_str);
+  
+  sprintf_P(gcode_str, PSTR("G1 X%s Y%s Z%s F%d"), x_str, y_str, z_str, f);
+#if ENABLED(DRILL_CYCLE_DEBUG)
+  SERIAL_ECHOPGM("DEBUG: ", gcode_str);
+#endif
+  gcode.process_subcommands_now(gcode_str);
+ }
+
+ void drill_start(bool initial) {
+  if(!drill_cycle_started) {
+    drill_cycle_started = true;
+    retract_to_initial = initial;
+  }
+}
+
+void drill_stop() {
+  drill_cycle_started = false;
+}
+
+void drill_cycle(uint8_t mode) {
+  if(!drill_cycle_started) return;
+
+  bool      allow_peck          = mode == 83 || mode == 73;
+  bool      allow_dwell         = mode == 82 || mode == 83 || mode == 73;
+
+  float     drill_x_position    = parser.seenval(AXIS_CHAR(X_AXIS)) ? parser.value_float() : NATIVE_TO_LOGICAL(current_position.x, X_AXIS);
+  float     drill_y_position    = parser.seenval(AXIS_CHAR(Y_AXIS)) ? parser.value_float() : NATIVE_TO_LOGICAL(current_position.y, Y_AXIS);
+  float     drill_initial_z     = NATIVE_TO_LOGICAL(current_position.z, Z_AXIS);
+
+  if(!parser.seenval(AXIS_CHAR(Z_AXIS))) return;
+  float     drill_finish_depth  = parser.value_float();
+
+  float     drill_rapid_z       = parser.seenval('R') ? parser.value_float() : drill_initial_z;
+  float     drill_retract_z     = retract_to_initial ? drill_initial_z : drill_rapid_z;
+  float     drill_current_depth = drill_rapid_z;
+
+  uint16_t  drill_feedrate      = parser.seenval('F') ? parser.value_int() : (drill_feedrate > 0 ? drill_feedrate : DRILL_CYCLES_DEFAULT_FEEDRATE);
+  float     drill_peck_distance = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
+  uint16_t  drill_dwell_time    = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
+
+  //move to initial xy position
+  move_to_XYZF(drill_x_position, 
+            drill_y_position,
+            drill_initial_z,
+            DRILL_CYCLES_XY_FEEDRATE);
+
+  //move to rapid z position
+  move_to_XYZF(drill_x_position,
+            drill_y_position,
+            drill_rapid_z,
+            DRILL_CYCLES_RETRACT_FEEDRATE);
+
+  //start drill cycle
+  float drill_last_z = drill_rapid_z;
+  while(drill_current_depth > drill_finish_depth) {
+    //calculate new drill depth
+    drill_current_depth -= drill_peck_distance;
+    if(drill_current_depth < drill_finish_depth) drill_current_depth = drill_finish_depth;
+
+    //drill into material
+    move_to_XYZF(drill_x_position, 
+            drill_y_position,
+            drill_current_depth,
+            drill_feedrate);
+
+    //do dwell
+    if(drill_dwell_time > 0) {
+      char gcode_str[15];
+      sprintf_P(gcode_str, PSTR("G4 P%d"), drill_dwell_time);
+    #if ENABLED(DRILL_CYCLE_DEBUG)
+      SERIAL_ECHOPGM("DEBUG: ", gcode_str);
+    #endif
+      gcode.process_subcommands_now(gcode_str);
+    }
+
+    //move to rapid z position
+    move_to_XYZF(drill_x_position,
+            drill_y_position,
+            mode == 73 ? drill_last_z : drill_rapid_z,
+            DRILL_CYCLES_RETRACT_FEEDRATE);
+
+    //store current depth
+    drill_last_z = drill_current_depth;
+  }
+
+  //retract to final z
+  move_to_XYZF(drill_x_position, 
+            drill_y_position,
+            drill_retract_z,
+            DRILL_CYCLES_RETRACT_FEEDRATE);
+}
+
+void GcodeSuite::G81(uint8_t mode) {
+  switch(mode) {
+    case 0:
+      drill_stop();
+      break;
+
+    case 1:
+      drill_cycle(81);
+      break;
+
+    case 2:
+      drill_cycle(82);
+      break;
+
+    case 3:
+      drill_cycle(83);
+      break;
+
+    case 4:
+      drill_cycle(73);
+      break;
+
+    case 18:
+      drill_start(true);
+      break;
+
+    case 19:
+      drill_start(false);
+      break;
+  }
+}
+
+#endif // DRILL_CYCLES

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -39,8 +39,9 @@
 
  //#define DRILL_CYCLE_DEBUG
 
-bool  retract_to_initial  = true;
-bool  drill_cycle_started = false;
+bool      retract_to_initial  = true;
+bool      drill_cycle_started = false;
+uint16_t  drill_feedrate      = 0;
 
 void move_to_XYZF(float x, float y, float z, uint16_t f) {
   char gcode_str[50], x_str[10], y_str[10], z_str[10];
@@ -58,7 +59,8 @@ void move_to_XYZF(float x, float y, float z, uint16_t f) {
  void drill_start(bool initial) {
   if(!drill_cycle_started) {
     drill_cycle_started = true;
-    retract_to_initial = initial;
+    retract_to_initial  = initial;
+    drill_feedrate      = 0;
   }
 }
 
@@ -83,9 +85,9 @@ void drill_cycle(uint8_t mode) {
   float     drill_retract_z     = retract_to_initial ? drill_initial_z : drill_rapid_z;
   float     drill_current_depth = drill_rapid_z;
 
-  uint16_t  drill_feedrate      = parser.seenval('F') ? parser.value_int() : (drill_feedrate > 0 ? drill_feedrate : DRILL_CYCLES_DEFAULT_FEEDRATE);
-  float     drill_peck_distance = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
-  uint16_t  drill_dwell_time    = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
+  drill_feedrate                = parser.seenval('F') ? parser.value_int() : (drill_feedrate > 0 ? drill_feedrate : DRILL_CYCLES_DEFAULT_FEEDRATE);
+  float drill_peck_distance     = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
+  float drill_dwell_time        = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
 
   //move to initial xy position
   move_to_XYZF(drill_x_position, 

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -37,80 +37,88 @@
  * G99: Start drill - retract to specified
  */
 
- //#define DRILL_CYCLE_DEBUG
+bool        retract_to_initial  = true;
+feedRate_t  drill_feedrate      = NAN;
+float       drill_rapid_z       = NAN;
+float       drill_finish_depth  = NAN;
 
-bool      retract_to_initial  = true;
-bool      drill_cycle_started = false;
-uint16_t  drill_feedrate      = 0;
+void move_to(xyze_pos_t position, float z, feedRate_t f) {
+  LOOP_NUM_AXES(i) {
+    destination[i] = position[i];
+  }
 
-void move_to_XYZF(float x, float y, float z, uint16_t f) {
-  char gcode_str[50], x_str[10], y_str[10], z_str[10];
-  dtostrf(x, 1, 3, x_str);
-  dtostrf(y, 1, 3, y_str);
-  dtostrf(z, 1, 3, z_str);
-  
-  sprintf_P(gcode_str, PSTR("G1 X%s Y%s Z%s F%d"), x_str, y_str, z_str, f);
-#if ENABLED(DRILL_CYCLE_DEBUG)
-  SERIAL_ECHOPGM("DEBUG: ", gcode_str);
-#endif
-  gcode.process_subcommands_now(gcode_str);
+  destination[Z_AXIS] = z;
+  feedrate_mm_s = f;
+
+  prepare_line_to_destination();
  }
 
- void drill_start(bool initial) {
-  if(!drill_cycle_started) {
-    drill_cycle_started = true;
-    retract_to_initial  = initial;
-    drill_feedrate      = 0;
-  }
-}
-
-void drill_stop() {
-  drill_cycle_started = false;
-}
-
 void drill_cycle(uint8_t mode) {
-  if(!drill_cycle_started) return;
+  //get input values and build positional variables
+  bool        allow_peck          = mode == 83 || mode == 73;
+  bool        allow_dwell         = mode == 82 || mode == 83 || mode == 73;
 
-  bool      allow_peck          = mode == 83 || mode == 73;
-  bool      allow_dwell         = mode == 82 || mode == 83 || mode == 73;
+  //drill depth, must not be NAN
+  if(parser.seenval(AXIS_CHAR(Z_AXIS))) {
+    const float v       = parser.value_axis_units(Z_AXIS);
+    drill_finish_depth  = gcode.axis_is_relative(AxisEnum(Z_AXIS)) ? current_position[Z_AXIS] + v : LOGICAL_TO_NATIVE(v, Z_AXIS);
+  }
+  if(drill_finish_depth == NAN) return;
 
-  float     drill_x_position    = parser.seenval(AXIS_CHAR(X_AXIS)) ? parser.value_float() : NATIVE_TO_LOGICAL(current_position.x, X_AXIS);
-  float     drill_y_position    = parser.seenval(AXIS_CHAR(Y_AXIS)) ? parser.value_float() : NATIVE_TO_LOGICAL(current_position.y, Y_AXIS);
-  float     drill_initial_z     = NATIVE_TO_LOGICAL(current_position.z, Z_AXIS);
+  //get position of all axes
+  xyze_pos_t  drill_position;
+  LOOP_NUM_AXES(i) {
+    if(i == Z_AXIS) {
+      drill_position[i]   = current_position.z;
+    } else if (parser.seenval(AXIS_CHAR(i))) {
+      const float v = parser.value_axis_units((AxisEnum)i);
+      drill_position[i] = gcode.axis_is_relative(AxisEnum(i)) ? current_position[i] + v : LOGICAL_TO_NATIVE(v, i);
+    } else {
+      drill_position[i] = current_position[i];
+    }
+  }
 
-  if(!parser.seenval(AXIS_CHAR(Z_AXIS))) return;
-  float     drill_finish_depth  = parser.value_float();
+  //rapid, retract planes
+  if(parser.seenval('R')) drill_rapid_z = LOGICAL_TO_NATIVE(parser.value_axis_units(Z_AXIS), Z_AXIS);
+  else if(drill_rapid_z == NAN) drill_rapid_z = drill_position[Z_AXIS];
+  float drill_retract_z = retract_to_initial ? drill_position[Z_AXIS] : drill_rapid_z;
 
-  float     drill_rapid_z       = parser.seenval('R') ? parser.value_float() : drill_initial_z;
-  float     drill_retract_z     = retract_to_initial ? drill_initial_z : drill_rapid_z;
-  float     drill_current_depth = drill_rapid_z;
+  //feedrate
+  if(parser.seenval('F')) drill_feedrate = parser.value_feedrate();
+  else if(drill_feedrate == NAN) drill_feedrate = MMM_TO_MMS(DRILL_CYCLES_DEFAULT_FEEDRATE);
 
-  drill_feedrate                = parser.seenval('F') ? parser.value_int() : (drill_feedrate > 0 ? drill_feedrate : DRILL_CYCLES_DEFAULT_FEEDRATE);
-  float     drill_peck_distance = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
-  int16_t   drill_dwell_time    = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
+  //peck
+  float drill_peck_distance = parser.axis_value_to_mm(Z_AXIS, 1000.0f);
+  if(allow_peck) {
+    drill_peck_distance = parser.seenval('Q') ? parser.value_axis_units(Z_AXIS) : parser.axis_value_to_mm(Z_AXIS, DRILL_CYCLES_DEFAULT_PECK);
+  }
+
+  //dwell
+  int16_t drill_dwell_time = 0;
+  if(allow_dwell) {
+    drill_dwell_time = parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL;
+  }
 
   //move to initial xy position
-  move_to_XYZF(drill_x_position, 
-            drill_y_position,
-            drill_initial_z,
+  move_to(drill_position, 
+            drill_position[Z_AXIS],
             DRILL_CYCLES_XY_FEEDRATE);
 
   //move to rapid z position
-  move_to_XYZF(drill_x_position,
-            drill_y_position,
+  move_to(drill_position, 
             drill_rapid_z,
             DRILL_CYCLES_RETRACT_FEEDRATE);
 
   //start drill cycle
-  float drill_last_z = drill_rapid_z;
+  float drill_current_depth = drill_rapid_z;
+  float drill_last_z        = drill_current_depth;
   while(drill_current_depth > drill_finish_depth) {
     //calculate new drill depth
     drill_current_depth -= drill_peck_distance;
     if(drill_current_depth < drill_finish_depth) drill_current_depth = drill_finish_depth;
 
     //drill into material
-    move_to_XYZF(drill_x_position, 
-            drill_y_position,
+    move_to(drill_position, 
             drill_current_depth,
             drill_feedrate);
 
@@ -118,15 +126,11 @@ void drill_cycle(uint8_t mode) {
     if(drill_dwell_time > 0) {
       char gcode_str[15];
       sprintf_P(gcode_str, PSTR("G4 P%d"), drill_dwell_time);
-    #if ENABLED(DRILL_CYCLE_DEBUG)
-      SERIAL_ECHOPGM("DEBUG: ", gcode_str);
-    #endif
       gcode.process_subcommands_now(gcode_str);
     }
 
     //move to rapid z position
-    move_to_XYZF(drill_x_position,
-            drill_y_position,
+    move_to(drill_position, 
             mode == 73 ? drill_last_z : drill_rapid_z,
             DRILL_CYCLES_RETRACT_FEEDRATE);
 
@@ -135,40 +139,41 @@ void drill_cycle(uint8_t mode) {
   }
 
   //retract to final z
-  move_to_XYZF(drill_x_position, 
-            drill_y_position,
+  move_to(drill_position,
             drill_retract_z,
             DRILL_CYCLES_RETRACT_FEEDRATE);
 }
 
 void GcodeSuite::G81(uint8_t mode) {
   switch(mode) {
-    case 0:
-      drill_stop();
+    case 0:         //End cycle and clear variables
+      drill_feedrate      = NAN;
+      drill_rapid_z       = NAN;
+      drill_finish_depth  = NAN;
       break;
 
-    case 1:
+    case 1:       //Start basic cycle
       drill_cycle(81);
       break;
 
-    case 2:
+    case 2:       //Start normal cycle
       drill_cycle(82);
       break;
 
-    case 3:
+    case 3:       //Start deep cycle
       drill_cycle(83);
       break;
 
-    case 4:
+    case 4:       //Start peck cycle
       drill_cycle(73);
       break;
 
-    case 18:
-      drill_start(true);
+    case 18:      //Set retract type
+      retract_to_initial = true;
       break;
 
-    case 19:
-      drill_start(false);
+    case 19:      //Set retract type
+      retract_to_initial = false;
       break;
   }
 }

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -29,7 +29,7 @@
 
 /**
  * G73: Shallow peck drill cycle
- * G80: Cancel drill cycle
+ * G80: End drill cycle
  * G81: Basic drill cycle
  * G82: Normal drill cycle (Basic with dwell)
  * G83: Deep drill cycle (Normal with peck)

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -86,8 +86,8 @@ void drill_cycle(uint8_t mode) {
   float     drill_current_depth = drill_rapid_z;
 
   drill_feedrate                = parser.seenval('F') ? parser.value_int() : (drill_feedrate > 0 ? drill_feedrate : DRILL_CYCLES_DEFAULT_FEEDRATE);
-  float drill_peck_distance     = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
-  float drill_dwell_time        = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
+  float     drill_peck_distance = allow_peck ? (parser.seenval('Q') ? parser.value_float() : (DRILL_CYCLES_DEFAULT_PECK > 0 ? DRILL_CYCLES_DEFAULT_PECK : 10000)) : 10000;
+  int16_t   drill_dwell_time    = allow_dwell ? (parser.seenval('P') ? parser.value_int() : DRILL_CYCLES_DEFAULT_DWELL) : 0;
 
   //move to initial xy position
   move_to_XYZF(drill_x_position, 

--- a/Marlin/src/gcode/motion/G81.cpp
+++ b/Marlin/src/gcode/motion/G81.cpp
@@ -26,6 +26,7 @@
 
 #include "../gcode.h"
 #include "../../module/motion.h"
+#include "../../module/planner.h"
 
 /**
  * G73: Shallow peck drill cycle
@@ -42,7 +43,9 @@ feedRate_t  drill_feedrate      = NAN;
 float       drill_rapid_z       = NAN;
 float       drill_finish_depth  = NAN;
 
-void move_to(xyze_pos_t position, float z, feedRate_t f) {
+bool move_to(xyze_pos_t position, float z, feedRate_t f) {
+  if(planner.cleaning_buffer_counter) return false;
+
   LOOP_NUM_AXES(i) {
     destination[i] = position[i];
   }
@@ -51,12 +54,14 @@ void move_to(xyze_pos_t position, float z, feedRate_t f) {
   feedrate_mm_s = f;
 
   prepare_line_to_destination();
+
+  return true;
  }
 
 void drill_cycle(uint8_t mode) {
   //get input values and build positional variables
-  bool        allow_peck          = mode == 83 || mode == 73;
-  bool        allow_dwell         = mode == 82 || mode == 83 || mode == 73;
+  bool  allow_peck    = mode == 83 || mode == 73;
+  bool  allow_dwell   = mode == 82 || mode == 83 || mode == 73;
 
   //drill depth, must not be NAN
   if(parser.seenval(AXIS_CHAR(Z_AXIS))) {
@@ -100,14 +105,14 @@ void drill_cycle(uint8_t mode) {
   }
 
   //move to initial xy position
-  move_to(drill_position, 
+  if(!move_to(drill_position, 
             drill_position[Z_AXIS],
-            DRILL_CYCLES_XY_FEEDRATE);
+            DRILL_CYCLES_XY_FEEDRATE)) return;
 
   //move to rapid z position
-  move_to(drill_position, 
+  if(!move_to(drill_position, 
             drill_rapid_z,
-            DRILL_CYCLES_RETRACT_FEEDRATE);
+            DRILL_CYCLES_RETRACT_FEEDRATE)) return;
 
   //start drill cycle
   float drill_current_depth = drill_rapid_z;
@@ -118,35 +123,35 @@ void drill_cycle(uint8_t mode) {
     if(drill_current_depth < drill_finish_depth) drill_current_depth = drill_finish_depth;
 
     //drill into material
-    move_to(drill_position, 
+    if(!move_to(drill_position, 
             drill_current_depth,
-            drill_feedrate);
+            drill_feedrate)) return;
 
     //do dwell
     if(drill_dwell_time > 0) {
-      char gcode_str[15];
-      sprintf_P(gcode_str, PSTR("G4 P%d"), drill_dwell_time);
-      gcode.process_subcommands_now(gcode_str);
+      if(planner.cleaning_buffer_counter) return;
+      planner.synchronize();
+      gcode.dwell(drill_dwell_time);
     }
 
     //move to rapid z position
-    move_to(drill_position, 
+    if(!move_to(drill_position, 
             mode == 73 ? drill_last_z : drill_rapid_z,
-            DRILL_CYCLES_RETRACT_FEEDRATE);
+            DRILL_CYCLES_RETRACT_FEEDRATE)) return;
 
     //store current depth
     drill_last_z = drill_current_depth;
   }
 
   //retract to final z
-  move_to(drill_position,
+  if(!move_to(drill_position,
             drill_retract_z,
-            DRILL_CYCLES_RETRACT_FEEDRATE);
+            DRILL_CYCLES_RETRACT_FEEDRATE)) return;
 }
 
 void GcodeSuite::G81(uint8_t mode) {
   switch(mode) {
-    case 0:         //End cycle and clear variables
+    case 0:       //End cycle and clear variables
       drill_feedrate      = NAN;
       drill_rapid_z       = NAN;
       drill_finish_depth  = NAN;

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -349,6 +349,7 @@ HAS_MULTI_LANGUAGE                     = build_src_filter=+<src/gcode/lcd/M414.c
 TOUCH_SCREEN_CALIBRATION               = build_src_filter=+<src/gcode/lcd/M995.cpp>
 ARC_SUPPORT                            = build_src_filter=+<src/gcode/motion/G2_G3.cpp>
 GCODE_MOTION_MODES                     = build_src_filter=+<src/gcode/motion/G80.cpp>
+DRILL_CYCLES                           = build_src_filter=+<src/gcode/motion/G81.cpp>
 BABYSTEPPING                           = build_src_filter=+<src/gcode/motion/M290.cpp> +<src/feature/babystep.cpp>
 OTA_FIRMWARE_UPDATE                    = build_src_filter=+<src/gcode/ota/M936.cpp>
 Z_PROBE_SLED                           = build_src_filter=+<src/gcode/probe/G31_G32.cpp>


### PR DESCRIPTION
### Description
/**
  * Adds canned drilling cycle G Codes:
  * G73: Shallow peck drill cycle
  * G80: Cancel drill cycle
  * G81: Basic drill cycle
  * G82: Normal drill cycle (Basic with dwell)
  * G83: Deep drill cycle (Normal with peck)
  * G98: Start drill - retract to initial
  * G99: Start drill - retract to specified
  *   or when DRILL_USE_81_ONLY is specified:
  * G81.4: Shallow peck drill cycle
  * G81.0: Cancel drill cycle
  * G81.1: Basic drill cycle
  * G81.2: Normal drill cycle (Basic with dwell)
  * G81.3: Deep drill cycle (Normal with peck)
  * G81.18: Start drill - retract to initial
  * G81.19: Start drill - retract to specified
  */

### Benefits
This can be used with CAM software to perform drilling operations.

### Configurations
#define DRILL_CYCLES
#if ENABLED(DRILL_CYCLES)
  //#define DRILL_USE_81_ONLY                   //Uses G81.x sub commands
  #define DRILL_CYCLES_XY_FEEDRATE      1600    //Feedrate for xy operations
  #define DRILL_CYCLES_RETRACT_FEEDRATE 1200    //Feedrate while retracting
  #define DRILL_CYCLES_DEFAULT_FEEDRATE 300     //Default drilling freedrate if one is not specified
  #define DRILL_CYCLES_DEFAULT_PECK     2.0     //Default pecking distance if one is not specified
  #define DRILL_CYCLES_DEFAULT_DWELL    0       //Default dwell distance if one is not specified
#endif
