### PR TITLE
FTM: fix resonance test motion and optimize compute

### DIFF
--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -55,12 +55,16 @@ class ResonanceGenerator {
       rt_time = t;
       active = true;
       done = false;
+      //Precompute frequency multiplier
+      current_freq = rt_params.min_freq;
+      const float inv_octave_duration = 1.0f / rt_params.octave_duration;
+      freq_mul = exp2f(FTM_TS * inv_octave_duration);
     }
 
     // Return frequency based on timeline
     float getFrequencyFromTimeline() {
       // Logarithmic approach with duration per octave
-      return rt_params.min_freq * 2.0f * exp2f((rt_time / rt_params.octave_duration) - 1);
+      return rt_params.min_freq * exp2f(timeline / rt_params.octave_duration);
     }
 
     void fill_stepper_plan_buffer();                // Fill stepper plan buffer with trajectory points
@@ -76,6 +80,8 @@ class ResonanceGenerator {
   private:
     float fast_sin(float x);  // Fast sine approximation
     static float rt_time;     // Test timer
+    float freq_mul;           // Frequency multiplier for sine sweeping
+    float current_freq;       // Current frequency being generated in sinusoidal motion
     static bool active;       // Resonance test active
     static bool done;         // Resonance test done
 };


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
After last code  merge :

1. Sine sweep motion (around a central point) is broken with `fast_sin()` as the value range is not -π <= r <= π, fixed.
2.  Optimize compute with `exp2f` precalculated outside the loop.
3. Fix broken resonance frequency calculation from menu
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Test works as intended, more optimization for MCU without FPU
Fix broken resonance frequency calculation in motion menu
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
