### PR TITLE
Fixed SCARA homing + improvements for MPSCARA

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1105,6 +1105,14 @@
 
   #elif ENABLED(MP_SCARA)
 
+    #define SCARA_IS_RIGHT_HANDED true   // Direction of elbow bend
+
+    // If distal arm angle (relative to cartesian X axis) is affected by shoulder
+    // movement, #define this to counteract it. Leave it undefined for original MPSCARA.
+    //#define SCARA_CROSSTALK_FACTOR 0.3333333
+
+    // Proximal and distal arm angles (degrees relative to cartesian X axis) when in home position.
+    // If left undefined, cartesian home is used and angles are calculated by inverse kinematics.
     #define SCARA_OFFSET_THETA1  12 // degrees
     #define SCARA_OFFSET_THETA2 131 // degrees
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -105,7 +105,26 @@
       };
     #endif
 
-    motion.blocking_move_xy(1.5 * motion.max_axis_length(X_AXIS) * x_axis_home_dir, 1.5 * motion.max_axis_length(Y_AXIS) * Y_HOME_DIR, fr_mm_s);
+    // SCARA should move in angular coordinates
+    #if IS_SCARA
+      // This code is similar to Motion::do_homing_move, but for two axes at once
+
+      #if HAS_DIST_MM_ARG
+        const xyze_float_t cart_dist_mm{0};
+      #endif
+
+      abce_pos_t target = planner.get_axis_positions_mm();
+
+      target[X_AXIS] += 360 * x_axis_home_dir; // Move 360 degrees towards the endstop
+      target[Y_AXIS] += 360 * Y_HOME_DIR;      // Move 360 degrees towards the endstop
+      planner.buffer_segment(target OPTARG(HAS_DIST_MM_ARG, cart_dist_mm), fr_mm_s, motion.extruder);
+      planner.synchronize();
+
+    #else
+
+      motion.blocking_move_xy(1.5 * motion.max_axis_length(X_AXIS) * x_axis_home_dir, 1.5 * motion.max_axis_length(Y_AXIS) * Y_HOME_DIR, fr_mm_s);
+
+    #endif
 
     endstops.validate_homing_move();
 
