### PR TITLE
add real availableForWrite to LPC176x

### DIFF
--- a/Marlin/src/HAL/LPC1768/MarlinSerial.h
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.h
@@ -40,7 +40,9 @@ extern DefaultSerial1 USBSerial;
 #include "../shared/serial_ports.h"
 
 #if defined(LCD_SERIAL_PORT) && ANY(HAS_DGUS_LCD, EXTENSIBLE_UI)
-  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.available()
+  // LCD_SERIAL is ForwardSerial<MarlinSerial> on LPC1768. ForwardSerial doesn't expose
+  // availableForWrite(), so call through the wrapped instance (`out`) to get real TX free space.
+  #define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.out.availableForWrite()
 #endif
 
 class MarlinSerial : public HardwareSerial<RX_BUFFER_SIZE, TX_BUFFER_SIZE> {
@@ -49,7 +51,6 @@ public:
 
   void end() {}
 
-  uint8_t availableForWrite(void) { /* flushTX(); */ return TX_BUFFER_SIZE; }
 
   #if ENABLED(EMERGENCY_PARSER)
     bool recv_callback(const char c) override;


### PR DESCRIPTION
### Description

Under LPC176x marlin availableForWrite always returned TX_BUFFER_SIZE  (a static define)

This is not a true value for the available bytes, and if TX_BUFFER_SIZE should be set to 256 it fails to build as it can't be stored in a uint8_t

further ```#define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.available()```  is not correct

Added missing fuction to https://github.com/p3p/pio-framework-arduino-lpc176x/pull/56  (awating review)
And updated  Marlin/src/HAL/LPC1768/MarlinSerial.h to use it

### Requirements

DGUS_LCD_UI_RELOADED and DGUS_LCD_UI_E3S1PRO uses this  LCD_SERIAL_TX_BUFFER_FREE define

### Benefits

Real availableForWrite

### Related Issues

<li>p3p/pio-framework-arduino-lpc176x/pull/56