### PR TITLE
Use H tag in FTM axis sync menu as in M493

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -550,7 +550,7 @@ void menu_move() {
 
       editable.state = c.axis_sync_enabled;
       EDIT_ITEM(bool, MSG_FTM_AXIS_SYNC, &editable.state, []{
-        queue.inject(TS(F("M493"), IAXIS_CHAR(MenuItemBase::itemIndex), 'T', int(editable.state)));
+        queue.inject(TS(F("M493"), IAXIS_CHAR(MenuItemBase::itemIndex), 'H', int(editable.state)));
       });
 
       #if ENABLED(FTM_RESONANCE_TEST)


### PR DESCRIPTION
Make FTM axis sync menu consistent with M493 H. Also merge  [H for axis sync #615 ](https://github.com/MarlinFirmware/MarlinDocumentation/pull/615)