### PR TITLE
HC32: Update environments

### DIFF
--- a/Marlin/src/HAL/HC32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MarlinSerial.cpp
@@ -67,8 +67,21 @@ constexpr bool serial_handles_emergency(int port) {
 
 #define DEFINE_SERIAL_MARLIN(name, n) TERN(SERIAL_DMA, DEFINE_DMA_SERIAL_MARLIN(name, n), DEFINE_IRQ_SERIAL_MARLIN(name, n))
 
-DEFINE_SERIAL_MARLIN(MSerial1, 1);
-DEFINE_SERIAL_MARLIN(MSerial2, 2);
+#if defined(BOARD_USART1_RX_PIN) && defined(BOARD_USART1_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial1, 1);
+#endif
+
+#if defined(BOARD_USART2_RX_PIN) && defined(BOARD_USART2_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial2, 2);
+#endif
+
+#if defined(BOARD_USART3_RX_PIN) && defined(BOARD_USART3_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial3, 3);
+#endif
+
+#if defined(BOARD_USART4_RX_PIN) && defined(BOARD_USART4_TX_PIN)
+  DEFINE_SERIAL_MARLIN(MSerial4, 4);
+#endif
 
 // TODO: remove this warning when SERIAL_DMA has been tested some more
 #if ENABLED(SERIAL_DMA)

--- a/Marlin/src/HAL/HC32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MarlinSerial.cpp
@@ -83,11 +83,6 @@ constexpr bool serial_handles_emergency(int port) {
   DEFINE_SERIAL_MARLIN(MSerial4, 4);
 #endif
 
-// TODO: remove this warning when SERIAL_DMA has been tested some more
-#if ENABLED(SERIAL_DMA)
-  #warning "SERIAL_DMA may be unstable on HC32F460."
-#endif
-
 //
 // Serial port assertions
 //

--- a/Marlin/src/HAL/HC32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MarlinSerial.cpp
@@ -30,17 +30,17 @@
  * it would not make sense to parse G-Code from TMC responses
  */
 constexpr bool serial_handles_emergency(int port) {
-  return false
+  return (false
     #ifdef SERIAL_PORT
-         || (SERIAL_PORT) == port
+      || (SERIAL_PORT) == port
     #endif
     #ifdef SERIAL_PORT_2
-         || (SERIAL_PORT_2) == port
+      || (SERIAL_PORT_2) == port
     #endif
     #ifdef LCD_SERIAL_PORT
-         || (LCD_SERIAL_PORT) == port
+      || (LCD_SERIAL_PORT) == port
     #endif
-      ;
+  );
 }
 
 //
@@ -48,7 +48,7 @@ constexpr bool serial_handles_emergency(int port) {
 //
 
 // serial port where RX and TX use IRQs
-#define DEFINE_IRQ_SERIAL_MARLIN(name, n)      \
+#define DEFINE_IRQ_SERIAL_MARLIN(name, n)    \
   MSerialT name(serial_handles_emergency(n), \
                 &USART##n##_config,          \
                 BOARD_USART##n##_TX_PIN,     \
@@ -57,7 +57,7 @@ constexpr bool serial_handles_emergency(int port) {
 // serial port where RX uses DMA and TX uses IRQs
 // all serial ports use DMA1
 // since there are 4 USARTs and 4 DMA channels, we can use the USART number as the DMA channel
-#define DEFINE_DMA_SERIAL_MARLIN(name, n)      \
+#define DEFINE_DMA_SERIAL_MARLIN(name, n)    \
   MSerialT name(serial_handles_emergency(n), \
                 &USART##n##_config,          \
                 BOARD_USART##n##_TX_PIN,     \
@@ -67,19 +67,16 @@ constexpr bool serial_handles_emergency(int port) {
 
 #define DEFINE_SERIAL_MARLIN(name, n) TERN(SERIAL_DMA, DEFINE_DMA_SERIAL_MARLIN(name, n), DEFINE_IRQ_SERIAL_MARLIN(name, n))
 
-#if defined(BOARD_USART1_RX_PIN) && defined(BOARD_USART1_TX_PIN)
+#if PINS_EXIST(BOARD_USART1_RX, BOARD_USART1_TX)
   DEFINE_SERIAL_MARLIN(MSerial1, 1);
 #endif
-
-#if defined(BOARD_USART2_RX_PIN) && defined(BOARD_USART2_TX_PIN)
+#if PINS_EXIST(BOARD_USART2_RX, BOARD_USART2_TX)
   DEFINE_SERIAL_MARLIN(MSerial2, 2);
 #endif
-
-#if defined(BOARD_USART3_RX_PIN) && defined(BOARD_USART3_TX_PIN)
+#if PINS_EXIST(BOARD_USART3_RX, BOARD_USART3_TX)
   DEFINE_SERIAL_MARLIN(MSerial3, 3);
 #endif
-
-#if defined(BOARD_USART4_RX_PIN) && defined(BOARD_USART4_TX_PIN)
+#if PINS_EXIST(BOARD_USART4_RX, BOARD_USART4_TX)
   DEFINE_SERIAL_MARLIN(MSerial4, 4);
 #endif
 

--- a/Marlin/src/HAL/HC32/MarlinSerial.h
+++ b/Marlin/src/HAL/HC32/MarlinSerial.h
@@ -92,3 +92,5 @@ typedef Serial1Class<MarlinSerial> MSerialT;
 
 extern MSerialT MSerial1;
 extern MSerialT MSerial2;
+extern MSerialT MSerial3;
+extern MSerialT MSerial4;

--- a/Marlin/src/HAL/HC32/MinSerial.cpp
+++ b/Marlin/src/HAL/HC32/MinSerial.cpp
@@ -33,7 +33,7 @@
 // Shared by both panic and PostMortem debugging
 //
 static void minserial_begin() {
-  #if !WITHIN(SERIAL_PORT, 1, 3)
+  #if !WITHIN(SERIAL_PORT, 1, 4)
     #warning "MinSerial requires a physical UART port for output."
     #warning "Disabling MinSerial because the used serial port is not a HW port."
   #else

--- a/Marlin/src/HAL/HC32/app_config.h
+++ b/Marlin/src/HAL/HC32/app_config.h
@@ -58,6 +58,9 @@
   #define USART_RX_DMA_SUPPORT 1
 #endif
 
+// SoftwareSerial uses STM32duino API compatibility mode
+#define SOFTWARE_SERIAL_STM32_API_COMPATIBILITY 1
+
 //
 // Misc.
 //

--- a/Marlin/src/HAL/HC32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HC32/inc/SanityCheck.h
@@ -43,8 +43,11 @@
   #error "FAST_PWM_FAN is not yet implemented for this platform."
 #endif
 
-#if !defined(HAVE_SW_SERIAL) && HAS_TMC_SW_SERIAL
-  #error "Missing SoftwareSerial implementation."
+// SoftwareSerial introduced in arduino core version 1.3.1
+#if ARDUINO_CORE_VERSION_INT < GET_VERSION_INT(1, 3, 1)
+  #if !defined(HAVE_SW_SERIAL) && HAS_TMC_SW_SERIAL
+    #error "Missing SoftwareSerial implementation."
+  #endif
 #endif
 
 #if ENABLED(SDCARD_EEPROM_EMULATION) && !HAS_MEDIA

--- a/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
+++ b/Marlin/src/pins/hc32f4/pins_AQUILA_101.h
@@ -222,10 +222,6 @@
 #define BOARD_USART2_TX_PIN                 PA9
 #define BOARD_USART2_RX_PIN                 PA15
 
-// Unused / Debug
-#define BOARD_USART3_TX_PIN                 PE5
-#define BOARD_USART3_RX_PIN                 PE4
-
 // Onboard LED (HIGH = off, LOW = on)
 #ifndef LED_BUILTIN
   #define LED_BUILTIN                       PA3

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -925,9 +925,9 @@
 //
 
 #elif MB(AQUILA_V101)
-  #include "hc32f4/pins_AQUILA_101.h"               // HC32F460                             env:HC32F460C_aquila_101
+  #include "hc32f4/pins_AQUILA_101.h"               // HC32F460                             env:HC32F460C_aquila_101 env:HC32F460C_openhc32boot
 #elif MB(CREALITY_ENDER2P_V24S4)
-  #include "hc32f4/pins_CREALITY_ENDER2P_V24S4.h"   // HC32F460                             env:HC32F460C_e2p24s4
+  #include "hc32f4/pins_CREALITY_ENDER2P_V24S4.h"   // HC32F460                             env:HC32F460C_e2p24s4 env:HC32F460C_openhc32boot
 
 //
 // GD32 ARM Cortex-M3

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -80,7 +80,7 @@ board_upload.maximum_size = 524288
 [env:HC32F460C_aquila_101]
 extends = HC32F460C_base
 board_upload.offset_address = 0xC000  # Bootloader start address, as logged by the bootloader on boot
-board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as secondary firmware
+board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as secondary firmware (no ICG)
 
 #
 # Creality Ender 2 Pro v2.4.S4_170 (HC32f460kcta) (256K Flash, 192K RAM).
@@ -88,3 +88,27 @@ board_build.boot_mode = secondary     # Save ~1.4k of flash by compiling as seco
 [env:HC32F460C_e2p24s4]
 extends = HC32F460C_base
 board_upload.offset_address = 0x8000
+
+#
+# OpenHC32Boot (256K Flash).
+# This can be used with any HC32F460C printer, provided it has OpenHC32Boot installed.
+# see https://github.com/shadow578/OpenHC32Boot for more information
+#
+[env:HC32F460C_openhc32boot]
+extends = HC32F460C_base
+board_upload.offset_address = 0x4000
+board_build.boot_mode = secondary
+build_flags =
+  ${HC32F460C_base.build_flags}
+  -D CORE_DONT_RESTORE_DEFAULT_CLOCKS=1     # OpenHC32Boot doesn't mess with the clock settings, so we can skip clock restore in the core
+
+#
+# OpenHC32Boot (512K Flash)
+#
+[env:HC32F460E_openhc32boot]
+extends = HC32F460E_base
+board_upload.offset_address = 0x4000
+board_build.boot_mode = secondary
+build_flags =
+  ${HC32F460E_base.build_flags}
+  -D CORE_DONT_RESTORE_DEFAULT_CLOCKS=1

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -29,7 +29,7 @@
 [HC32F460_base]
 platform          = https://github.com/shadow578/platform-hc32f46x/archive/1.1.1.zip
 platform_packages = framework-hc32f46x-ddl@https://github.com/shadow578/framework-hc32f46x-ddl/archive/2.2.3.zip
-                    framework-arduino-hc32f46x@https://github.com/shadow578/framework-arduino-hc32f46x/archive/1.2.0.zip
+                    framework-arduino-hc32f46x@https://github.com/shadow578/framework-arduino-hc32f46x/archive/1.3.1.zip
 board             = generic_hc32f460
 build_src_filter  = ${common.default_src_filter} +<src/HAL/HC32> +<src/HAL/shared/backtrace>
 build_type        = release


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

This PR updates the HC32 targets supported by Marlin to the latest available.
This basically just publishes what i've been testing for about 6 months now, but due to a recent change in job didn't manage to merge yet. 

Changes in Detail:
- Update the HC32 arduino framework to [version 1.3.1](https://github.com/shadow578/framework-arduino-hc32f46x/releases/tag/1.3.1)
  - adds full support for SoftwareSerial library, plus experimental support for SPI library.
- update HC32 HAL to support UARTs 3 and 4
- remove warning that `SERIAL_DMA` may be unstable (stable for 1 year now)
- add [OpenHC32Boot](https://github.com/shadow578/OpenHC32Boot) environments


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Any HC32-based printer


### Benefits

<!-- What does this PR fix or improve? -->

- Use total of 4 hardware serial ports (previously: 2)
- Use software serial ports in full- or half-duplex mode (control steppers after [hardware mod](https://shadow578.github.io/2025/02/10/tmc-stepper-control-mod/))
- Use OpenHC32Boot on supported printers (smaller flash footprint)


### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

N/A


### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

N/A
