### PR TITLE
remove missed XY Followup to ba8b685

### DIFF
--- a/Marlin/src/inc/Conditionals-1-axes.h
+++ b/Marlin/src/inc/Conditionals-1-axes.h
@@ -293,7 +293,7 @@
 #if NUM_AXES >= 1
   #define HAS_X_AXIS 1
   #define HAS_A_AXIS 1
-  #if NUM_AXES >= XY
+  #if NUM_AXES >= 2
     #define HAS_Y_AXIS 1
     #define HAS_B_AXIS 1
     #if NUM_AXES >= 3


### PR DESCRIPTION
### Description

Commit https://github.com/marlinfirmware/Marlin/commit/ba8b685ede00a05390b80947ee7a802b481a68aa removed 

```
#define XYZ  3
#define XY   2

```
But Marlin/src/inc/Conditionals-1-axes.h sill has #if NUM_AXES >= XY

Converted it to a 2

### Requirements

Have just one axis, X  

