### PR TITLE
🧑‍💻 Use LLM for language translation

### DIFF
--- a/Marlin/src/feature/mmu3/mmu3_error_converter.cpp
+++ b/Marlin/src/feature/mmu3/mmu3_error_converter.cpp
@@ -198,14 +198,14 @@ namespace MMU3 {
 
   uint16_t PrusaErrorCode(const uint8_t i) { return pgm_read_word(errorCodes + i); }
 
-  FSTR_P const PrusaErrorTitle(const uint8_t i) { return (FSTR_P const)pgm_read_ptr(errorTitles + i); }
-  FSTR_P const PrusaErrorDesc(const uint8_t i) { return (FSTR_P const)pgm_read_ptr(errorDescs + i); }
+  FSTR_P const PrusaErrorTitle(const uint8_t i) { return (FSTR_P const)pgm_read_ptr(&errorTitles[i]); }
+  FSTR_P const PrusaErrorDesc(const uint8_t i) { return (FSTR_P const)pgm_read_ptr(&errorDescs[i]); }
 
-  uint8_t PrusaErrorButtons(const uint8_t i) { return pgm_read_byte(errorButtons + i); }
+  uint8_t PrusaErrorButtons(const uint8_t i) { return pgm_read_byte(&errorButtons[i]); }
 
   FSTR_P const PrusaErrorButtonTitle(const uint8_t bi) {
     // -1 represents the hidden NoOperation button which is not drawn in any way
-    return (FSTR_P const)pgm_read_ptr(btnOperation + bi - 1);
+    return (FSTR_P const)pgm_read_ptr(&btnOperation[bi - 1]);
   }
 
   Buttons ButtonPressed(const ErrorCode ec) {

--- a/Marlin/src/feature/mmu3/mmu3_supported_version.h
+++ b/Marlin/src/feature/mmu3/mmu3_supported_version.h
@@ -30,3 +30,5 @@
 #define mmuVersionMajor 3
 #define mmuVersionMinor 0
 #define mmuVersionPatch 2
+
+#define MMU_VERSION STRINGIFY(mmuVersionMajor) "." STRINGIFY(mmuVersionMinor) "." STRINGIFY(mmuVersionPatch)

--- a/Marlin/src/lcd/language/language_an.h
+++ b/Marlin/src/lcd/language/language_an.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_bg.h
+++ b/Marlin/src/lcd/language/language_bg.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_5

--- a/Marlin/src/lcd/language/language_ca.h
+++ b/Marlin/src/lcd/language/language_ca.h
@@ -26,7 +26,16 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_ca {
   using namespace Language_en; // Inherit undefined strings from English
 

--- a/Marlin/src/lcd/language/language_cz.h
+++ b/Marlin/src/lcd/language/language_cz.h
@@ -23,11 +23,20 @@
 
 /**
  * Czech
- * UTF-8 for Graphical Display
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
+ */
+
+/**
  * Translated by Petr Zahradnik, Computer Laboratory
  * Blog and video blog Zahradnik se bavi
  * https://www.zahradniksebavi.cz

--- a/Marlin/src/lcd/language/language_da.h
+++ b/Marlin/src/lcd/language/language_da.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_de.h
+++ b/Marlin/src/lcd/language/language_de.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 namespace LanguageNarrow_de {

--- a/Marlin/src/lcd/language/language_el.h
+++ b/Marlin/src/lcd/language/language_el.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_GREEK
@@ -187,8 +195,6 @@ namespace LanguageNarrow_el {
   LSTR MSG_RUN_AUTOFILES                  = _UxGT("Αυτόματη εκκίνηση");
 
   LSTR MSG_ZPROBE_OUT                     = _UxGT("Διερεύνηση Z εκτός Επ.Εκτύπωσης"); // SHORTEN
-  LSTR MSG_YX_UNHOMED                     = _UxGT("Επαναφορά Χ/Υ πρώτα");
-  LSTR MSG_XYZ_UNHOMED                    = _UxGT("Επαναφορά ΧΥZ πρώτα");
   LSTR MSG_ZPROBE_XOFFSET                 = _UxGT("Μετατόπιση X");
   LSTR MSG_ZPROBE_YOFFSET                 = _UxGT("Μετατόπιση Y");
   LSTR MSG_ZPROBE_ZOFFSET                 = _UxGT("Μετατόπιση Z");

--- a/Marlin/src/lcd/language/language_el_CY.h
+++ b/Marlin/src/lcd/language/language_el_CY.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #include "language_el.h"

--- a/Marlin/src/lcd/language/language_el_gr.h
+++ b/Marlin/src/lcd/language/language_el_gr.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_GREEK
@@ -177,8 +185,6 @@ namespace LanguageNarrow_el_gr {
   LSTR MSG_RUN_AUTOFILES                  = _UxGT("Αυτόματη εκκίνηση");
 
   LSTR MSG_ZPROBE_OUT                     = _UxGT("Διερεύνηση Z εκτός κλίνης");
-  LSTR MSG_YX_UNHOMED                     = _UxGT("Επαναφορά Χ/Υ πριν από Z");
-  LSTR MSG_XYZ_UNHOMED                    = _UxGT("Επαναφορά ΧΥZ πρώτα");
   LSTR MSG_ZPROBE_XOFFSET                 = _UxGT("Μετατόπιση X");
   LSTR MSG_ZPROBE_YOFFSET                 = _UxGT("Μετατόπιση Y");
   LSTR MSG_ZPROBE_ZOFFSET                 = _UxGT("Μετατόπιση Z");

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -53,21 +53,20 @@
 #ifndef PREHEAT_1_LABEL
   #define PREHEAT_1_LABEL ""
 #endif
-
 #ifndef PREHEAT_2_LABEL
   #define PREHEAT_2_LABEL ""
 #endif
-
 #ifndef PREHEAT_3_LABEL
   #define PREHEAT_3_LABEL ""
 #endif
-
 #ifndef PREHEAT_4_LABEL
   #define PREHEAT_4_LABEL ""
 #endif
-
 #ifndef CUSTOM_MENU_MAIN_TITLE
   #define CUSTOM_MENU_MAIN_TITLE ""
+#endif
+#ifndef MMU_VERSION
+  #define MMU_VERSION ""
 #endif
 
 namespace LanguageNarrow_en {
@@ -1092,7 +1091,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_DESC_FILAMENT_CHANGE           = _UxGT("M600 Filament Change. Load a new filament or eject the old one.");
   LSTR MSG_DESC_UNKNOWN_ERROR             = _UxGT("Unexpected error occurred.");
 
-  LSTR MSG_DESC_FW_UPDATE_NEEDED          = _UxGT("MMU FW version is not supported. Update to version " STRINGIFY(mmuVersionMajor) "." STRINGIFY(mmuVersionMinor) "." STRINGIFY(mmuVersionPatch) ".");
+  LSTR MSG_DESC_FW_UPDATE_NEEDED          = _UxGT("MMU FW version is not supported. Update to version " MMU_VERSION ".");
 
   LSTR MSG_BTN_RETRY                      = _UxGT("Retry");
   LSTR MSG_BTN_RESET_MMU                  = _UxGT("ResetMMU");

--- a/Marlin/src/lcd/language/language_es.h
+++ b/Marlin/src/lcd/language/language_es.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #if HAS_SDCARD && !HAS_USB_FLASH_DRIVE

--- a/Marlin/src/lcd/language/language_eu.h
+++ b/Marlin/src/lcd/language/language_eu.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_fi.h
+++ b/Marlin/src/lcd/language/language_fi.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_fr_na.h
+++ b/Marlin/src/lcd/language/language_fr_na.h
@@ -22,10 +22,18 @@
 #pragma once
 
 /**
- * French (without accent for DWIN T5UID1)
+ * French (no accent)
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_gl.h
+++ b/Marlin/src/lcd/language/language_gl.h
@@ -22,10 +22,18 @@
 #pragma once
 
 /**
- * Galician language
+ * Galician
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_hr.h
+++ b/Marlin/src/lcd/language/language_hr.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.

--- a/Marlin/src/lcd/language/language_hu.h
+++ b/Marlin/src/lcd/language/language_hu.h
@@ -24,13 +24,21 @@
 /**
  * Hungarian / Magyar
  *
- * LCD Menu Messages. See also https://marlinfw.org/docs/development/lcd_language.html
+ * LCD Menu Messages
+ * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
+ */
+
+/**
  * Hungarian translation by AntoszHUN. I am constantly improving and updating the translation.
  * Translation last updated: 08/30/2021 - 22:20
- *
- * LCD Menü Üzenetek. Lásd még https://marlinfw.org/docs/development/lcd_language.html
- * A Magyar fordítást készítette: AntoszHUN. A fordítást folyamatosan javítom és frissítem.
- * A Fordítás utolsó frissítése: 2021.08.30. - 22:20
  */
 
 namespace LanguageNarrow_hu {

--- a/Marlin/src/lcd/language/language_it.h
+++ b/Marlin/src/lcd/language/language_it.h
@@ -999,7 +999,7 @@ namespace LanguageNarrow_it {
   LSTR MSG_DESC_FILAMENT_CHANGE           = _UxGT("Sostituzione del filamento M600. Carica un nuovo filamento o espelli quello vecchio.");
   LSTR MSG_DESC_UNKNOWN_ERROR             = _UxGT("Si è verificato un errore imprevisto.");
 
-  LSTR MSG_DESC_FW_UPDATE_NEEDED          = _UxGT("LA versione di FW della MMU non è supportato. Aggiornare alla versione " STRINGIFY(mmuVersionMajor) "." STRINGIFY(mmuVersionMinor) "." STRINGIFY(mmuVersionPatch) ".");
+  LSTR MSG_DESC_FW_UPDATE_NEEDED          = _UxGT("LA versione di FW della MMU non è supportato. Aggiornare alla versione " MMU_VERSION ".");
 
   LSTR MSG_BTN_RETRY                      = _UxGT("Riprova");
   LSTR MSG_BTN_RESET_MMU                  = _UxGT("Resetta MMU");

--- a/Marlin/src/lcd/language/language_jp_kana.h
+++ b/Marlin/src/lcd/language/language_jp_kana.h
@@ -23,10 +23,17 @@
 
 /**
  * Japanese (Kana)
- * UTF-8 for Graphical Display
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 //#define DISPLAY_CHARSET_ISO10646_KANA

--- a/Marlin/src/lcd/language/language_ko_KR.h
+++ b/Marlin/src/lcd/language/language_ko_KR.h
@@ -26,7 +26,16 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_ko_KR {
   using namespace Language_en; // Inherit undefined strings from English
 

--- a/Marlin/src/lcd/language/language_nl.h
+++ b/Marlin/src/lcd/language/language_nl.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_pl.h
+++ b/Marlin/src/lcd/language/language_pl.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * Polish - includes accented characters
+ * Polish
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html

--- a/Marlin/src/lcd/language/language_pt.h
+++ b/Marlin/src/lcd/language/language_pt.h
@@ -23,10 +23,17 @@
 
 /**
  * Portuguese
- * UTF-8 for Graphical Display
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/src/lcd/language/language_pt_br.h
+++ b/Marlin/src/lcd/language/language_pt_br.h
@@ -23,11 +23,19 @@
 
 /**
  * Portuguese (Brazil)
- * UTF-8 for Graphical Display
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_pt_br {
   using namespace Language_en; // Inherit undefined strings from English
 
@@ -441,7 +449,7 @@ namespace LanguageNarrow_pt_br {
   LSTR MSG_MAZE                           = _UxGT("Labirinto");
 
   LSTR MSG_ADVANCED_PAUSE_WAITING         = _UxGT(MSG_1_LINE("Clique p. continuar"));
-  LSTR MSG_PAUSE_PRINT_INIT               = _UxGT(MSG_1_LINE("Estacionando..."));
+  LSTR MSG_PAUSE_PRINT_PARKING            = _UxGT(MSG_1_LINE("Estacionando..."));
   LSTR MSG_FILAMENT_CHANGE_INIT           = _UxGT(MSG_1_LINE("Aguarde..."));
   LSTR MSG_FILAMENT_CHANGE_INSERT         = _UxGT(MSG_1_LINE("Insira e Clique"));
   LSTR MSG_FILAMENT_CHANGE_HEAT           = _UxGT(MSG_1_LINE("Clique para Aquecer"));

--- a/Marlin/src/lcd/language/language_ro.h
+++ b/Marlin/src/lcd/language/language_ro.h
@@ -21,14 +21,25 @@
  */
 #pragma once
 
- /**
-  * Romanian
-  *
-  * LCD Menu Messages
-  * See also https://marlinfw.org/docs/development/lcd_language.html
-  *
-  * Translation by cristyanul
-  */
+/**
+ * Romanian
+ *
+ * LCD Menu Messages
+ * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
+ */
+
+/**
+ * Translation by cristyanul
+ */
+
 namespace LanguageNarrow_ro {
   using namespace Language_en; // Inherit undefined strings from English
 

--- a/Marlin/src/lcd/language/language_ru.h
+++ b/Marlin/src/lcd/language/language_ru.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 #define DISPLAY_CHARSET_ISO10646_5
 

--- a/Marlin/src/lcd/language/language_sk.h
+++ b/Marlin/src/lcd/language/language_sk.h
@@ -23,12 +23,10 @@
 
 /**
  * Slovak
- * UTF-8 for Graphical Display
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
  *
- * Translated by Michal Holeš, Farma MaM
  * https://www.facebook.com/farmamam
  *
  * Substitutions are applied for the following characters when used in menu items titles:
@@ -39,6 +37,12 @@
  *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
  *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
+/**
+ * Translated by Michal Holeš, Farma MaM
+ * https://www.facebook.com/farmamam
+ */
+
 #define DISPLAY_CHARSET_ISO10646_SK
 
 namespace LanguageNarrow_sk {

--- a/Marlin/src/lcd/language/language_sv.h
+++ b/Marlin/src/lcd/language/language_sv.h
@@ -13,7 +13,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License för more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_1
@@ -47,9 +55,9 @@ namespace LanguageNarrow_sv {
   LSTR MSG_MEDIA_ABORTING                 = _UxGT("Avbryter...");
   LSTR MSG_MEDIA_INSERTED                 = _UxGT("Minneskort isatt");
   LSTR MSG_MEDIA_REMOVED                  = _UxGT("Minneskort avlägsnat");
-  LSTR MSG_MEDIA_WAITING                  = _UxGT("Väntar på minneskort");
   LSTR MSG_MEDIA_INIT_FAIL                = _UxGT("Misslyckad läsning av minneskort");
   LSTR MSG_MEDIA_READ_ERROR               = _UxGT("Läsningsfel minneskort");
+  LSTR MSG_USB_FD_WAITING_FOR_MEDIA       = _UxGT("Väntar på minneskort");
   LSTR MSG_USB_FD_DEVICE_REMOVED          = _UxGT("USB-minne avlägsnat");
   LSTR MSG_USB_FD_USB_FAILED              = _UxGT("USB-start misslyckad");
   LSTR MSG_KILL_SUBCALL_OVERFLOW          = _UxGT("Underanrop överskriden");
@@ -58,15 +66,13 @@ namespace LanguageNarrow_sv {
   LSTR MSG_LCD_SOFT_ENDSTOPS              = _UxGT("Mjukvarugränslägen");
   LSTR MSG_MAIN_MENU                      = _UxGT("Huvudmeny");
   LSTR MSG_ADVANCED_SETTINGS              = _UxGT("Advancerade inställningar");
-  LSTR MSG_TOOLBAR_SETUP                  = _UxGT("Inställningar verktygsfält");
-  LSTR MSG_OPTION_DISABLED                = _UxGT("Alternativ avaktiverad");
   LSTR MSG_CONFIGURATION                  = _UxGT("Konfiguration");
   LSTR MSG_DISABLE_STEPPERS               = _UxGT("Inaktivera stegmotorer");
   LSTR MSG_DEBUG_MENU                     = _UxGT("Debugmeny");
   LSTR MSG_PROGRESS_BAR_TEST              = _UxGT("Förloppindikator test");
   LSTR MSG_HOMING                         = _UxGT("Hemkörning");
   LSTR MSG_AUTO_HOME                      = _UxGT("Auto hem");
-  LSTR MSG_AUTO_HOME_A                    = _UxGT("Hem @");
+  LSTR MSG_AUTO_HOME_N                    = _UxGT("Hem @");
   LSTR MSG_AUTO_HOME_X                    = _UxGT("Hem X");
   LSTR MSG_AUTO_HOME_Y                    = _UxGT("Hem Y");
   LSTR MSG_AUTO_HOME_Z                    = _UxGT("Hem Z");
@@ -74,11 +80,11 @@ namespace LanguageNarrow_sv {
   LSTR MSG_FILAMENT_SET                   = _UxGT("Trådinställningar");
   LSTR MSG_FILAMENT_MAN                   = _UxGT("Trådhantering");
   LSTR MSG_MANUAL_LEVELING                = _UxGT("Manuell höjdjustering");
-  LSTR MSG_LEVBED_FL                      = _UxGT("Övre vänster");
-  LSTR MSG_LEVBED_FR                      = _UxGT("Övre höger");
-  LSTR MSG_LEVBED_C                       = _UxGT("Mittpunkt");
-  LSTR MSG_LEVBED_BL                      = _UxGT("Nedre vänster");
-  LSTR MSG_LEVBED_BR                      = _UxGT("Nedre höger");
+  LSTR MSG_TRAM_FL                        = _UxGT("Övre vänster");
+  LSTR MSG_TRAM_FR                        = _UxGT("Övre höger");
+  LSTR MSG_TRAM_C                         = _UxGT("Mittpunkt");
+  LSTR MSG_TRAM_BL                        = _UxGT("Nedre vänster");
+  LSTR MSG_TRAM_BR                        = _UxGT("Nedre höger");
   LSTR MSG_MANUAL_MESH                    = _UxGT("Manellt meshmät");
   LSTR MSG_AUTO_MESH                      = _UxGT("Automatiskt meshnät");
 
@@ -130,10 +136,6 @@ namespace LanguageNarrow_sv {
   LSTR MSG_SPINDLE_TOGGLE                 = _UxGT("Växla spindel");
   LSTR MSG_SPINDLE_FORWARD                = _UxGT("Spindel framåt");
   LSTR MSG_SPINDLE_REVERSE                = _UxGT("Spindel bakåt");
-  LSTR MSG_LASER_OFF                      = _UxGT("Laser från");
-  LSTR MSG_LASER_ON                       = _UxGT("Laser till");
-  LSTR MSG_SPINDLE_OFF                    = _UxGT("Spindel från");
-  LSTR MSG_SPINDLE_ON                     = _UxGT("Spindel till");
   LSTR MSG_SWITCH_PS_ON                   = _UxGT("Spänning till");
   LSTR MSG_SWITCH_PS_OFF                  = _UxGT("Spänning från");
   LSTR MSG_EXTRUDE                        = _UxGT("Extrudera");
@@ -155,7 +157,7 @@ namespace LanguageNarrow_sv {
   LSTR MSG_MESH_X                         = _UxGT("Index X");
   LSTR MSG_MESH_Y                         = _UxGT("Index Y");
   LSTR MSG_MESH_EDIT_Z                    = _UxGT("Z-värde");
-  LSTR MSG_USER_MENU                      = _UxGT("Anpassade kommandon");
+  LSTR MSG_CUSTOM_COMMANDS                = _UxGT("Anpassade kommandon");
   LSTR MSG_M48_TEST                       = _UxGT("M48 probtest");
   LSTR MSG_M48_POINT                      = _UxGT("M48 punkt");
   LSTR MSG_M48_OUT_OF_BOUNDS              = _UxGT("Mätprob utanför tolerans");
@@ -556,9 +558,6 @@ namespace LanguageNarrow_sv {
   LSTR MSG_FILAMENT_CHANGE_NOZZLE         = _UxGT("  Munstycke: ");
   LSTR MSG_RUNOUT_SENSOR                  = _UxGT("Trådkontrollgivare");
   LSTR MSG_RUNOUT_DISTANCE_MM             = _UxGT("Förbrukad trådlängd mm");
-  LSTR MSG_RUNOUT_ENABLE                  = _UxGT("Aktivera trådövervakning");
-  LSTR MSG_RUNOUT_ACTIVE                  = _UxGT("Trådövervakning i drift");
-  LSTR MSG_INVERT_EXTRUDER                = _UxGT("Invertera extruder");
   LSTR MSG_EXTRUDER_MIN_TEMP              = _UxGT("Extruder Minimumtemp.");
   LSTR MSG_FANCHECK                       = _UxGT("Fläktvarvövervakning");
   LSTR MSG_KILL_HOMING_FAILED             = _UxGT("Hemkörning misslyckad");

--- a/Marlin/src/lcd/language/language_uk.h
+++ b/Marlin/src/lcd/language/language_uk.h
@@ -26,6 +26,14 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 
 #define DISPLAY_CHARSET_ISO10646_5

--- a/Marlin/src/lcd/language/language_vi.h
+++ b/Marlin/src/lcd/language/language_vi.h
@@ -26,7 +26,16 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_vi {
   using namespace Language_en; // Inherit undefined strings from English
 
@@ -102,12 +111,8 @@ namespace LanguageNarrow_vi {
   LSTR MSG_IDEX_MENU                      = _UxGT("chế độ IDEX");                          // IDEX Mode
   LSTR MSG_IDEX_MODE_AUTOPARK             = _UxGT("Đậu tự động");                          // Auto-Park
   LSTR MSG_IDEX_MODE_DUPLICATE            = _UxGT("Sự gấp đôi");                           // Duplication
-  LSTR MSG_IDEX_MODE_SCALED_COPY          = _UxGT("Bản sao thu nhỏ");
+  LSTR MSG_IDEX_MODE_MIRRORED_COPY        = _UxGT("Bản sao thu nhỏ");
   LSTR MSG_IDEX_MODE_FULL_CTRL            = _UxGT("Toàn quyền điều khiển");                // Full control
-  LSTR MSG_IDEX_X_OFFSET                  = _UxGT("Đầu phun X nhì");                       // 2nd nozzle X
-  LSTR MSG_IDEX_Y_OFFSET                  = _UxGT("Đầu phun Y nhì");
-  LSTR MSG_IDEX_Z_OFFSET                  = _UxGT("Đầu phun Z nhì");
-  LSTR MSG_IDEX_SAVE_OFFSETS              = _UxGT("Lưu bù đắp");                           // Save offsets
   LSTR MSG_UBL_MANUAL_MESH                = _UxGT("Tự xây dựng lưới");                     // Manually Build Mesh
   LSTR MSG_UBL_BC_INSERT                  = _UxGT("Đặt chêm và đo");                       // Place shim & measure
   LSTR MSG_UBL_BC_INSERT2                 = _UxGT("Đo");                                   // Measure
@@ -156,7 +161,7 @@ namespace LanguageNarrow_vi {
   LSTR MSG_UBL_SAVE_MESH                  = _UxGT("Lưu lưới bàn");                         // Save Bed Mesh
   LSTR MSG_MESH_LOADED                    = _UxGT("%i lưới được nạp");                     // Mesh %i loaded
   LSTR MSG_MESH_SAVED                     = _UxGT("%i lưới đã lưu");
-  LSTR MSG_NO_STORAGE                     = _UxGT("Không lưu trữ");                        // No Storage
+  LSTR MSG_UBL_NO_STORAGE                 = _UxGT("Không lưu trữ");                        // No Storage
   LSTR MSG_UBL_SAVE_ERROR                 = _UxGT("Điều sai: Lưu UBL");                    // Err: UBL Save
   LSTR MSG_UBL_RESTORE_ERROR              = _UxGT("Điều Sai: Khôi Phục UBL");              // Err: UBL Restore
   LSTR MSG_UBL_Z_OFFSET_STOPPED           = _UxGT("Đầu Dò-Z Đã Ngừng");                    // Z-Offset Stopped
@@ -391,7 +396,6 @@ namespace LanguageNarrow_vi {
   LSTR MSG_FILAMENT_CHANGE_OPTION_PURGE   = _UxGT("Xả thêm");                             // Purge more
   LSTR MSG_FILAMENT_CHANGE_OPTION_RESUME  = _UxGT("Tiếp tục");                            // Continue
   LSTR MSG_FILAMENT_CHANGE_NOZZLE         = _UxGT("  Đầu Phun: ");                        // Nozzle
-  LSTR MSG_RUNOUT_SENSOR_ENABLE           = _UxGT("Cảm Biến Hết");                        // Runout Sensor
   LSTR MSG_KILL_HOMING_FAILED             = _UxGT("Sự nhà không thành công");             // Homing failed
   LSTR MSG_LCD_PROBING_FAILED             = _UxGT(" không thành công");                   // Probing failed
 

--- a/Marlin/src/lcd/language/language_zh_CN.h
+++ b/Marlin/src/lcd/language/language_zh_CN.h
@@ -26,7 +26,16 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_zh_CN {
   using namespace Language_en; // Inherit undefined strings from English
 

--- a/Marlin/src/lcd/language/language_zh_TW.h
+++ b/Marlin/src/lcd/language/language_zh_TW.h
@@ -26,7 +26,16 @@
  *
  * LCD Menu Messages
  * See also https://marlinfw.org/docs/development/lcd_language.html
+ *
+ * Substitutions are applied for the following characters when used in menu items titles:
+ *
+ *   $ displays an inserted string
+ *   { displays  '0'....'10' for indexes 0 - 10
+ *   ~ displays  '1'....'11' for indexes 0 - 10
+ *   * displays 'E1'...'E11' for indexes 0 - 10 (By default. Uses LCD_FIRST_TOOL)
+ *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
+
 namespace LanguageNarrow_zh_TW {
   using namespace Language_en; // Inherit undefined strings from English
 

--- a/buildroot/share/fonts/uxggenpages.sh
+++ b/buildroot/share/fonts/uxggenpages.sh
@@ -147,7 +147,7 @@ grep -Hrn _UxGT . | grep '"' \
       ${EXEC_BDF2U8G} -u ${PAGE} -b ${BEGIN} -e ${END} ${FN_FONT} fontpage_${PAGE}_${BEGIN}_${END} ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h > /dev/null 2>&1 ;
     fi ; \
     grep -A 10000000000 u8g_fntpgm_uint8_t ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h >> tmpa ; \
-    echo "  FONTDATA_ITEM(${PAGE}, ${BEGIN}, ${END}, fontpage_${PAGE}_${BEGIN}_${END}), // '${UTF8BEGIN}' -- '${UTF8END}'" >> tmpb ;\
+    echo "  FONTDATA_ITEM(${PAGE}, ${BEGIN}, ${END}, fontpage_${PAGE}_${BEGIN}_${END}), // ' ${UTF8BEGIN} ' - ' ${UTF8END} '" >> tmpb ;\
   done
 
 TMPA=$(cat tmpa)

--- a/buildroot/share/scripts/languageExport.py
+++ b/buildroot/share/scripts/languageExport.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 '''
-languageExport.py [--single]
+languageExport.py [--single] [--translate]
 
 Export LCD language strings to CSV files for easier translation.
 Use languageImport.py to import CSV into the language files.
@@ -8,148 +8,272 @@ Use languageImport.py to import CSV into the language files.
 Use --single to export all languages to a single CSV file.
 '''
 
-import re
+import re, argparse
 from pathlib import Path
-from sys import argv
-from languageUtil import namebyid
+from sys import argv, exit
+from languageUtil import *
 
 LANGHOME = "Marlin/src/lcd/language"
-
-# Write multiple sheets if true, otherwise write one giant sheet
-MULTISHEET = '--single' not in argv[1:]
 OUTDIR = Path('out-csv')
 
-# Check for the path to the language files
-if not Path(LANGHOME).is_dir():
-    print("Error: Couldn't find the '%s' directory." % LANGHOME)
-    print("Edit LANGHOME or cd to the root of the repo before running.")
-    exit(1)
+def language_export(args={}):
+    # A dictionary to contain strings for each language.
+    # Init with 'en' so English will always be first.
+    language_strings = { 'en': {} }
 
-# A limit just for testing
-LIMIT = 0
+    # A dictionary to contain all distinct LCD string names
+    names = {}
 
-# A dictionary to contain strings for each language.
-# Init with 'en' so English will always be first.
-language_strings = { 'en': {} }
+    # Get all "language_*.h" files
+    langfiles = sorted(list(Path(LANGHOME).glob('language_*.h')))
 
-# A dictionary to contain all distinct LCD string names
-names = {}
+    # Read each language file
+    for langfile in langfiles:
+        # Get the language code from the filename
+        langcode = langfile.name.replace('language_', '').replace('.h', '')
 
-# Get all "language_*.h" files
-langfiles = sorted(list(Path(LANGHOME).glob('language_*.h')))
+        # Skip 'test' and any others that we don't want
+        if langcode in ['test']: continue
+        if langcode != 'en' and args.languages and langcode not in args.languages: continue
 
-# Read each language file
-for langfile in langfiles:
-    # Get the language code from the filename
-    langcode = langfile.name.replace('language_', '').replace('.h', '')
+        # Open the file
+        f = open(langfile, 'r', encoding='utf-8')
+        if not f: continue
 
-    # Skip 'test' and any others that we don't want
-    if langcode in ['test']: continue
+        # Flags to indicate a wide or tall section
+        wideflag, tallflag = False, False
+        # A counter for the number of strings in the file
+        stringcount = 0
+        # A dictionary to hold all the strings
+        strings = { 'narrow': {}, 'wide': {}, 'tall': {} }
+        # Read each line in the file
+        for line in f:
+            # Clean up the line for easier parsing
+            line = line.split("//")[0].strip()
+            if line.endswith(';'): line = line[:-1].strip()
 
-    # Open the file
-    f = open(langfile, 'r', encoding='utf-8')
-    if not f: continue
+            # Check for wide or tall sections, assume no complicated nesting
+            if line.startswith("#endif") or line.startswith("#else"):
+                wideflag, tallflag = False, False
+            elif re.match(r'#if.*WIDTH\s*>=?\s*2[01].*', line): wideflag = True
+            elif re.match(r'#if.*LCD_HEIGHT\s*>=?\s*4.*', line): tallflag = True
 
-    # Flags to indicate a wide or tall section
-    wideflag, tallflag = False, False
-    # A counter for the number of strings in the file
-    stringcount = 0
-    # A dictionary to hold all the strings
-    strings = { 'narrow': {}, 'wide': {}, 'tall': {} }
-    # Read each line in the file
-    for line in f:
-        # Clean up the line for easier parsing
-        line = line.split("//")[0].strip()
-        if line.endswith(';'): line = line[:-1].strip()
+            # For string-defining lines capture the string data
+            match = re.match(r'LSTR\s+([A-Z0-9_]+)\s*=\s*(.+)\s*', line)
+            if match:
+                # Name and quote-sanitized value
+                name, value = match.group(1), match.group(2).replace('\\"', '$$$')
 
-        # Check for wide or tall sections, assume no complicated nesting
-        if line.startswith("#endif") or line.startswith("#else"):
-            wideflag, tallflag = False, False
-        elif re.match(r'#if.*WIDTH\s*>=?\s*2[01].*', line): wideflag = True
-        elif re.match(r'#if.*LCD_HEIGHT\s*>=?\s*4.*', line): tallflag = True
+                # Remove all _UxGT wrappers from the value in a non-greedy way
+                value = re.sub(r'_UxGT\((".*?")\)', r'\1', value)
 
-        # For string-defining lines capture the string data
-        match = re.match(r'LSTR\s+([A-Z0-9_]+)\s*=\s*(.+)\s*', line)
-        if match:
-            # Name and quote-sanitized value
-            name, value = match.group(1), match.group(2).replace('\\"', '$$$')
+                # Multi-line strings get one or more bars | for identification
+                multiline = 0
+                multimatch = re.match(r'.*MSG_(\d)_LINE\s*\(\s*(.+?)\s*\).*', value)
+                if multimatch:
+                    multiline = int(multimatch.group(1))
+                    value = '|' + re.sub(r'"\s*,\s*"', '|', multimatch.group(2))
 
-            # Remove all _UxGT wrappers from the value in a non-greedy way
-            value = re.sub(r'_UxGT\((".*?")\)', r'\1', value)
+                # Wrap inline defines in parentheses
+                value = re.sub(r' *([A-Z0-9]+_[A-Z0-9_]+) *', r'(\1)', value)
+                # Remove quotes around strings
+                value = re.sub(r'"(.*?)"', r'\1', value).replace('$$$', '""')
+                # Store all unique names as dictionary keys
+                names[name] = 1
+                # Store the string as narrow or wide
+                strings['tall' if tallflag else 'wide' if wideflag else 'narrow'][name] = value
 
-            # Multi-line strings get one or more bars | for identification
-            multiline = 0
-            multimatch = re.match(r'.*MSG_(\d)_LINE\s*\(\s*(.+?)\s*\).*', value)
-            if multimatch:
-                multiline = int(multimatch.group(1))
-                value = '|' + re.sub(r'"\s*,\s*"', '|', multimatch.group(2))
+                # Increment the string counter
+                stringcount += 1
+                # Break for testing
+                if args.limit and stringcount >= int(args.limit): break
 
-            # Wrap inline defines in parentheses
-            value = re.sub(r' *([A-Z0-9]+_[A-Z0-9_]+) *', r'(\1)', value)
-            # Remove quotes around strings
-            value = re.sub(r'"(.*?)"', r'\1', value).replace('$$$', '""')
-            # Store all unique names as dictionary keys
-            names[name] = 1
-            # Store the string as narrow or wide
-            strings['tall' if tallflag else 'wide' if wideflag else 'narrow'][name] = value
+        # Close the file
+        f.close()
+        # Store the array in the dict
+        language_strings[langcode] = strings
 
-            # Increment the string counter
-            stringcount += 1
-            # Break for testing
-            if LIMIT and stringcount >= LIMIT: break
+    # Get the codes of all imported languages
+    langcodes = list(language_strings.keys())
 
-    # Close the file
-    f.close()
-    # Store the array in the dict
-    language_strings[langcode] = strings
+    print("Languages:", ' '.join(langcodes))
 
-# Get the language codes from the dictionary
-langcodes = list(language_strings.keys())
+    # Print the array
+    #print(language_strings)
 
-# Print the array
-#print(language_strings)
+    # Report the total number of unique strings
+    print("Found %s distinct LCD strings." % len(names))
 
-# Report the total number of unique strings
-print("Found %s distinct LCD strings." % len(names))
+    #exit(0)
 
-# Write a single language entry to the CSV file with narrow, wide, and tall strings
-def write_csv_lang(f, strings, name):
-    f.write(',')
-    if name in strings['narrow']: f.write('"%s"' % strings['narrow'][name])
-    f.write(',')
-    if name in strings['wide']: f.write('"%s"' % strings['wide'][name])
-    f.write(',')
-    if name in strings['tall']: f.write('"%s"' % strings['tall'][name])
+    # Add missing translations, if specified
+    if args.translate:
 
-if MULTISHEET:
-    #
-    # Export a separate sheet for each language
-    #
-    OUTDIR.mkdir(exist_ok=True)
+        MIN_TRANSLATE_LEN = 2
+        NEVER_TRANSLATE_LANGS = ( 'el_CY', 'fr_na' )
+        NEVER_TRANSLATE_NAMES = (
+          "MSG_MARLIN", "MSG_CUSTOM_MENU_MAIN_TITLE",
+          "MSG_PID_P", "MSG_PID_P_E",
+          "MSG_PID_I", "MSG_PID_I_E",
+          "MSG_PID_D", "MSG_PID_D_E",
+          "MSG_PID_C", "MSG_PID_C_E",
+          "MSG_PID_F", "MSG_PID_F_E",
+          "MSG_BACKLASH_N",
+          "MSG_SHORT_DAY", "MSG_SHORT_HOUR", "MSG_SHORT_MINUTE",
+          "MSG_FTM_ZV", "MSG_FTM_ZVD", "MSG_FTM_ZVDD", "MSG_FTM_ZVDDD",
+          "MSG_FTM_EI", "MSG_FTM_2HEI", "MSG_FTM_3HEI", "MSG_FTM_MZV"
+        )
 
-    for lang in langcodes:
-        with open(OUTDIR / f"language_{lang}.csv", 'w', encoding='utf-8') as f:
-            lname = lang + ' ' + namebyid(lang)
-            header = ['name', lname, lname + ' (wide)', lname + ' (tall)']
+        import ollama
+
+        DEFAULT_MODEL = (
+          "qwen3:32b",                 #  0  22 GB
+          "gpt-oss:20b",               #  1  13 GB
+          "llama3.3",                  #  2  45 GB
+          "deepseek-r1:14b",           #  3   9 GB
+          "deepseek-r1-qwen-14b",      #  4  15 GB
+          "devstral:24b",              #  5  15 GB
+          "qwen3-coder:30b",           #  6  18 GB
+          "mistral-small-3.2",         #  7  14 GB
+          "openthinker:32b",           #  8  19 GB
+          "deepseek-v2",               #  9   9 GB
+          "deepseek-coder-v2",         # 10   9 GB
+          "llama3.2:3b-instruct-fp16"  # 11   6 GB
+        )[0]
+
+        llm_model = args.model if args.model else DEFAULT_MODEL
+
+        def get_system_prompt(args, sect):
+            if sect == 'narrow':
+                length_limit = "no more than 18 characters long! Use common abbreviations whenever necessary"
+            elif sect == 'tall':
+                length_limit = "no more than 3 strings of 20 characters. Use common abbreviations if necessary"
+            else: # wide
+                length_limit = "around the same length as the given example(s)"
+
+            no_thinking = "" if args.dothink else "Do not think! Just translate.\n"
+
+            system_prompt_text = f"""You are an expert in language translation in the context of 3D printing.
+You will be given a list of existing translations and will be asked to provide a new translation in the given language.
+When provided, the English (en) translation should be considered the most authoritative source.
+Named variable substitutions are written as UPPERCASE_WITH_UNDERSCORES. Never translate or modify these!
+The symbols `@`, `~`, `*`, `{{`, and `$` are special characters used for substitution. Never translate or modify these!
+Your translations must be {length_limit}.
+Assume that variable substitutions such as (MACHINE_NAME) are short strings for the purpose of character counting.
+{no_thinking}For each translation requested, respond only with the translated string, no introduction, explanation, or assessment.
+This clean output will be perfect for our use case."""
+
+            return [{ 'role': 'system', 'content': system_prompt_text }]
+
+        # Send a prompt to Ollama and return the reply text
+        def prompt_with_ollama(SYSTEM_PROMPT, prompt:str):
+            msg = [{ 'role': 'user', 'content': prompt }]
+            response = ollama.chat(model=llm_model, messages=SYSTEM_PROMPT + msg, stream=False)
+            reply = response['message']['content'].strip('\n')
+            reply = re.sub(r'<think>[\s\S]+</think>\n*', '', reply)
+            reply = re.sub(r'(^"|"$)', '', reply)
+            return reply
+
+        # For each named string fill in any missing translations
+        for sect in ('narrow','wide','tall'):
+            system_prompt = get_system_prompt(args, sect)
+            for name in names.keys():
+                if name in NEVER_TRANSLATE_NAMES: continue
+                en_string = language_strings['en'][sect][name] if name in language_strings['en'][sect] else ""
+                glyphs = len(en_string)
+
+                done = {} # All existing translations for the given name
+                todo = [] # Missing translation keys to create
+                for lang in langcodes:
+                    strings = language_strings[lang]
+                    if name in strings[sect]:
+                        done[lang] = strings[sect][name]
+                    elif glyphs >= MIN_TRANSLATE_LEN and lang not in NEVER_TRANSLATE_LANGS:
+                        todo += [lang]
+
+                # For each untranslated language, fill in a translation
+                for lang in todo:
+                    # Show existing translations to the LLM and ask for one more
+                    prompt = [ f"Please translate the following string into {language_name(lang)} ({lang})." ]
+                    if lang.endswith("_na"):
+                        prompt += [ "(Substitute plain unaccented ASCII characters for accented characters in the output.)" ]
+                    prompt += [ "Here are the existing translations:" ]
+                    for dlang in done.keys():
+                        prompt += [ f"- {dlang} {language_name(dlang)}: \"{done[dlang]}\"" ]
+                    prompt = '\n'.join(prompt)
+                    #print(f"Prompt: {prompt}")
+                    reply = prompt_with_ollama(system_prompt, prompt)
+                    newstring = reply.replace('–','-').replace('‑','-').replace('／','/').replace('’',"'").replace('…','...').replace('\u202F',' ').replace('\uFEFF', '').replace('！', '! ').replace('。', '. ').replace('ç','ç').replace('ş','ş').replace('６','6').replace('＠', '@').replace('～', '~')
+                    newstring = re.sub(r'([!.]) $', '\1', newstring)
+                    if newstring != en_string:
+                        print(f"{name} ({lang}) = \"{newstring}\"")
+                        done[lang] = newstring
+                        if not sect in language_strings[lang]: language_strings[lang][sect] = {}
+                        language_strings[lang][sect][name] = newstring
+                    else:
+                        print(f"{name} ({lang}) = (same as English)")
+
+    # Write a single language entry to the CSV file with narrow, wide, and tall strings
+    def write_csv_lang(f, strings, name):
+        f.write(',')
+        if name in strings['narrow']: f.write('"%s"' % strings['narrow'][name])
+        f.write(',')
+        if name in strings['wide']: f.write('"%s"' % strings['wide'][name])
+        f.write(',')
+        if name in strings['tall']: f.write('"%s"' % strings['tall'][name])
+
+    if args.single:
+        #
+        # Export one large sheet containing all specified languages
+        #
+        with open("languages.csv", 'w', encoding='utf-8') as f:
+            header = ['name']
+            for lang in langcodes:
+                lname = lang + ' ' + language_name(lang)
+                header += [lname, lname + ' (wide)', lname + ' (tall)']
             f.write('"' + '","'.join(header) + '"\n')
 
             for name in names.keys():
                 f.write('"' + name + '"')
-                write_csv_lang(f, language_strings[lang], name)
+                for lang in langcodes: write_csv_lang(f, language_strings[lang], name)
                 f.write('\n')
+    else:
+        #
+        # Export a separate sheet for each language
+        #
+        OUTDIR.mkdir(exist_ok=True)
 
-else:
-    #
-    # Export one large sheet containing all languages
-    #
-    with open("languages.csv", 'w', encoding='utf-8') as f:
-        header = ['name']
         for lang in langcodes:
-            lname = lang + ' ' + namebyid(lang)
-            header += [lname, lname + ' (wide)', lname + ' (tall)']
-        f.write('"' + '","'.join(header) + '"\n')
+            with open(OUTDIR / f"language_{lang}.csv", 'w', encoding='utf-8') as f:
+                lname = lang + ' ' + language_name(lang)
+                header = ['name', lname, lname + ' (wide)', lname + ' (tall)']
+                f.write('"' + '","'.join(header) + '"\n')
 
-        for name in names.keys():
-            f.write('"' + name + '"')
-            for lang in langcodes: write_csv_lang(f, language_strings[lang], name)
-            f.write('\n')
+                for name in names.keys():
+                    f.write('"' + name + '"')
+                    write_csv_lang(f, language_strings[lang], name)
+                    f.write('\n')
+
+if __name__ == "__main__":
+    # Check for the path to the language files
+    if not Path(LANGHOME).is_dir():
+        print(f"Error: Couldn't find the '{LANGHOME}' directory.")
+        print("Edit LANGHOME or cd to the root of the repo before running.")
+        exit(1)
+
+    # Parse and validate all arguments
+    parser = argparse.ArgumentParser(description="Export LCD language strings to CSV with optional translation")
+    parser.add_argument('-l', '--languages', action="append", default=None, help="Languages to translate (otherwise all)")
+    parser.add_argument('-s', '--single', action="store_true", help="Output a single spreadsheet (languages.csv)")
+    parser.add_argument('-v', '--verbose', action="store_true", help="Extra output for debugging")
+    parser.add_argument('-n', '--limit', default=0, help="Limit the number of exported items")
+    parser.add_argument('-t', '--translate', action="store_true", help="Use an LLM to translate strings")
+    parser.add_argument('-d', '--dothink', action="store_true", help="Use thinking if the model supports it")
+    parser.add_argument('-m', '--model', default=None, help="Override the default LLM model for translation")
+    args = parser.parse_args()
+
+    if not args.translate:
+        if args.model: print("--model ignored when not translating")
+        if args.dothink: print("--dothink ignored when not translating")
+
+    language_export(args)

--- a/buildroot/share/scripts/languageUtil.py
+++ b/buildroot/share/scripts/languageUtil.py
@@ -5,37 +5,48 @@
 
 # A dictionary to contain language names
 LANGNAME = {
-    'an': "Aragonese",
-    'bg': "Bulgarian",
-    'ca': "Catalan",
-    'cz': "Czech",
-    'da': "Danish",
-    'de': "German",
-    'el': "Greek", 'el_CY': "Greek (Cyprus)", 'el_gr': "Greek (Greece)",
-    'en': "English",
-    'es': "Spanish",
-    'eu': "Basque-Euskera",
-    'fi': "Finnish",
-    'fr': "French", 'fr_na': "French (no accent)",
-    'gl': "Galician",
-    'hr': "Croatian (Hrvatski)",
-    'hu': "Hungarian / Magyar",
-    'it': "Italian",
-    'jp_kana': "Japanese (Kana)",
-    'ko_KR': "Korean",
-    'nl': "Dutch",
-    'pl': "Polish",
-    'pt': "Portuguese", 'pt_br': "Portuguese (Brazil)",
-    'ro': "Romanian",
-    'ru': "Russian",
-    'sk': "Slovak",
-    'sv': "Swedish",
-    'tr': "Turkish",
-    'uk': "Ukrainian",
-    'vi': "Vietnamese",
-    'zh_CN': "Simplified Chinese", 'zh_TW': "Traditional Chinese"
+  'an':      { 'size':1, 'iso': "1",     'name':"Aragonese", 'noext':1 },
+  'bg':      { 'size':2, 'iso': "5",     'name':"Bulgarian" },
+  'ca':      { 'size':2,                 'name':"Catalan" },
+  'cz':      { 'size':2, 'iso': "CZ",    'name':"Czech" },
+  'da':      { 'size':2, 'iso': "1",     'name':"Danish" },
+  'de':      { 'size':2,                 'name':"German" },
+  'el':      { 'size':2, 'iso': "GREEK", 'name':"Greek" },
+  'el_CY':   { 'size':2,                 'name':"Greek (Cyprus)" },
+  'el_gr':   { 'size':2, 'iso': "GREEK", 'name':"Greek (Greece)" },
+  'en':      { 'size':2,                 'name':"English" },
+  'es':      { 'size':2,                 'name':"Spanish" },
+  'eu':      { 'size':1, 'iso': "1",     'name':"Basque-Euskera", 'noext':1 },
+  'fi':      { 'size':2, 'iso': "1",     'name':"Finnish" },
+  'fr':      { 'size':2, 'iso': "1",     'name':"French" },
+  'fr_na':   { 'size':1, 'iso': "1",     'name':"French (no accent)", 'noext':1 },
+  'gl':      { 'size':1, 'iso': "1",     'name':"Galician" },
+  'hr':      { 'size':2, 'iso': "1",     'name':"Croatian (Hrvatski)" },
+  'hu':      { 'size':2,                 'name':"Hungarian / Magyar" },
+  'it':      { 'size':1, 'iso': "1",     'name':"Italian" },
+  'jp_kana': { 'size':3, 'iso': "KANA",  'name':"Japanese (Kana)" },
+  'ko_KR':   { 'size':1,                 'name':"Korean" },
+  'nl':      { 'size':1, 'iso': "1",     'name':"Dutch", 'noext':1 },
+  'pl':      { 'size':2, 'iso': "PL",    'name':"Polish" },
+  'pt':      { 'size':2, 'iso': "1",     'name':"Portuguese" },
+  'pt_br':   { 'size':2,                 'name':"Portuguese (Brazil)" },
+  'ro':      { 'size':2,                 'name':"Romanian" },
+  'ru':      { 'size':2, 'iso': "5",     'name':"Russian" },
+  'sk':      { 'size':2, 'iso': "SK",    'name':"Slovak" },
+  'sv':      { 'size':2, 'iso': "1",     'name':"Swedish" },
+  'tr':      { 'size':2, 'iso': "TR",    'name':"Turkish" },
+  'uk':      { 'size':2, 'iso': "5",     'name':"Ukrainian" },
+  'vi':      { 'size':2,                 'name':"Vietnamese" },
+  'zh_CN':   { 'size':3,                 'name':"Simplified Chinese" },
+  'zh_TW':   { 'size':3,                 'name':"Traditional Chinese" }
 }
 
-def namebyid(id):
-    if id in LANGNAME: return LANGNAME[id]
-    return '<unknown>'
+def infobyid(id, fld):
+    if id in LANGNAME and fld in LANGNAME[id]:
+        return LANGNAME[id][fld]
+    return None
+
+def language_name(id):       return infobyid(id, 'name') or '<unknown>'
+def language_iso(id):        return infobyid(id, 'iso')
+def language_charsize(id):   return infobyid(id, 'size')
+def language_noext(id):      return infobyid(id, 'noext')


### PR DESCRIPTION
Add an option `--translate` to `languageExport.py` which fills in missing LCD strings with LLM translations.