### PR TITLE
Fix MKS TFT UI resume after filament change w/ PARK_HEAD_ON_PAUSE

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -721,7 +721,7 @@ void Marlin::manage_inactivity(const bool no_stepper_sleep/*=false*/) {
       motion.position.e += EXTRUDER_RUNOUT_EXTRUDE;
       motion.goto_current_position(MMM_TO_MMS(EXTRUDER_RUNOUT_SPEED));
       motion.position.e = olde;
-      planner.set_e_position_mm(olde);
+      motion.sync_plan_position_e();
       planner.synchronize();
 
       if (e_off) stepper.DISABLE_EXTRUDER(e_stepper);

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -731,7 +731,8 @@ void resume_print(
 
   // Now all extrusion positions are resumed and ready to be confirmed
   // Set extruder to saved position
-  planner.set_e_position_mm((motion.destination.e = motion.position.e = resume_position.e));
+  motion.destination.e = motion.position.e = resume_position.e;
+  motion.sync_plan_position_e();
 
   ui.pause_show_message(PAUSE_MESSAGE_STATUS);
   #if ENABLED(SOVOL_SV06_RTS)

--- a/Marlin/src/lcd/dwin/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/jyersui/dwin.cpp
@@ -4600,12 +4600,8 @@ void JyersDWIN::printScreenControl() {
               card.startOrResumeFilePrinting();
               TERN_(POWER_LOSS_RECOVERY, recovery.prepare());
             #else
-              #if HAS_HEATED_BED
-                queue.inject(TS(F("M140 S"), pausebed));
-              #endif
-              #if HAS_EXTRUDERS
-                queue.inject(TS(F("M109 S"), pausetemp));
-              #endif
+              TERN_(HAS_HEATED_BED, queue.inject(TS(F("M140 S"), pausebed)));
+              TERN_(HAS_EXTRUDERS, queue.inject(TS(F("M109 S"), pausetemp)));
               TERN_(HAS_FAN, thermalManager.fan_speed[0] = pausefan);
               planner.synchronize();
               TERN_(HAS_MEDIA, queue.inject(FPSTR(M24_STR)));
@@ -4641,9 +4637,7 @@ void JyersDWIN::popupControl() {
       case Popup_Pause:
         if (selection == 0) {
           if (sdprint) {
-            #if ENABLED(POWER_LOSS_RECOVERY)
-              if (recovery.enabled) recovery.save(true);
-            #endif
+            TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
             #if ENABLED(PARK_HEAD_ON_PAUSE)
               popupHandler(Popup_Home, true);
               #if HAS_MEDIA

--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -176,7 +176,7 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
       uiCfg.hotendTargetTempBak = thermalManager.degTargetHotend(active_extruder);
       uiCfg.moveSpeed_bak = (uint16_t)feedrate_mm_s;
       lv_clear_dialog();
-      disp_state_stack._disp_index--;  
+      disp_state_stack._disp_index--;
       lv_draw_filament_change();
     }
   }

--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -35,6 +35,7 @@
 #include "../../../gcode/queue.h"
 #include "../../../module/temperature.h"
 #include "../../../module/planner.h"
+#include "../../../module/motion.h"
 #include "../../../gcode/gcode.h"
 #include "../../../inc/MarlinConfig.h"
 
@@ -168,6 +169,16 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
     uiCfg.filament_heat_completed_unload = true;
   else if (DIALOG_IS(TYPE_FILAMENT_LOAD_COMPLETED, TYPE_FILAMENT_UNLOAD_COMPLETED)) {
     goto_previous_ui();
+  }
+  else if (DIALOG_IS(TYPE_FILAMENT_NO_PRESS)) {
+    if(uiCfg.print_state == PAUSED)
+    {
+      uiCfg.hotendTargetTempBak = thermalManager.degTargetHotend(active_extruder);
+      uiCfg.moveSpeed_bak = (uint16_t)feedrate_mm_s;
+      lv_clear_dialog();
+      disp_state_stack._disp_index--;  
+      lv_draw_filament_change();
+    }
   }
   #if ENABLED(MKS_WIFI_MODULE)
     else if (DIALOG_IS(TYPE_UNBIND)) {
@@ -436,6 +447,10 @@ void lv_draw_dialog(uint8_t type) {
   else if (DIALOG_IS(TYPE_FILAMENT_UNLOADING)) {
     lv_label_set_text(labelDialog, filament_menu.filament_dialog_unloading);
     lv_obj_align(labelDialog, nullptr, LV_ALIGN_CENTER, 0, -70);
+  }
+  else if (DIALOG_IS(TYPE_FILAMENT_NO_PRESS)) {
+    lv_label_set_text(labelDialog, print_file_dialog_menu.filament_no_press);
+    lv_obj_align(labelDialog, nullptr, LV_ALIGN_CENTER, 0, -20);
   }
   #if ENABLED(MKS_WIFI_MODULE)
     else if (DIALOG_IS(TYPE_UNBIND)) {

--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -173,8 +173,8 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
   else if (DIALOG_IS(TYPE_FILAMENT_NO_PRESS)) {
     if(uiCfg.print_state == PAUSED)
     {
-      uiCfg.hotendTargetTempBak = thermalManager.degTargetHotend(active_extruder);
-      uiCfg.moveSpeed_bak = (uint16_t)feedrate_mm_s;
+      uiCfg.hotendTargetTempBak = thermalManager.degTargetHotend(motion.extruder);
+      uiCfg.moveSpeed_bak = (uint16_t)motion.feedrate_mm_s;
       lv_clear_dialog();
       disp_state_stack._disp_index--;
       lv_draw_filament_change();

--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -76,9 +76,7 @@ extern bool temps_update_flag;
 static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
   if (DIALOG_IS(TYPE_PRINT_FILE)) {
-    #if HAS_GCODE_PREVIEW
-      preview_gcode_prehandle(list_file.file_name[sel_id]);
-    #endif
+    TERN_(HAS_GCODE_PREVIEW, preview_gcode_prehandle(list_file.file_name[sel_id]));
     reset_print_time();
     start_print_time();
 
@@ -129,10 +127,12 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
     lv_draw_ready_print();
   }
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
-    else if (DIALOG_IS(PAUSE_MESSAGE_WAITING, PAUSE_MESSAGE_INSERT, PAUSE_MESSAGE_HEAT))
+    else if (DIALOG_IS(PAUSE_MESSAGE_WAITING, PAUSE_MESSAGE_INSERT, PAUSE_MESSAGE_HEAT)) {
       marlin.user_resume();
-    else if (DIALOG_IS(PAUSE_MESSAGE_OPTION))
+    }
+    else if (DIALOG_IS(PAUSE_MESSAGE_OPTION)) {
       pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
+    }
     else if (DIALOG_IS(PAUSE_MESSAGE_RESUME)) {
       goto_previous_ui();
     }
@@ -163,16 +163,17 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
     uiCfg.configWifi = true;
     goto_previous_ui();
   }
-  else if (DIALOG_IS(TYPE_FILAMENT_HEAT_LOAD_COMPLETED))
+  else if (DIALOG_IS(TYPE_FILAMENT_HEAT_LOAD_COMPLETED)) {
     uiCfg.filament_heat_completed_load = true;
-  else if (DIALOG_IS(TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED))
+  }
+  else if (DIALOG_IS(TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED)) {
     uiCfg.filament_heat_completed_unload = true;
+  }
   else if (DIALOG_IS(TYPE_FILAMENT_LOAD_COMPLETED, TYPE_FILAMENT_UNLOAD_COMPLETED)) {
     goto_previous_ui();
   }
   else if (DIALOG_IS(TYPE_FILAMENT_NO_PRESS)) {
-    if(uiCfg.print_state == PAUSED)
-    {
+    if (uiCfg.print_state == PAUSED) {
       uiCfg.hotendTargetTempBak = thermalManager.degTargetHotend(motion.extruder);
       uiCfg.moveSpeed_bak = (uint16_t)motion.feedrate_mm_s;
       lv_clear_dialog();
@@ -195,10 +196,10 @@ static void btn_cancel_event_cb(lv_obj_t *btn, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
   if (DIALOG_IS(PAUSE_MESSAGE_OPTION)) {
     TERN_(ADVANCED_PAUSE_FEATURE, pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT);
+    return;
   }
-  else if (DIALOG_IS(TYPE_FILAMENT_LOAD_HEAT, TYPE_FILAMENT_UNLOAD_HEAT, TYPE_FILAMENT_HEAT_LOAD_COMPLETED, TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED)) {
+  if (DIALOG_IS(TYPE_FILAMENT_LOAD_HEAT, TYPE_FILAMENT_UNLOAD_HEAT, TYPE_FILAMENT_HEAT_LOAD_COMPLETED, TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED)) {
     thermalManager.setTargetHotend(uiCfg.hotendTargetTempBak, uiCfg.extruderIndex);
-    goto_previous_ui();
   }
   else if (DIALOG_IS(TYPE_FILAMENT_LOADING, TYPE_FILAMENT_UNLOADING)) {
     queue.enqueue_one(F("M410"));
@@ -210,11 +211,8 @@ static void btn_cancel_event_cb(lv_obj_t *btn, lv_event_t event) {
     uiCfg.filament_unloading_time_flg  = false;
     uiCfg.filament_unloading_time_cnt  = 0;
     thermalManager.setTargetHotend(uiCfg.hotendTargetTempBak, uiCfg.extruderIndex);
-    goto_previous_ui();
   }
-  else {
-    goto_previous_ui();
-  }
+  goto_previous_ui();
 }
 
 void lv_draw_dialog(uint8_t type) {

--- a/Marlin/src/lcd/extui/mks_ui/draw_filament_change.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_filament_change.cpp
@@ -97,8 +97,10 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
           gcode.process_subcommands_now(uiCfg.extruderIndexBak == 1 ? F("T1") : F("T0"));
       #endif
       motion.feedrate_mm_s = (float)uiCfg.moveSpeed_bak;
-      if (uiCfg.print_state == PAUSED)
-        planner.set_e_position_mm((motion.destination.e = motion.position.e = uiCfg.current_e_position_bak));
+      if (uiCfg.print_state == PAUSED) {
+        motion.destination.e = motion.position.e = uiCfg.current_position_bak.e;
+        motion.sync_plan_position_e();
+      }
       thermalManager.setTargetHotend(uiCfg.hotendTargetTempBak, uiCfg.extruderIndex);
 
       goto_previous_ui();

--- a/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_number_key.cpp
@@ -156,9 +156,9 @@ static void disp_key_value() {
     case E0current: TERN_(E0_IS_TRINAMIC, dtostrf(stepperE0.getMilliamps(), 1, 1, public_buf_m)); break;
     case E1current: TERN_(E1_IS_TRINAMIC, dtostrf(stepperE1.getMilliamps(), 1, 1, public_buf_m)); break;
 
-    case pause_pos_x: dtostrf(gCfgItems.pausePosX, 1, 1, public_buf_m); break;
-    case pause_pos_y: dtostrf(gCfgItems.pausePosY, 1, 1, public_buf_m); break;
-    case pause_pos_z: dtostrf(gCfgItems.pausePosZ, 1, 1, public_buf_m); break;
+    case pause_pos_x: dtostrf(gCfgItems.pausePos.x, 1, 1, public_buf_m); break;
+    case pause_pos_y: dtostrf(gCfgItems.pausePos.y, 1, 1, public_buf_m); break;
+    case pause_pos_z: dtostrf(gCfgItems.pausePos.z, 1, 1, public_buf_m); break;
 
     case level_pos_x1: itoa(gCfgItems.trammingPos[0].x, public_buf_m, 10); break;
     case level_pos_y1: itoa(gCfgItems.trammingPos[0].y, public_buf_m, 10); break;
@@ -271,9 +271,9 @@ static void set_value_confirm() {
     case E0current: TERN_(E0_IS_TRINAMIC, stepperE0.rms_current(atoi(key_value))); break;
     case E1current: TERN_(E1_IS_TRINAMIC, stepperE1.rms_current(atoi(key_value))); break;
 
-    case pause_pos_x: gCfgItems.pausePosX = atof(key_value); update_spi_flash(); break;
-    case pause_pos_y: gCfgItems.pausePosY = atof(key_value); update_spi_flash(); break;
-    case pause_pos_z: gCfgItems.pausePosZ = atof(key_value); update_spi_flash(); break;
+    case pause_pos_x: gCfgItems.pausePos.x = atof(key_value); update_spi_flash(); break;
+    case pause_pos_y: gCfgItems.pausePos.y = atof(key_value); update_spi_flash(); break;
+    case pause_pos_z: gCfgItems.pausePos.z = atof(key_value); update_spi_flash(); break;
 
     case level_pos_x1: gCfgItems.trammingPos[0].x = atoi(key_value); update_spi_flash(); break;
     case level_pos_y1: gCfgItems.trammingPos[0].y = atoi(key_value); update_spi_flash(); break;

--- a/Marlin/src/lcd/extui/mks_ui/draw_pause_position.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_pause_position.cpp
@@ -63,13 +63,13 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
 void lv_draw_pause_position() {
   scr = lv_screen_create(PAUSE_POS_UI, machine_menu.PausePosText);
 
-  dtostrf(gCfgItems.pausePosX, 1, 1, public_buf_l);
+  dtostrf(gCfgItems.pausePos.x, 1, 1, public_buf_l);
   lv_screen_menu_item_1_edit(scr, machine_menu.xPos, PARA_UI_POS_X, PARA_UI_POS_Y, event_handler, ID_PAUSE_X, 0, public_buf_l);
 
-  dtostrf(gCfgItems.pausePosY, 1, 1, public_buf_l);
+  dtostrf(gCfgItems.pausePos.y, 1, 1, public_buf_l);
   lv_screen_menu_item_1_edit(scr, machine_menu.yPos, PARA_UI_POS_X, PARA_UI_POS_Y * 2, event_handler, ID_PAUSE_Y, 1, public_buf_l);
 
-  dtostrf(gCfgItems.pausePosZ, 1, 1, public_buf_l);
+  dtostrf(gCfgItems.pausePos.z, 1, 1, public_buf_l);
   lv_screen_menu_item_1_edit(scr, machine_menu.zPos, PARA_UI_POS_X, PARA_UI_POS_Y * 3, event_handler, ID_PAUSE_Z, 2, public_buf_l);
 
   lv_big_button_create(scr, "F:/bmp_back70x40.bin", common_menu.text_back, PARA_UI_BACK_POS_X, PARA_UI_BACK_POS_Y, event_handler, ID_PAUSE_RETURN, true);

--- a/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
@@ -116,9 +116,7 @@ void gCfgItems_init() {
   gCfgItems.curFilesize       = 0;
   gCfgItems.finish_power_off  = false;
   gCfgItems.pause_reprint     = false;
-  gCfgItems.pausePosX         = -1;
-  gCfgItems.pausePosY         = -1;
-  gCfgItems.pausePosZ         = 5;
+  gCfgItems.pausePos.set(-1, -1, 5);
   gCfgItems.trammingPos[0].x  = X_MIN_POS + 30;
   gCfgItems.trammingPos[0].y  = Y_MIN_POS + 30;
   gCfgItems.trammingPos[1].x  = X_MAX_POS - 30;

--- a/Marlin/src/lcd/extui/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/mks_ui/draw_ui.h
@@ -205,7 +205,7 @@ typedef struct {
             filamentchange_unload_length,
             filamentchange_unload_speed;
   celsius_t filament_limit_temp;
-  float     pausePosX, pausePosY, pausePosZ;
+  xyz_pos_t pausePos;
   uint32_t  curFilesize;
 } CFG_ITMES;
 
@@ -255,10 +255,7 @@ typedef struct UI_Config_Struct {
            filament_unloading_time_cnt;
   float move_dist;
   celsius_t hotendTargetTempBak;
-  float current_x_position_bak,
-        current_y_position_bak,
-        current_z_position_bak,
-        current_e_position_bak;
+  xyze_pos_t current_position_bak;
 } UI_CFG;
 
 typedef enum {

--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
@@ -49,7 +49,6 @@ extern uint32_t To_pre_view;
 extern bool flash_preview_begin, default_preview_flg, gcode_preview_over;
 
 void printer_state_polling() {
-  char str_1[16], str_2[16];
   if (uiCfg.print_state == PAUSING) {
     #if HAS_MEDIA
       if (!planner.has_blocks_queued() && card.getIndex() > MIN_FILE_PRINTED)
@@ -62,25 +61,18 @@ void printer_state_polling() {
         card.pauseSDPrint();
         print_job_timer.pause();
 
-        #if ENABLED(POWER_LOSS_RECOVERY)
-          if (recovery.enabled) recovery.save(true);
-        #endif
+        TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
 
         // save the position
-        uiCfg.current_x_position_bak = motion.position.x;
-        uiCfg.current_y_position_bak = motion.position.y;
-        uiCfg.current_z_position_bak = motion.position.z;
+        uiCfg.current_position_bak = motion.position;
 
-        if (gCfgItems.pausePosZ != (float)-1) {
-          sprintf_P(public_buf_l, PSTR("G91\nG1 Z%s\nG90"), dtostrf(gCfgItems.pausePosZ, 1, 1, str_1));
-          gcode.process_subcommands_now(public_buf_l);
+        if (gCfgItems.pausePos.z != -1.0f) {
+          gcode.process_subcommands_now(TS(F("G91\nG1Z"), p_float_t(gCfgItems.pausePos.z, 1), F("\nG90")));
         }
-        if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
-          sprintf_P(public_buf_l, PSTR("G1 X%s Y%s"), dtostrf(gCfgItems.pausePosX, 1, 1, str_1), dtostrf(gCfgItems.pausePosY, 1, 1, str_2));
-          gcode.process_subcommands_now(public_buf_l);
+        if (gCfgItems.pausePos.x != -1.0f && gCfgItems.pausePos.y != -1.0f) {
+          gcode.process_subcommands_now(TS(F("G1X"), p_float_t(gCfgItems.pausePos.x, 1), C('Y'), p_float_t(gCfgItems.pausePos.y, 1)));
         }
         uiCfg.print_state = PAUSED;
-        uiCfg.current_e_position_bak = motion.position.e;
 
         gCfgItems.pause_reprint = true;
         update_spi_flash();
@@ -95,15 +87,10 @@ void printer_state_polling() {
 
   if (uiCfg.print_state == RESUMING) {
     if (card.isPaused()) {
-      if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
-        sprintf_P(public_buf_m, PSTR("G1 X%s Y%s"), dtostrf(uiCfg.current_x_position_bak, 1, 1, str_1), dtostrf(uiCfg.current_y_position_bak, 1, 1, str_2));
-        gcode.process_subcommands_now(public_buf_m);
-      }
-      if (gCfgItems.pausePosZ != (float)-1) {
-        ZERO(public_buf_m);
-        sprintf_P(public_buf_m, PSTR("G1 Z%s"), dtostrf(uiCfg.current_z_position_bak, 1, 1, str_1));
-        gcode.process_subcommands_now(public_buf_m);
-      }
+      if (gCfgItems.pausePos.x != -1.0f && gCfgItems.pausePos.y != -1.0f)
+        gcode.process_subcommands_now(TS(F("G1X"), p_float_t(uiCfg.current_position_bak.x, 1), C('Y'), p_float_t(uiCfg.current_position_bak.y, 1)));
+      if (gCfgItems.pausePos.z != -1.0f)
+        gcode.process_subcommands_now(TS(F("G1Z"), p_float_t(uiCfg.current_position_bak.z, 1)));
       card.startOrResumeFilePrinting();
       marlin.startOrResumeJob();
       TERN_(POWER_LOSS_RECOVERY, recovery.prepare());
@@ -121,12 +108,8 @@ void printer_state_polling() {
         HOTEND_LOOP() {
           const int16_t et = recovery.info.target_temperature[e];
           if (et) {
-            #if HAS_MULTI_HOTEND
-              sprintf_P(public_buf_m, PSTR("T%i"), e);
-              gcode.process_subcommands_now(public_buf_m);
-            #endif
-            sprintf_P(public_buf_m, PSTR("M109 S%i"), et);
-            gcode.process_subcommands_now(public_buf_m);
+            TERN_(HAS_MULTI_HOTEND, gcode.process_subcommands_now(TS(C('T'), e)));
+            gcode.process_subcommands_now(TS(F("M109S"), et));
           }
         }
       #endif
@@ -135,17 +118,9 @@ void printer_state_polling() {
 
       #if 0
         // Move back to the saved XY
-        char str_1[16], str_2[16];
-        sprintf_P(public_buf_m, PSTR("G1 X%s Y%s F2000"),
-          dtostrf(recovery.info.current_position.x, 1, 3, str_1),
-          dtostrf(recovery.info.current_position.y, 1, 3, str_2)
-        );
-        gcode.process_subcommands_now(public_buf_m);
-
-        if (gCfgItems.pause_reprint && gCfgItems.pausePosZ != -1.0f) {
-          sprintf_P(public_buf_l, PSTR("G91\nG1 Z-%s\nG90"), dtostrf(gCfgItems.pausePosZ, 1, 1, str_2));
-          gcode.process_subcommands_now(public_buf_l);
-        }
+        gcode.process_subcommands_now(TS(F("G1F2000X"), p_float_t(recovery.info.current_position.x, 3), C('Y'), p_float_t(recovery.info.current_position.y, 3)));
+        if (gCfgItems.pause_reprint && gCfgItems.pausePos.z != -1.0f)
+          gcode.process_subcommands_now(TS(F("G91\nG1Z-"), p_float_t(gCfgItems.pausePos.z, 1), F("\nG90")));
       #endif
       uiCfg.print_state = WORKING;
       start_print_time();

--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
@@ -38,6 +38,7 @@
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../../../feature/powerloss.h"
 #endif
+#include "../../../module/printcounter.h"
 
 #define FILAMENT_IS_OUT(N...) (READ(FIL_RUNOUT##N##_PIN) == FIL_RUNOUT##N##_STATE)
 #ifndef FILAMENT_RUNOUT_THRESHOLD
@@ -47,8 +48,8 @@
 extern uint32_t To_pre_view;
 extern bool flash_preview_begin, default_preview_flg, gcode_preview_over;
 
-void printer_state_polling() {
-  char str_1[16];
+void printer_state_polling() {  
+  char str_1[16], str_2[16];
   if (uiCfg.print_state == PAUSING) {
     #if HAS_MEDIA
       if (!planner.has_blocks_queued() && card.getIndex() > MIN_FILE_PRINTED)
@@ -57,8 +58,13 @@ void printer_state_polling() {
       if (uiCfg.waitEndMoves > 20) {
         uiCfg.waitEndMoves = 0;
         planner.synchronize();
+       
+        card.pauseSDPrint();
+        print_job_timer.pause();
 
-        gcode.process_subcommands_now(F("M25"));
+        #if ENABLED(POWER_LOSS_RECOVERY)
+          if (recovery.enabled) recovery.save(true);
+        #endif
 
         // save the position
         uiCfg.current_x_position_bak = motion.position.x;
@@ -69,8 +75,8 @@ void printer_state_polling() {
           sprintf_P(public_buf_l, PSTR("G91\nG1 Z%s\nG90"), dtostrf(gCfgItems.pausePosZ, 1, 1, str_1));
           gcode.process_subcommands_now(public_buf_l);
         }
-        if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
-          sprintf_P(public_buf_l, PSTR("G1 X%s Y%s"), dtostrf(gCfgItems.pausePosX, 1, 1, str_1), dtostrf(gCfgItems.pausePosY, 1, 1, str_1));
+        if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {          
+          sprintf_P(public_buf_l, PSTR("G1 X%s Y%s"), dtostrf(gCfgItems.pausePosX, 1, 1, str_1), dtostrf(gCfgItems.pausePosY, 1, 1, str_2));
           gcode.process_subcommands_now(public_buf_l);
         }
         uiCfg.print_state = PAUSED;
@@ -89,16 +95,18 @@ void printer_state_polling() {
 
   if (uiCfg.print_state == RESUMING) {
     if (card.isPaused()) {
-      if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
-        sprintf_P(public_buf_m, PSTR("G1 X%s Y%s"), dtostrf(uiCfg.current_x_position_bak, 1, 1, str_1), dtostrf(uiCfg.current_y_position_bak, 1, 1, str_1));
+      if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {        
+        sprintf_P(public_buf_m, PSTR("G1 X%s Y%s"), dtostrf(uiCfg.current_x_position_bak, 1, 1, str_1), dtostrf(uiCfg.current_y_position_bak, 1, 1, str_2));
         gcode.process_subcommands_now(public_buf_m);
       }
       if (gCfgItems.pausePosZ != (float)-1) {
         ZERO(public_buf_m);
         sprintf_P(public_buf_m, PSTR("G1 Z%s"), dtostrf(uiCfg.current_z_position_bak, 1, 1, str_1));
         gcode.process_subcommands_now(public_buf_m);
-      }
-      gcode.process_subcommands_now(FPSTR(M24_STR));
+      }      
+      card.startOrResumeFilePrinting();
+      startOrResumeJob();
+      TERN_(POWER_LOSS_RECOVERY, recovery.prepare());
       uiCfg.print_state = WORKING;
       start_print_time();
 
@@ -209,8 +217,8 @@ void filament_check() {
       flash_preview_begin = true;
     else
       default_preview_flg = true;
-
-    lv_draw_printing();
+    
+    lv_draw_dialog(DIALOG_TYPE_FILAMENT_NO_PRESS);
   }
 }
 

--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
@@ -105,7 +105,7 @@ void printer_state_polling() {
         gcode.process_subcommands_now(public_buf_m);
       }
       card.startOrResumeFilePrinting();
-      startOrResumeJob();
+      marlin.startOrResumeJob();
       TERN_(POWER_LOSS_RECOVERY, recovery.prepare());
       uiCfg.print_state = WORKING;
       start_print_time();

--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
@@ -48,7 +48,7 @@
 extern uint32_t To_pre_view;
 extern bool flash_preview_begin, default_preview_flg, gcode_preview_over;
 
-void printer_state_polling() {  
+void printer_state_polling() {
   char str_1[16], str_2[16];
   if (uiCfg.print_state == PAUSING) {
     #if HAS_MEDIA
@@ -58,7 +58,7 @@ void printer_state_polling() {
       if (uiCfg.waitEndMoves > 20) {
         uiCfg.waitEndMoves = 0;
         planner.synchronize();
-       
+
         card.pauseSDPrint();
         print_job_timer.pause();
 
@@ -75,7 +75,7 @@ void printer_state_polling() {
           sprintf_P(public_buf_l, PSTR("G91\nG1 Z%s\nG90"), dtostrf(gCfgItems.pausePosZ, 1, 1, str_1));
           gcode.process_subcommands_now(public_buf_l);
         }
-        if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {          
+        if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
           sprintf_P(public_buf_l, PSTR("G1 X%s Y%s"), dtostrf(gCfgItems.pausePosX, 1, 1, str_1), dtostrf(gCfgItems.pausePosY, 1, 1, str_2));
           gcode.process_subcommands_now(public_buf_l);
         }
@@ -95,7 +95,7 @@ void printer_state_polling() {
 
   if (uiCfg.print_state == RESUMING) {
     if (card.isPaused()) {
-      if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {        
+      if (gCfgItems.pausePosX != (float)-1 && gCfgItems.pausePosY != (float)-1) {
         sprintf_P(public_buf_m, PSTR("G1 X%s Y%s"), dtostrf(uiCfg.current_x_position_bak, 1, 1, str_1), dtostrf(uiCfg.current_y_position_bak, 1, 1, str_2));
         gcode.process_subcommands_now(public_buf_m);
       }
@@ -103,7 +103,7 @@ void printer_state_polling() {
         ZERO(public_buf_m);
         sprintf_P(public_buf_m, PSTR("G1 Z%s"), dtostrf(uiCfg.current_z_position_bak, 1, 1, str_1));
         gcode.process_subcommands_now(public_buf_m);
-      }      
+      }
       card.startOrResumeFilePrinting();
       startOrResumeJob();
       TERN_(POWER_LOSS_RECOVERY, recovery.prepare());
@@ -217,7 +217,7 @@ void filament_check() {
       flash_preview_begin = true;
     else
       default_preview_flg = true;
-    
+
     lv_draw_dialog(DIALOG_TYPE_FILAMENT_NO_PRESS);
   }
 }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1943,8 +1943,8 @@ void Motion::prepare_line_to_destination() {
       #endif
 
       if (ignore_e) {
-        position.e = destination.e;       // Behave as if the E move really took place
-        planner.set_e_position_mm(destination.e); // Prevent the planner from complaining too
+        position.e = destination.e; // Behave as if the E move really took place
+        sync_plan_position_e();     // Prevent the planner from complaining too
       }
     }
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1094,7 +1094,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       if (motion.position.e < 0) motion.unscaled_e_move(motion.position.e, MMM_TO_MMS(toolchange_settings.retract_speed));
 
       planner.synchronize();
-      planner.set_e_position_mm(motion.position.e); // Extruder primed and ready
+      motion.sync_plan_position_e(); // Extruder primed and ready
     }
   }
 
@@ -1635,7 +1635,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     motion.position.e = resume_current_e;
 
     planner.synchronize();
-    planner.set_e_position_mm(motion.position.e); // New extruder primed and ready
+    motion.sync_plan_position_e();  // New extruder primed and ready
 
     DEBUG_ECHOLNPGM("Migration Complete");
     return true;


### PR DESCRIPTION
### Description

Fix resume button not working after filament change on MKS TFT UI when `PARK_HEAD_ON_PAUSE` is enabled.

**Root cause:** The MKS PAUSING handler called `M25` via `process_subcommands_now()`. With `PARK_HEAD_ON_PAUSE` enabled, M25 triggers M125 which enters `wait_for_confirmation()` — a blocking `while(wait_for_user)` loop. This prevents `uiCfg.print_state` from ever reaching `PAUSED`, so the Resume button (which checks for `PAUSED` state) does nothing.

**Changes in `printer_operation.cpp`:**
- **PAUSING handler:** Replace `M25` with direct calls (`card.pauseSDPrint()`, `print_job_timer.pause()`, power-loss save) to avoid M125 blocking
- **RESUMING handler:** Replace `M24` with direct calls (`card.startOrResumeFilePrinting()`, `startOrResumeJob()`) to avoid `resume_print()` conflicting with MKS UI's own park/unpark logic
- **Fix dtostrf buffer reuse bug:** X and Y coordinates both used the same `str_1` buffer in `dtostrf()`, causing both to get the same value. Now uses separate `str_1`/`str_2` buffers

**Changes in `draw_dialog.cpp`:**
- Add `DIALOG_TYPE_FILAMENT_NO_PRESS` dialog with OK/Cancel for filament runout, giving the user the option to load new filament before resuming
- Guard filament change entry with `print_state == PAUSED` check

### Requirements

MKS TFT LVGL UI with `PARK_HEAD_ON_PAUSE` enabled and MKS filament detection pins (`MT_DET_1`/`2`/`3`).

### Benefits

- Filament change after runout detection works correctly — Resume button functions as expected
- Fixes position corruption from shared `dtostrf` buffer (X/Y park coordinates)
- Prevents entering filament change screen before pause is fully completed

### Related Issues

Fixes: Resume button unresponsive after filament change on MKS Robin boards with `PARK_HEAD_ON_PAUSE`
