### PR TITLE
Fix printing pauses with FTM_DIR_CHANGE_HOLD

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1239,26 +1239,22 @@
   #define FTM_MIN_SHAPE_FREQ           20   // (Hz) Minimum shaping frequency, lower consumes more RAM
 
   /**
-   * TMC2208 Direction-Flip Delay
-   *
-   * Enable on axes that use stealthchop and if you notice that motor turns off during print,
-   * typically only necessary on E.
-   *
-   * TMC2208 / TMC2208_STANDALONE drivers may require a short delay after a DIR change
-   * to prevent a standstill error when using stealthChop (the standalone default).
-   * When enabled, FT Motion will hold that axis still for > 750µs after a DIR change.
+   * TMC2208 / TMC2208_STANDALONE drivers require a brief pause after a DIR change
+   * to prevent a standstill shutdown when using StealthChop (the standalone default).
+   * These options cause FT Motion to delay for > 750µs after a DIR change on a given axis.
+   * Disable only if you are certain that this can never happen with your TMC2208s.
    */
   #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE)
-    //#define FTM_DIR_CHANGE_HOLD_X 1
+    #define FTM_DIR_CHANGE_HOLD_X
   #endif
   #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE)
-    //#define FTM_DIR_CHANGE_HOLD_Y 1
+    #define FTM_DIR_CHANGE_HOLD_Y
   #endif
   #if AXIS_DRIVER_TYPE_Z(TMC2208) || AXIS_DRIVER_TYPE_Z(TMC2208_STANDALONE)
-    //#define FTM_DIR_CHANGE_HOLD_Z 1
+    #define FTM_DIR_CHANGE_HOLD_Z
   #endif
   #if HAS_E_DRIVER(TMC2208) || HAS_E_DRIVER(TMC2208_STANDALONE)
-    //#define FTM_DIR_CHANGE_HOLD_E 1
+    #define FTM_DIR_CHANGE_HOLD_E
   #endif
 
 #endif // FT_MOTION

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1238,6 +1238,33 @@
   #define FTM_FS                     1000   // (Hz) Frequency for trajectory generation.
   #define FTM_MIN_SHAPE_FREQ           20   // (Hz) Minimum shaping frequency, lower consumes more RAM
 
+  /**
+   * TMC2208 Direction-Flip Delay
+   *
+   * Some TMC2208 / TMC2208_STANDALONE drivers may require a short delay after a DIR change
+   * to prevent a standstill error, especially when using stealthChop (the standalone default).
+   *
+   * When enabled for an axis, FT Motion will hold that axis for > 750µs after a DIR change
+   * by holding its trajectory coordinate constant for a multiple of FTM_TS frames. For the
+   * default FTM_FS = 1000, it is a single 1ms frame.
+   *
+   * Other axes keep moving normally, and the wait is canceled if the axis flips again.
+   *
+   * Disable if you use spreadcycle
+   */
+  #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE)
+    #define FTM_DIR_CHANGE_HOLD_X 1
+  #endif
+  #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE)
+    #define FTM_DIR_CHANGE_HOLD_Y 1
+  #endif
+  #if AXIS_DRIVER_TYPE_Z(TMC2208) || AXIS_DRIVER_TYPE_Z(TMC2208_STANDALONE)
+    #define FTM_DIR_CHANGE_HOLD_Z 1
+  #endif
+  #if HAS_E_DRIVER(TMC2208) || HAS_E_DRIVER(TMC2208_STANDALONE)
+    #define FTM_DIR_CHANGE_HOLD_E 1
+  #endif
+
 #endif // FT_MOTION
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1241,28 +1241,24 @@
   /**
    * TMC2208 Direction-Flip Delay
    *
-   * Some TMC2208 / TMC2208_STANDALONE drivers may require a short delay after a DIR change
-   * to prevent a standstill error, especially when using stealthChop (the standalone default).
+   * Enable on axes that use stealthchop and if you notice that motor turns off during print,
+   * typically only necessary on E.
    *
-   * When enabled for an axis, FT Motion will hold that axis for > 750µs after a DIR change
-   * by holding its trajectory coordinate constant for a multiple of FTM_TS frames. For the
-   * default FTM_FS = 1000, it is a single 1ms frame.
-   *
-   * Other axes keep moving normally, and the wait is canceled if the axis flips again.
-   *
-   * Disable if you use spreadcycle
+   * TMC2208 / TMC2208_STANDALONE drivers may require a short delay after a DIR change
+   * to prevent a standstill error when using stealthChop (the standalone default).
+   * When enabled, FT Motion will hold that axis still for > 750µs after a DIR change.
    */
   #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_X 1
+    //#define FTM_DIR_CHANGE_HOLD_X 1
   #endif
   #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_Y 1
+    //#define FTM_DIR_CHANGE_HOLD_Y 1
   #endif
   #if AXIS_DRIVER_TYPE_Z(TMC2208) || AXIS_DRIVER_TYPE_Z(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_Z 1
