### PR TITLE
Add bed corner coordinate sanity checks

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -264,6 +264,14 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #if HAS_Y_AXIS
     static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS) are too narrow to contain Y_BED_SIZE.");
   #endif
+  #if HAS_X_AXIS && HAS_Y_AXIS && !IS_KINEMATIC
+    // Enforce a right-handed, monotonic XY bed definition (rotation + translation only)
+    constexpr float _bed_dx = X_MAX_POS - X_MIN_POS;
+    constexpr float _bed_dy = Y_MAX_POS - Y_MIN_POS;
+    static_assert(_bed_dx > 0, "X_MIN_POS must be less than X_MAX_POS (no mirrored X bed).");
+    static_assert(_bed_dy > 0, "Y_MIN_POS must be less than Y_MAX_POS (front is Y_MIN, back is Y_MAX).");
+    static_assert((_bed_dx * _bed_dy) > 0, "Bed corner winding is inverted (left-handed / mirrored bed definition).");
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
### Description

- Users can define bed corners that reflect the bed (e.g., front-left at YMAX, back-right at YMIN) instead of a rotation/translation of the canonical right-handed layout.
- Reflection flips handedness (right-handed -> left-handed) while axis directions stay the same.

## Impact
- Bed leveling math (ABL/UBL/bilinear) silently produces wrong mesh gradients and plane normals.
- Probe correction signs invert; leveling corrections move the nozzle the wrong way.
- No crash or explicit error—just bad leveling results.
- "Fixing" by flipping Z to restore handedness would also mirror every printed part (and toolpaths), so it is not a viable workaround.

## Fix / Sanity Check
- Added a compile-time check for Cartesian-style machines to enforce:
  - `X_MIN_POS < X_MAX_POS` and `Y_MIN_POS < Y_MAX_POS` (positive spans, monotonic axes).
  - Positive signed area / preserved winding: `_bed_dx * _bed_dy > 0` (reject mirrored/left-handed beds).
- This rejects reflected bed definitions while allowing any rotation/translation that preserves handedness.

### Requirements

A Bed

### Benefits

Valid beds are enforced

### Configurations

## Configuration context
- Bed dimensions come from `X_BED_SIZE` / `Y_BED_SIZE`.
- Axis travel limits (`X_MIN_POS`, `Y_MIN_POS`, `X_MAX_POS`, `Y_MAX_POS`) must form positive spans; the sanity check enforces right-handed XY orientation.

## Examples that trip the asserts
- X span inverted: `X_MIN_POS 10`, `X_MAX_POS 0` → `_bed_dx > 0` fails (`X_MIN_POS must be less than X_MAX_POS`).
- Y span inverted (mirrors front/back): `Y_MIN_POS 230`, `Y_MAX_POS 0` → `_bed_dy > 0` fails (`Y_MIN_POS must be less than Y_MAX_POS`).
- Mirrored winding: any config making `_bed_dx * _bed_dy <= 0` (e.g., both spans negative) → winding check fails (`Bed corner winding is inverted...`).

### Related Issues
<li>MarlinFirmware/Marlin/issues/28307

The incident-reported mapping

Front-Left  : (0, 230)
Front-Right : (230, 230)
Back-Left   : (0, 0)
Back-Right  : (230, 0)

is equivalent to setting Y to grow toward the front. Expressed as firmware bounds that mirror the bed, this corresponds to `Y_MIN_POS 230`, `Y_MAX_POS 0`, which the new `_bed_dy > 0` (and product) assertions will reject.
