### PR TITLE
Fix over zealous code reformatting in visualize_memory_map.py

### DIFF
--- a/buildroot/share/scripts/visualize_memory_map.py
+++ b/buildroot/share/scripts/visualize_memory_map.py
@@ -716,7 +716,7 @@ def generate_html(symbols, special_symbols, output_path, flash_size, ram_size, a
     ram_items = []
 
     for item in symbols:
-        color, mem_type = categorize_section(item['section'])
+        _, color, mem_type = categorize_section(item['section'])
         if mem_type == 'flash':
             total_flash += item['size']
             module_stats[item['module']]['flash'] += item['size']


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/28360 broke buildroot/share/scripts/visualize_memory_map.py

```
 File "buildroot\share\scripts\visualize_memory_map.py", line 719, in generate_html
    color, mem_type = categorize_section(item['section'])
    ^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```
### Requirements

Attempt to use the script visualize_memory_map.py

### Benefits

Works as expected 

### Related Issues

Was reported on discord. 

