### PR TITLE
Fix Resonance Testing with TMC2208

### DIFF
--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -106,8 +106,8 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
 
     #if HAS_FTM_DIR_CHANGE_HOLD
 
-    // When a flip is detected (and the axis is in stealthChop or is standalone),
-    // hold that axis' trajectory coordinate constant for at least 750µs.
+      // When a flip is detected (and the axis is in stealthChop or is standalone),
+      // hold that axis' trajectory coordinate constant for at least 750µs.
 
       #define DIR_FLIP_HOLD_S 0.000'750f
       static constexpr uint32_t dir_flip_hold_frames = 1 + (DIR_FLIP_HOLD_S) / (FTM_TS);

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -113,23 +113,24 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
       static constexpr uint32_t dir_flip_hold_frames = 1 + (DIR_FLIP_HOLD_S) / (FTM_TS);
 
       auto start_hold_if_dir_flip = [&](const AxisEnum a) {
-        const bool dir = traj_coords[a] > last_target_traj[a],
-                   moved = traj_coords[a] != last_target_traj[a],
-                   flipped = moved && (dir != last_traj_dir[a]),
-                   hold = !moved || (flipped && hold_frames[a] > 0);
+        const bool dir = traj_coords[a] > ftMotion.last_target_traj[a],
+                   moved = traj_coords[a] != ftMotion.last_target_traj[a],
+                   flipped = moved && (dir != ftMotion.last_traj_dir[a]),
+                   hold = !moved || (flipped && ftMotion.hold_frames[a] > 0);
         if (hold) {
-          if (hold_frames[a]) hold_frames[a]--;
-          traj_coords[a] = last_target_traj[a];
+          if (ftMotion.hold_frames[a]) ftMotion.hold_frames[a]--;
+          traj_coords[a] = ftMotion.last_target_traj[a];
         }
         else {
-          last_traj_dir[a] = dir;
-          hold_frames[a] = dir_flip_hold_frames;
+          ftMotion.last_traj_dir[a] = dir;
+          ftMotion.hold_frames[a] = dir_flip_hold_frames;
         }
       };
 
       #define START_HOLD_IF_DIR_FLIP(A) TERN_(FTM_DIR_CHANGE_HOLD_##A, start_hold_if_dir_flip(_AXIS(A)));
 
       LOGICAL_AXIS_MAP(START_HOLD_IF_DIR_FLIP);
+      ftMotion.last_target_traj = traj_coords;
 
     #endif // HAS_FTM_DIR_CHANGE_HOLD
 

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -104,6 +104,35 @@ void ResonanceGenerator::fill_stepper_plan_buffer() {
     rt_time += FTM_TS;
     rt_factor += FTM_TS * M_TAU;
 
+    #if HAS_FTM_DIR_CHANGE_HOLD
+
+    // When a flip is detected (and the axis is in stealthChop or is standalone),
+    // hold that axis' trajectory coordinate constant for at least 750µs.
+
+      #define DIR_FLIP_HOLD_S 0.000'750f
+      static constexpr uint32_t dir_flip_hold_frames = 1 + (DIR_FLIP_HOLD_S) / (FTM_TS);
+
+      auto start_hold_if_dir_flip = [&](const AxisEnum a) {
+        const bool dir = traj_coords[a] > last_target_traj[a],
+                   moved = traj_coords[a] != last_target_traj[a],
+                   flipped = moved && (dir != last_traj_dir[a]),
+                   hold = !moved || (flipped && hold_frames[a] > 0);
+        if (hold) {
+          if (hold_frames[a]) hold_frames[a]--;
+          traj_coords[a] = last_target_traj[a];
+        }
+        else {
+          last_traj_dir[a] = dir;
+          hold_frames[a] = dir_flip_hold_frames;
+        }
+      };
+
+      #define START_HOLD_IF_DIR_FLIP(A) TERN_(FTM_DIR_CHANGE_HOLD_##A, start_hold_if_dir_flip(_AXIS(A)));
+
+      LOGICAL_AXIS_MAP(START_HOLD_IF_DIR_FLIP);
+
+    #endif // HAS_FTM_DIR_CHANGE_HOLD
+
     // Store in buffer
     ftMotion.stepping_enqueue(traj_coords);
   }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
As reported by @Huang-wjj, FT_MOTION resonance test fails with TMC2208 because `HAS_FTM_DIR_CHANGE_HOLD` is not used. This PR adds the relevant code.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
Fix #28383 
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
