### PR TITLE
🩹 Skip One-Click on EEPROM error

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1876,8 +1876,13 @@ void MarlinSettings::postprocess() {
 
     TERN_(EXTENSIBLE_UI, ExtUI::onSettingsStored(success));
 
+    // Remember the error condition so One-Click Printing can be skipped
+    #if ENABLED(ONE_CLICK_PRINT) && NONE(EEPROM_AUTO_INIT, EEPROM_INIT_NOW)
+      working_crc = uint16_t(eeprom_error);
+    #endif
+
     return success;
-  }
+  } // save
 
   EEPROM_Error MarlinSettings::check_version() {
     if (!EEPROM_START(EEPROM_OFFSET)) return ERR_EEPROM_NOPROM;
@@ -3077,8 +3082,13 @@ void MarlinSettings::postprocess() {
       if (!validating && TERN1(EEPROM_BOOT_SILENT, marlin.isRunning())) report();
     #endif
 
+    // Remember the error condition so One-Click Printing can be skipped
+    #if ENABLED(ONE_CLICK_PRINT) && NONE(EEPROM_AUTO_INIT, EEPROM_INIT_NOW)
+      working_crc = uint16_t(eeprom_error);
+    #endif
+
     return eeprom_error;
-  }
+  } // _load
 
   #ifdef ARCHIM2_SPI_FLASH_EEPROM_BACKUP_SIZE
     extern bool restoreEEPROM();
@@ -3146,7 +3156,7 @@ void MarlinSettings::postprocess() {
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
-    inline void ubl_invalid_slot(const int s) {
+    static void ubl_invalid_slot(const int s) {
       DEBUG_ECHOLN(F("?Invalid "), F("slot.\n"), s, F(" mesh slots available."));
       UNUSED(s);
     }

--- a/Marlin/src/module/settings.h
+++ b/Marlin/src/module/settings.h
@@ -67,6 +67,10 @@ class MarlinSettings {
       static bool load();      // Return 'true' if data was loaded ok
       static bool validate();  // Return 'true' if EEPROM data is ok
 
+      #if ENABLED(ONE_CLICK_PRINT) && NONE(EEPROM_AUTO_INIT, EEPROM_INIT_NOW)
+        static EEPROM_Error eeprom_status() { return (EEPROM_Error)working_crc; }
+      #endif
+
       static EEPROM_Error check_version();
 
       static void first_load() {
@@ -100,10 +104,8 @@ class MarlinSettings {
 
     #else // !EEPROM_SETTINGS
 
-      FORCE_INLINE
-      static bool load() { reset(); report(); return true; }
-      FORCE_INLINE
-      static void first_load() { (void)load(); }
+      FORCE_INLINE static bool load() { reset(); report(); return true; }
+      FORCE_INLINE static void first_load() { (void)load(); }
 
     #endif // !EEPROM_SETTINGS
 
@@ -114,8 +116,7 @@ class MarlinSettings {
     #if DISABLED(DISABLE_M503)
       static void report(const bool forReplay=false);
     #else
-      FORCE_INLINE
-      static void report(const bool=false) {}
+      FORCE_INLINE static void report(const bool=false) {}
     #endif
 
   private:

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1030,11 +1030,16 @@ void CardReader::write_command(char * const buf) {
    * Select the newest file and ask the user if they want to print it.
    */
   bool CardReader::one_click_check() {
+    // Don't proceed if an EEPROM error needs a response
+    #if ENABLED(EEPROM_SETTINGS) && NONE(EEPROM_AUTO_INIT, EEPROM_INIT_NOW)
+      if (settings.eeprom_status() != ERR_EEPROM_NOERR) return false;
+    #endif
+
     const bool found = selectNewestFile();    // Changes the current workDir if found
     if (found) {
       //SERIAL_ECHO_MSG(" OCP File: ", longest_filename(), "\n");
       //ui.init();
-      one_click_print();                      // Restores workkDir to root (eventually)
+      one_click_print();                      // Restores workDir to root (eventually)
     }
     return found;
   }


### PR DESCRIPTION
If an EEPROM error needs a response (e.g., after a new flash), skip the one-click printing prompt.

Fixes #28095
