### PR TITLE
in preprocessor.py fail on exception vs silently continuing in vain 

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -37,16 +37,20 @@ def run_preprocessor(env, fn=None):
         else:
             cmd += ['-D' + s]
 
-    cmd += ['-D__MARLIN_DEPS__ -w -dM -E -x c++']
-    depcmd = cmd + [ filename ]
-    cmd = ' '.join(depcmd)
+    cmd += ['-D__MARLIN_DEPS__ -w -dM -E -x c++', filename]
+
+    cmd = ' '.join(cmd)
     blab(cmd)
+
     try:
-        define_list = subprocess.check_output(cmd, shell=True).splitlines()
-        blab("define_list: %s" % define_list)
+        define_list_text = subprocess.check_output(cmd, shell=True)
     except:
-        raise RuntimeError(f"A serious error occurred and the build cannot continue. Command `{cmd}` returned no data.")
+        raise RuntimeError(f"Command `{cmd}` failed during build pre-processing.")
+
+    define_list = define_list_text.splitlines() if define_list_text else []
+
     preprocessor_cache[filename] = define_list
+
     return define_list
 
 

--- a/buildroot/share/PlatformIO/scripts/preprocessor.py
+++ b/buildroot/share/PlatformIO/scripts/preprocessor.py
@@ -43,8 +43,9 @@ def run_preprocessor(env, fn=None):
     blab(cmd)
     try:
         define_list = subprocess.check_output(cmd, shell=True).splitlines()
+        blab("define_list: %s" % define_list)
     except:
-        define_list = {}
+        raise RuntimeError(f"A serious error occurred and the build cannot continue. Command `{cmd}` returned no data.")
     preprocessor_cache[filename] = define_list
     return define_list
 


### PR DESCRIPTION
### Description

A user was trying to build the marlin simulator under windows and just got 

```
platformio run -e simulator_windows
Processing simulator_windows (platform: native; framework: )
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via -v, --verbose option
Error: Failed to parse Marlin features. See previous error messages.
```

Which wasn't at all helpful.

 Traced the issue to preprocessor.py attempting to execute a command to generate define_list.
But instead of producing an error it quietly set define_list = {} and continued like there was no issue.

But you cannot continue if define_list is empty.

Added `raise RuntimeError(f"A serious error occurred and the build cannot continue. Command `{cmd}` returned no data.")`  instead of setting the list to empty.  

### Requirements

Failing to populate define_list

### Benefits

Errors at the point it fails, not much later with an generic "Error: Failed to parse Marlin features. See previous error messages."

