### PR TITLE
fix for machines with z_min end-stops + probes

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -2898,6 +2898,11 @@ void Motion::set_axis_is_at_home(const AxisEnum axis) {
         #endif
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed with PROBE" TERN_(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, " (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)") " ***\n> (M851 Z", probe.offset.z, ")");
       #else
+      /**
+       * This is critical for machines with z_min endstops + probes (probe and Z endstop are independent), 
+       * force Z to be 0 so that auto MESH bed leveling correctly applies probe offset from a properly endstop zeroed bed.
+       */      
+        position.z = 0; //critical for machines with z_min endstops + probes
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z homed to ENDSTOP ***");
       #endif
     }


### PR DESCRIPTION
fix for machines with z_min endstops + probes

### Description
fix for machines with z_min endstops + probes, which are independent of each other.
When using AUTO_BED_LEVELING_BILINEAR the Z homing must be zeroed before creating the bed meshes; otherwise the bed mesh never subtracts the Z offset during creation. 
Currently the Z position is only zeroed when using a probe to home. Now it will be zeroed when using a mechanical endstop to home, or a probe to home. The fix is a single line of code.

### Related Issues
fixes all these issues...
https://github.com/MarlinFirmware/Marlin/issues/27680
https://github.com/MarlinFirmware/Marlin/issues/22653
https://github.com/MarlinFirmware/Marlin/issues/21727
https://github.com/MarlinFirmware/Marlin/issues/21833


