### PR TITLE
Ensure that changing XYZ smoothing doesn't result in shifts.

### DIFF
--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -525,12 +525,14 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
 
     // Approximate Gaussian smoothing via chained EMAs
     auto _smoothen = [&](const AxisEnum axis, axis_smoothing_t &smoo) {
-      float smooth_val = traj_coords[axis];
-      for (uint8_t _i = 0; _i < FTM_SMOOTHING_ORDER; ++_i) {
-        smoo.smoothing_pass[_i] += (smooth_val - smoo.smoothing_pass[_i]) * smoo.alpha;
-        smooth_val = smoo.smoothing_pass[_i];
+      if (smoo.alpha < 1) {
+        float smooth_val = traj_coords[axis];
+        for (uint8_t _i = 0; _i < FTM_SMOOTHING_ORDER; ++_i) {
+          smoo.smoothing_pass[_i] += (smooth_val - smoo.smoothing_pass[_i]) * smoo.alpha;
+          smooth_val = smoo.smoothing_pass[_i];
+        }
+        traj_coords[axis] = smooth_val;
       }
-      traj_coords[axis] = smooth_val;
     };
 
     #define _SMOOTHEN(A) _smoothen(_AXIS(A), smoothing.A);

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -70,7 +70,8 @@ AxisBits FTMotion::moving_axis_flags,           // These axes are moving in the 
 
 // Block data variables.
 xyze_pos_t   FTMotion::startPos,                    // (mm) Start position of block
-             FTMotion::endPos_prevBlock = { 0.0f }; // (mm) End position of previous block
+             FTMotion::endPos_prevBlock = { 0.0f }, // (mm) End position of previous block
+             FTMotion::last_target_traj = { 0.0f }; // (mm) Last target position after shaping and smoothing
 xyze_float_t FTMotion::ratio;                       // (ratio) Axis move ratio of block
 float FTMotion::tau = 0.0f;                         // (s) Time since start of block
 bool FTMotion::fastForwardUntilMotion = false;      // Fast forward time if there is no motion
@@ -524,7 +525,6 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
 
     // Approximate Gaussian smoothing via chained EMAs
     auto _smoothen = [&](const AxisEnum axis, axis_smoothing_t &smoo) {
-      if (smoo.alpha <= 0.0f) return;
       float smooth_val = traj_coords[axis];
       for (uint8_t _i = 0; _i < FTM_SMOOTHING_ORDER; ++_i) {
         smoo.smoothing_pass[_i] += (smooth_val - smoo.smoothing_pass[_i]) * smoo.alpha;
@@ -604,7 +604,7 @@ void FTMotion::fill_stepper_plan_buffer() {
 
     // Get distance from trajectory generator
     xyze_float_t traj_coords = calc_traj_point(currentGenerator->getDistanceAtTime(tau));
-    if (fastForwardUntilMotion && traj_coords == startPos) {
+    if (fastForwardUntilMotion && traj_coords == last_target_traj) {
       // Axis synchronization delays all axes. When coming from a reset, there is a ramp up time filling all buffers.
       // If the slowest axis doesn't move and it isn't smoothened, this time can be skipped.
       // It eliminates idle time when changing smoothing time or shapers and speeds up homing and bed leveling.
@@ -614,6 +614,7 @@ void FTMotion::fill_stepper_plan_buffer() {
       // Calculate and store stepper plan in buffer
       stepping_enqueue(traj_coords);
     }
+    last_target_traj = traj_coords;
   }
 }
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -525,7 +525,7 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
 
     // Approximate Gaussian smoothing via chained EMAs
     auto _smoothen = [&](const AxisEnum axis, axis_smoothing_t &smoo) {
-      if (smoo.alpha < 1) {
+      if (smoo.alpha != 1.0f) {
         float smooth_val = traj_coords[axis];
         for (uint8_t _i = 0; _i < FTM_SMOOTHING_ORDER; ++_i) {
           smoo.smoothing_pass[_i] += (smooth_val - smoo.smoothing_pass[_i]) * smoo.alpha;

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -376,10 +376,10 @@ class FTMotion {
     // Synchronize and reset motion prior to parameter changes
     friend void ft_config_t::prep_for_shaper_change();
     static void prep_for_shaper_change() {
-      // planner.synchronize guarantees that motion reached a stand still with no echoes pending execution (including a runout block)
+      // planner.synchronize guarantees that motion reached a standstill with no echoes pending execution (including a runout block)
       planner.synchronize();
       // Due to smoothing, the end position may not have been reached exactly.
-      // This is normally fine, but if smoothing time changes, and we assume it was reached
+      // This is normally fine, but if smoothing time changes, and we assume it was reached,
       // it may cause discontinuities.
       // Therefore, set the next starting position to the exact reached position.
       endPos_prevBlock = last_target_traj;

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -326,7 +326,8 @@ class FTMotion {
   private:
     // Block data variables.
     static xyze_pos_t   startPos,         // (mm) Start position of block
-                        endPos_prevBlock; // (mm) End position of previous block
+                        endPos_prevBlock, // (mm) End position of previous block
+                        last_target_traj; // (mm) Last target position after shaping and smoothing
     static xyze_float_t ratio;            // (ratio) Axis move ratio of block
     static float tau;                     // (s) Time since start of block
     static bool fastForwardUntilMotion;   // Fast forward time if there is no motion
@@ -375,8 +376,19 @@ class FTMotion {
     // Synchronize and reset motion prior to parameter changes
     friend void ft_config_t::prep_for_shaper_change();
     static void prep_for_shaper_change() {
+      // planner.synchronize guarantees that motion reached a stand still with no echoes pending execution (including a runout block)
       planner.synchronize();
-      reset();
+      // Due to smoothing, the end position may not have been reached exactly.
+      // This is normally fine, but if smoothing time changes, and we assume it was reached
+      // it may cause discontinuities.
+      // Therefore, set the next starting position to the exact reached position.
+      endPos_prevBlock = last_target_traj;
+      // We now know that we are not moving and there are no pending echoes,
+      // so set all shaping buffers to current position in case the new smoothing/shaping
+      // parameters force input shaping to look in a past position for echoes.
+      shaping.fill(endPos_prevBlock);
+      TERN_(FTM_SMOOTHING, smoothing.fill(endPos_prevBlock));
+      fastForwardUntilMotion = true;
     }
 
     // Buffers

--- a/Marlin/src/module/ft_motion/shaping.h
+++ b/Marlin/src/module/ft_motion/shaping.h
@@ -151,7 +151,7 @@ typedef struct Shaping {
     SHAPED_MAP(_RESET_ZI);
     zi_idx = 0;
   }
-  void fill(xyze_float_t pos) {
+  void fill(const xyze_float_t pos) {
     #define _FILL_ZI(A) for (uint32_t i = 0; i < ftm_zmax; i++) A.d_zi[i] = pos.A;
     SHAPED_MAP(_FILL_ZI);
     #undef _FILL_ZI

--- a/Marlin/src/module/ft_motion/shaping.h
+++ b/Marlin/src/module/ft_motion/shaping.h
@@ -151,4 +151,9 @@ typedef struct Shaping {
     SHAPED_MAP(_RESET_ZI);
     zi_idx = 0;
   }
+  void fill(xyze_float_t pos) {
+    #define _FILL_ZI(A) for (uint32_t i = 0; i < ftm_zmax; i++) A.d_zi[i] = pos.A;
+    SHAPED_MAP(_FILL_ZI);
+    #undef _FILL_ZI
+  }
 } shaping_t;

--- a/Marlin/src/module/ft_motion/smoothing.cpp
+++ b/Marlin/src/module/ft_motion/smoothing.cpp
@@ -29,7 +29,7 @@
 // Set smoothing time and recalculate alpha and delay.
 void AxisSmoothing::set_time(const float s_time) {
   if (s_time >= 0.0001f) {
-    alpha = 1.0f - expf(-(FTM_TS) * (FTM_SMOOTHING_ORDER) / s_time );
+    alpha = 1.0f - expf(-(FTM_TS) * (FTM_SMOOTHING_ORDER) / s_time);
     delay_samples = s_time * FTM_FS;
   }
   else {

--- a/Marlin/src/module/ft_motion/smoothing.cpp
+++ b/Marlin/src/module/ft_motion/smoothing.cpp
@@ -28,14 +28,13 @@
 
 // Set smoothing time and recalculate alpha and delay.
 void AxisSmoothing::set_time(const float s_time) {
-  if (s_time > 0.001f) {
+  if (s_time >= 0.00001f) {
     alpha = 1.0f - expf(-(FTM_TS) * (FTM_SMOOTHING_ORDER) / s_time );
-    delay_samples = s_time * FTM_FS;
   }
   else {
-    alpha = 0.0f;
-    delay_samples = 0;
+    alpha = 1.0f;
   }
+  delay_samples = s_time * FTM_FS;
 }
 
 #endif // FTM_SMOOTHING

--- a/Marlin/src/module/ft_motion/smoothing.cpp
+++ b/Marlin/src/module/ft_motion/smoothing.cpp
@@ -28,13 +28,14 @@
 
 // Set smoothing time and recalculate alpha and delay.
 void AxisSmoothing::set_time(const float s_time) {
-  if (s_time >= 0.00001f) {
+  if (s_time >= 0.0001f) {
     alpha = 1.0f - expf(-(FTM_TS) * (FTM_SMOOTHING_ORDER) / s_time );
+    delay_samples = s_time * FTM_FS;
   }
   else {
     alpha = 1.0f;
+    delay_samples = 0;
   }
-  delay_samples = s_time * FTM_FS;
 }
 
 #endif // FTM_SMOOTHING

--- a/Marlin/src/module/ft_motion/smoothing.h
+++ b/Marlin/src/module/ft_motion/smoothing.h
@@ -55,4 +55,9 @@ typedef struct Smoothing {
     LOGICAL_AXIS_MAP(_CLEAR);
     #undef _CLEAR
   }
+  void fill(xyze_float_t pos) {
+    #define _FILL_SMO(A) for (uint32_t i = 0; i < FTM_SMOOTHING_ORDER; i++) A.smoothing_pass[i] = pos.A;
+    LOGICAL_AXIS_MAP(_FILL_SMO);
+    #undef _FILL_SMO
+  }
 } smoothing_t;

--- a/Marlin/src/module/ft_motion/smoothing.h
+++ b/Marlin/src/module/ft_motion/smoothing.h
@@ -55,7 +55,7 @@ typedef struct Smoothing {
     LOGICAL_AXIS_MAP(_CLEAR);
     #undef _CLEAR
   }
-  void fill(xyze_float_t pos) {
+  void fill(const xyze_float_t pos) {
     #define _FILL_SMO(A) for (uint32_t i = 0; i < FTM_SMOOTHING_ORDER; i++) A.smoothing_pass[i] = pos.A;
     LOGICAL_AXIS_MAP(_FILL_SMO);
     #undef _FILL_SMO


### PR DESCRIPTION
Instead of blindly resetting everything when changing shaping/smoothing, this approach takes into account that smoothing can result in the target position not being exactly reached after the runout.

The new approach in this PR is to ensure smoothing and shaping buffers are all filled with the latest actual position reached. Any transient positional error related to a lagging smoother will be corrected gradually during the next block. This way the coordinate system stays referenced to the original frame of reference.

Also changed FTM_NEVER to be as small as possible so the ISR doesn't end up waiting an arbitrarily large amount of time

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
