### PR TITLE
FTM Resonance Test : Remove unused function

### DIFF
--- a/Marlin/src/module/ft_motion/resonance_generator.h
+++ b/Marlin/src/module/ft_motion/resonance_generator.h
@@ -46,8 +46,6 @@ class ResonanceGenerator {
 
     ResonanceGenerator();
 
-    void planRunout(const float duration);
-
     void reset();
 
     void start(const xyze_pos_t &spos, const float t) {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Remove unused  `void planRunout(const float duration)` in `class ResonanceGenerator`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
None
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
