### PR TITLE
Fix #28340 : Compilation error with NO_MOTION_BEFORE_HOMING & HOME_AFTER_DEACTIVATE

### DIFF
--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -581,7 +581,7 @@ inline float home_bump_mm(const AxisEnum axis) {
 #endif
 
 #if ENABLED(NO_MOTION_BEFORE_HOMING)
-  #define MOTION_CONDITIONS (marlin.isRunning() && !homing_needed_error())
+  #define MOTION_CONDITIONS (marlin.isRunning() && !motion.homing_needed_error())
 #else
   #define MOTION_CONDITIONS marlin.isRunning()
 #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
In `motion.h`,  `#define MOTION_CONDITIONS (marlin.isRunning() && !homing_needed_error())` should be `#define MOTION_CONDITIONS (marlin.isRunning() && !motion.homing_needed_error())`
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
Bug #28340 
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