@@ -418,6 +437,11 @@ void GcodeSuite::G28() {
           #if ENABLED(DUAL_X_CARRIAGE)
             motion.idex_home_x();
           #else
+
+            #if (ENABLED(MP_SCARA) && DISABLED(HOME_Y_BEFORE_X))
+              DISABLE_AXIS_Y(); // Allow elbow to be dragged around freely during shoulder homing
+            #endif
+
             motion.homeaxis(X_AXIS);
           #endif
         }

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -311,7 +311,7 @@
 #endif
 
 /**
- * SCARA cannot use SLOWDOWN and requires QUICKHOME
+ * SCARA cannot use SLOWDOWN
  * Printable radius assumes joints can fully extend
  *
  * TPARA cannot use SLOWDOWN nor QUICKHOME
@@ -332,7 +332,6 @@
       #define MANUAL_Z_HOME_POS (TPARA_ARM_Z_HOME_POS + TPARA_TCP_OFFSET_Z - TPARA_OFFSET_Z)
     #endif
   #else
-    #define QUICK_HOME
     #define PRINTABLE_RADIUS (SCARA_LINKAGE_1 + SCARA_LINKAGE_2)
   #endif
 #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -2292,27 +2292,19 @@ void Motion::prepare_line_to_destination() {
       #endif
     } // is_home_dir
 
-    #if ANY(MORGAN_SCARA, MP_SCARA)
-      // Tell the planner the axis is at 0
-      position[axis] = 0;
-      sync_plan_position();
-      position[axis] = distance;
-      goto_current_position(home_fr_mm_s);
-    #else
-      // Get the ABC or XYZ positions in mm
-      abce_pos_t target = planner.get_axis_positions_mm();
+    // Get the ABC or XYZ positions in mm
+    abce_pos_t target = planner.get_axis_positions_mm();
 
-      target[axis] = 0;                         // Set the single homing axis to 0
-      planner.set_machine_position_mm(target);  // Update the machine position
+    target[axis] = 0;                         // Set the single homing axis to 0
+    planner.set_machine_position_mm(target);  // Update the machine position
 
-      #if HAS_DIST_MM_ARG
-        const xyze_float_t cart_dist_mm{0};
-      #endif
-
-      // Set delta/cartesian axes directly
-      target[axis] = distance;                  // The move will be towards the endstop
-      planner.buffer_segment(target OPTARG(HAS_DIST_MM_ARG, cart_dist_mm), home_fr_mm_s, extruder);
+    #if HAS_DIST_MM_ARG
+      const xyze_float_t cart_dist_mm{0};
     #endif
+
+    // Set delta/cartesian axes directly
+    target[axis] = distance;                  // The move will be towards the endstop
+    planner.buffer_segment(target OPTARG(HAS_DIST_MM_ARG, cart_dist_mm), home_fr_mm_s, extruder);
 
     planner.synchronize();
 
@@ -2492,14 +2484,9 @@ void Motion::prepare_line_to_destination() {
 
   void Motion::homeaxis(const AxisEnum axis) {
 
-    #if ANY(MORGAN_SCARA, MP_SCARA)
-      // Only Z homing (with probe) is permitted
-      if (axis != Z_AXIS) { BUZZ(100, 880); return; }
-    #else
-      #define _CAN_HOME(A) (axis == _AXIS(A) && (ANY(A##_SPI_SENSORLESS, HAS_##A##_STATE) || TERN0(HOMING_Z_WITH_PROBE, _AXIS(A) == Z_AXIS)))
-      #define _ANDCANT(N) && !_CAN_HOME(N)
-      if (true MAIN_AXIS_MAP(_ANDCANT)) return;
-    #endif
+    #define _CAN_HOME(A) (axis == _AXIS(A) && (ANY(A##_SPI_SENSORLESS, HAS_##A##_STATE) || TERN0(HOMING_Z_WITH_PROBE, _AXIS(A) == Z_AXIS)))
+    #define _ANDCANT(N) && !_CAN_HOME(N)
+    if (true MAIN_AXIS_MAP(_ANDCANT)) return;
 
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(">>> homeaxis(", C(AXIS_CHAR(axis)), ")");
 
@@ -2876,7 +2863,7 @@ void Motion::set_axis_is_at_home(const AxisEnum axis) {
     }
   #endif
 
-  #if ANY(MORGAN_SCARA, AXEL_TPARA)
+  #if IS_SCARA
     scara_set_axis_is_at_home(axis);
   #elif ENABLED(DELTA)
     position[axis] = (axis == Z_AXIS) ? DIFF_TERN(HAS_BED_PROBE, delta_height, probe.offset.z) : base_home_pos(axis);

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -31,9 +31,14 @@
 #include "scara.h"
 #include "motion.h"
 #include "planner.h"
+#include "../core/debug_out.h"
 
 #if ENABLED(AXEL_TPARA)
   #include "endstops.h"
+#endif
+
+#ifdef SCARA_CROSSTALK_FACTOR
+  #define HAS_CROSSTALK 1 // Needed for TERN macros which don't work with the floating point value of SCARA_CROSSTALK_FACTOR itself
 #endif
 
 float segments_per_second = DEFAULT_SEGMENTS_PER_SECOND;
@@ -50,8 +55,8 @@ float segments_per_second = DEFAULT_SEGMENTS_PER_SECOND;
   void forward_kinematics(const float a, const float b) {
     const float a_sin = sin(RADIANS(a)) * L1,
                 a_cos = cos(RADIANS(a)) * L1,
-                b_sin = sin(RADIANS(SUM_TERN(MP_SCARA, b, a))) * L2,
-                b_cos = cos(RADIANS(SUM_TERN(MP_SCARA, b, a))) * L2;
+                b_sin = sin(RADIANS(SUM_TERN(HAS_CROSSTALK, b, a * SCARA_CROSSTALK_FACTOR))) * L2,
+                b_cos = cos(RADIANS(SUM_TERN(HAS_CROSSTALK, b, a * SCARA_CROSSTALK_FACTOR))) * L2;
 
     motion.cartes.x = a_cos + b_cos + scara_offset.x;  // theta
     motion.cartes.y = a_sin + b_sin + scara_offset.y;  // phi
@@ -138,40 +143,47 @@ float segments_per_second = DEFAULT_SEGMENTS_PER_SECOND;
 #elif ENABLED(MP_SCARA)
 
   void scara_set_axis_is_at_home(const AxisEnum axis) {
-    if (axis == Z_AXIS)
-      motion.position.z = Z_HOME_POS;
-    else {
-      // MP_SCARA uses arm angles for AB home position
-      #ifndef SCARA_OFFSET_THETA1
-        #define SCARA_OFFSET_THETA1  12 // degrees
-      #endif
-      #ifndef SCARA_OFFSET_THETA2
-        #define SCARA_OFFSET_THETA2 131 // degrees
-      #endif
-      ab_float_t homeposition = { SCARA_OFFSET_THETA1, SCARA_OFFSET_THETA2 };
-      //DEBUG_ECHOLNPGM("homeposition A:", homeposition.a, " B:", homeposition.b);
-
-      inverse_kinematics(homeposition);
-      forward_kinematics(motion.delta.a, motion.delta.b);
-      motion.position[axis] = motion.cartes[axis];
-
-      //DEBUG_ECHOLNPGM_P(PSTR("Cartesian X"), motion.position.x, SP_Y_LBL, motion.position.y);
-      motion.update_software_endstops(axis);
-    }
+    #ifdef SCARA_OFFSET_THETA1
+      // Special handling for X and Y if home angles are used rather than a cartesian position
+      if (axis == X_AXIS || axis == Y_AXIS) {
+        motion.delta.a = SCARA_OFFSET_THETA1 - motion.scara_home_offset.a;
+        motion.delta.b = SCARA_OFFSET_THETA2 - motion.scara_home_offset.a - 
+          SUM_TERN(HAS_CROSSTALK, motion.scara_home_offset.b, motion.delta.a * SCARA_CROSSTALK_FACTOR);
+        forward_kinematics(motion.delta.a, motion.delta.b);
+        motion.position[axis] = motion.cartes[axis];
+        //DEBUG_ECHOLNPGM("homeposition (a,b):", motion.delta.a, ",", motion.delta.b);
+        //DEBUG_ECHOLNPGM("  (x,y)", motion.position.x, ",", motion.position.y);
+        motion.update_software_endstops(axis);
+        return;
+      }
+    #endif
+    // Normal handling for Z axis or cartesian home position
+    motion.position[axis] = SUM_TERN(HAS_HOME_OFFSET, motion.base_home_pos(axis), motion.home_offset[axis]);
+    motion.update_software_endstops(axis);
+    // Note: For X and Y, inverse_kinematics needs to be called after this to update delta.a and b.
+    // As of this writing, Motion::homeaxis calls sync_plan_position after set_axis_is_at_home, which does it.
   }
 
   void inverse_kinematics(const xyz_pos_t &raw) {
-    const float x = raw.x, y = raw.y, c = HYPOT(x, y),
-                THETA3 = ATAN2(y, x),
-                THETA1 = THETA3 + ACOS((sq(c) + sq(L1) - sq(L2)) / (2.0f * c * L1)),
-                THETA2 = THETA3 - ACOS((sq(c) + sq(L2) - sq(L1)) / (2.0f * c * L2));
-
-    motion.delta.set(DEGREES(THETA1), DEGREES(THETA2), raw.z);
+    // Theta3 is angle from shoulder to nozzle. c is distance from shoulder to nozzle.
+    // The shoulder-to-nozzle line, proximal arm, and distal arm make up a triangle,
+    // so the "law of cosines" can be used to calculate the shoulder and elbow angles.
+    const float x = raw.x - scara_offset.x, y = raw.y - scara_offset.y,
+                c2 = HYPOT2(x, y), c = SQRT(c2), THETA3 = ATAN2(y, x),
+              #if ENABLED(SCARA_IS_RIGHT_HANDED)
+                THETA1 = THETA3 - ACOS((c2 + (sq(L1) - sq(L2))) / (c * (2.0f * L1))),
+                THETA2 = THETA3 + ACOS((c2 + (sq(L2) - sq(L1))) / (c * (2.0f * L2)));
+              #else
+                THETA1 = THETA3 + ACOS((c2 + (sq(L1) - sq(L2))) / (c * (2.0f * L1))),
+                THETA2 = THETA3 - ACOS((c2 + (sq(L2) - sq(L1))) / (c * (2.0f * L2)));
+              #endif
+    motion.delta.set(DEGREES(THETA1), DEGREES(DIFF_TERN(HAS_CROSSTALK, THETA2, THETA1 * SCARA_CROSSTALK_FACTOR)), raw.z);
 
     /*
-      DEBUG_POS("SCARA IK", raw);
-      DEBUG_POS("SCARA IK", motion.delta);
-      SERIAL_ECHOLNPGM("  SCARA (x,y) ", x, ",", y," Theta1=", THETA1, " Theta2=", THETA2);
+      DEBUG_ECHOLNPGM("SCARA IK");
+      DEBUG_ECHOLNPGM("  (x,y) raw ", raw.x, ",", raw.y, "  offset ", x, ",", y);
+      DEBUG_ECHOLNPGM("  (a,b)", motion.delta.a, ",", motion.delta.b);
+      DEBUG_ECHOLNPGM("  Theta1=", DEGREES(THETA1), " Theta2=", DEGREES(THETA2), " Theta3=", DEGREES(THETA3));
     //*/
   }
 


