### PR TITLE
FTM: fix printer reset with resonance test for MCU without FPU

### DIFF
--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -50,13 +50,19 @@ void ResonanceGenerator::reset() {
   done = false;
 }
 
+float ResonanceGenerator::fast_sin(float x) {
+  // Fast sine approximation
+  x = fmodf(x + M_PI, 2.0f * M_PI) - M_PI;
+  return x * (1.27323954f - 0.405284735f * fabsf(x));
+}
+
 void ResonanceGenerator::fill_stepper_plan_buffer() {
   xyze_float_t traj_coords = {};
 
   while (!ftMotion.stepping.is_full()) {
     // Calculate current frequency
     // Logarithmic approach with duration per octave
-    const float freq = rt_params.min_freq * powf(2.0f, rt_time / rt_params.octave_duration);
+    const float freq = rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1);
     if (freq > rt_params.max_freq) {
       done = true;
       return;
@@ -71,7 +77,7 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     const float phase = 2.0f * M_PI * freq * rt_time;
 
     // Position Offset : between -A and +A
-    const float pos_offset = amplitude * sinf(phase);
+    const float pos_offset = amplitude * fast_sin(phase);
 
     // Set base position and apply offset to the test axis in one step for all axes
     #define _SET_TRAJ(A) traj_coords.A = rt_params.start_pos.A + (rt_params.axis == A##_AXIS ? pos_offset : 0.0f);

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -50,8 +50,8 @@ void ResonanceGenerator::reset() {
   done = false;
 }
 
+// Fast sine approximation
 float ResonanceGenerator::fast_sin(float x) {
-  // Fast sine approximation
   x = fmodf(x + M_PI, 2.0f * M_PI) - M_PI;
   return x * (1.27323954f - 0.405284735f * fabsf(x));
 }
@@ -61,8 +61,7 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
 
   while (!ftMotion.stepping.is_full()) {
     // Calculate current frequency
-    // Logarithmic approach with duration per octave
-    const float freq = rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1);
+    const float freq = getFrequencyFromTimeline();
     if (freq > rt_params.max_freq) {
       done = true;
       return;

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -52,8 +52,19 @@ void ResonanceGenerator::reset() {
 
 // Fast sine approximation
 float ResonanceGenerator::fast_sin(float x) {
-  x = fmodf(x + M_PI, M_TAU) - M_PI;
-  return x * (1.27323954f - 0.405284735f * fabsf(x));
+  static constexpr float INV_TAU = (1.0f / M_TAU);
+
+  // Reduce the angle to [-π, π]
+  const float y = x * INV_TAU;      // Multiples of 2π
+  int k = static_cast<int>(y);      // Truncates toward zero
+
+  // Negative? The truncation is one too high.
+  if (y < 0.0f) --k;                // Correct for negatives
+
+  const float r = x - k * M_TAU;    // -π <= r <= π
+
+  // Cheap polynomial approximation of sin(r)
+  return r * (1.27323954f - 0.405284735f * ABS(r));
 }
 
 void ResonanceGenerator::fill_stepper_plan_buffer() {

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -52,14 +52,16 @@ void ResonanceGenerator::reset() {
 
 // Fast sine approximation
 float ResonanceGenerator::fast_sin(float x) {
-  x = fmodf(x + M_PI, 2.0f * M_PI) - M_PI;
+  x = fmodf(x + M_PI, M_TAU) - M_PI;
   return x * (1.27323954f - 0.405284735f * fabsf(x));
 }
 
 void ResonanceGenerator::fill_stepper_plan_buffer() {
   xyze_float_t traj_coords = rt_params.start_pos;
 
-  const float amplitude_numerator = rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f;
+  const float amplitude_precalc = (rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f) / sq(M_PI);
+
+  float rt_factor = rt_time * M_TAU;
 
   while (!ftMotion.stepping.is_full()) {
     // Calculate current frequency
@@ -72,10 +74,10 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     // Amplitude based on a sinusoidal wave : A = accel / (4 * PI^2 * f^2)
     //const float accel_magnitude = rt_params.accel_per_hz * freq;
     //const float amplitude = rt_params.amplitude_correction * accel_magnitude / (4.0f * sq(M_PI) * sq(freq));
-    const float amplitude = amplitude_numerator / (sq(M_PI) * freq);
+    const float amplitude = amplitude_precalc / freq;
 
     // Phase in radians
-    const float phase = 2.0f * M_PI * freq * rt_time;
+    const float phase = freq * rt_factor;
 
     // Position Offset : between -A and +A
     const float pos_offset = amplitude * fast_sin(phase);
@@ -83,8 +85,9 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     // Resonate the axis being tested
     traj_coords[rt_params.axis] = rt_params.start_pos[rt_params.axis] + pos_offset;
 
-    // Increment time for the next point (before calling out)
+    // Increment for the next point (before calling out)
     rt_time += FTM_TS;
+    rt_factor += FTM_TS * M_TAU;
 
     // Store in buffer
     ftMotion.stepping_enqueue(traj_coords);

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -57,7 +57,7 @@ float ResonanceGenerator::fast_sin(float x) {
 }
 
 void ResonanceGenerator::fill_stepper_plan_buffer() {
-  xyze_float_t traj_coords = {};
+  xyze_float_t traj_coords = rt_params.start_pos;
 
   const float amplitude_numerator = rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f;
 
@@ -80,15 +80,14 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     // Position Offset : between -A and +A
     const float pos_offset = amplitude * fast_sin(phase);
 
-    // Set base position and apply offset to the test axis in one step for all axes
-    #define _SET_TRAJ(A) traj_coords.A = rt_params.start_pos.A + (rt_params.axis == A##_AXIS ? pos_offset : 0.0f);
-    LOGICAL_AXIS_MAP(_SET_TRAJ);
+    // Resonate the axis being tested
+    traj_coords[rt_params.axis] = rt_params.start_pos[rt_params.axis] + pos_offset;
+
+    // Increment time for the next point (before calling out)
+    rt_time += FTM_TS;
 
     // Store in buffer
     ftMotion.stepping_enqueue(traj_coords);
-
-    // Increment time for the next point
-    rt_time += FTM_TS;
   }
 }
 

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -59,6 +59,8 @@ float ResonanceGenerator::fast_sin(float x) {
 void ResonanceGenerator::fill_stepper_plan_buffer() {
   xyze_float_t traj_coords = {};
 
+  const float amplitude_numerator = rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f;
+
   while (!ftMotion.stepping.is_full()) {
     // Calculate current frequency
     const float freq = getFrequencyFromTimeline();
@@ -70,7 +72,7 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     // Amplitude based on a sinusoidal wave : A = accel / (4 * PI^2 * f^2)
     //const float accel_magnitude = rt_params.accel_per_hz * freq;
     //const float amplitude = rt_params.amplitude_correction * accel_magnitude / (4.0f * sq(M_PI) * sq(freq));
-    const float amplitude = rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f / (sq(M_PI) * freq);
+    const float amplitude = amplitude_numerator / (sq(M_PI) * freq);
 
     // Phase in radians
     const float phase = 2.0f * M_PI * freq * rt_time;
@@ -84,6 +86,7 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
 
     // Store in buffer
     ftMotion.stepping_enqueue(traj_coords);
+
     // Increment time for the next point
     rt_time += FTM_TS;
   }

--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -26,13 +26,13 @@
 #include <math.h>
 
 typedef struct FTMResonanceTestParams {
-  AxisEnum axis       = NO_AXIS_ENUM; // Axis to test
-  float min_freq      = 5.0f;         // Minimum frequency [Hz]
-  float max_freq      = 100.0f;       // Maximum frequency [Hz]
-  float octave_duration = 40.0f;      // Octave duration for logarithmic progression
-  float accel_per_hz  = 60.0f;        // Acceleration per Hz [mm/sec/Hz] or [g/Hz]
-  int16_t amplitude_correction = 5;   // Amplitude correction factor
-  xyze_pos_t start_pos;               // Initial stepper position
+  AxisEnum axis         = NO_AXIS_ENUM; // Axis to test
+  float min_freq        =   5.0f;       // Minimum frequency [Hz]
+  float max_freq        = 100.0f;       // Maximum frequency [Hz]
+  float octave_duration =  40.0f;       // Octave duration for logarithmic progression
+  float accel_per_hz    =  60.0f;       // Acceleration per Hz [mm/sec/Hz] or [g/Hz]
+  int16_t amplitude_correction = 5;     // Amplitude correction factor
+  xyze_pos_t start_pos;                 // Initial stepper position
 } ftm_resonance_test_params_t;
 
 class ResonanceGenerator {
@@ -61,10 +61,11 @@ class ResonanceGenerator {
 
     void fill_stepper_plan_buffer();                // Fill stepper plan buffer with trajectory points
 
+    void setActive(const bool state) { active = state; }
     bool isActive() const { return active; }
+
+    void setDone(const bool state) { done = state; }
     bool isDone() const { return done; }
-    void setActive(bool state) { active = state; }
-    void setDone(bool state) { done = state; }
 
     void abort();             // Abort resonance test
 

--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -25,6 +25,10 @@
 
 #include <math.h>
 
+#ifndef M_TAU
+  #define M_TAU (2.0f * M_PI)
+#endif
+
 typedef struct FTMResonanceTestParams {
   AxisEnum axis         = NO_AXIS_ENUM; // Axis to test
   float min_freq        =   5.0f;       // Minimum frequency [Hz]

--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -54,7 +54,7 @@ class ResonanceGenerator {
     }
 
     float getFrequencyFromTimeline() {
-      return (rt_params.min_freq * powf(2.0f, timeline / rt_params.octave_duration)); // Return frequency based on timeline
+      return (rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1)); // Return frequency based on timeline
     }
 
     void fill_stepper_plan_buffer();                // Fill stepper plan buffer with trajectory points
@@ -67,6 +67,7 @@ class ResonanceGenerator {
     void abort();               // Abort resonance test
 
   private:
+    float fast_sin(float x); // Fast sine approximation
     static float rt_time;    // Test timer
     static bool active;         // Resonance test active
     static bool done;           // Resonance test done

--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -53,8 +53,10 @@ class ResonanceGenerator {
       done = false;
     }
 
+    // Return frequency based on timeline
     float getFrequencyFromTimeline() {
-      return (rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1)); // Return frequency based on timeline
+      // Logarithmic approach with duration per octave
+      return rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1);
     }
 
     void fill_stepper_plan_buffer();                // Fill stepper plan buffer with trajectory points
@@ -64,11 +66,11 @@ class ResonanceGenerator {
     void setActive(bool state) { active = state; }
     void setDone(bool state) { done = state; }
 
-    void abort();               // Abort resonance test
+    void abort();             // Abort resonance test
 
   private:
-    float fast_sin(float x); // Fast sine approximation
-    static float rt_time;    // Test timer
-    static bool active;         // Resonance test active
-    static bool done;           // Resonance test done
+    float fast_sin(float x);  // Fast sine approximation
+    static float rt_time;     // Test timer
+    static bool active;       // Resonance test active
+    static bool done;         // Resonance test done
 };


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
@plampix reports in #28259, SKR mini E3 V3 reset when a `FT_MOTION` resonance test is launched. The cause is probably a math error related to the absence of FPU in the STM32G0. I adapted the math of resonance generator. @plampix reports success with the patch.
@dbuezas , could you have a look at the code to be sure it's ok.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
FT_MOTION resonance test success on MCU without FPU
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
#28259
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
