### PR TITLE
add checks for maximum number neopixels

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2712,14 +2712,14 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "NEO2_COLOR_PRESETS requires NEOPIXEL2_SEPARATE to be enabled."
   #endif
   #ifdef BOARD_NEOPIXEL_MAX
-    #if (NEOPIXEL_PIXELS >= BOARD_NEOPIXEL_MAX && NEOPIXEL_PIN == BOARD_NEOPIXEL_PIN) || (NEOPIXEL_PIXELS >= BOARD_NEOPIXEL_MAX && DISABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN)
+    #if (NEOPIXEL_PIXELS > BOARD_NEOPIXEL_MAX && NEOPIXEL_PIN == BOARD_NEOPIXEL_PIN) || (NEOPIXEL_PIXELS > BOARD_NEOPIXEL_MAX && DISABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN)
       #ifdef BOARD_HAS_DCDC5V
         #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board."
       #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)
         #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board. Consider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration,h."
       #endif
     #endif
-    #if ENABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIXELS >= BOARD_NEOPIXEL_MAX && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN
+    #if ENABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIXELS > BOARD_NEOPIXEL_MAX && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN
       #ifdef BOARD_HAS_DCDC5V
         #error "NEOPIXEL2_PIXELS exceeds the recommended maximum supported by this board."
       #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2711,6 +2711,22 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   #elif ENABLED(NEO2_COLOR_PRESETS) && DISABLED(NEOPIXEL2_SEPARATE)
     #error "NEO2_COLOR_PRESETS requires NEOPIXEL2_SEPARATE to be enabled."
   #endif
+  #ifdef BOARD_NEOPIXEL_MAX
+    #if (NEOPIXEL_PIXELS >= BOARD_NEOPIXEL_MAX && NEOPIXEL_PIN == BOARD_NEOPIXEL_PIN) || (NEOPIXEL_PIXELS >= BOARD_NEOPIXEL_MAX && DISABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN)
+      #ifdef BOARD_HAS_DCDC5V
+        #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board."
+      #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)
+        #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board. Consider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration,h."
+      #endif
+    #endif
+    #if ENABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIXELS >= BOARD_NEOPIXEL_MAX && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN
+      #ifdef BOARD_HAS_DCDC5V
+        #error "NEOPIXEL2_PIXELS exceeds the recommended maximum supported by this board."
+      #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)
+        #error "NEOPIXEL2_PIXELS exceeds the recommended maximum supported by this board. Consider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration,h."
+      #endif
+    #endif
+  #endif
 #endif
 
 #if DISABLED(NO_COMPILE_TIME_PWM)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2713,17 +2713,17 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
   #endif
   #ifdef BOARD_NEOPIXEL_MAX
     #if (NEOPIXEL_PIXELS > BOARD_NEOPIXEL_MAX && NEOPIXEL_PIN == BOARD_NEOPIXEL_PIN) || (NEOPIXEL_PIXELS > BOARD_NEOPIXEL_MAX && DISABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN)
-      #ifdef BOARD_HAS_DCDC5V
-        #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board."
+      #if ENABLED(BOARD_HAS_DCDC5V)
+        #error "NEOPIXEL_PIXELS exceeds the recommended maximum for your MOTHERBOARD."
       #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)
-        #error "NEOPIXEL_PIXELS exceeds the recommended maximum supported by this board. Consider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration,h."
+        static_assert(false, "\nNEOPIXEL_PIXELS exceeds the recommended maximum for your MOTHERBOARD.\nConsider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration.h.");
       #endif
     #endif
     #if ENABLED(NEOPIXEL2_SEPARATE) && NEOPIXEL2_PIXELS > BOARD_NEOPIXEL_MAX && NEOPIXEL2_PIN == BOARD_NEOPIXEL_PIN
-      #ifdef BOARD_HAS_DCDC5V
-        #error "NEOPIXEL2_PIXELS exceeds the recommended maximum supported by this board."
+      #if ENABLED(BOARD_HAS_DCDC5V)
+        #error "NEOPIXEL2_PIXELS exceeds the recommended maximum for your MOTHERBOARD."
       #elif MB(BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0)
-        #error "NEOPIXEL2_PIXELS exceeds the recommended maximum supported by this board. Consider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration,h."
+        static_assert(false, "\nNEOPIXEL2_PIXELS exceeds the recommended maximum for your MOTHERBOARD.\nConsider adding a 5V DC-DC converter and #define BOARD_HAS_DCDC5V to your Configuration.h.");
       #endif
     #endif
   #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -69,8 +69,11 @@
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG
 
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA8   // LED driving pin
+#define BOARD_NEOPIXEL_PIN                  PA8   // LED driving pin
+#ifndef BOARD_HAS_DCDC5V
+  #define BOARD_NEOPIXEL_MAX                  8   // Max number of NEOPIXELS supported on this board
+#else
+  #define BOARD_NEOPIXEL_MAX                 30   // With 5V DC-DC converter
 #endif
 
 #ifndef PS_ON_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -71,9 +71,9 @@
 
 #define BOARD_NEOPIXEL_PIN                  PA8   // LED driving pin
 #ifndef BOARD_HAS_DCDC5V
-  #define BOARD_NEOPIXEL_MAX                  8   // Max number of NEOPIXELS supported on this board
+  #define BOARD_NEOPIXEL_MAX                  7   // Max number of NEOPIXELS supported on this board
 #else
-  #define BOARD_NEOPIXEL_MAX                 30   // With 5V DC-DC converter
+  #define BOARD_NEOPIXEL_MAX                 29   // With 5V DC-DC converter
 #endif
 
 #ifndef PS_ON_PIN

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -453,8 +453,11 @@
 //
 // NeoPixel
 //
-#ifndef BOARD_NEOPIXEL_PIN
-  #define BOARD_NEOPIXEL_PIN                PA8   // LED driving pin
+#define BOARD_NEOPIXEL_PIN                  PA8   // LED driving pin
+#ifndef BOARD_HAS_DCDC5V
+  #define BOARD_NEOPIXEL_MAX                  8   // Max number of NEOPIXELS supported on this board
+#else
+  #define BOARD_NEOPIXEL_MAX                 30   // With 5V DC-DC converter
 #endif
 
 // Pins for documentation and sanity checks only.

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -455,9 +455,9 @@
 //
 #define BOARD_NEOPIXEL_PIN                  PA8   // LED driving pin
 #ifndef BOARD_HAS_DCDC5V
-  #define BOARD_NEOPIXEL_MAX                  8   // Max number of NEOPIXELS supported on this board
+  #define BOARD_NEOPIXEL_MAX                  7   // Max number of NEOPIXELS supported on this board
 #else
-  #define BOARD_NEOPIXEL_MAX                 30   // With 5V DC-DC converter
+  #define BOARD_NEOPIXEL_MAX                 29   // With 5V DC-DC converter
 #endif
 
 // Pins for documentation and sanity checks only.


### PR DESCRIPTION
### Description

Some motherboards have dedicated neopixel ports. but the ports have limited current capacity

In particular the SKR_MINI_E3_V2_0 and BTT_SKR_MINI_E3_V3_0

DCDC converter boards are also available for these boards to provide more  current capacity

 ### Requirements

SKR_MINI_E3_V2_0 or BTT_SKR_MINI_E3_V3_0
NEOPIXELs
optional BOARD_HAS_DCDC5V

### Benefits

Stops users blowing up  their boards

### Configurations

Some will need updated

### Related Issues

<li>MarlinFirmware/Configurations/issues/1171</li>