### PR DESCRIPTION
### Description

MPSCARA now supports either cartesian home position or home angles (including handling of M665 scara_home_offset). Also added SCARA_IS_RIGHT_HANDED and SCARA_CROSSTALK_FACTOR to support a wider variety of serial SCARA arms.

scara_set_axis_is_at_home was totally broken, and forward_kinematics was applying full crosstalk for MPSCARA (correct for arms where the elbow motor rides on the proximal arm, but not for MPSCARA which has a fixed elbow motor with an intermediate idler pulley).

I made some small optimizations in inverse_kinematics to ensure that it only multiplies by a single compile-time constant rather than evaluating left-to-right, and to avoid squaring the result of a square root.


Homing: There were two problematic and unnecessary blocks of SCARA code in Motion.cpp, so I removed them. 

QUICKHOME is now optional. If it is used, it moves in angular coordinates like regular sequential homing, rather than trying to move toward a cartesian point (which was out of range anyway) when the current arm angles are unknown. And the regular sequential homing is done afterward like normal, since quickhome stops at the first endstop it hits.

I also added a call to DISABLE_Y_AXIS before homing X alone, which allows the elbow to be dragged around freely so it won't jam on arms that home with the elbow in fully bent position, or when not using quickhome.

### Requirements

SCARA arm. Homing fixes apply to Reprap Morgan as well, so it would be helpful if someone could verify that it works properly.

### Benefits

I've helped several people get SCARA arms running over the past few years and it's always a struggle, so hopefully it will be much easier now.

### Configurations

Added settings and documentation in SCARA section of Configuration.h
Removed force-enable of QUICKHOME in Conditionals-5-post.h

### Related Issues

Fixes bug #27575 and (I think) #17214
