### PR TITLE
add HAS_MARLINUI_MENU guard to menu_probe_offset.cpp

### DIFF
--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -26,7 +26,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(PROBE_OFFSET_WIZARD)
+#if ALL(HAS_MARLINUI_MENU, PROBE_OFFSET_WIZARD)
 
 #include "menu_item.h"
 #include "menu_addon.h"

--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -175,4 +175,4 @@ void goto_probe_offset_wizard() {
 
 }
 
-#endif // PROBE_OFFSET_WIZARD
+#endif // HAS_MARLINUI_MENU && PROBE_OFFSET_WIZARD


### PR DESCRIPTION
### Description

Enabling PROBE_OFFSET_WIZARD triggers 
"PROBE_OFFSET_WIZARD                    = build_src_filter=+<src/lcd/menu/menu_probe_offset.cpp>"

But TFT_LVGL_UI also support PROBE_OFFSET_WIZARD and including this code causes compile errors as this code is for MARLINUI 

Added an additional  HAS_MARLINUI_MENU check. 

### Requirements

TFT_LVGL_UI + PROBE_OFFSET_WIZARD

### Benefits

PROBE_OFFSET_WIZARD builds and works on TFT_LVGL_UI

### Related Issues

<li>MarlinFirmware/Marlin/issues/28427