### PR TITLE
Add a feature flag to disable LCD reinit

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1529,6 +1529,12 @@
 // Turn off the display blinking that warns about possible accuracy reduction
 //#define DISABLE_REDUCED_ACCURACY_WARNING
 
+/**
+ * Do not reinit the LCD after SD insertion or when going to the main menu from info screen
+ * Resolves hiccups on some displays, at the cost of having to do a full power cycle if frames are broken mid-print
+ */
+//#define REINIT_NOISY_LCD 0
+
 #if HAS_MANUAL_MOVE_MENU
   #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 2*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
   #define FINE_MANUAL_MOVE 0.025    // (mm) Smallest manual move (< 0.1mm) applying to Z on most machines

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1529,12 +1529,6 @@
 // Turn off the display blinking that warns about possible accuracy reduction
 //#define DISABLE_REDUCED_ACCURACY_WARNING
 
-/**
- * Do not reinit the LCD after SD insertion or when going to the main menu from info screen
- * Resolves hiccups on some displays, at the cost of having to do a full power cycle if frames are broken mid-print
- */
-//#define REINIT_NOISY_LCD 0
-
 #if HAS_MANUAL_MOVE_MENU
   #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 2*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
   #define FINE_MANUAL_MOVE 0.025    // (mm) Smallest manual move (< 0.1mm) applying to Z on most machines
@@ -1787,6 +1781,12 @@
    * :['SPI_HALF_SPEED', 'SPI_QUARTER_SPEED', 'SPI_EIGHTH_SPEED']
    */
   //#define SD_SPI_SPEED SPI_HALF_SPEED
+
+  /**
+   * Reinit the LCD after SD Card insert/remove or when entering the menu.
+   * Required for some LCDs that use shared SPI with an external SD Card reader.
+   */
+  #define REINIT_NOISY_LCD
 
   // The standard SD detect circuit reads LOW when media is inserted and HIGH when empty.
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -606,7 +606,9 @@
   #endif
 
   #if HAS_SD_DETECT && NONE(HAS_GRAPHICAL_TFT, LCD_USE_DMA_FSMC, HAS_FSMC_GRAPHICAL_TFT, HAS_SPI_GRAPHICAL_TFT, IS_DWIN_MARLINUI, EXTENSIBLE_UI, HAS_DWIN_E3V2, HAS_U8GLIB_I2C_OLED)
-    #define REINIT_NOISY_LCD 1  // Have the LCD re-init on SD insertion
+    #ifndef REINIT_NOISY_LCD
+      #define REINIT_NOISY_LCD 1  // Have the LCD re-init on SD insertion
+    #endif
   #endif
 
 #endif // HAS_MEDIA

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -605,13 +605,9 @@
     #endif
   #endif
 
-  #if HAS_SD_DETECT && NONE(HAS_GRAPHICAL_TFT, LCD_USE_DMA_FSMC, HAS_FSMC_GRAPHICAL_TFT, HAS_SPI_GRAPHICAL_TFT, IS_DWIN_MARLINUI, EXTENSIBLE_UI, HAS_DWIN_E3V2, HAS_U8GLIB_I2C_OLED)
-    #ifndef REINIT_NOISY_LCD
-      #define REINIT_NOISY_LCD 1  // Have the LCD re-init on SD insertion
-    #endif
-  #endif
-
-#endif // HAS_MEDIA
+#else // !HAS_MEDIA
+  #undef REINIT_NOISY_LCD
+#endif
 
 /**
  * Power Supply

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -993,3 +993,12 @@
 #if ALL(SMOOTH_LIN_ADVANCE, MIXING_EXTRUDER)
   #warning "SMOOTH_LIN_ADVANCE with MIXING_EXTRUDER is untested. Use with caution."
 #endif
+
+/**
+ * Some LCDs need re-init to deal with flaky SPI bus sharing
+ */
+#if HAS_SD_DETECT && NONE(REINIT_NOISY_LCD, HAS_GRAPHICAL_TFT, LCD_USE_DMA_FSMC, HAS_FSMC_GRAPHICAL_TFT, HAS_SPI_GRAPHICAL_TFT, IS_DWIN_MARLINUI, EXTENSIBLE_UI, HAS_DWIN_E3V2, HAS_U8GLIB_I2C_OLED)
+  #warning "It is recommended to enable REINIT_NOISY_LCD with your LCD controller model."
+#elif ENABLED(REINIT_NOISY_LCD)
+  #warning "REINIT_NOISY_LCD is probably not required with your LCD controller model."
+#endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Some displays (e.g. MKS Mini12864 V3) have slow, blocking initialization procedures. When going from the main menu to the info screen or when inserting an SD card, Marlin attempts to reinitialize the display to combat noise. If done mid-print, the whole printer may pause, including all motion, causing blobs. This PR adds a feature flag to disable this behavior, at the cost of having to restart the printer to restore display if noise becomes an issue.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

Add a feature flag to disable LCD reinit during operation.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

Simply uncomment `#define REINIT_NOISY_LCD 0` at line 1536 in `Configuration_adv.h`.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
