### PR TITLE
🧑‍💻 Macros *_AXIS_ANY/ALL/NONE

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -377,7 +377,7 @@ void GcodeSuite::G28() {
         float z_homing_height = seenR ? parser.value_linear_units() : Z_CLEARANCE_FOR_HOMING;
 
         // Check for any lateral motion that might require clearance
-        const bool may_skate = seenR NUM_AXIS_GANG(|| doX, || doY, || TERN0(Z_SAFE_HOMING, doZ), || doI, || doJ, || doK, || doU, || doV, || doW);
+        const bool may_skate = seenR && NUM_AXIS_ANY(doX, doY, TERN0(Z_SAFE_HOMING, doZ), doI, doJ, doK, doU, doV, doW);
 
         if (seenR && z_homing_height == 0) {
           if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("R0 = No Z raise");

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1438,7 +1438,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
 float get_move_distance(const xyze_pos_t &diff OPTARG(HAS_ROTATIONAL_AXES, bool &is_cartesian_move)) {
   #if NUM_AXES
 
-    if (!(NUM_AXIS_GANG(diff.x, || diff.y, /* skip z */, || diff.i, || diff.j, || diff.k, || diff.u, || diff.v, || diff.w)))
+    if (NUM_AXIS_NONE(diff.x, diff.y, 0, diff.i, diff.j, diff.k, diff.u, diff.v, diff.w))
       return TERN0(HAS_Z_AXIS, ABS(diff.z));
 
     #if ENABLED(ARTICULATED_ROBOT_ARM)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1188,10 +1188,18 @@ class Planner {
   #define PLANNER_XY_FEEDRATE_MM_S 60.0f
 #endif
 
-#define ANY_AXIS_MOVES(BLOCK)  \
-  (false NUM_AXIS_GANG(        \
-  || BLOCK->steps.a, || BLOCK->steps.b, || BLOCK->steps.c, \
-  || BLOCK->steps.i, || BLOCK->steps.j, || BLOCK->steps.k, \
-  || BLOCK->steps.u, || BLOCK->steps.v, || BLOCK->steps.w))
+#define XYZ_HAS_STEPS(B) NUM_AXIS_ANY( \
+  B->steps.a, B->steps.b, B->steps.c,  \
+  B->steps.i, B->steps.j, B->steps.k,  \
+  B->steps.u, B->steps.v, B->steps.w)
+
+#if MIN_STEPS_PER_SEGMENT <= 1
+  #define XYZ_HAS_ENOUGH_STEPS XYZ_HAS_STEPS
+#else
+  #define XYZ_HAS_ENOUGH_STEPS(B) NUM_AXIS_ANY( \
+    B->steps.a >= MIN_STEPS_PER_SEGMENT, B->steps.b >= MIN_STEPS_PER_SEGMENT, B->steps.c >= MIN_STEPS_PER_SEGMENT, \
+    B->steps.i >= MIN_STEPS_PER_SEGMENT, B->steps.j >= MIN_STEPS_PER_SEGMENT, B->steps.k >= MIN_STEPS_PER_SEGMENT, \
+    B->steps.u >= MIN_STEPS_PER_SEGMENT, B->steps.v >= MIN_STEPS_PER_SEGMENT, B->steps.w >= MIN_STEPS_PER_SEGMENT)
+#endif
 
 extern Planner planner;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2905,7 +2905,7 @@ void Stepper::isr() {
           ne.edividend = advance_dividend.e;
           const float scale = (float(ne.edividend) / advance_divisor) * planner.mm_per_step[E_AXIS_N(current_block->extruder)];
           ne.scale_q24 = _BV32(24) * scale;
-          if (ne.settings.enabled && current_block->direction_bits.e && ANY_AXIS_MOVES(current_block)) {
+          if (ne.settings.enabled && current_block->direction_bits.e && XYZ_HAS_STEPS(current_block)) {
             ne.q24.A = _BV32(24) * ne.settings.coeff.A;
             ne.q24.B = _BV32(24) * ne.settings.coeff.B;
             ne.q24.C = _BV32(24) * ne.settings.coeff.C;
@@ -2959,7 +2959,7 @@ void Stepper::isr() {
         const bool forward_e = step_rate > 0;
 
         #if ENABLED(NONLINEAR_EXTRUSION)
-          if (ne.settings.enabled && forward_e && ANY_AXIS_MOVES(current_block)) {
+          if (ne.settings.enabled && forward_e && XYZ_HAS_STEPS(current_block)) {
             // Maximum polynomial value is just above 1, like 1.05..1.2, less than 2 anyway, so we can use 30 bits for fractional part
             int32_t vd_q30 = ne.q30.A * sq(step_rate) + ne.q30.B * step_rate;
             NOLESS(vd_q30, 0);
@@ -3676,11 +3676,11 @@ void Stepper::report_positions() {
     #endif
 
     // Only wait for axes without edge stepping
-    const bool any_wait = false LOGICAL_AXIS_GANG(
-      || (!e_axis_has_dedge  && step_bits.E),
-      || (!AXIS_HAS_DEDGE(X) && step_bits.X), || (!AXIS_HAS_DEDGE(Y) && step_bits.Y), || (!AXIS_HAS_DEDGE(Z) && step_bits.Z),
-      || (!AXIS_HAS_DEDGE(I) && step_bits.I), || (!AXIS_HAS_DEDGE(J) && step_bits.J), || (!AXIS_HAS_DEDGE(K) && step_bits.K),
-      || (!AXIS_HAS_DEDGE(U) && step_bits.U), || (!AXIS_HAS_DEDGE(V) && step_bits.V), || (!AXIS_HAS_DEDGE(W) && step_bits.W)
+    const bool any_wait = LOGICAL_AXIS_ANY(
+      !e_axis_has_dedge  && step_bits.E,
+      !AXIS_HAS_DEDGE(X) && step_bits.X, !AXIS_HAS_DEDGE(Y) && step_bits.Y, !AXIS_HAS_DEDGE(Z) && step_bits.Z,
+      !AXIS_HAS_DEDGE(I) && step_bits.I, !AXIS_HAS_DEDGE(J) && step_bits.J, !AXIS_HAS_DEDGE(K) && step_bits.K,
+      !AXIS_HAS_DEDGE(U) && step_bits.U, !AXIS_HAS_DEDGE(V) && step_bits.V, !AXIS_HAS_DEDGE(W) && step_bits.W
     );
 
     // Allow pulses to be registered by stepper drivers


### PR DESCRIPTION
Shorthand macros for concatenated condition tests.
- `NUM_AXIS_ANY` / `NUM_AXIS_ALL` / `NUM_AXIS_NONE`
- `LOGICAL_AXIS_ANY` / `LOGICAL_AXIS_ALL` / `LOGICAL_AXIS_NONE`
- `XY_ANY` / `XY_ALL` / `XYZ_ANY` / `XYZ_ALL`

Caveats:
- If there are no axes except E, all comparison operators for `XYZVal`, `XYZEVal` will always be false, where they were previously always true.