### PR TITLE
Fix ZONESTAR_LCD with NO_LCD_MENUS

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1206,7 +1206,9 @@ void MarlinUI::init() {
             break;
         } // switch
 
-        TERN_(HAS_ADC_BUTTONS, keypad_buttons = 0);
+        #if ALL(HAS_ADC_BUTTONS, HAS_ENCODER_ACTION, IS_RRW_KEYPAD)
+          keypad_buttons = 0;
+        #endif
 
         #if HAS_MARLINUI_U8GLIB
 


### PR DESCRIPTION
### Description

Enabling ZONESTAR_LCD with NO_LCD_MENUS fails to compile with

```cpp
Marlin/src/lcd/marlinui.cpp: In static member function 'static void MarlinUI::update()':
Marlin/src/lcd/marlinui.cpp:1209:32: error: 'keypad_buttons' was not declared in this scope
         TERN_(HAS_ADC_BUTTONS, keypad_buttons = 0);

```

Added a better guard around the use of keypad_buttons

### Requirements

ZONESTAR_LCD with NO_LCD_MENUS

### Benefits

This is now builds.

### Configurations

Stock + ZONESTAR_LCD and NO_LCD_MENUS and add #define NO_CONTROLLER_CUSTOM_WIRING_WARNING will trigger this error

### Related Issues

<li>MarlinFirmware/Marlin/issues/25383