### PR TITLE
FTM_MINIMUM_CRUISE_RATIO

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1230,8 +1230,9 @@
     #define FTM_POLY6_ACCELERATION_OVERSHOOT 1.875f // Max acceleration overshoot factor for POLY6 (1.25 to 1.875)
   #endif
 
-  // Minimum fraction of distance to spend at cruising speed (0.0f disables)
-  #define FTM_MINIMUM_CRUISE_RATIO 0.5f
+  #define FTM_MINIMUM_CRUISE_RATIO 0.5f         // Minimum fraction of distance to spend at cruising speed (0.0f disables)
+                                                // Reduces vibrations and extrusion artefacts in short blocks like small surface
+                                                // features and thin solid infills
 
   /**
    * Advanced configuration

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1230,6 +1230,9 @@
     #define FTM_POLY6_ACCELERATION_OVERSHOOT 1.875f // Max acceleration overshoot factor for POLY6 (1.25 to 1.875)
   #endif
 
+  // Minimum fraction of distance to spend at cruising speed (0.0f disables)
+  #define FTM_MINIMUM_CRUISE_RATIO 0.5f
+
   /**
    * Advanced configuration
    */

--- a/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
+++ b/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
@@ -52,8 +52,11 @@ public:
       const float min_cruise_dist = distance * FTM_MINIMUM_CRUISE_RATIO;
       const float max_nominal_from_ratio = (distance - min_cruise_dist) * acceleration
                                            + 0.5f * (sq(initial_speed) + sq(final_speed));
-      const float ratio_limited_speed = SQRT(max_nominal_from_ratio);
-      nominal_speed = _MIN(ratio_limited_speed, nominal_speed);
+      float ratio_limited_speed = SQRT(max_nominal_from_ratio);
+      // Don’t allow it to go below endpoints (otherwise T1/T3 go negative)
+      const float v_floor = MAX(initial_speed, final_speed);
+      NOLESS(ratio_limited_speed, v_floor);
+      NOMORE(nominal_speed, ratio_limited_speed);
     }
 
     T2 = ldiff / nominal_speed - one_over_accel * nominal_speed;

--- a/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
+++ b/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
@@ -24,6 +24,10 @@
 #include "trajectory_generator.h"
 #include <math.h>
 
+#ifndef FTM_MINIMUM_CRUISE_RATIO
+  #define FTM_MINIMUM_CRUISE_RATIO 0
+#endif
+
 /**
  * Trapezoidal trajectory generator.
  * Provides continuous velocity, but acceleration is discontinuous.

--- a/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
+++ b/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
@@ -41,9 +41,16 @@ public:
     const float distance = distance_in;
     const float final_speed = final_speed_in; // just for consistency
 
-
     const float one_over_accel = 1.0f / acceleration;
     const float ldiff = distance + 0.5f * one_over_accel * (sq(initial_speed) + sq(final_speed));
+
+    if (FTM_MINIMUM_CRUISE_RATIO > 0) {
+      const float min_cruise_dist = distance * FTM_MINIMUM_CRUISE_RATIO;
+      const float max_nominal_from_ratio = (distance - min_cruise_dist) * acceleration
+                                           + 0.5f * (sq(initial_speed) + sq(final_speed));
+      const float ratio_limited_speed = SQRT(max_nominal_from_ratio);
+      nominal_speed = _MIN(ratio_limited_speed, nominal_speed);
+    }
 
     T2 = ldiff / nominal_speed - one_over_accel * nominal_speed;
     if (T2 < 0.0f) {

--- a/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
+++ b/Marlin/src/module/ft_motion/trajectory_trapezoidal.h
@@ -54,7 +54,7 @@ public:
                                            + 0.5f * (sq(initial_speed) + sq(final_speed));
       float ratio_limited_speed = SQRT(max_nominal_from_ratio);
       // Don’t allow it to go below endpoints (otherwise T1/T3 go negative)
-      const float v_floor = MAX(initial_speed, final_speed);
+      const float v_floor = _MAX(initial_speed, final_speed);
       NOLESS(ratio_limited_speed, v_floor);
       NOMORE(nominal_speed, ratio_limited_speed);
     }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Adds MINIMUM_CRUISE_RATIO to FTM. It does the same as klipper (see here: https://www.klipper3d.org/Config_Reference.html)

Minimum fraction of distance to spend at cruising speed (0.0f disables)
Reduces vibrations and extrusion artefacts in short blocks like small surface
features and thin solid infills
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
