### PR TITLE
Fix insuficient digits when displaying the tilt matrix

### DIFF
--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -99,12 +99,12 @@ void SERIAL_WARN_START()  { SERIAL_ECHO(F("Warning:")); }
 
 void SERIAL_ECHO_SP(uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR(' '); }
 
-void serial_offset(const float v, const uint8_t sp/*=0*/) {
+void serial_offset(const float v, const uint8_t sp/*=0*/, const uint8_t prec/*=SERIAL_FLOAT_PRECISION*/) {
   if (v == 0 && sp == 1)
     SERIAL_CHAR(' ');
   else if (v > 0 || (v == 0 && sp == 2))
     SERIAL_CHAR('+');
-  SERIAL_ECHO(v);
+  SERIAL_ECHO(p_float_t(v,prec));
 }
 
 void serial_ternary(FSTR_P const pre, const bool onoff, FSTR_P const on, FSTR_P const off, FSTR_P const post/*=nullptr*/) {

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -236,7 +236,8 @@ void SERIAL_ECHO_SP(uint8_t count);
 inline FSTR_P const ON_OFF(const bool onoff) { return onoff ? F("ON") : F("OFF"); }
 inline FSTR_P const TRUE_FALSE(const bool tf) { return tf ? F("true") : F("false"); }
 
-void serial_offset(const float v, const uint8_t sp=0); // For v==0 draw space (sp==1) or plus (sp==2)
+ // For v==0 draw space (sp==1) or plus (sp==2)
+void serial_offset(const float v, const uint8_t sp=0, const uint8_t prec=SERIAL_FLOAT_PRECISION);
 
 void print_bin(const uint16_t val);
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -1705,7 +1705,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     }
 
     if (DEBUGGING(LEVELING)) {
-      rotation.debug(F("rotation matrix:\n"));
+      rotation.debug(F("rotation matrix:\n"), 7);
       DEBUG_ECHOLN(F("LSF Results A="), p_float_t(lsf_results.A, 7), F("  B="), p_float_t(lsf_results.B, 7), F("  D="), p_float_t(lsf_results.D, 7));
       DEBUG_DELAY(55);
       DEBUG_ECHOLN(F("bed plane normal = ["), p_float_t(normal.x, 7), C(','), p_float_t(normal.y, 7), C(','), p_float_t(normal.z, 7), C(']'));

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -200,7 +200,7 @@ void GcodeSuite::M420() {
   // V to print the matrix or mesh
   if (seenV) {
     #if ABL_PLANAR
-      planner.bed_level_matrix.debug(F("Bed Level Correction Matrix:"));
+      planner.bed_level_matrix.debug(F("Bed Level Correction Matrix:"), 4);
     #else
       if (leveling_is_valid()) {
         #if ENABLED(AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -974,7 +974,7 @@ G29_TYPE GcodeSuite::G29() {
       // For LINEAR and 3POINT leveling correct the current position
 
       if (abl.verbose_level > 0)
-        planner.bed_level_matrix.debug(F("\n\nBed Level Correction Matrix:"));
+        planner.bed_level_matrix.debug(F("\n\nBed Level Correction Matrix:"), 4);
 
       if (!abl.dryrun) {
         //

--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -138,11 +138,11 @@ matrix_3x3 matrix_3x3::transpose(const matrix_3x3 &original) {
   return new_matrix;
 }
 
-void matrix_3x3::debug(FSTR_P const title) {
+void matrix_3x3::debug(FSTR_P const title, const uint8_t prec/*=SERIAL_FLOAT_PRECISION*/) {
   if (title) SERIAL_ECHOLN(title);
   for (uint8_t i = 0; i < 3; ++i) {
     for (uint8_t j = 0; j < 3; ++j) {
-      serial_offset(vectors[i][j], 2);
+      serial_offset(vectors[i][j], 2, prec);
       SERIAL_CHAR(' ');
     }
     SERIAL_EOL();

--- a/Marlin/src/libs/vector_3.h
+++ b/Marlin/src/libs/vector_3.h
@@ -91,7 +91,7 @@ struct matrix_3x3 {
 
   void set_to_identity();
 
-  void debug(FSTR_P const title);
+  void debug(FSTR_P const title, const uint8_t prec=SERIAL_FLOAT_PRECISION);
 
   void apply_rotation_xyz(float &x, float &y, float &z);
 };


### PR DESCRIPTION

### Description

This increases the number of digits used  for displaying the tilt matrix in `G29 V2` and `M420 S1 V` from 2 to 4. This is important because the coefficients are expected to be very low, even for a significantly tilted bed, and the matrix would look like the identity matrix otherwise.

### Requirements

None

### Benefits

Avoids displaying a misleading identity tilt matrix in verbose calls to G29 and M420 which would suggest that leveling somehow failed.

### Output with only two digits:

```
> G29 V2
SENDING:G29 V2
G29 Auto Bed Leveling
Probing mesh point 3/25.
Probing mesh point 7/25.
Probing mesh point 8/25.
Probing mesh point 9/25.
Probing mesh point 11/25.
Probing mesh point 12/25.
Probing mesh point 13/25.
Probing mesh point 14/25.
Probing mesh point 15/25.
Probing mesh point 17/25.
Probing mesh point 18/25.
Probing mesh point 19/25.
Probing mesh point 23/25.
Eqn coefficients: a: 0.00125742 b: 0.00181860 d: 0.92799848
Bed Level Correction Matrix:
+1.00 +0.00 +0.00
-0.00 +1.00 +0.00
-0.00 -0.00 +1.00
> M420 S1 V
SENDING:M420 S1 V
Bed Level Correction Matrix:
+1.00 +0.00 +0.00
-0.00 +1.00 +0.00
-0.00 -0.00 +1.00
Bed Leveling ON

```

### Output with four digits:


```
> G29 V2
SENDING:G29 V2
G29 Auto Bed Leveling
Probing mesh point 3/25.
Probing mesh point 7/25.
Probing mesh point 8/25.
Probing mesh point 9/25.
Probing mesh point 11/25.
Probing mesh point 12/25.
Probing mesh point 13/25.
Probing mesh point 14/25.
Probing mesh point 15/25.
Probing mesh point 17/25.
Probing mesh point 18/25.
Probing mesh point 19/25.
Probing mesh point 23/25.
Eqn coefficients: a: 0.00124202 b: 0.00187187 d: 0.92893869
Bed Level Correction Matrix:
+1.0000 +0.0000 +0.0012
-0.0000 +1.0000 +0.0019
-0.0012 -0.0019 +1.0000
> M420 S1 V
SENDING:M420 S1 V
Bed Level Correction Matrix:
+1.0000 +0.0000 +0.0012
-0.0000 +1.0000 +0.0019
-0.0012 -0.0019 +1.0000
Bed Leveling ON

```