+    //#define FTM_DIR_CHANGE_HOLD_Z 1
   #endif
   #if HAS_E_DRIVER(TMC2208) || HAS_E_DRIVER(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_E 1
+    //#define FTM_DIR_CHANGE_HOLD_E 1
   #endif
 
 #endif // FT_MOTION

--- a/Marlin/src/inc/Conditionals-4-adv.h
+++ b/Marlin/src/inc/Conditionals-4-adv.h
@@ -360,30 +360,6 @@
     #define HAS_FTM_EI_SHAPING 1
   #endif
 
-  /**
-   * TMC2208 Direction-Flip Delay
-   *
-   * Some TMC2208 / TMC2208_STANDALONE drivers may require a short delay after a DIR change
-   * to prevent a standstill error, especially when using stealthChop (the standalone default).
-   *
-   * When enabled for an axis, FT Motion will hold that axis for > 750µs after a DIR change
-   * by holding its trajectory coordinate constant for a multiple of FTM_TS frames. For the
-   * default FTM_FS = 1000, it is a single 1ms frame.
-   *
-   * Other axes keep moving normally, and the wait is canceled if the axis flips again.
-   */
-  #if AXIS_DRIVER_TYPE_X(TMC2208) || AXIS_DRIVER_TYPE_X(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_X 1
-  #endif
-  #if AXIS_DRIVER_TYPE_Y(TMC2208) || AXIS_DRIVER_TYPE_Y(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_Y 1
-  #endif
-  #if AXIS_DRIVER_TYPE_Z(TMC2208) || AXIS_DRIVER_TYPE_Z(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_Z 1
-  #endif
-  #if HAS_E_DRIVER(TMC2208) || HAS_E_DRIVER(TMC2208_STANDALONE)
-    #define FTM_DIR_CHANGE_HOLD_E 1
-  #endif
   #if ANY(FTM_DIR_CHANGE_HOLD_X, FTM_DIR_CHANGE_HOLD_Y, FTM_DIR_CHANGE_HOLD_Z, FTM_DIR_CHANGE_HOLD_E)
     #define HAS_FTM_DIR_CHANGE_HOLD 1
   #endif

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -462,6 +462,10 @@ bool FTMotion::plan_next_block() {
     // Offset linear advance previous position
     prev_traj_e += offset;
 
+    #if ENABLED(HAS_FTM_DIR_CHANGE_HOLD)
+      last_target_traj.e += offset;
+    #endif
+
     // Offset stepper current position
     const int64_t delta_steps_q48_16 = offset * planner.settings.axis_steps_per_mm[block_extruder_axis] * (1ULL << 16);
     stepping.curr_steps_q48_16.E += delta_steps_q48_16;

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -380,7 +380,7 @@ bool FTMotion::plan_next_block() {
       if (current_block->is_sync_pos()) stepper._set_position(current_block->position);
       continue;
     }
-    ensure_float_precision();
+    ensure_extruder_float_precision();
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       recovery.info.sdpos = current_block->sdpos;
@@ -441,7 +441,7 @@ bool FTMotion::plan_next_block() {
    * resolution = 2^(floor(log2(|x|)) - 23)
    * By resetting at ±1'000mm (1 meter), we get a minimum resolution of ~ 0.00006mm, enough for smoothing to work well.
    */
-  void FTMotion::ensure_float_precision() {
+  void FTMotion::ensure_extruder_float_precision() {
     constexpr float FTM_POSITION_WRAP_THRESHOLD = 1000; // (mm) Reset when position exceeds this to prevent floating point precision loss
     if (ABS(endPos_prevBlock.E) < FTM_POSITION_WRAP_THRESHOLD) return;
 
@@ -462,6 +462,7 @@ bool FTMotion::plan_next_block() {
     // Offset linear advance previous position
     prev_traj_e += offset;
 
+    // Make sure the difference is accounted-for in the past
     last_target_traj.e += offset;
 
     // Offset stepper current position

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -462,9 +462,7 @@ bool FTMotion::plan_next_block() {
     // Offset linear advance previous position
     prev_traj_e += offset;
 
-    #if ENABLED(HAS_FTM_DIR_CHANGE_HOLD)
-      last_target_traj.e += offset;
-    #endif
+    last_target_traj.e += offset;
 
     // Offset stepper current position
     const int64_t delta_steps_q48_16 = offset * planner.settings.axis_steps_per_mm[block_extruder_axis] * (1ULL << 16);

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -403,7 +403,7 @@ class FTMotion {
     static void fill_stepper_plan_buffer();
     static xyze_float_t calc_traj_point(const float dist);
     static bool plan_next_block();
-    static void ensure_float_precision() IF_DISABLED(HAS_EXTRUDERS, {});
+    static void ensure_extruder_float_precision() IF_DISABLED(HAS_EXTRUDERS, {});
 
 }; // class FTMotion
 


### PR DESCRIPTION
Fixes #28274
Also brings back the defines to configuration_adv.h since this timing fix shouldn't be applied for spreadcycle (and we can't know the driver mode in standalone mode, since it may be configured via jumperpads)

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
