### PR TITLE
Reduce stuttering on segmented leveled moves

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2556,13 +2556,13 @@ bool Planner::_populate_block(
         vmax_junction_sqr = minimum_planner_speed_sqr;
       }
       else {
-        // Convert delta vector to unit vector
+        // Diff of unit vectors is normal (perpendicular) vector - itself normalized on next line
         xyze_float_t junction_unit_vec = unit_vec - prev_unit_vec;
-        normalize_junction_vector(junction_unit_vec);
-
-        // TODO: Don't limit acceleration on axes with very small distance relative to others
-        // See https://github.com/MarlinFirmware/Marlin/issues/27918#issuecomment-3145339116
-        const float junction_acceleration = limit_value_by_axis_maximum(block->acceleration, junction_unit_vec);
+        // Do not limit_value_by_axis if normal vector is marginal (solves real-live motion issue)
+        const float junction_acceleration = normalize_junction_vector(junction_unit_vec)
+          ? block->acceleration
+          : limit_value_by_axis_maximum(block->acceleration, junction_unit_vec);
+        // MEMO: it very much looks like block->acceleration is actually a MAXIMUM (scalar) acceleration
 
         if (TERN0(HINTS_CURVE_RADIUS, hints.curve_radius)) {
           TERN_(HINTS_CURVE_RADIUS, vmax_junction_sqr = junction_acceleration * hints.curve_radius);
@@ -2636,23 +2636,24 @@ bool Planner::_populate_block(
               #else
 
                 // Fast acos(-t) approximation (max. error +-0.033rad = 1.89°)
-                // Based on MinMax polynomial published by W. Randolph Franklin, see
+                // based on MinMax polynomial for asin(t) by W. Randolph Franklin; see
                 // https://wrfranklin.org/Research/Short_Notes/arcsin/onlyelem.html
-                //  acos( t) = pi / 2 - asin(x)
-                //  acos(-t) = pi - acos(t) ... pi / 2 + asin(x)
+                // * Current code is conditional to junction_cos_theta < -0.7071067812f
+                // so math is simplified under the assumption that junction_cos_theta < 0.
+                // * Converted asin to acos with acos(-t) = pi - acos(t) = pi / 2 + asin(x)
 
-                const float neg = junction_cos_theta < 0 ? -1 : 1,
-                            t = neg * junction_cos_theta,
-                            asinx =       0.032843707f
-                                  + t * (-1.451838349f
-                                  + t * ( 29.66153956f
-                                  + t * (-131.1123477f
-                                  + t * ( 262.8130562f
-                                  + t * (-242.7199627f
-                                  + t * ( 84.31466202f ) ))))),
-                            junction_theta = RADIANS(90) + neg * asinx; // acos(-t)
-
-                // NOTE: junction_theta bottoms out at 0.033 which avoids divide by 0.
+                const float junction_theta =       (1.5379526198f
+                            + junction_cos_theta * (-1.451838349f
+                            + junction_cos_theta * (-29.66153956f
+                            + junction_cos_theta * (-131.1123477f
+                            + junction_cos_theta * (-262.8130562f
+                            + junction_cos_theta * (-242.7199627f
+                            + junction_cos_theta * -84.31466202f))))))
+                            / (1.0f + 1.4545e-4f / (1.0f + junction_cos_theta));
+                // Last line is kennovo's correction factor for asymptotic behavior when
+                // junction_cos_theta --> -1.0; potentially important because limit_sqr
+                // DIVIDES by junction_theta below. Note: correction reintroduces
+                // divide-by-almost-zero hazard, but that's addressed by NOLESS above.
 
               #endif
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2558,10 +2558,10 @@ bool Planner::_populate_block(
       else {
         // Diff of unit vectors is normal (perpendicular) vector - itself normalized on next line
         xyze_float_t junction_unit_vec = unit_vec - prev_unit_vec;
-        // Do not limit_value_by_axis if normal vector is marginal (solves real-live motion issue)
+        // Do not limit_jd_acceleration_by_axis_maximum if normal vector is marginal (solves real-live motion issue)
         const float junction_acceleration = normalize_junction_vector(junction_unit_vec)
           ? block->acceleration
-          : limit_value_by_axis_maximum(block->acceleration, junction_unit_vec);
+          : limit_jd_acceleration_by_axis_maximum(block->acceleration, junction_unit_vec);
         // NOTE: Here block->acceleration is used as the scalar acceleration limit for the junction calculation.
 
         if (TERN0(HINTS_CURVE_RADIUS, hints.curve_radius)) {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2539,7 +2539,7 @@ bool Planner::_populate_block(
      * Elsewise, when needed JD will factor-in the E component
      */
     if (ANY(IS_CORE, MARKFORGED_XY, MARKFORGED_YX) || esteps > 0)
-      normalize_junction_vector(unit_vec);  // Normalize with XYZE components
+      (void)normalize_junction_vector(unit_vec);  // Normalize with XYZE components
     else
       unit_vec *= inverse_millimeters;      // Use pre-calculated (1 / SQRT(x^2 + y^2 + z^2))
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2562,7 +2562,7 @@ bool Planner::_populate_block(
         const float junction_acceleration = normalize_junction_vector(junction_unit_vec)
           ? block->acceleration
           : limit_value_by_axis_maximum(block->acceleration, junction_unit_vec);
-        // MEMO: it very much looks like block->acceleration is actually a MAXIMUM (scalar) acceleration
+        // NOTE: Here block->acceleration is used as the scalar acceleration limit for the junction calculation.
 
         if (TERN0(HINTS_CURVE_RADIUS, hints.curve_radius)) {
           TERN_(HINTS_CURVE_RADIUS, vmax_junction_sqr = junction_acceleration * hints.curve_radius);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2638,9 +2638,9 @@ bool Planner::_populate_block(
                 // Fast acos(-t) approximation (max. error +-0.033rad = 1.89°)
                 // based on MinMax polynomial for asin(t) by W. Randolph Franklin; see
                 // https://wrfranklin.org/Research/Short_Notes/arcsin/onlyelem.html
-                // * Current code is conditional to junction_cos_theta < -0.7071067812f
-                // so math is simplified under the assumption that junction_cos_theta < 0.
-                // * Converted asin to acos with acos(-t) = pi - acos(t) = pi / 2 + asin(x)
+                // - Current code is conditional to junction_cos_theta < -0.7071067812f
+                //   so math is simplified under the assumption that junction_cos_theta < 0.
+                // - Converted asin to acos with acos(-t) = π - acos(t) = π / 2 + asin(x)
 
                 const float jct1 = 1.0f + junction_cos_theta;
                 const float junction_theta =       (   1.5379526198f

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2633,7 +2633,7 @@ bool Planner::_populate_block(
                 float junction_theta = t * pgm_read_float(&jd_lut_k[idx]) + pgm_read_float(&jd_lut_b[idx]);
                 if (neg > 0) junction_theta = RADIANS(180) - junction_theta; // acos(-t)
 
-              #else
+              #else // !JD_USE_MATH_ACOS && !JD_USE_LOOKUP_TABLE
 
                 // Fast acos(-t) approximation (max. error +-0.033rad = 1.89°)
                 // based on MinMax polynomial for asin(t) by W. Randolph Franklin; see
@@ -2642,20 +2642,24 @@ bool Planner::_populate_block(
                 // so math is simplified under the assumption that junction_cos_theta < 0.
                 // * Converted asin to acos with acos(-t) = pi - acos(t) = pi / 2 + asin(x)
 
-                const float junction_theta =       (1.5379526198f
-                            + junction_cos_theta * (-1.451838349f
-                            + junction_cos_theta * (-29.66153956f
+                const float jct1 = 1.0f + junction_cos_theta;
+                const float junction_theta =       (   1.5379526198f
+                            + junction_cos_theta * (  -1.451838349f
+                            + junction_cos_theta * ( -29.66153956f
                             + junction_cos_theta * (-131.1123477f
                             + junction_cos_theta * (-262.8130562f
                             + junction_cos_theta * (-242.7199627f
-                            + junction_cos_theta * -84.31466202f))))))
-                            / (1.0f + 1.4545e-4f / (1.0f + junction_cos_theta));
+                            + junction_cos_theta *   -84.31466202f))))))
+                         // / (1.0f + (1.4545e-4f / jct1));
+                         // / ((jct1 / jct1) + (1.4545e-4f / jct1)));
+                         // / (jct1 + 1.4545e-4f) / jct1));
+                            * (jct1 / (jct1 + 1.4545e-4f)));
                 // Last line is kennovo's correction factor for asymptotic behavior when
                 // junction_cos_theta --> -1.0; potentially important because limit_sqr
                 // DIVIDES by junction_theta below. Note: correction reintroduces
                 // divide-by-almost-zero hazard, but that's addressed by NOLESS above.
 
-              #endif
+              #endif // !JD_USE_MATH_ACOS && !JD_USE_LOOKUP_TABLE
 
               const float limit_sqr = (block->millimeters * junction_acceleration) / junction_theta;
               NOMORE(vmax_junction_sqr, limit_sqr);

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1231,7 +1231,7 @@ class Planner {
       }
 
       // max_value is block->acceleration here used as our nominal or maximum
-      // unit_vec is the direction of the normal (i.e. perpendicular) acceleration _only_
+      // unit_vec is the direction of the normal (i.e., perpendicular) acceleration _only_
       FORCE_INLINE static float limit_jd_acceleration_by_axis_maximum(const float max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
         LOOP_LOGICAL_AXES(axis) {

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1205,7 +1205,8 @@ class Planner {
 
     #if HAS_JUNCTION_DEVIATION
 
-      FORCE_INLINE static int normalize_junction_vector(xyze_float_t &vector) {
+      // Return 'true' if the magnitude_sq is insignificant
+      FORCE_INLINE static bool normalize_junction_vector(xyze_float_t &vector) {
         float magnitude_sq = 0.0f;
         LOOP_LOGICAL_AXES(idx) if (vector[idx]) magnitude_sq += sq(vector[idx]);
         // Avoid divide by almost-zero (solves real-live motion issue). Threshold consistent with
@@ -1213,8 +1214,9 @@ class Planner {
         // limit_value_by_axis_maximum below and NOLESS(junction_cos_theta,-0.999968f) in planner.cpp
         if (magnitude_sq > 2.0e-6f) {
           vector *= RSQRT(magnitude_sq);
-          return 0;
-        } else return 1;
+          return false;
+        }
+        return true;
       }
 
       // max_value is block->acceleration

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1205,18 +1205,26 @@ class Planner {
 
     #if HAS_JUNCTION_DEVIATION
 
-      FORCE_INLINE static void normalize_junction_vector(xyze_float_t &vector) {
-        float magnitude_sq = 0;
+      FORCE_INLINE static int normalize_junction_vector(xyze_float_t &vector) {
+        float magnitude_sq = 0.0f;
         LOOP_LOGICAL_AXES(idx) if (vector[idx]) magnitude_sq += sq(vector[idx]);
-        vector *= RSQRT(magnitude_sq);
+        // Avoid divide by almost-zero (solves real-live motion issue). Threshold consistent with
+        // junction_cos_theta. TODO: *might* need to increase _both_ a bit, e.g. 6.4e-5f here, 8e-3f for
+        // limit_value_by_axis_maximum below and NOLESS(junction_cos_theta,-0.999968f) in planner.cpp
+        if (magnitude_sq > 2.0e-6f) {
+          vector *= RSQRT(magnitude_sq);
+          return 0;
+        } else return 1;
       }
 
       // max_value is block->acceleration
+      // unit_vec is the direction of the normal (i.e. perpendicular) acceleration _only_
       FORCE_INLINE static float limit_value_by_axis_maximum(const float max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
         LOOP_LOGICAL_AXES(idx) {
-          if (unit_vec[idx]) {
-            const uint32_t abs_vec = ABS(unit_vec[idx]);
+          const float abs_vec = ABS(unit_vec[idx]);
+          // Skip small components, avoiding divide by almost-zero
+          if (abs_vec > 1.5e-3f) {  // sqrt of normalize_junction_vector() threshold (for good measure)
             if (limit_value * abs_vec > settings.max_acceleration_mm_per_s2[idx])
               limit_value = settings.max_acceleration_mm_per_s2[idx] / abs_vec;
           }

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1205,30 +1205,43 @@ class Planner {
 
     #if HAS_JUNCTION_DEVIATION
 
+
+      // TODO: *might* need to increase a bit, e.g., 6.4e-5f
+      #ifndef JD_VECTOR_NORMALIZE_M2_THRESHOLD
+        #define JD_VECTOR_NORMALIZE_M2_THRESHOLD 2.0e-6f
+      #endif
+      // TODO: *might* need to increase a bit, e.g., 8e-3f
+      #ifndef LIMIT_DIVISOR_THRESHOLD
+        #define LIMIT_DIVISOR_THRESHOLD 1.5e-3f
+      #endif
+
+      // TODO: Might change to NOLESS(junction_cos_theta,-0.999968f) in planner.cpp also
+
       // Return 'true' if the magnitude_sq is insignificant
       FORCE_INLINE static bool normalize_junction_vector(xyze_float_t &vector) {
         float magnitude_sq = 0.0f;
-        LOOP_LOGICAL_AXES(idx) if (vector[idx]) magnitude_sq += sq(vector[idx]);
-        // Avoid divide by almost-zero (solves real-live motion issue). Threshold consistent with
-        // junction_cos_theta. TODO: *might* need to increase _both_ a bit, e.g. 6.4e-5f here, 8e-3f for
-        // limit_value_by_axis_maximum below and NOLESS(junction_cos_theta,-0.999968f) in planner.cpp
-        if (magnitude_sq > 2.0e-6f) {
+        LOOP_LOGICAL_AXES(axis) if (vector[axis]) magnitude_sq += sq(vector[axis]);
+        // Avoid divide by near-zero (to prevent stuttering).
+        // Threshold consistent with junction_cos_theta.
+        if (magnitude_sq > JD_VECTOR_NORMALIZE_M2_THRESHOLD) {
           vector *= RSQRT(magnitude_sq);
           return false;
         }
         return true;
       }
 
-      // max_value is block->acceleration
+      // max_value is block->acceleration here used as our nominal or maximum
       // unit_vec is the direction of the normal (i.e. perpendicular) acceleration _only_
-      FORCE_INLINE static float limit_value_by_axis_maximum(const float max_value, xyze_float_t &unit_vec) {
+      FORCE_INLINE static float limit_jd_acceleration_by_axis_maximum(const float max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
-        LOOP_LOGICAL_AXES(idx) {
-          const float abs_vec = ABS(unit_vec[idx]);
+        LOOP_LOGICAL_AXES(axis) {
+          const float abs_vec = ABS(unit_vec[axis]);
           // Skip small components, avoiding divide by almost-zero
-          if (abs_vec > 1.5e-3f) {  // sqrt of normalize_junction_vector() threshold (for good measure)
-            if (limit_value * abs_vec > settings.max_acceleration_mm_per_s2[idx])
-              limit_value = settings.max_acceleration_mm_per_s2[idx] / abs_vec;
+          if (abs_vec > LIMIT_DIVISOR_THRESHOLD) {  // sqrt of normalize_junction_vector() threshold (for good measure)
+            // i.e., NOMORE(limit_valuw, settings.max_acceleration_mm_per_s2[axis] / abs_vec)
+            //       But we do it this way to avoid division unless limiting.
+            if (limit_value * abs_vec > settings.max_acceleration_mm_per_s2[axis])
+              limit_value = settings.max_acceleration_mm_per_s2[axis] / abs_vec;
           }
         }
         return limit_value;


### PR DESCRIPTION
Fixes #19217
Based on #27918 — Adapted by @kennovo

Mysterious stuttering related to JD and segmented leveled moves. Could it be related to small Z motions possibly causing reciprocals to blow up? Perhaps Z can just be left out of speed/acceleration limiting when the only Z motion is being introduced by Z leveling and where the Z part of the segment is typically well under 0.1mm.

Whatever the cause, the changes proposed here seem to mitigate the issue for some.

Goal: Work this into a solution, understand the dynamics, potentially solve the issue at a more fundamental level.

Compare to FT Motion, experiment with different levels of Z compensation to see how the issue presents. Does it still appear when the mesh is all zero but leveling is still activated? Keep poking this bear until it comes out of its cave.