### PR TITLE
[RP2040] Allow events scheduled in the past to trigger

### DIFF
--- a/Marlin/src/HAL/RP2040/timers.h
+++ b/Marlin/src/HAL/RP2040/timers.h
@@ -128,16 +128,16 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, hal_time
 
   switch (timer_num) {
     case 0:
-      alarm_pool_add_alarm_in_us(HAL_timer_pool_0, compare, HAL_timer_alarm_pool_0_callback, 0, false);
+      alarm_pool_add_alarm_in_us(HAL_timer_pool_0, compare, HAL_timer_alarm_pool_0_callback, 0, true);
       break;
     case 1:
-      alarm_pool_add_alarm_in_us(HAL_timer_pool_1, compare, HAL_timer_alarm_pool_1_callback, 0, false);
+      alarm_pool_add_alarm_in_us(HAL_timer_pool_1, compare, HAL_timer_alarm_pool_1_callback, 0, true);
       break;
     case 2:
-      alarm_pool_add_alarm_in_us(HAL_timer_pool_2, compare, HAL_timer_alarm_pool_2_callback, 0, false);
+      alarm_pool_add_alarm_in_us(HAL_timer_pool_2, compare, HAL_timer_alarm_pool_2_callback, 0, true);
       break;
     case 3:
-      alarm_pool_add_alarm_in_us(HAL_timer_pool_3, compare, HAL_timer_alarm_pool_3_callback, 0, false);
+      alarm_pool_add_alarm_in_us(HAL_timer_pool_3, compare, HAL_timer_alarm_pool_3_callback, 0, true);
       break;
   }
 }


### PR DESCRIPTION


### Description

Due to the relatively low resolution of the RP2040 timer, in some cases, especially FT_MOTION, scheduling a step can be in the past and never happen, stopping motion. Changing the last argument in `alarm_pool_add_alarm_in_us` to true allows those events to be executed on the next timer tick and catch up.

On my test rig with an RP2040, this leads to full motion capability including mesh bed leveling, with FT_MOTION. A video of successful print activity has been posted to the #dev-talk channel on Discor previously.

-->

### Requirements

This applies only to RP2040 boards. Tested with the SKR Pico

### Benefits

Makes FT_MOTION work

### Configurations

[Configs.zip](https://github.com/user-attachments/files/24695341/Configs.zip)

### Related Issues

N/A
