### PR TITLE
Fix Bug FT_LVGL_UI (MKS_UI): Y axis motion loss / offset

### DIFF
--- a/Marlin/src/HAL/STM32/MarlinSPI.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSPI.cpp
@@ -39,14 +39,14 @@ static void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb, u
 
 void MarlinSPI::setClockDivider(uint8_t _div) {
   _speed = spi_getClkFreq(&_spi);// / _div;
-  if(_clockDivider != _div) {
-  _clockDivider = _div;
+  if (_clockDivider != _div) {
+    _clockDivider = _div;
     _mustInit = true;
   }
 }
 
 void MarlinSPI::begin(void) {
-  if(!_mustInit) return;
+  if (!_mustInit) return;
   spi_init(&_spi, _speed, _dataMode, _bitOrder, _dataSize);
   _mustInit = false;
 }

--- a/Marlin/src/HAL/STM32/MarlinSPI.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSPI.cpp
@@ -39,12 +39,16 @@ static void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb, u
 
 void MarlinSPI::setClockDivider(uint8_t _div) {
   _speed = spi_getClkFreq(&_spi);// / _div;
+  if(_clockDivider != _div) {
   _clockDivider = _div;
+    _mustInit = true;
+  }
 }
 
 void MarlinSPI::begin(void) {
-  //TODO: only call spi_init if any parameter changed!!
+  if(!_mustInit) return;
   spi_init(&_spi, _speed, _dataMode, _bitOrder, _dataSize);
+  _mustInit = false;
 }
 
 void MarlinSPI::setupDma(SPI_HandleTypeDef &_spiHandle, DMA_HandleTypeDef &_dmaHandle, uint32_t direction, bool minc) {

--- a/Marlin/src/HAL/STM32/MarlinSPI.h
+++ b/Marlin/src/HAL/STM32/MarlinSPI.h
@@ -77,7 +77,7 @@ public:
    * Use SPISettings with SPI.beginTransaction() to configure SPI parameters.
    */
   void setBitOrder(BitOrder order) {
-    if(_bitOrder == order) return;
+    if (_bitOrder == order) return;
     _bitOrder = order;
     _mustInit = true;
   }
@@ -91,7 +91,7 @@ public:
       case SPI_MODE3: _dataMode = SPI_MODE_3; break;
       default: return;
     }
-    if(previous_mode != _dataMode)
+    if (previous_mode != _dataMode)
       _mustInit = true;
   }
 

--- a/Marlin/src/HAL/STM32/MarlinSPI.h
+++ b/Marlin/src/HAL/STM32/MarlinSPI.h
@@ -76,15 +76,23 @@ public:
   /* These methods are deprecated and kept for compatibility.
    * Use SPISettings with SPI.beginTransaction() to configure SPI parameters.
    */
-  void setBitOrder(BitOrder _order) { _bitOrder = _order; }
+  void setBitOrder(BitOrder order) {
+    if(_bitOrder == order) return;
+    _bitOrder = order;
+    _mustInit = true;
+  }
 
