### PR TITLE
fix REPETIER_GCODE M360

### DIFF
--- a/Marlin/src/gcode/host/M360.cpp
+++ b/Marlin/src/gcode/host/M360.cpp
@@ -37,13 +37,11 @@
   #include "../../module/temperature.h"
 #endif
 
-#include <cstddef>
-
 struct ProgStr {
   PGM_P ptr;
   constexpr ProgStr(PGM_P p) : ptr(p) {}
   ProgStr(FSTR_P f) : ptr(FTOP(f)) {}
-  ProgStr(std::nullptr_t) : ptr(nullptr) {}
+  ProgStr(nullptr_t) : ptr(nullptr) {}
 
   constexpr operator PGM_P() const { return ptr; }
   constexpr explicit operator bool() const { return ptr != nullptr; }
@@ -92,13 +90,13 @@ void GcodeSuite::M360() {
   //
   // Axis letters, in PROGMEM
   //
-  #define _DEFINE_A_STR(Q) PGMSTR(Q##_STR, STR_##Q);
+  #define _DEFINE_A_STR(Q) static PGMSTR(Q##_STR, STR_##Q);
   MAIN_AXIS_MAP(_DEFINE_A_STR);
 
   //
   // Homing Directions
   //
-  PGMSTR(H_DIR_STR, "HomeDir");
+  static PGMSTR(H_DIR_STR, "HomeDir");
   #if X_HOME_DIR
     config_line(H_DIR_STR, X_HOME_DIR, X_STR);
   #endif
@@ -128,7 +126,7 @@ void GcodeSuite::M360() {
   #endif
 
   #if ANY(CLASSIC_JERK, HAS_LINEAR_E_JERK)
-    PGMSTR(JERK_STR, "Jerk");
+    static PGMSTR(JERK_STR, "Jerk");
   #endif
 
   //
@@ -136,6 +134,10 @@ void GcodeSuite::M360() {
   //
   #if ENABLED(CLASSIC_JERK)
     #define _REPORT_JERK(Q) config_line(Q##_STR, planner.max_jerk.Q, JERK_STR);
+    #define XY_MAP(FUNC) do { \
+      TERN_(HAS_X_AXIS, FUNC(X)) \
+      TERN_(HAS_Y_AXIS, FUNC(Y)) \
+    }while(0)
     if (TERN0(HAS_Y_AXIS, planner.max_jerk.x == planner.max_jerk.y))
       config_line(F("XY"), planner.max_jerk.x, JERK_STR);
     else {
@@ -150,9 +152,9 @@ void GcodeSuite::M360() {
   //
   config_line(F("SupportG10G11"), ENABLED(FWRETRACT));
   #if ENABLED(FWRETRACT)
-    PGMSTR(RET_STR, "Retraction");
-    PGMSTR(UNRET_STR, "RetractionUndo");
-    PGMSTR(SPEED_STR, "Speed");
+    static PGMSTR(RET_STR, "Retraction");
+    static PGMSTR(UNRET_STR, "RetractionUndo");
+    static PGMSTR(SPEED_STR, "Speed");
     // M10 Retract with swap (long) moves
     config_line(F("Length"),     fwretract.settings.retract_length, RET_STR);
     config_line(F("LongLength"), fwretract.settings.swap_retract_length, RET_STR);
@@ -175,22 +177,22 @@ void GcodeSuite::M360() {
   motion.apply_limits(cmax);
   const xyz_pos_t wmin = cmin.asLogical(), wmax = cmax.asLogical();
 
-  PGMSTR(MIN_STR, "Min");
+  static PGMSTR(MIN_STR, "Min");
   #define _REPORT_MIN(Q) config_line(MIN_STR, wmin.Q, Q##_STR);
   MAIN_AXIS_MAP(_REPORT_MIN);
 
-  PGMSTR(MAX_STR, "Max");
+  static PGMSTR(MAX_STR, "Max");
   #define _REPORT_MAX(Q) config_line(MAX_STR, wmax.Q, Q##_STR);
   MAIN_AXIS_MAP(_REPORT_MAX);
 
-  PGMSTR(SIZE_STR, "Size");
+  static PGMSTR(SIZE_STR, "Size");
   #define _REPORT_SIZE(Q) config_line(SIZE_STR, wmax.Q - wmin.Q, Q##_STR);
   MAIN_AXIS_MAP(_REPORT_SIZE);
 
   //
   // Axis Steps per mm
   //
-  PGMSTR(S_MM_STR, "Steps/mm");
+  static PGMSTR(S_MM_STR, "Steps/mm");
   #define _REPORT_S_MM(Q) config_line(S_MM_STR, planner.settings.axis_steps_per_mm[_AXIS(Q)], Q##_STR);
   MAIN_AXIS_MAP(_REPORT_S_MM);
 
@@ -199,11 +201,11 @@ void GcodeSuite::M360() {
   //
   #define _ACCEL(Q,B) _MIN(planner.settings.max_acceleration_mm_per_s2[Q##_AXIS], planner.settings.B)
 
-  PGMSTR(P_ACC_STR, "PrintAccel");
+  static PGMSTR(P_ACC_STR, "PrintAccel");
   #define _REPORT_P_ACC(Q) config_line(P_ACC_STR, _ACCEL(Q, acceleration), Q##_STR);
   MAIN_AXIS_MAP(_REPORT_P_ACC);
 
-  PGMSTR(T_ACC_STR, "TravelAccel");
+  static PGMSTR(T_ACC_STR, "TravelAccel");
   #define _REPORT_T_ACC(Q) config_line(T_ACC_STR, _ACCEL(Q, travel_acceleration), Q##_STR);
   MAIN_AXIS_MAP(_REPORT_T_ACC);
 


### PR DESCRIPTION
### Description

REPETIER_GCODE_M360 doesn't work at all especially under 8 bit arduino it wont even compile

On 8 bit it errors with
```
Marlin/src/gcode/host/M360.cpp:40:10: fatal error: cstddef: No such file or directory
 #include <cstddef>
          ^~~~~~~~~
compilation terminated.
*** [.pio/build/mega2560/src/src/gcode/host/M360.cpp.o] Error 1
 ```

Second a missing macro  XY_MAP

added the missing macro, Now it builds, but this macro seems unnecessary to me, its only used once.
```cpp
 #define XY_MAP(FUNC) do { \
      TERN_(HAS_X_AXIS, FUNC(X)) \
      TERN_(HAS_Y_AXIS, FUNC(Y)) \
    }while(0)
```

Third the output is messed up on Harvard architecture

eg REPETIER_GCODE M360 output on mega2560
```
04:24:00.107 > Config:Baudrate:250000
04:24:00.107 > Config:InputBuffer:96
04:24:00.111 > Config:PrintlineCache:4
04:24:00.111 > Config:MixingExtruder:0
04:24:00.111 > Config:SDCard:0
04:24:00.111 > Config:Fan:1
04:24:00.111 > Config:LCD:0
04:24:00.111 > Config:SoftwarePowerSwitch:1
04:24:00.115 > Config:SupportLocalFilamentchange:0
04:24:00.115 > Config:CaseLights:0
04:24:00.115 > Config:ZProbe:0
04:24:00.119 > Config:Autolevel:0
04:24:00.119 > Config:EEPROM:0
04:24:00.119 > Config:�yyk|���В������`�p�.�I�P��hr��`�p�����yyk|���В������`�p�.:-1
04:24:00.123 > Config:yyk|���В������`�p�.�I�P��hr��`�p�����yyk|���В������`�p�.:-1
04:24:00.127 > Config:k|���В������`�p�.�I�P��hr��`�p�����yyk|���В������`�p�.:-1
04:24:00.131 > Config:SupportG10G11:0
04:24:00.131 > Config:�yyk|���В������`�p�.`�p�����yyk|���В������`�p�.:0.00
04:24:00.135 > Config:yyk|���В������`�p�.`�p�����yyk|���В������`�p�.:0.00
04:24:00.140 > Config:k|���В������`�p�.`�p�����yyk|���В������`�p�.:0.00
04:24:00.144 > Config:�yyk|���В������`�p�.����yyk|���В������`�p�.:200.00
04:24:00.144 > Config:yyk|���В������`�p�.����yyk|���В������`�p�.:200.00
04:24:00.148 > Config:k|���В������`�p�.����yyk|���В������`�p�.:200.00
04:24:00.152 > Config:�yyk|���В������`�p�.r��`�p�����yyk|���В������`�p�.:200.00
04:24:00.156 > Config:yyk|���В������`�p�.r��`�p�����yyk|���В������`�p�.:200.00
04:24:00.160 > Config:k|���В������`�p�.r��`�p�����yyk|���В������`�p�.:200.00
04:24:00.164 > Config:�yyk|���В������`�p�.��hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:80.00
04:24:00.168 > Config:yyk|���В������`�p�.��hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:80.00
04:24:00.172 > Config:k|���В������`�p�.��hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:400.00
04:24:00.176 > Config:�yyk|���В������`�p�.����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:3000.00
04:24:00.185 > Config:yyk|���В������`�p�.����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:3000.00
04:24:00.189 > Config:k|���В������`�p�.����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:100.00
04:24:00.193 > Config:�yyk|���В������`�p�.#     �E� �0�@�_����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:3000.00
04:24:00.197 > Config:yyk|���В������`�p�.#      �E� �0�@�_����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:3000.00
04:24:00.205 > Config:k|���В������`�p�.#        �E� �0�@�_����hr���hr+�?�I�P��hr��`�p�����yyk|���В������`�p�.:100.00
04:24:00.209 > Config:PrinterType:Cartesian
04:24:00.209 > Config:HeatedBed:1
04:24:00.209 > Config:MaxBedTemp:140
04:24:00.213 > Config:NumExtruder:1
04:24:00.213 > Config:Extr.1:Acceleration:10000
04:24:00.213 > Config:Extr.1:MaxSpeed:25.00
04:24:00.217 > Config:Extr.1:Diameter:1.75
04:24:00.217 > Config:Extr.1:MaxTemp:275
04:24:00.217 > ok
``` 

PGMSTR's needed to be static 

Corrected output 
```
05:04:01.546 > Config:Baudrate:250000
05:04:01.546 > Config:InputBuffer:96
05:04:01.546 > Config:PrintlineCache:4
05:04:01.546 > Config:MixingExtruder:0
05:04:01.550 > Config:SDCard:0
05:04:01.550 > Config:Fan:1
05:04:01.550 > Config:LCD:0
05:04:01.550 > Config:SoftwarePowerSwitch:1
05:04:01.550 > Config:SupportLocalFilamentchange:0
05:04:01.554 > Config:CaseLights:0
05:04:01.554 > Config:ZProbe:0
05:04:01.554 > Config:Autolevel:0
05:04:01.554 > Config:EEPROM:0
05:04:01.554 > Config:XHomeDir:-1
05:04:01.558 > Config:YHomeDir:-1
05:04:01.558 > Config:ZHomeDir:-1
05:04:01.558 > Config:JerkXY:10.00
05:04:01.558 > Config:JerkZ:0.30
05:04:01.558 > Config:SupportG10G11:0
05:04:01.562 > Config:XMin:0.00
05:04:01.562 > Config:YMin:0.00
05:04:01.562 > Config:ZMin:0.00
05:04:01.562 > Config:XMax:200.00
05:04:01.562 > Config:YMax:200.00
05:04:01.566 > Config:ZMax:200.00
05:04:01.566 > Config:XSize:200.00
05:04:01.566 > Config:YSize:200.00
05:04:01.566 > Config:ZSize:200.00
05:04:01.570 > Config:XSteps/mm:80.00
05:04:01.571 > Config:YSteps/mm:80.00
05:04:01.571 > Config:ZSteps/mm:400.00
05:04:01.571 > Config:XPrintAccel:3000.00
05:04:01.575 > Config:YPrintAccel:3000.00
05:04:01.575 > Config:ZPrintAccel:100.00
05:04:01.575 > Config:XTravelAccel:3000.00
05:04:01.575 > Config:YTravelAccel:3000.00
05:04:01.579 > Config:ZTravelAccel:100.00
05:04:01.579 > Config:PrinterType:Cartesian
05:04:01.579 > Config:HeatedBed:1
05:04:01.583 > Config:MaxBedTemp:140
05:04:01.583 > Config:NumExtruder:1
05:04:01.583 > Config:Extr.1:Jerk:5.00
05:04:01.583 > Config:Extr.1:Acceleration:10000
05:04:01.583 > Config:Extr.1:MaxSpeed:25.00
05:04:01.587 > Config:Extr.1:Diameter:1.75
05:04:01.587 > Config:Extr.1:MaxTemp:275
05:04:01.587 > ok
```

### Requirements

#define REPETIER_GCODE_M360 In Configuration_adv.h

### Benefits

Builds and works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/commit/5a88a806909ca1c1942511d4e3c2bdcfbd3f02b1
<li>MarlinFirmware/Marlin/pull/28084</li>
<li>MarlinFirmware/Marlin/pull/16741</li>
