### PR TITLE
fix display unit in inch mode

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -169,7 +169,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
   }
   else if (parser.using_inch_units()) {
     #ifdef MANUAL_MOVE_DISTANCE_IN
-      #define _MOVE_IN(I) __MOVE_SUB(MSG_MOVE_N_MM, STRINGIFY(I), IN_TO_MM(I));
+      #define _MOVE_IN(I) __MOVE_SUB(MSG_MOVE_N_IN, STRINGIFY(I), IN_TO_MM(I));
       MAP(_MOVE_IN, MANUAL_MOVE_DISTANCE_IN)
     #endif
   }


### PR DESCRIPTION
### Description

In inch mode, the move axis menu of the display in Marlin mode (MarlinIUI) now shows unit label "in" instead of "mm". one line of code changed.

### Requirements

any display with support for MarlinUI

### Benefits

correct unit

### Configurations

none

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/28362