-  void setDataMode(uint8_t _mode) {
-    switch (_mode) {
+  void setDataMode(uint8_t mode) {
+    auto previous_mode = _dataMode;
+    switch (mode) {
       case SPI_MODE0: _dataMode = SPI_MODE_0; break;
       case SPI_MODE1: _dataMode = SPI_MODE_1; break;
       case SPI_MODE2: _dataMode = SPI_MODE_2; break;
       case SPI_MODE3: _dataMode = SPI_MODE_3; break;
+      default: return;
     }
+    if(previous_mode != _dataMode)
+      _mustInit = true;
   }
 
   void setClockDivider(uint8_t _div);
@@ -104,4 +112,5 @@ private:
   pin_t _misoPin;
   pin_t _sckPin;
   pin_t _ssPin;
+  bool _mustInit = true;
 };


### PR DESCRIPTION
### Description

This PR proposes a few simple changes to fix a bug that occurs on printers based on the MKS Robin Nano 1.2 with an STM32F103 MCU. From time to time, the print head is shifted along the Y-axis by a variable amount. As a consequence, the printed object is unusable.

This bug is caused by a conflict when accessing GPIO port B between the Y stepper motor and the SPI flash memory that contains the images.

The bug occurs when the SPI memory pins are reconfigured. Usually, this configuration is performed once at startup, but in Marlin it is performed for every access to the flash memory. The workaround is therefore to avoid this and perform the configuration only when necessary (i.e., when the parameters have changed).

#### Details

The DIR (direction) pin of the Y stepper motor is connected to `PB9` on GPIO port B.

The SPI flash memory (which contains the images) is also connected to GPIO port B: `CS` is connected to `PB12`, `SCK` to `PB13`, `MISO` to `PB14`, and `MOSI` to `PB15`.

When printing from an SD card, the screen is refreshed frequently, and during each refresh the SPI pins are (re)configured. This reconfiguration is performed for each refresh, each image or character, and for each pin. As a result, it occurs very often.

As part of this SPI configuration (`spi_init`), the pull mode of each pin (open-drain or push-pull) is set by the function `pin_PullConfig`, which calls the low-level function `LL_GPIO_SetPinPull`. For the STM32F103, this function is defined as:

```
__STATIC_INLINE void LL_GPIO_SetPinPull(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Pull)
{
  MODIFY_REG(GPIOx->ODR, (Pin >> GPIO_PIN_MASK_POS), Pull << (POSITION_VAL(Pin >> GPIO_PIN_MASK_POS)));
}
```

In other words, the Output Data Register (`ODR`) is read, modified, and written back. This is not an atomic operation per pin: the data for all pins are written at once.

For other MCUs (such as the `STM32F4`), this function uses a different register, `PUPDR` (Pull-Up/Pull-Down Register), which is atomic per pin:

```
__STATIC_INLINE void LL_GPIO_SetPinPull(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Pull)
{
  MODIFY_REG(GPIOx->PUPDR, ((Pin * Pin) * GPIO_PUPDR_PUPD0), ((Pin * Pin) * Pull));
}
```

Why is the same approach not used for the `STM32F103` MCU? Because this register (`PUPDR`) does not exist on this MCU.

During screen updates, other code is also executed, in particular code that controls the stepper motors. This is handled using a timer (`TIM4`), an interrupt, and the corresponding interrupt service routine (ISR). The firmware does not use the `ODR` register (which is not atomic per pin), but instead uses `BSRR` (Bit Set Reset Register), which is atomic per pin.

When these two actions occur at exactly the same time (reading/modifying/writing ODR for pin configuration and writing to BSRR to set or clear the DIR pin of the motor), the wrong value can be written to the `ODR` register. The old value is written, rather than the value that was updated via `BSRR`. As a result, an incorrect signal is sent and the motor moves in the wrong direction.

The probability of this happening is very low, but high enough to occur occasionally and be noticeable.

For reference, the call stack is similar to the following when the problem occurs:

```
LL_GPIO_SetPinPull at framework-arduinoststm32@4.10900.200819/system/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_ll_gpio.h:567
pin_PullConfig at framework-arduinoststm32@4.10900.200819/libraries/SrcWrapper/src/stm32/pinconfig.h
pin_function at framework-arduinoststm32@4.10900.200819/libraries/SrcWrapper/src/stm32/pinmap.c:163
pinmap_pinout at ramework-arduinoststm32@4.10900.200819/libraries/SrcWrapper/src/stm32/pinmap.c:180
spi_init at framework-arduinoststm32@4.10900.200819/libraries/SPI/src/utility/spi_com.c:256
spi_init at Marlin/src/HAL/STM32/MarlinSPI.cpp:30
MarlinSPI::begin at Marlin/src/HAL/STM32/MarlinSPI.cpp:47
W25QXXFlash::init at Marlin/src/libs/W25Qxx.cpp:72
get_spi_flash_data at Marlin/src/lcd/extui/mks_ui/pic_manager.cpp:652
__user_font_getdata at Marlin/src/lcd/extui/mks_ui/gb2312_puhui16.cpp:54
__user_font_get_bitmap at Marlin/src/lcd/extui/mks_ui/gb2312_puhui16.cpp:69
lv_draw_letter at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_draw/lv_draw_basic.c:291
lv_draw_label at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_draw/lv_draw_label.c:260
lv_label_design at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_objx/lv_label.c:1074
lv_label_design at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_objx/lv_label.c:1004
lv_refr_obj at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:517
lv_refr_obj at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:494
lv_refr_obj at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:547
lv_refr_obj at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:494
lv_refr_obj_and_children at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:459
lv_refr_area_part at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:397
lv_refr_area at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:353
lv_refr_areas at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:278
lv_disp_refr_task at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_core/lv_refr.c:171
lv_task_exec at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_misc/lv_task.c:370
lv_task_handler at .pio/libdeps/mks_robin_nano_v1v2/lvgl/src/lv_misc/lv_task.c:135
LV_TASK_HANDLER at Marlin/src/lcd/extui/mks_ui/draw_ui.cpp:1361
idle at Marlin/src/MarlinCore.cpp:883
```

As a side note, I was able to find this bug thanks to an emulator (not a simulator) I have created especially for that (emulation of the MCU, of its internal peripherals and of the peripherals of the printer).

### Requirements

The modified code is not specific to `STM32F1`, nor to any particular motherboard. However, to see its effect, it requires a printer based on the MKS Robin Nano 1.2 motherboard with a STM32F103 MCU (other MCUs like the STM32F4 are not affected). An example of such printer is a Wanhao D12-230 with a MKS Robin Nano 1.2 motherboard.

### Benefits

All hardware using SPI will benefit from this change as it avoid reconfiguring over and over the pins of the SPI. It is more particularly beneficial for printers based on the MKS Robin Nano 1.2 motherboard.

### Configurations

This modification has been tested on a Wanhao D12-230.

[Configuration.zip](https://github.com/user-attachments/files/24740520/Configuration.zip)

### Related Issues

##22967: [BUG] TFT_LVGL_UI (MKS_UI): Y axis motion loss / offset, does not occur with TFT_COLOR_UI
