### PR TITLE
FTMotion snappy lcd

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -337,6 +337,9 @@ void MarlinUI::init() {
   #include "lcdprint.h"
 
   #include "../module/planner.h"
+  #if ENABLED(FT_MOTION)
+    #include "../module/ft_motion.h"
+  #endif
   #include "../module/motion.h"
 
   #if HAS_MARLINUI_MENU
@@ -1161,8 +1164,17 @@ void MarlinUI::init() {
     }
 
     if (lcd_update_ms_elapsed || drawing_screen) {
+      const auto buffer_runtime = [&]() -> uint16_t {
+        #if ENABLED(FT_MOTION)
+          // In ftmotion, the isr only looks at the stepping buffer and the planner buffer is
+          // consumed from the idle loop.
+          if (ftMotion.cfg.active) return ftMotion.stepping.buffer_runtime();
+        #endif
+        return planner.block_buffer_runtime();
+      };
+
       // Then we want to use only 50% of the time
-      const uint16_t bbr2 = planner.block_buffer_runtime() >> 1;
+      const uint16_t bbr2 = buffer_runtime() >> 1;
 
       if ((should_draw() || drawing_screen) && (!bbr2 || bbr2 > max_display_update_time)) {
 

--- a/Marlin/src/module/ft_motion/stepping.h
+++ b/Marlin/src/module/ft_motion/stepping.h
@@ -251,4 +251,11 @@ typedef struct Stepping {
     return ((stepper_plan_head + 1) & FTM_BUFFER_MASK) == stepper_plan_tail;
   }
 
+  // Buffer runtime in milliseconds (ignoring ticks left in current frame)
+  FORCE_INLINE uint16_t buffer_runtime() const {
+    const uint32_t queued_frames = (stepper_plan_head - stepper_plan_tail) & FTM_BUFFER_MASK;
+    const uint32_t queued_ms = queued_frames * (1000UL * FTM_TS);
+    return queued_ms;
+  }
+
 } stepping_t;


### PR DESCRIPTION
In ftm, the ISR doesn't consume the block buffer, so no need to check for its runtime when rendering the lcd. Instead, we need to check if there is enough time inside the stepping plan buffer.

This makes the LCD stay super snappy even when printing curves that have many small segments, since the stepping buffer contains a fixed amount of time worth of steps.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
