### PR TITLE
fix adc_result on esp32

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -271,7 +271,7 @@ void MarlinHAL::adc_start(const pin_t pin) {
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
 
-  adc_result = (mv * 1023) * (1000.f / (ADC_REFERENCE_VOLTAGE));
+  adc_result = (mv * 1023) / ((uint32_t)(ADC_REFERENCE_VOLTAGE * 1000));
 
   // Change the attenuation level based on the new reading
   adc_atten_t atten;

--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -271,7 +271,8 @@ void MarlinHAL::adc_start(const pin_t pin) {
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
 
-  adc_result = (mv * 1023) / ((uint32_t)(ADC_REFERENCE_VOLTAGE * 1000));
+  static constexpr uint32_t adc_divisor = uint32_t((ADC_REFERENCE_VOLTAGE) * 1000UL);
+  adc_result = (mv * 1023UL) / adc_divisor;
 
   // Change the attenuation level based on the new reading
   adc_atten_t atten;


### PR DESCRIPTION
### Description

commit 89379cd373b2597d0c8cadd6a005de8d640a8273    Broke reading the ADC on ESP32's

Updated to `adc_result = (mv * 1023) / ((uint32_t)(ADC_REFERENCE_VOLTAGE * 1000));`

### Requirements

ESP32

### Benefits

Temperatures read as it used to 

### Related Issues

<li>MarlinFirmware/Marlin/issues/28268