### PR TITLE
Fix MMU2 build

### DIFF
--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -82,7 +82,8 @@ void _mmu2_eject_filament(uint8_t index) {
   ui.reset_status();
   ui.return_to_status();
   ui.status_printf(0, GET_TEXT_F(MSG_MMU2_EJECTING_FILAMENT), int(index + 1));
-  if (mmu3.eject_filament(index, true)) ui.reset_status();
+  if (TERN(HAS_PRUSA_MMU3, mmu3.eject_filament(index, true), mmu2.eject_filament(index, true)))
+    ui.reset_status();
 }
 
 void _mmu2_cut_filament(uint8_t index) {
@@ -342,7 +343,7 @@ void menu_mmu2_choose_filament() {
 //
 
 void menu_mmu2_pause() {
-  feeder_index = mmu3.get_current_tool();
+  feeder_index = TERN(HAS_PRUSA_MMU3, mmu3.get_current_tool(), mmu2.get_current_tool());
   START_MENU();
   #if LCD_HEIGHT > 2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, SS_DEFAULT|SS_INVERT);

--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -43,7 +43,7 @@ inline void action_mmu2_load_to_nozzle(const uint8_t tool) {
   ui.reset_status();
   ui.return_to_status();
   ui.status_printf(0, GET_TEXT_F(MSG_MMU2_LOADING_FILAMENT), int(tool + 1));
-  TERN(HAS_PRUSA_MMU3, mmu3.load_to_nozzle(tool), mmu2.load_to_nozzle(tool));
+  TERN(HAS_PRUSA_MMU3, mmu3, mmu2).load_to_nozzle(tool);
   ui.reset_status();
 }
 
@@ -51,7 +51,7 @@ void _mmu2_load_to_feeder(const uint8_t tool) {
   ui.reset_status();
   ui.return_to_status();
   ui.status_printf(0, GET_TEXT_F(MSG_MMU2_LOADING_FILAMENT), int(tool + 1));
-  TERN(HAS_PRUSA_MMU3, mmu3.load_to_feeder(tool), mmu2.load_to_feeder(tool));
+  TERN(HAS_PRUSA_MMU3, mmu3, mmu2).load_to_feeder(tool);
   ui.reset_status();
 }
 
@@ -82,7 +82,7 @@ void _mmu2_eject_filament(uint8_t index) {
   ui.reset_status();
   ui.return_to_status();
   ui.status_printf(0, GET_TEXT_F(MSG_MMU2_EJECTING_FILAMENT), int(index + 1));
-  if (TERN(HAS_PRUSA_MMU3, mmu3.eject_filament(index, true), mmu2.eject_filament(index, true)))
+  if (TERN(HAS_PRUSA_MMU3, mmu3, mmu2).eject_filament(index, true))
     ui.reset_status();
 }
 
@@ -98,7 +98,7 @@ void action_mmu2_unload_filament() {
   ui.reset_status();
   ui.return_to_status();
   LCD_MESSAGE(MSG_MMU2_UNLOADING_FILAMENT);
-  while (!TERN(HAS_PRUSA_MMU3, mmu3.unload(), mmu2.unload())) {
+  while (!TERN(HAS_PRUSA_MMU3, mmu3, mmu2).unload()) {
     safe_delay(50);
     TERN(HAS_PRUSA_MMU3, MMU3::marlin_idle(true), marlin.idle());
   }
@@ -343,7 +343,7 @@ void menu_mmu2_choose_filament() {
 //
 
 void menu_mmu2_pause() {
-  feeder_index = TERN(HAS_PRUSA_MMU3, mmu3.get_current_tool(), mmu2.get_current_tool());
+  feeder_index = TERN(HAS_PRUSA_MMU3, mmu3, mmu2).get_current_tool();
   START_MENU();
   #if LCD_HEIGHT > 2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, SS_DEFAULT|SS_INVERT);


### PR DESCRIPTION
### Description

The addition of MMU3 support broke a few MMU2 calls. Conditionally added them back.

This is a minor edit

```diff
diff --git a/Marlin/src/lcd/menu/menu_mmu2.cpp b/Marlin/src/lcd/menu/menu_mmu2.cpp
index 7e725bd20c..f5dee71310 100644
--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -82,7 +82,8 @@ void _mmu2_eject_filament(uint8_t index) {
   ui.reset_status();
   ui.return_to_status();
   ui.status_printf(0, GET_TEXT_F(MSG_MMU2_EJECTING_FILAMENT), int(index + 1));
-  if (mmu3.eject_filament(index, true)) ui.reset_status();
+  if (TERN(HAS_PRUSA_MMU3, mmu3.eject_filament(index, true), mmu2.eject_filament(index, true)))
+    ui.reset_status();
 }
 
 void _mmu2_cut_filament(uint8_t index) {
@@ -342,7 +343,7 @@ void menu_mmu2_choose_filament() {
 //
 
 void menu_mmu2_pause() {
-  feeder_index = mmu3.get_current_tool();
+  feeder_index = TERN(HAS_PRUSA_MMU3, mmu3.get_current_tool(), mmu2.get_current_tool());
   START_MENU();
   #if LCD_HEIGHT > 2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, SS_DEFAULT|SS_INVERT);
```

### Requirements

MMU2

### Benefits

Builds as expected.

### Related Issues

<li>MarlinFirmware/Marlin/issues/28024