### PR TITLE
restore original logic to fix Z_CLEARANCE_FOR_HOMING

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -377,7 +377,7 @@ void GcodeSuite::G28() {
         float z_homing_height = seenR ? parser.value_linear_units() : Z_CLEARANCE_FOR_HOMING;
 
         // Check for any lateral motion that might require clearance
-        const bool may_skate = seenR && NUM_AXIS_ANY(doX, doY, TERN0(Z_SAFE_HOMING, doZ), doI, doJ, doK, doU, doV, doW);
+        const bool may_skate = seenR || NUM_AXIS_ANY(doX, doY, TERN0(Z_SAFE_HOMING, doZ), doI, doJ, doK, doU, doV, doW);
 
         if (seenR && z_homing_height == 0) {
           if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("R0 = No Z raise");


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/28275 incorrectly changed the logic for 

`const bool may_skate`  from  A || B || C || D to A && (B || C || D)

Restored original logic while keeping new macro

### Requirements

Z_CLEARANCE_FOR_HOMING

### Benefits

Z_CLEARANCE_FOR_HOMING works as expected

### Related Issues

Fixes #28297