### PR TITLE
clear wait_for_heatup on PID_autotune exit

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1017,7 +1017,8 @@ void Temperature::factory_reset() {
         if (set_result)
           PER_CBH(_set_chamber_pid(tune_pid), _set_bed_pid(tune_pid), _set_hotend_pid(heater_id, tune_pid));
 
-        goto EXIT_M303;
+          marlin.heatup_done();
+          goto EXIT_M303;
       }
     }
     marlin.heatup_done();

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1017,8 +1017,8 @@ void Temperature::factory_reset() {
         if (set_result)
           PER_CBH(_set_chamber_pid(tune_pid), _set_bed_pid(tune_pid), _set_hotend_pid(heater_id, tune_pid));
 
-          marlin.heatup_done();
-          goto EXIT_M303;
+        marlin.heatup_done();
+        goto EXIT_M303;
       }
     }
     marlin.heatup_done();

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1017,15 +1017,14 @@ void Temperature::factory_reset() {
         if (set_result)
           PER_CBH(_set_chamber_pid(tune_pid), _set_bed_pid(tune_pid), _set_hotend_pid(heater_id, tune_pid));
 
-        marlin.heatup_done();
         goto EXIT_M303;
       }
     }
-    marlin.heatup_done();
 
     disable_all_heaters();
 
     EXIT_M303:
+      marlin.heatup_done();
       TERN_(PRINTER_EVENT_LEDS, printerEventLEDs.onPIDTuningDone(oldcolor));
       TERN_(EXTENSIBLE_UI, ExtUI::onPIDTuning(ExtUI::pidresult_t::PID_DONE));
       TERN_(TEMP_TUNING_MAINTAIN_FAN, adaptive_fan_slowing = true);


### PR DESCRIPTION
### Description

If you set Temperature Auto-Report eg 'M155 S2' Marlin correctly starts auto reporting the temperature.
Then call PID tune eg 'M303 E0 S150 C3' Marlin suspends the Temperature Auto-Report and does the PID tune.
On completion of the PID tune the Temperature Auto-Report should resume but it does not.
Attempts to restart Temperature Auto-Report  eg annother 'M155 S2' does not restart it. 

Additionally this causes Octoprint to disconnect

Traced issue to wait_for_heatup flag still being set true after PID tune compleates, this leaves Temperature Auto-Report  suspended.

Added marlin.heatup_done(); to set wait_for_heatup to false on PID tune completion.

### Requirements

AUTO_REPORT_TEMPERATURES
HAS_PID_HEATING  

### Benefits

Works as expected, Octoprint doesn't disconnect  

### Configurations

Stock default Confgs have all requirements

### Related Issues

<li>MarlinFirmware/Marlin/issues/28373