### PR TITLE
fix typo on #endif comment

### DIFF
--- a/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/dgus_e3s1pro_extui.cpp
@@ -203,4 +203,4 @@ namespace ExtUI {
   void onAxisEnabled(const axis_t) {}
 }
 
-#endif // DGUS_LCD_UI_RELOADED
+#endif // DGUS_LCD_UI_E3S1PRO


### PR DESCRIPTION
### Description

fix typo on #endif comment

dgus_e3s1pro_extui.cpp erroneously has a  #endif // DGUS_LCD_UI_RELOADED

### Requirements

none

### Benefits

one less typo
