### PR TITLE
catch DGUS_UI_IS define

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -802,3 +802,6 @@
 #define _HAS_E_TEMP(N) || TEMP_SENSOR(N)
 #define HAS_E_TEMP_SENSOR (0 REPEAT(EXTRUDERS, _HAS_E_TEMP))
 #define TEMP_SENSOR_IS_MAX_TC(T) (TEMP_SENSOR(T) == -5 || TEMP_SENSOR(T) == -3 || TEMP_SENSOR(T) == -2)
+
+// DGUS_UI_IS is only supported in Marlin >= 2.1.3
+#define DGUS_UI_IS(...) static_assert(false, "DGUS_UI_IS is only supported in Marlin Configuration.h >= 2.1.3; this version does not support it")

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -803,5 +803,4 @@
 #define HAS_E_TEMP_SENSOR (0 REPEAT(EXTRUDERS, _HAS_E_TEMP))
 #define TEMP_SENSOR_IS_MAX_TC(T) (TEMP_SENSOR(T) == -5 || TEMP_SENSOR(T) == -3 || TEMP_SENSOR(T) == -2)
 
-// DGUS_UI_IS is only supported in Marlin >= 2.1.3
-#define DGUS_UI_IS(...) static_assert(false, "DGUS_UI_IS is only supported in Marlin Configuration.h >= 2.1.3; this version does not support it")
+#define DGUS_UI_IS(...) 0 // Dummy macro needed for future preflight checking

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -87,6 +87,16 @@ if pioutil.is_pio_build():
                     raise SystemExit(err)
 
         #
+        # Check for DGUS_UI_IS in Configuration.h
+        #
+        config_path = epath / "Marlin" / "Configuration.h"
+        if config_path.is_file():
+            with config_path.open() as f:
+                if "DGUS_UI_IS" in f.read():
+                    err = "ERROR: Future Configurations (2.1.3 and up) are not supported for Marlin 2.1.2."
+                    raise SystemExit(err)
+
+        #
         # Find the name.cpp.o or name.o and remove it
         #
         def rm_ofile(subdir, name):


### PR DESCRIPTION
### Description

I've seen this to many times to count...

A user will attempt downgrade bugfix or a 2.1.3 Configuration.h to an older version and they get this error

```cpp
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../../Configuration.h:3339:15: error: missing binary operator before token "("
 3339 | #if DGUS_UI_IS(MKS)
      |               ^
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../../Configuration.h:3341:17: error: missing binary operator before token "("
 3341 | #elif DGUS_UI_IS(IA_CREALITY)
      |                 ^

```

They have no idea what this means

added a simple macro
```cpp
#define DGUS_UI_IS(...) static_assert(false, "DGUS_UI_IS is only supported in Marlin Configuration.h >= 2.1.3; this version does not support it")
```

So now it errors with

buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../core/macros.h:807:38: error: missing binary operator before token "("
 #define DGUS_UI_IS(...) static_assert(false, "DGUS_UI_IS is only supported in Marlin Configuration.h >= 2.1.3; this version does not support it")

### Requirements


Triggers if they have left in 

#if DGUS_UI_IS(MKS) or #elif DGUS_UI_IS(IA_CREALITY)

### Benefits

Less confused users (hopefully) 

### Related Issues

<li>MarlinFirmware/Marlin/issues/27986#issuecomment-3844573331