### PR TITLE
FTM: Fix Linear Advance extruder skip when k-factor changes from k = 0 to k > 0

### DIFF
--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -478,12 +478,11 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
   LOGICAL_AXIS_MAP_LC(_SET_TRAJ);
 
   #if FTM_HAS_LIN_ADVANCE
+    float traj_e = traj_coords.e;
 
     // Apply LA/NLE only to printing (not retract/unretract) blocks
-
     if (use_advance_lead) {
       const float advK = planner.get_advance_k();
-      float traj_e = traj_coords.e;
       const float traj_e_delta = traj_e - prev_traj_e; // extruder delta in mm, always positive for use_advance_lead (printing moves)
       const float e_rate = traj_e_delta * FTM_FS;      // extruder velocity in mm/s
 
@@ -501,9 +500,9 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
           endPos_prevBlock.e += nle_term;
         }
       #endif
-
-      prev_traj_e = traj_e;
     }
+
+    prev_traj_e = traj_e;
 
   #endif // FTM_HAS_LIN_ADVANCE
 

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -483,30 +483,26 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
 
     if (use_advance_lead) {
       const float advK = planner.get_advance_k();
-      if (advK || TERN0(NONLINEAR_EXTRUSION, stepper.ne.settings.enabled)) {
-        float traj_e = traj_coords.e;
-        const float traj_e_delta = traj_e - prev_traj_e; // extruder delta in mm, always positive for use_advance_lead (printing moves)
-        const float e_rate = traj_e_delta * FTM_FS;      // extruder velocity in mm/s
+      float traj_e = traj_coords.e;
+      const float traj_e_delta = traj_e - prev_traj_e; // extruder delta in mm, always positive for use_advance_lead (printing moves)
+      const float e_rate = traj_e_delta * FTM_FS;      // extruder velocity in mm/s
 
-        traj_coords.e += e_rate * advK;
+      traj_coords.e += e_rate * advK;
 
-        #if ENABLED(NONLINEAR_EXTRUSION)
-          if (stepper.ne.settings.enabled) {
-            const nonlinear_coeff_t &coeff = stepper.ne.settings.coeff;
-            const float multiplier = max(coeff.C, coeff.A * sq(e_rate) + coeff.B * e_rate + coeff.C),
-                        nle_term = traj_e_delta * (multiplier - 1);
+      #if ENABLED(NONLINEAR_EXTRUSION)
+        if (stepper.ne.settings.enabled) {
+          const nonlinear_coeff_t &coeff = stepper.ne.settings.coeff;
+          const float multiplier = max(coeff.C, coeff.A * sq(e_rate) + coeff.B * e_rate + coeff.C),
+                      nle_term = traj_e_delta * (multiplier - 1);
 
-            traj_coords.e += nle_term;
-            traj_e += nle_term;
-            startPos.e += nle_term;
-            endPos_prevBlock.e += nle_term;
-          }
-        #endif
+          traj_coords.e += nle_term;
+          traj_e += nle_term;
+          startPos.e += nle_term;
+          endPos_prevBlock.e += nle_term;
+        }
+      #endif
 
-        prev_traj_e = traj_e;
-      } else {
-        prev_traj_e = traj_coords.e;
-      }
+      prev_traj_e = traj_e;
     }
 
   #endif // FTM_HAS_LIN_ADVANCE

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -482,11 +482,10 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
 
     // Apply LA/NLE only to printing (not retract/unretract) blocks
     if (use_advance_lead) {
-      const float advK = planner.get_advance_k();
-      const float traj_e_delta = traj_e - prev_traj_e; // extruder delta in mm, always positive for use_advance_lead (printing moves)
-      const float e_rate = traj_e_delta * FTM_FS;      // extruder velocity in mm/s
+      const float traj_e_delta = traj_e - prev_traj_e; // Extruder delta in mm, always positive for use_advance_lead (printing moves)
+      const float e_rate = traj_e_delta * (FTM_FS);    // Extruder velocity in mm/s
 
-      traj_coords.e += e_rate * advK;
+      traj_coords.e += e_rate * planner.get_advance_k();
 
       #if ENABLED(NONLINEAR_EXTRUSION)
         if (stepper.ne.settings.enabled) {

--- a/Marlin/src/module/ft_motion.cpp
+++ b/Marlin/src/module/ft_motion.cpp
@@ -504,6 +504,8 @@ xyze_float_t FTMotion::calc_traj_point(const float dist) {
         #endif
 
         prev_traj_e = traj_e;
+      } else {
+        prev_traj_e = traj_coords.e;
       }
     }
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
While printing a linear advance k-factor test tower, I noticed my extruder skipping during the transition from layer 4 to layer 5. During that time, the k-factor changes from 0 to 0.05. Looking at the code, the extruder velocity, _e_rate_, determined for the linear advance calculation was likely incorrect during the transition because _prev_traj_e_ was not updated when the k-factor is 0. I believe this caused the calculated _e_rate_ to skyrocket, which caused the extruder position to change dramatically, resulting in the extruder skipping. 
The fix updates _prev_traj_e_ even when the k-factor is 0.


https://github.com/user-attachments/assets/55485ee3-f5cc-4f75-8e1a-f408a7a2a37f


### Requirements

FT_Motion must be enabled, and the linear advance k-factor, set by M900, changes mid-print.

### Benefits

Prevents extruder skipping when k-factor transitions from k = 0 to k > 0. Helps prevent extruder skipping when using adaptive pressure advance in Orcaslicer.

### Configurations

- FT_MOTION is enabled

This is the configuration I used to test on my Ender 3 V2:
[Configurations.zip](https://github.com/user-attachments/files/24991039/Configurations.zip)

### Note
This is my first PR in this repo, and I would greatly appreciate any feedback.
