### PR TITLE
Fix code out of order in do move after z homing

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1106,6 +1106,14 @@ void Motion::blocking_move(const xy_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*
    * Move Z to Z_POST_CLEARANCE,
    * The axis is allowed to move down.
    */
+  #ifndef Z_POST_CLEARANCE  // May be set by proui/dwin.h :-P
+    #ifdef Z_AFTER_HOMING
+      #define Z_POST_CLEARANCE Z_AFTER_HOMING
+    #else
+      #define Z_POST_CLEARANCE Z_CLEARANCE_FOR_HOMING
+    #endif
+  #endif
+
   void Motion::do_move_after_z_homing() {
     DEBUG_SECTION(mzah, "do_move_after_z_homing", DEBUGGING(LEVELING));
     #ifdef Z_POST_CLEARANCE
@@ -1118,14 +1126,6 @@ void Motion::blocking_move(const xy_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*
       probe.move_z_after_probing();
     #endif
   }
-
-  #ifndef Z_POST_CLEARANCE  // May be set by proui/dwin.h :-P
-    #ifdef Z_AFTER_HOMING
-      #define Z_POST_CLEARANCE Z_AFTER_HOMING
-    #else
-      #define Z_POST_CLEARANCE Z_CLEARANCE_FOR_HOMING
-    #endif
-  #endif
 
   void Motion::do_z_post_clearance() { do_z_clearance(Z_POST_CLEARANCE); }
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1116,15 +1116,11 @@ void Motion::blocking_move(const xy_pos_t &raw, const feedRate_t fr_mm_s/*=0.0f*
 
   void Motion::do_move_after_z_homing() {
     DEBUG_SECTION(mzah, "do_move_after_z_homing", DEBUGGING(LEVELING));
-    #ifdef Z_POST_CLEARANCE
-      do_z_clearance(
-        Z_POST_CLEARANCE,
-        ALL(HOMING_Z_WITH_PROBE, HAS_STOWABLE_PROBE) && TERN0(HAS_BED_PROBE, endstops.z_probe_enabled),
-        true
-      );
-    #elif ENABLED(USE_PROBE_FOR_Z_HOMING)
-      probe.move_z_after_probing();
-    #endif
+    do_z_clearance(
+      Z_POST_CLEARANCE,
+      ALL(HOMING_Z_WITH_PROBE, HAS_STOWABLE_PROBE) && TERN0(HAS_BED_PROBE, endstops.z_probe_enabled),
+      true
+    );
   }
 
   void Motion::do_z_post_clearance() { do_z_clearance(Z_POST_CLEARANCE); }


### PR DESCRIPTION
### Description

In do_move_after_z_homing Z_POST_CLEARANCE is defined after the code that wants to use it (if not using proui)
This causes Z raise after after homing not to work. 

I re ordered the code a little

After the code re order   Z_POST_CLEARANCE is always defined, so I removed an redundant #ifdef Z_POST_CLEARANCE block and the else case that is never called.

### Requirements

A Z axis, if a probe if present it is not used for homing, home using a z-stop
not using proui (as it defines its own Z_POST_CLEARANCE) 

### Benefits

Z raise after after homing functions correctly.

### Configurations

Confgs from the issue 
https://github.com/user-attachments/files/26753084/Configuration.zip

### Related Issues

<li>MarlinFirmware/Marlin/issues/28391
