### PR TITLE
stop checking for enable pin conflicts with SOFTWARE_DRIVER_ENABLE

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -88,12 +88,6 @@ typedef struct {
 typedef bits_t(NUM_AXES + E_STATES) e_axis_bits_t;
 constexpr e_axis_bits_t e_axis_mask = (_BV(E_STATES) - 1) << NUM_AXES;
 
-// All the stepper enable pins
-constexpr pin_t ena_pins[] = {
-  NUM_AXIS_LIST_(X_ENABLE_PIN, Y_ENABLE_PIN, Z_ENABLE_PIN, I_ENABLE_PIN, J_ENABLE_PIN, K_ENABLE_PIN, U_ENABLE_PIN, V_ENABLE_PIN, W_ENABLE_PIN)
-  LIST_N(E_STEPPERS, E0_ENABLE_PIN, E1_ENABLE_PIN, E2_ENABLE_PIN, E3_ENABLE_PIN, E4_ENABLE_PIN, E5_ENABLE_PIN, E6_ENABLE_PIN, E7_ENABLE_PIN)
-};
-
 // Index of the axis or extruder element in a combined array
 constexpr uint8_t index_of_axis(const AxisEnum axis E_OPTARG(const uint8_t eindex=0)) {
   return uint8_t(axis) + (E_TERN0(axis < NUM_AXES ? 0 : eindex));
@@ -106,34 +100,54 @@ constexpr uint8_t index_of_axis(const AxisEnum axis E_OPTARG(const uint8_t einde
 
 #define INDEX_OF_AXIS(A,V...)     index_of_axis(A E_OPTARG(V+0))
 
-// Bit mask for a matching enable pin, or 0
-constexpr ena_mask_t ena_same(const uint8_t a, const uint8_t b) {
-  return ena_pins[a] == ena_pins[b] ? _BV(b) : 0;
-}
+#if DISABLED(SOFTWARE_DRIVER_ENABLE)
+  // All the stepper enable pins
+  constexpr pin_t ena_pins[] = {
+    NUM_AXIS_LIST_(X_ENABLE_PIN, Y_ENABLE_PIN, Z_ENABLE_PIN, I_ENABLE_PIN, J_ENABLE_PIN, K_ENABLE_PIN, U_ENABLE_PIN, V_ENABLE_PIN, W_ENABLE_PIN)
+    LIST_N(E_STEPPERS, E0_ENABLE_PIN, E1_ENABLE_PIN, E2_ENABLE_PIN, E3_ENABLE_PIN, E4_ENABLE_PIN, E5_ENABLE_PIN, E6_ENABLE_PIN, E7_ENABLE_PIN)
+  };
 
-// Recursively get the enable overlaps mask for a given linear axis or extruder
-constexpr ena_mask_t ena_overlap(const uint8_t a=0, const uint8_t b=0) {
-  return b >= ENABLE_COUNT ? 0 : (a == b ? 0 : ena_same(a, b)) | ena_overlap(a, b + 1);
-}
+  // Bit mask for a matching enable pin, or 0
+  constexpr ena_mask_t ena_same(const uint8_t a, const uint8_t b) {
+    return ena_pins[a] == ena_pins[b] ? _BV(b) : 0;
+  }
 
-// Recursively get whether there's any overlap at all
-constexpr bool any_enable_overlap(const uint8_t a=0) {
-  return a >= ENABLE_COUNT ? false : ena_overlap(a) || any_enable_overlap(a + 1);
-}
+  // Recursively get the enable overlaps mask for a given linear axis or extruder
+  constexpr ena_mask_t ena_overlap(const uint8_t a=0, const uint8_t b=0) {
+    return b >= ENABLE_COUNT ? 0 : (a == b ? 0 : ena_same(a, b)) | ena_overlap(a, b + 1);
+  }
 
-// Array of axes that overlap with each
-// TODO: Consider cases where >=2 steppers are used by a linear axis or extruder
-//       (e.g., CoreXY, Dual XYZ, or E with multiple steppers, etc.).
-constexpr ena_mask_t enable_overlap[] = {
-  #define _OVERLAP(N) ena_overlap(INDEX_OF_AXIS(AxisEnum(N))),
-  REPEAT(NUM_AXES, _OVERLAP)
-  #if HAS_EXTRUDERS
-    #define _E_OVERLAP(N) ena_overlap(INDEX_OF_AXIS(E_AXIS, N)),
-    REPEAT(E_STEPPERS, _E_OVERLAP)
-  #endif
-};
+  // Recursively get whether there's any overlap at all
+  constexpr bool any_enable_overlap(const uint8_t a=0) {
+    return a >= ENABLE_COUNT ? false : ena_overlap(a) || any_enable_overlap(a + 1);
+  }
 
-//static_assert(!any_enable_overlap(), "There is some overlap.");
+  // Array of axes that overlap with each
+  // TODO: Consider cases where >=2 steppers are used by a linear axis or extruder
+  //       (e.g., CoreXY, Dual XYZ, or E with multiple steppers, etc.).
+  constexpr ena_mask_t enable_overlap[] = {
+    #define _OVERLAP(N) ena_overlap(INDEX_OF_AXIS(AxisEnum(N))),
+    REPEAT(NUM_AXES, _OVERLAP)
+    #if HAS_EXTRUDERS
+      #define _E_OVERLAP(N) ena_overlap(INDEX_OF_AXIS(E_AXIS, N)),
+      REPEAT(E_STEPPERS, _E_OVERLAP)
+    #endif
+  };
+
+  //static_assert(!any_enable_overlap(), "There is some overlap.");
+
+#else
+  // With SOFTWARE_DRIVER_ENABLE there are no shared hardware pins, so no overlap
+  constexpr bool any_enable_overlap(const uint8_t=0) { return false; }
+  constexpr ena_mask_t enable_overlap[] = {
+    #define _OVERLAP(N) ena_mask_t(0),
+    REPEAT(NUM_AXES, _OVERLAP)
+    #if HAS_EXTRUDERS
+      #define _E_OVERLAP(N) ena_mask_t(0),
+      REPEAT(E_STEPPERS, _E_OVERLAP)
+    #endif
+  };
+#endif // !SOFTWARE_DRIVER_ENABLE
 
 #if HAS_ZV_SHAPING
 


### PR DESCRIPTION
### Description

Fix compile error when SOFTWARE_DRIVER_ENABLE is enabled with TMC drivers without Enable pins defined

Issue: When SOFTWARE_DRIVER_ENABLE is defined (required for TMC drivers that use UART/SPI for enable control rather than a dedicated enable pin), the code unconditionally declared ena_pins[] and related constexpr helpers that reference X_ENABLE_PIN, Y_ENABLE_PIN, etc. Those pin macros are undefined (or commented out) when using software enable, causing a compile failure.

Changes:

stepper.h: Wrapped ena_pins[], ena_same(), ena_overlap(), any_enable_overlap(), and enable_overlap[] in #if DISABLED(SOFTWARE_DRIVER_ENABLE). Added an #else branch providing no-op stubs (any_enable_overlap returns false, enable_overlap is all zeros) so the rest of the stepper logic compiles cleanly without hardware enable pins.

### Requirements

EG using BOARD_RAMPS_14_EFB

Configuration.h: Changed X/Y/Z/E0 driver types from A4988 to TMC2209 (test config).
Configuration_adv.h: Enabled SOFTWARE_DRIVER_ENABLE (test config).
pins_RAMPS.h: Commented out the hardware enable pin definitions for X/Y/Z/E0/E1 to reflect that software enable is in use.

### Benefits

Code no longer expects ENABLE_PIN's with SOFTWARE_DRIVER_ENABLE

### Configurations

[SOFTWARE_DRIVER_ENABLE Test Configuration.zip](https://github.com/user-attachments/files/27678160/SOFTWARE_DRIVER_ENABLE.Test.Configuration.zip)

### Related Issues
Was noticed in discord chat