### PR TITLE
FTM: fix typo in e_parser.cpp,  M496 gcode not processed, fix menu

### DIFF
--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -150,7 +150,7 @@ void EmergencyParser::update(EmergencyParser::State &state, const uint8_t c) {
     case EP_M4:
       switch (c) {
         case '1' :state = EP_M41;    break;
-        #if ENABLED(FT_MOTION_RESONANCE_TEST)
+        #if ENABLED(FTM_RESONANCE_TEST)
           case '9': state = EP_M49;  break;
         #endif
         default: state  = EP_IGNORE;

--- a/Marlin/src/gcode/feature/ft_motion/M495_M496.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M495_M496.cpp
@@ -25,6 +25,7 @@
 #if ENABLED(FTM_RESONANCE_TEST)
 
 #include "../../gcode.h"
+#include "../../../lcd/marlinui.h"
 #include "../../../module/ft_motion.h"
 #include "../../../module/ft_motion/resonance_generator.h"
 
@@ -173,6 +174,7 @@ void GcodeSuite::M496() {
   if (ftMotion.rtg.isActive()) {
       ftMotion.rtg.abort();
       EmergencyParser::rt_stop_by_M496 = false;
+      ui.refresh();
       #if DISABLED(MARLIN_SMALL_BUILD)
         SERIAL_ECHOLN(F("Resonance Test"), F(" aborted."));
       #endif

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -424,7 +424,7 @@ void menu_move() {
 
       if (ftMotion.rtg.isActive() && !ftMotion.rtg.isDone()) {
         STATIC_ITEM(MSG_FTM_RT_RUNNING);
-        ACTION_ITEM(MSG_FTM_RT_STOP, []{ ftMotion.rtg.abort(); ui.refresh(); });
+        ACTION_ITEM(MSG_FTM_RT_STOP, []{ queue.inject(F("M496")); ui.refresh(); });
       }
       else {
         GCODES_ITEM_N(X_AXIS, MSG_FTM_RT_START_N, F("M495 X S"));

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -424,12 +424,18 @@ void menu_move() {
 
       if (ftMotion.rtg.isActive() && !ftMotion.rtg.isDone()) {
         STATIC_ITEM(MSG_FTM_RT_RUNNING);
-        ACTION_ITEM(MSG_FTM_RT_STOP, []{ queue.inject(F("M496")); ui.refresh(); });
+        GCODES_ITEM(MSG_FTM_RT_STOP, F("M496"));
       }
       else {
-        GCODES_ITEM_N(X_AXIS, MSG_FTM_RT_START_N, F("M495 X S"));
-        GCODES_ITEM_N(Y_AXIS, MSG_FTM_RT_START_N, F("M495 Y S"));
-        GCODES_ITEM_N(Z_AXIS, MSG_FTM_RT_START_N, F("M495 Z S"));
+        #if HAS_X_AXIS
+          GCODES_ITEM_N(X_AXIS, MSG_FTM_RT_START_N, F("M495 X S"));
+        #endif
+        #if HAS_Y_AXIS
+          GCODES_ITEM_N(Y_AXIS, MSG_FTM_RT_START_N, F("M495 Y S"));
+        #endif
+        #if HAS_Z_AXIS
+          GCODES_ITEM_N(Z_AXIS, MSG_FTM_RT_START_N, F("M495 Z S"));
+        #endif
         SUBMENU(MSG_FTM_RETRIEVE_FREQ, menu_ftm_resonance_freq);
       }
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
There is a typo error in `e_parser.cpp` which prevents M496 processing.
@GNN3 also reports the impossibility to stop the test via the menu, inject M496 in `ACTION_ITEM`, and the test is correctly stopped.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
`FT_MOTION ` and` FTM_RESONANCE_TEST` enabled
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Fix emergency parser M496 command
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
