### PR TITLE
Replace line_to_z with do_z_clearance_by for probing

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_tramming.cpp
@@ -217,7 +217,7 @@ static void _lcd_bed_tramming_get_next_position() {
   }
 
   bool _lcd_bed_tramming_probe(bool verify=false) {
-    if (verify) line_to_z(BED_TRAMMING_Z_HOP); // do clearance if needed
+    if (verify) do_z_clearance_by(BED_TRAMMING_Z_HOP); // do clearance if needed
     TERN_(BLTOUCH, if (!bltouch.high_speed_mode) bltouch.deploy()); // Deploy in LOW SPEED MODE on every probe action
     do_blocking_move_to_z(last_z - BED_TRAMMING_PROBE_TOLERANCE, MMM_TO_MMS(Z_PROBE_FEEDRATE_SLOW)); // Move down to lower tolerance
     if (TEST(endstops.trigger_state(), Z_MIN_PROBE)) { // check if probe triggered


### PR DESCRIPTION
Fix to make ZHOP happen before BLTOUCH deploys

### Description

<!--

When  using LCD_BED_TRAMMING with BLtouch, the VERIFY option makes the BLTOUCH stow, deploy then ZHOP happens.

-->

### Requirements

This affects any servos as Z endstop using LCD_BED_TRAMMING, so for this to be relevant, you need a BLTOUCH and use LCD_BED_TRAMMING. On my capacitive probe, it doesn't change anything.

### Benefits

The fix makes the ZHOP happen after STOW and before DEPLOY.