### PR TITLE
bug fix: treat XY_PROBE_FEEDRATE_MIN as units/min

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -406,7 +406,7 @@ G29_TYPE GcodeSuite::G29() {
       feedRate_t xy_probe_feedrate_mm_m = parser.linearval('S', XY_PROBE_FEEDRATE);
       if (xy_probe_feedrate_mm_m < min_probe_feedrate_mm_m) {
         xy_probe_feedrate_mm_m = min_probe_feedrate_mm_m;
-        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_probe_feedrate_mm_m, " units/min)"));
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", LINEAR_UNIT(min_probe_feedrate_mm_m), " units/min)"));
       }
       motion.xy_probe_feedrate_mm_s = MMM_TO_MMS(xy_probe_feedrate_mm_m);
     #endif

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -402,13 +402,13 @@ G29_TYPE GcodeSuite::G29() {
     #endif
 
     #if HAS_VARIABLE_XY_PROBE_FEEDRATE
-      static constexpr feedRate_t min_probe_feedrate_mm_m = XY_PROBE_MIN_FEEDRATE_MM_M;
-      feedRate_t xy_probe_feedrate_mm_m = parser.linearval('S', XY_PROBE_FEEDRATE);
-      if (xy_probe_feedrate_mm_m < min_probe_feedrate_mm_m) {
-        xy_probe_feedrate_mm_m = min_probe_feedrate_mm_m;
-        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", LINEAR_UNIT(min_probe_feedrate_mm_m), " units/min)"));
+      static constexpr feedRate_t min_fr_mm_m = XY_PROBE_MIN_FEEDRATE_MM_M;
+      feedRate_t fr_mm_m = parser.linearval('S', XY_PROBE_FEEDRATE);
+      if (fr_mm_m < min_fr_mm_m) {
+        fr_mm_m = min_fr_mm_m;
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", LINEAR_UNIT(min_fr_mm_m), " units/min)"));
       }
-      motion.xy_probe_feedrate_mm_s = MMM_TO_MMS(xy_probe_feedrate_mm_m);
+      motion.xy_probe_feedrate_mm_s = MMM_TO_MMS(fr_mm_m);
     #endif
 
     #if ABL_USES_GRID

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -402,12 +402,13 @@ G29_TYPE GcodeSuite::G29() {
     #endif
 
     #if HAS_VARIABLE_XY_PROBE_FEEDRATE
-      constexpr feedRate_t min_probe_feedrate_mm_s = XY_PROBE_FEEDRATE_MIN;
-      motion.xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
-      if (motion.xy_probe_feedrate_mm_s < min_probe_feedrate_mm_s) {
-        motion.xy_probe_feedrate_mm_s = min_probe_feedrate_mm_s;
-        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_probe_feedrate_mm_s, ")"));
+      constexpr feedRate_t min_probe_feedrate_mm_m = XY_PROBE_FEEDRATE_MIN;
+      feedRate_t xy_probe_feedrate_mm_m = parser.linearval('S', XY_PROBE_FEEDRATE);
+      if (xy_probe_feedrate_mm_m < min_probe_feedrate_mm_m) {
+        xy_probe_feedrate_mm_m = min_probe_feedrate_mm_m;
+        SERIAL_ECHOLNPGM(GCODE_ERR_MSG("Feedrate (S) too low. (Using ", min_probe_feedrate_mm_m, " units/min)"));
       }
+      motion.xy_probe_feedrate_mm_s = MMM_TO_MMS(xy_probe_feedrate_mm_m);
     #endif
 
     #if ABL_USES_GRID

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -402,7 +402,7 @@ G29_TYPE GcodeSuite::G29() {
     #endif
 
     #if HAS_VARIABLE_XY_PROBE_FEEDRATE
-      constexpr feedRate_t min_probe_feedrate_mm_m = XY_PROBE_FEEDRATE_MIN;
+      static constexpr feedRate_t min_probe_feedrate_mm_m = XY_PROBE_MIN_FEEDRATE_MM_M;
       feedRate_t xy_probe_feedrate_mm_m = parser.linearval('S', XY_PROBE_FEEDRATE);
       if (xy_probe_feedrate_mm_m < min_probe_feedrate_mm_m) {
         xy_probe_feedrate_mm_m = min_probe_feedrate_mm_m;

--- a/Marlin/src/inc/Conditionals-3-etc.h
+++ b/Marlin/src/inc/Conditionals-3-etc.h
@@ -471,8 +471,8 @@
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
   #define ABL_USES_GRID 1
   #define HAS_VARIABLE_XY_PROBE_FEEDRATE 1
-  #ifndef XY_PROBE_FEEDRATE_MIN
-    #define XY_PROBE_FEEDRATE_MIN 60 // Minimum mm/min value for 'G29 S<feedrate>'
+  #ifndef XY_PROBE_MIN_FEEDRATE_MM_M
+    #define XY_PROBE_MIN_FEEDRATE_MM_M 60 // (mm/min) Minimum permitted speed for 'G29 S<feedrate>'
   #endif
 #endif
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR, AUTO_BED_LEVELING_3POINT)


### PR DESCRIPTION

### Description

This fixes a conversion issue (min, s) with `XY_PROBE_FEEDRATE_MIN`:
The value is described as being in mm/min, but was stored directly in `min_probe_feedrate_mm_s`, so the default minimum was actually 60mm/s and not 60mm/m (not sure what was the intended value though).
My change applies the comparison in terms of units/min, before converting to units/s, and adds "units/min" to the error message.
