### PR TITLE
🔧 MAX_SAVED_MESHES (Set to 0 for no EEPROM mesh)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2267,6 +2267,8 @@
     #define G26_RETRACT_MULTIPLIER   1.0  // G26 Q (retraction) used by default between mesh test elements.
   #endif
 
+  #define MAX_SAVED_MESHES    100         // Maximum number of meshes to store to EEPROM. Use 0 to disable saving.
+
 #endif
 
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -61,7 +61,9 @@ void unified_bed_leveling::report_state() {
   serial_delay(50);
 }
 
-int8_t unified_bed_leveling::storage_slot;
+#if HAS_MESH_STORAGE
+  int8_t unified_bed_leveling::storage_slot;
+#endif
 
 bed_mesh_t unified_bed_leveling::z_values;
 
@@ -90,7 +92,7 @@ unified_bed_leveling::unified_bed_leveling() { reset(); }
 void unified_bed_leveling::reset() {
   const bool was_enabled = planner.leveling_active;
   set_bed_leveling_enabled(false);
-  storage_slot = -1;
+  TERN_(HAS_MESH_STORAGE, storage_slot = -1);
   ZERO(z_values);
   #if ENABLED(EXTENSIBLE_UI)
     GRID_LOOP(x, y) ExtUI::onMeshUpdate(x, y, 0);
@@ -244,14 +246,16 @@ void unified_bed_leveling::display_map(const uint8_t map_type) {
 }
 
 bool unified_bed_leveling::sanity_check() {
-  uint8_t error_flag = 0;
+  bool error_flag = false;
 
-  if (settings.calc_num_meshes() < 1) {
-    SERIAL_ECHOLNPGM("?Mesh too big for EEPROM.");
-    error_flag++;
-  }
+  #if HAS_MESH_STORAGE
+    if (settings.calc_num_meshes() < 1) {
+      SERIAL_ECHOLNPGM("?Mesh too big for EEPROM.");
+      error_flag = true;
+    }
+  #endif
 
-  return !!error_flag;
+  return error_flag;
 }
 
 #if ENABLED(UBL_MESH_WIZARD)
@@ -285,11 +289,10 @@ bool unified_bed_leveling::sanity_check() {
                               PROBE_GCODE "\n"    // Build mesh with available hardware
                               "G29P3\nG29P3"));   // Ensure mesh is complete by running smart fill twice
 
-    if (parser.seenval('S')) {
-      char umw_gcode[32];
-      sprintf_P(umw_gcode, PSTR("G29S%i"), parser.value_int());
-      queue.inject(umw_gcode);
-    }
+    #if HAS_MESH_STORAGE
+      if (parser.seenval('S'))
+        queue.inject(TS(F("G29S"), parser.value_int()));
+    #endif
 
     process_subcommands_now(F("G29A\nG29F10\n"    // Set UBL Active & Fade 10
                               "M140S0\nM104S0\n"  // Turn off heaters

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -44,7 +44,9 @@ struct mesh_index_pair;
 
 typedef struct {
   bool      C_seen;
-  int8_t    KLS_storage_slot;
+  #if HAS_MESH_STORAGE
+    int8_t  KLS_storage_slot;
+  #endif
   grid_count_t R_repetition;
   uint8_t   V_verbosity,
             P_phase,
@@ -92,8 +94,10 @@ private:
 
   #if ENABLED(UBL_DEVEL_DEBUGGING)
     static void g29_what_command();
-    static void g29_eeprom_dump();
-    static void g29_compare_current_mesh_to_stored_mesh();
+    #if HAS_MESH_STORAGE
+      static void g29_eeprom_dump();
+      static void g29_compare_current_mesh_to_stored_mesh();
+    #endif
   #endif
 
 public:
@@ -116,7 +120,9 @@ public:
   static void G29() __O0;                           // O0 for no optimization
   static void smart_fill_wlsf(const float ) __O2; // O2 gives smaller code than Os on A2560
 
-  static int8_t storage_slot;
+  #if HAS_MESH_STORAGE
+    static int8_t storage_slot;
+  #endif
 
   static bed_mesh_t z_values;
   #if ENABLED(OPTIMIZED_MESH_STORAGE)

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -246,8 +246,8 @@
  *                    current state of the Unified Bed Leveling system in the EEPROM.
  *
  *   S #   Store      Store the current Mesh at the specified location in EEPROM. Activate this location
- *                    for subsequent Load and Store operations. Valid storage slot numbers begin at 0 and
- *                    extend to a limit related to the available EEPROM storage.
+ *                    for subsequent Load and Store operations. Valid storage slot numbers range from 0
+ *                    to the highest index permitted, based on available EEPROM storage.
  *
  *   S -1  Store      Print the current Mesh as G-code that can be used to restore the mesh anytime.
  *
@@ -368,24 +368,34 @@ void unified_bed_leveling::G29_handle_post_processing() {
   //
 
   if (parser.seen('L')) {     // Load Current Mesh Data
-    param.KLS_storage_slot = parser.has_value() ? (int8_t)parser.value_int() : storage_slot;
 
-    int16_t a = settings.calc_num_meshes();
+    #if !HAS_MESH_STORAGE
 
-    if (!a) {
       SERIAL_ECHOLNPGM("?EEPROM storage not available.");
       return;
-    }
 
-    if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
-      SERIAL_ECHOLN(F("?Invalid "), F("storage slot.\n?Use 0 to "), a - 1);
-      return;
-    }
+    #else // HAS_MESH_STORAGE
 
-    settings.load_mesh(param.KLS_storage_slot);
-    storage_slot = param.KLS_storage_slot;
+      param.KLS_storage_slot = parser.has_value() ? (int8_t)parser.value_int() : storage_slot;
 
-    SERIAL_ECHOLNPGM(STR_DONE);
+      const int16_t a = settings.calc_num_meshes();
+
+      if (!a) {
+        SERIAL_ECHOLNPGM("?EEPROM storage not available.");
+        return;
+      }
+
+      if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
+        SERIAL_ECHOLN(F("?Invalid "), F("storage slot. (0.."), a - 1, C(')'));
+        return;
+      }
+
+      settings.load_mesh(param.KLS_storage_slot);
+      storage_slot = param.KLS_storage_slot;
+
+      SERIAL_ECHOLNPGM(STR_DONE);
+
+    #endif // HAS_MESH_STORAGE
   }
 
   //
@@ -393,27 +403,37 @@ void unified_bed_leveling::G29_handle_post_processing() {
   //
 
   else if (parser.seen('S')) {     // Store (or Save) Current Mesh Data
-    param.KLS_storage_slot = parser.has_value() ? (int8_t)parser.value_int() : storage_slot;
 
-    if (param.KLS_storage_slot == -1)               // Special case: 'Export' the mesh to the
-      return report_current_mesh();                 // host so it can be saved in a file.
+    #if !HAS_MESH_STORAGE
 
-    int16_t a = settings.calc_num_meshes();
-
-    if (!a) {
       SERIAL_ECHOLNPGM("?EEPROM storage not available.");
       goto LEAVE;
-    }
 
-    if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
-      SERIAL_ECHOLN(F("?Invalid "), F("storage slot.\n?Use 0 to "), a - 1);
-      goto LEAVE;
-    }
+    #else // HAS_MESH_STORAGE
 
-    settings.store_mesh(param.KLS_storage_slot);
-    storage_slot = param.KLS_storage_slot;
+      param.KLS_storage_slot = parser.has_value() ? (int8_t)parser.value_int() : storage_slot;
 
-    SERIAL_ECHOLNPGM(STR_DONE);
+      if (param.KLS_storage_slot == -1)               // Special case: 'Export' the mesh to the
+        return report_current_mesh();                 // host so it can be saved in a file.
+
+      const int16_t a = settings.calc_num_meshes();
+
+      if (!a) {
+        SERIAL_ECHOLNPGM("?EEPROM storage not available.");
+        goto LEAVE;
+      }
+
+      if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
+        SERIAL_ECHOLN(F("?Invalid "), F("storage slot. (0.."), a - 1, C(')'));
+        goto LEAVE;
+      }
+
+      settings.store_mesh(param.KLS_storage_slot);
+      storage_slot = param.KLS_storage_slot;
+
+      SERIAL_ECHOLNPGM(STR_DONE);
+
+    #endif // HAS_MESH_STORAGE
   }
 
   if (parser.seen_test('T'))
@@ -444,10 +464,13 @@ void unified_bed_leveling::G29_handle_post_processing() {
  * @return true if successful, false if error occurred
  */
 bool unified_bed_leveling::G29_handle_phase_ops() {
-  if (WITHIN(param.P_phase, 0, 1) && storage_slot == -1) {
-    storage_slot = 0;
-    SERIAL_ECHOLNPGM("Default storage slot 0 selected.");
-  }
+
+  #if HAS_MESH_STORAGE
+    if (WITHIN(param.P_phase, 0, 1) && storage_slot == -1) {
+      storage_slot = 0;
+      SERIAL_ECHOLNPGM("Default storage slot 0 selected.");
+    }
+  #endif
 
   switch (param.P_phase) {
     case 0:
@@ -1809,11 +1832,13 @@ void unified_bed_leveling::smart_fill_mesh() {
   void unified_bed_leveling::g29_what_command() {
     report_state();
 
-    if (storage_slot == -1)
-      SERIAL_ECHOLNPGM("No Mesh Loaded.");
-    else
-      SERIAL_ECHOLNPGM("Mesh ", storage_slot, " Loaded.");
-    serial_delay(50);
+    #if HAS_MESH_STORAGE
+      if (storage_slot == -1)
+        SERIAL_ECHOLNPGM("No Mesh Loaded.");
+      else
+        SERIAL_ECHOLNPGM("Mesh ", storage_slot, " Loaded.");
+      serial_delay(50);
+    #endif
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       SERIAL_ECHOLN(F("Fade Height M420 Z"), p_float_t(planner.z_fade_height, 4));
@@ -1863,11 +1888,12 @@ void unified_bed_leveling::smart_fill_mesh() {
     SERIAL_ECHOLNPGM("z_value[][] size: ", sizeof(z_values));
     serial_delay(25);
 
-    SERIAL_ECHOLNPGM("EEPROM free for UBL: ", _hex_word(settings.meshes_end_index() - settings.meshes_start_index()));
-    serial_delay(50);
-
-    SERIAL_ECHOLNPGM("EEPROM can hold ", settings.calc_num_meshes(), " meshes.\n");
-    serial_delay(25);
+    #if HAS_MESH_STORAGE
+      SERIAL_ECHOLNPGM("EEPROM free for UBL: ", _hex_word(settings.meshes_end_index() - settings.meshes_start_index()));
+      serial_delay(50);
+      SERIAL_ECHOLNPGM("EEPROM can hold ", settings.calc_num_meshes(), " meshes.\n");
+      serial_delay(25);
+    #endif
 
     if (!sanity_check()) {
       echo_name();
@@ -1875,60 +1901,64 @@ void unified_bed_leveling::smart_fill_mesh() {
     }
   }
 
-  /**
-   * When we are fully debugged, the EEPROM dump command will get deleted also. But
-   * right now, it is good to have the extra information. Soon... we prune this.
-   */
-  void unified_bed_leveling::g29_eeprom_dump() {
-    uint8_t cccc;
+  #if HAS_MESH_STORAGE
 
-    SERIAL_ECHO_MSG("EEPROM Dump:");
-    persistentStore.access_start();
-    for (uint16_t i = 0; i < persistentStore.capacity(); i += 16) {
-      if (!(i & 0x3)) marlin.idle();
-      print_hex_word(i);
-      SERIAL_ECHOPGM(": ");
-      for (uint16_t j = 0; j < 16; j++) {
-        int pos = i + j;
-        persistentStore.read_data(pos, &cccc, sizeof(uint8_t));
-        print_hex_byte(cccc);
-        SERIAL_CHAR(' ');
+    /**
+    * When we are fully debugged, the EEPROM dump command will get deleted also. But
+    * right now, it is good to have the extra information. Soon... we prune this.
+    */
+    void unified_bed_leveling::g29_eeprom_dump() {
+      uint8_t cccc;
+
+      SERIAL_ECHO_MSG("EEPROM Dump:");
+      persistentStore.access_start();
+      for (uint16_t i = 0; i < persistentStore.capacity(); i += 16) {
+        if (!(i & 0x3)) marlin.idle();
+        print_hex_word(i);
+        SERIAL_ECHOPGM(": ");
+        for (uint16_t j = 0; j < 16; j++) {
+          int pos = i + j;
+          persistentStore.read_data(pos, &cccc, sizeof(uint8_t));
+          print_hex_byte(cccc);
+          SERIAL_CHAR(' ');
+        }
+        SERIAL_EOL();
       }
       SERIAL_EOL();
-    }
-    SERIAL_EOL();
-    persistentStore.access_finish();
-  }
-
-  /**
-   * When we are fully debugged, this may go away. But there are some valid
-   * use cases for the users. So we can wait and see what to do with it.
-   */
-  void unified_bed_leveling::g29_compare_current_mesh_to_stored_mesh() {
-    const int16_t a = settings.calc_num_meshes();
-
-    if (!a) {
-      SERIAL_ECHOLNPGM("?EEPROM storage not available.");
-      return;
+      persistentStore.access_finish();
     }
 
-    if (!parser.has_value() || !WITHIN(parser.value_int(), 0, a - 1)) {
-      SERIAL_ECHOLN(F("?Invalid "), F("storage slot.\n?Use 0 to "), a - 1);
-      return;
+    /**
+    * When we are fully debugged, this may go away. But there are some valid
+    * use cases for the users. So we can wait and see what to do with it.
+    */
+    void unified_bed_leveling::g29_compare_current_mesh_to_stored_mesh() {
+      const int16_t a = settings.calc_num_meshes();
+
+      if (!a) {
+        SERIAL_ECHOLNPGM("?EEPROM storage not available.");
+        return;
+      }
+
+      if (!parser.has_value() || !WITHIN(parser.value_int(), 0, a - 1)) {
+        SERIAL_ECHOLN(F("?Invalid "), F("storage slot. (0.."), a - 1, C(')'));
+        return;
+      }
+
+      param.KLS_storage_slot = (int8_t)parser.value_int();
+
+      float tmp_z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
+      settings.load_mesh(param.KLS_storage_slot, &tmp_z_values);
+
+      SERIAL_ECHOLNPGM("Subtracting mesh in slot ", param.KLS_storage_slot, " from current mesh.");
+
+      GRID_LOOP(x, y) {
+        z_values[x][y] -= tmp_z_values[x][y];
+        TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, z_values[x][y]));
+      }
     }
 
-    param.KLS_storage_slot = (int8_t)parser.value_int();
-
-    float tmp_z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-    settings.load_mesh(param.KLS_storage_slot, &tmp_z_values);
-
-    SERIAL_ECHOLNPGM("Subtracting mesh in slot ", param.KLS_storage_slot, " from current mesh.");
-
-    GRID_LOOP(x, y) {
-      z_values[x][y] -= tmp_z_values[x][y];
-      TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, z_values[x][y]));
-    }
-  }
+  #endif // HAS_MESH_STORAGE
 
 #endif // UBL_DEVEL_DEBUGGING
 

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -97,14 +97,18 @@ void GcodeSuite::M420() {
   // (Don't disable for just M420 or M420 V)
   if (seen_S && !to_enable) set_bed_leveling_enabled(false);
 
+  const bool seenV = parser.seen_test('V');
+
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
     // L to load a mesh from the EEPROM
-    if (parser.seen('L')) {
+    const bool seenL = parser.seen('L');
+    if (seenL) {
 
-      set_bed_leveling_enabled(false);
+      #if HAS_MESH_STORAGE
 
-      #if ENABLED(EEPROM_SETTINGS)
+        set_bed_leveling_enabled(false);
+
         const int8_t storage_slot = parser.has_value() ? parser.value_int() : bedlevel.storage_slot;
         const int16_t a = settings.calc_num_meshes();
 
@@ -130,16 +134,15 @@ void GcodeSuite::M420() {
     }
 
     // L or V display the map info
-    if (parser.seen("LV")) {
+    if (seenL || seenV) {
       bedlevel.display_map(parser.byteval('T'));
-      SERIAL_ECHOPGM("Mesh is ");
-      if (!bedlevel.mesh_is_valid()) SERIAL_ECHOPGM("in");
-      SERIAL_ECHOLNPGM("valid\nStorage slot: ", bedlevel.storage_slot);
+      SERIAL_ECHO_TERNARY(bedlevel.mesh_is_valid(), "Mesh is ", "", "in", "valid\n");
+      #if HAS_MESH_STORAGE
+        SERIAL_ECHOLNPGM("Storage slot: ", bedlevel.storage_slot);
+      #endif
     }
 
   #endif // AUTO_BED_LEVELING_UBL
-
-  const bool seenV = parser.seen_test('V');
 
   #if HAS_MESH
 

--- a/Marlin/src/inc/Conditionals-4-adv.h
+++ b/Marlin/src/inc/Conditionals-4-adv.h
@@ -1559,6 +1559,20 @@
   #define NEED_LSF 1
 #endif
 
+// Saving meshes to EEPROM?
+#if ALL(EEPROM_ENABLED, HAS_MESH)
+  #ifndef MAX_SAVED_MESHES
+    #define MAX_SAVED_MESHES 100
+  #endif
+  #if MAX_SAVED_MESHES > 0
+    #define HAS_MESH_STORAGE 1
+  #endif
+#endif
+#if !HAS_MESH_STORAGE
+  #undef OPTIMIZED_MESH_STORAGE
+  #undef UBL_SAVE_ACTIVE_ON_M500
+#endif
+
 #if ALL(HAS_TFT_LVGL_UI, CUSTOM_MENU_MAIN)
   #define _HAS_1(N) (defined(MAIN_MENU_ITEM_##N##_DESC) && defined(MAIN_MENU_ITEM_##N##_GCODE))
   #define HAS_USER_ITEM(V...) DO(HAS,||,V)

--- a/Marlin/src/lcd/dwin/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/jyersui/dwin.cpp
@@ -3216,7 +3216,9 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
               if (draw)
                 drawMenuItem(row, ICON_Tilt, GET_TEXT_F(MSG_UBL_TILT_MESH));
               else {
-                if (bedlevel.storage_slot < 0) { popupHandler(Popup_MeshSlot); break; }
+                #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
+                  if (bedlevel.storage_slot < 0) { popupHandler(Popup_MeshSlot); break; }
+                #endif
                 popupHandler(Popup_Home);
                 gcode.home_all_axes(true);
                 popupHandler(Popup_Level);
@@ -3282,7 +3284,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
                   break;
                 }
               #endif
-              #if ENABLED(AUTO_BED_LEVELING_UBL)
+              #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
                 if (bedlevel.storage_slot < 0) {
                   popupHandler(Popup_MeshSlot);
                   break;
@@ -3317,7 +3319,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             if (draw)
               drawMenuItem(row, ICON_Mesh, GET_TEXT_F(MSG_MESH_VIEW), nullptr, true);
             else {
-              #if ENABLED(AUTO_BED_LEVELING_UBL)
+              #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
                 if (bedlevel.storage_slot < 0) {
                   popupHandler(Popup_MeshSlot);
                   break;
@@ -3332,7 +3334,7 @@ void JyersDWIN::menuItemHandler(const uint8_t menu, const uint8_t item, bool dra
             else
               drawMenu(ID_LevelSettings);
             break;
-          #if ENABLED(AUTO_BED_LEVELING_UBL)
+          #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
             case LEVELING_SLOT:
               if (draw) {
                 drawMenuItem(row, ICON_PrintSize, GET_TEXT_F(MSG_UBL_STORAGE_SLOT));
@@ -4308,7 +4310,7 @@ void JyersDWIN::popupHandler(const PopupID popupid, const bool option/*=false*/)
     case Popup_Resume:        drawPopup(F("Resume Print?"), F("Looks Like the last"), F("print was interrupted."), Proc_Popup); break;
     case Popup_ConfFilChange: drawPopup(F("Confirm Filament Change"), F(""), F(""), Proc_Popup); break;
     case Popup_PurgeMore:     drawPopup(F("Purge more filament?"), F("(Cancel to finish process)"), F(""), Proc_Popup); break;
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
+    #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
       case Popup_SaveLevel:   drawPopup(GET_TEXT_F(MSG_LEVEL_BED_DONE), F("Save to EEPROM?"), F(""), Proc_Popup); break;
       case Popup_MeshSlot:    drawPopup(F("Mesh slot not selected"), F("(Confirm to select slot 0)"), F(""), Proc_Popup); break;
     #endif
@@ -4738,7 +4740,7 @@ void JyersDWIN::popupControl() {
           break;
       #endif // ADVANCED_PAUSE_FEATURE
 
-      #if HAS_MESH
+      #if HAS_MESH_STORAGE
         case Popup_SaveLevel:
           if (selection == 0) {
             #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -4753,7 +4755,7 @@ void JyersDWIN::popupControl() {
           break;
       #endif
 
-      #if ENABLED(AUTO_BED_LEVELING_UBL)
+      #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
         case Popup_MeshSlot:
           if (selection == 0) bedlevel.storage_slot = 0;
           redrawMenu(true, true);

--- a/Marlin/src/lcd/dwin/jyersui/dwin.h
+++ b/Marlin/src/lcd/dwin/jyersui/dwin.h
@@ -50,7 +50,9 @@ enum PopupID : uint8_t {
   Popup_ETemp,
   Popup_ConfFilChange,
   Popup_PurgeMore,
-  Popup_MeshSlot,
+  #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
+    Popup_MeshSlot,
+  #endif
   Popup_Level,
   Popup_Home,
   Popup_MoveWait,

--- a/Marlin/src/lcd/dwin/proui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/proui/dwin.cpp
@@ -2049,7 +2049,7 @@ void MarlinUI::kill_screen(FSTR_P const lcd_error, FSTR_P const) {
     DONE_BUZZ(true);
   }
 
-  #if HAS_MESH
+  #if HAS_MESH_STORAGE
     void saveMesh() { TERN(AUTO_BED_LEVELING_UBL, ublMeshSave(), writeEEPROM()); }
   #endif
 
@@ -2492,18 +2492,22 @@ void gotoConfirmToPrint() {
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
 
-  void applyUBLSlot() { bedlevel.storage_slot = menuData.value; }
-  void setUBLSlot() { setIntOnClick(0, settings.calc_num_meshes() - 1, bedlevel.storage_slot, applyUBLSlot); }
-  void onDrawUBLSlot(MenuItem* menuitem, int8_t line) {
-    NOLESS(bedlevel.storage_slot, 0);
-    onDrawIntMenu(menuitem, line, bedlevel.storage_slot);
-  }
+  #if HAS_MESH_STORAGE
+    void applyUBLSlot() { bedlevel.storage_slot = menuData.value; }
+    void setUBLSlot() { setIntOnClick(0, settings.calc_num_meshes() - 1, bedlevel.storage_slot, applyUBLSlot); }
+    void onDrawUBLSlot(MenuItem* menuitem, int8_t line) {
+      NOLESS(bedlevel.storage_slot, 0);
+      onDrawIntMenu(menuitem, line, bedlevel.storage_slot);
+    }
+  #endif
 
   void applyUBLTiltGrid() { bedLevelTools.tilt_grid = menuData.value; }
   void setUBLTiltGrid() { setIntOnClick(1, 3, bedLevelTools.tilt_grid, applyUBLTiltGrid); }
 
   void ublMeshTilt() {
-    NOLESS(bedlevel.storage_slot, 0);
+    #if HAS_MESH_STORAGE
+      NOLESS(bedlevel.storage_slot, 0);
+    #endif
     if (bedLevelTools.tilt_grid > 1)
       gcode.process_subcommands_now(TS(F("G29J"), bedLevelTools.tilt_grid));
     else
@@ -2516,17 +2520,19 @@ void gotoConfirmToPrint() {
     LCD_MESSAGE(MSG_UBL_MESH_FILLED);
   }
 
-  void ublMeshSave() {
-    NOLESS(bedlevel.storage_slot, 0);
-    settings.store_mesh(bedlevel.storage_slot);
-    ui.status_printf(0, GET_TEXT_F(MSG_MESH_SAVED), bedlevel.storage_slot);
-    DONE_BUZZ(true);
-  }
+  #if HAS_MESH_STORAGE
+    void ublMeshSave() {
+      NOLESS(bedlevel.storage_slot, 0);
+      settings.store_mesh(bedlevel.storage_slot);
+      ui.status_printf(0, GET_TEXT_F(MSG_MESH_SAVED), bedlevel.storage_slot);
+      DONE_BUZZ(true);
+    }
 
-  void ublMeshLoad() {
-    NOLESS(bedlevel.storage_slot, 0);
-    settings.load_mesh(bedlevel.storage_slot);
-  }
+    void ublMeshLoad() {
+      NOLESS(bedlevel.storage_slot, 0);
+      settings.load_mesh(bedlevel.storage_slot);
+    }
+  #endif
 
 #endif // AUTO_BED_LEVELING_UBL
 
@@ -4555,9 +4561,11 @@ void drawLevelMenu() {
       #endif
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      EDIT_ITEM(ICON_UBLSlot, MSG_UBL_STORAGE_SLOT, onDrawUBLSlot, setUBLSlot, &bedlevel.storage_slot);
-      MENU_ITEM(ICON_UBLMeshSave, MSG_UBL_SAVE_MESH, onDrawMenuItem, ublMeshSave);
-      MENU_ITEM(ICON_UBLMeshLoad, MSG_UBL_LOAD_MESH, onDrawMenuItem, ublMeshLoad);
+      #if HAS_MESH_STORAGE
+        EDIT_ITEM(ICON_UBLSlot, MSG_UBL_STORAGE_SLOT, onDrawUBLSlot, setUBLSlot, &bedlevel.storage_slot);
+        MENU_ITEM(ICON_UBLMeshSave, MSG_UBL_SAVE_MESH, onDrawMenuItem, ublMeshSave);
+        MENU_ITEM(ICON_UBLMeshLoad, MSG_UBL_LOAD_MESH, onDrawMenuItem, ublMeshLoad);
+      #endif
       MENU_ITEM(ICON_UBLTiltGrid, MSG_UBL_TILT_MESH, onDrawMenuItem, ublMeshTilt);
       MENU_ITEM(ICON_UBLSmartFill, MSG_UBL_SMART_FILLIN, onDrawMenuItem, ublSmartFillMesh);
     #endif

--- a/Marlin/src/lcd/dwin/proui/dwin.h
+++ b/Marlin/src/lcd/dwin/proui/dwin.h
@@ -236,7 +236,7 @@ uint32_t getHash(char * str);
   void writeEEPROM();
   void readEEPROM();
   void resetEEPROM();
-  #if HAS_MESH
+  #if HAS_MESH_STORAGE
     void saveMesh();
   #endif
 #endif
@@ -278,8 +278,10 @@ void autoHome();
 #endif
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   void ublMeshTilt();
-  void ublMeshSave();
-  void ublMeshLoad();
+  #if HAS_MESH_STORAGE
+    void ublMeshSave();
+    void ublMeshLoad();
+  #endif
 #endif
 
 // Other

--- a/Marlin/src/lcd/dwin/proui/meshviewer.cpp
+++ b/Marlin/src/lcd/dwin/proui/meshviewer.cpp
@@ -140,7 +140,10 @@ void MeshViewer::draw(const bool withsave/*=false*/, const bool redraw/*=true*/)
 
 void drawMeshViewer() { meshViewer.draw(true, meshredraw); }
 
-void onClick_MeshViewer() { if (hmiFlag.select_flag) saveMesh(); hmiReturnScreen(); }
+void onClick_MeshViewer() {
+  TERN_(HAS_MESH_STORAGE, if (hmiFlag.select_flag) saveMesh());
+  hmiReturnScreen();
+}
 
 void gotoMeshViewer(const bool redraw) {
   meshredraw = redraw;

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -39,8 +39,11 @@
   #include "../../module/temperature.h"
 #endif
 
-static int16_t ubl_storage_slot = 0,
-               custom_hotend_temp = 150,
+#if HAS_MESH_STORAGE
+  static int16_t ubl_storage_slot = 0;
+#endif
+
+static int16_t custom_hotend_temp = 150,
                side_points = 3,
                ubl_fillin_amount = 5,
                ubl_height_amount = 1;
@@ -338,39 +341,43 @@ void _lcd_ubl_build_mesh() {
   END_MENU();
 }
 
-/**
- * UBL Load / Save Mesh Commands
- */
-inline void _lcd_ubl_load_save_cmd(const char loadsave, FSTR_P const fmsg) {
-  char ubl_lcd_gcode[40];
-  sprintf_P(ubl_lcd_gcode, PSTR("G29%c%i\nM117 "), loadsave, ubl_storage_slot);
-  sprintf_P(&ubl_lcd_gcode[strlen(ubl_lcd_gcode)], FTOP(fmsg), ubl_storage_slot);
-  gcode.process_subcommands_now(ubl_lcd_gcode);
-}
-void _lcd_ubl_load_mesh_cmd() { _lcd_ubl_load_save_cmd('L', GET_TEXT_F(MSG_MESH_LOADED)); }
-void _lcd_ubl_save_mesh_cmd() { _lcd_ubl_load_save_cmd('S', GET_TEXT_F(MSG_MESH_SAVED)); }
+#if HAS_MESH_STORAGE
 
-/**
- * UBL Mesh Storage submenu
- *
- * << Unified Bed Leveling
- *    Memory Slot: ---
- *    Load Bed Mesh
- *    Save Bed Mesh
- */
-void _lcd_ubl_storage_mesh() {
-  int16_t a = settings.calc_num_meshes();
-  START_MENU();
-  BACK_ITEM(MSG_UBL_LEVELING);
-  if (!WITHIN(ubl_storage_slot, 0, a - 1))
-    STATIC_ITEM(MSG_UBL_NO_STORAGE);
-  else {
-    EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, a - 1);
-    ACTION_ITEM(MSG_UBL_LOAD_MESH, _lcd_ubl_load_mesh_cmd);
-    ACTION_ITEM(MSG_UBL_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
+ /**
+  * UBL Load / Save Mesh Commands
+  */
+  inline void _lcd_ubl_load_save_cmd(const char loadsave, FSTR_P const fmsg) {
+    char ubl_lcd_gcode[40];
+    sprintf_P(ubl_lcd_gcode, PSTR("G29%c%i\nM117 "), loadsave, ubl_storage_slot);
+    sprintf_P(&ubl_lcd_gcode[strlen(ubl_lcd_gcode)], FTOP(fmsg), ubl_storage_slot);
+    gcode.process_subcommands_now(ubl_lcd_gcode);
   }
-  END_MENU();
-}
+  void _lcd_ubl_load_mesh_cmd() { _lcd_ubl_load_save_cmd('L', GET_TEXT_F(MSG_MESH_LOADED)); }
+  void _lcd_ubl_save_mesh_cmd() { _lcd_ubl_load_save_cmd('S', GET_TEXT_F(MSG_MESH_SAVED)); }
+
+ /**
+  * UBL Mesh Storage submenu
+  *
+  * << Unified Bed Leveling
+  *    Memory Slot: ---
+  *    Load Bed Mesh
+  *    Save Bed Mesh
+  */
+  void _lcd_ubl_storage_mesh() {
+    int16_t a = settings.calc_num_meshes();
+    START_MENU();
+    BACK_ITEM(MSG_UBL_LEVELING);
+    if (!WITHIN(ubl_storage_slot, 0, a - 1))
+      STATIC_ITEM(MSG_UBL_NO_STORAGE);
+    else {
+      EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, a - 1);
+      ACTION_ITEM(MSG_UBL_LOAD_MESH, _lcd_ubl_load_mesh_cmd);
+      ACTION_ITEM(MSG_UBL_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
+    }
+    END_MENU();
+  }
+
+#endif // HAS_MESH_STORAGE
 
 /**
  * UBL LCD "radar" map point editing
@@ -577,7 +584,9 @@ void _menu_ubl_tools() {
     GCODES_ITEM(MSG_UBL_4_FINE_TUNE_ALL, F("G29P4RT"));
     SUBMENU(MSG_UBL_5_VALIDATE_MESH_MENU, _lcd_ubl_validate_mesh);
     GCODES_ITEM(MSG_UBL_6_FINE_TUNE_ALL, F("G29P4RT"));
-    ACTION_ITEM(MSG_UBL_7_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
+    #if HAS_MESH_STORAGE
+      ACTION_ITEM(MSG_UBL_7_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
+    #endif
     END_MENU();
   }
 
@@ -589,20 +598,27 @@ void _menu_ubl_tools() {
    * UBL Mesh Wizard - One-click mesh creation with or without a probe
    */
   void _lcd_ubl_mesh_wizard() {
-    char ubl_lcd_gcode[30];
-    #if HAS_HEATED_BED && HAS_HOTEND
-      sprintf_P(ubl_lcd_gcode, PSTR("M1004B%iH%iS%i"), custom_bed_temp, custom_hotend_temp, ubl_storage_slot);
-    #elif HAS_HOTEND
-      sprintf_P(ubl_lcd_gcode, PSTR("M1004H%iS%i"), custom_hotend_temp, ubl_storage_slot);
-    #else
-      sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
-    #endif
+    MString<30> ubl_lcd_gcode;
+    ubl_lcd_gcode.setf_P(
+      PSTR(
+        "M1004"
+        TERN(HAS_HOTEND, "H%i", "")
+        TERN(HAS_HEATED_BED, "B%i", "")
+        TERN(HAS_MESH_STORAGE, "S%i", "")
+      )
+      OPTARG(HAS_HOTEND, custom_hotend_temp)
+      OPTARG(HAS_HEATED_BED, custom_bed_temp)
+      OPTARG(HAS_MESH_STORAGE, ubl_storage_slot)
+    );
     queue.inject(ubl_lcd_gcode);
     ui.return_to_status();
   }
 
   void _menu_ubl_mesh_wizard() {
-    const int16_t total_slots = settings.calc_num_meshes();
+    #if HAS_MESH_STORAGE
+      const int16_t total_slots = settings.calc_num_meshes();
+    #endif
+
     START_MENU();
     BACK_ITEM(MSG_UBL_LEVELING);
 
@@ -614,7 +630,9 @@ void _menu_ubl_tools() {
       EDIT_ITEM(int3, MSG_UBL_BED_TEMP_CUSTOM, &custom_bed_temp, BED_MINTEMP + 20, BED_MAX_TARGET);
     #endif
 
-    EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, total_slots);
+    #if HAS_MESH_STORAGE
+      EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, total_slots);
+    #endif
 
     ACTION_ITEM(MSG_UBL_MESH_WIZARD, _lcd_ubl_mesh_wizard);
 
@@ -663,7 +681,9 @@ void _lcd_ubl_level_bed() {
   #endif
 
   ACTION_ITEM(MSG_MESH_EDITOR, _ubl_goto_map_screen);
-  SUBMENU(MSG_UBL_STORAGE_MESH_MENU, _lcd_ubl_storage_mesh);
+  #if HAS_MESH_STORAGE
+    SUBMENU(MSG_UBL_STORAGE_MESH_MENU, _lcd_ubl_storage_mesh);
+  #endif
   SUBMENU(MSG_UBL_OUTPUT_MAP, _lcd_ubl_output_map);
   SUBMENU(MSG_UBL_TOOLS, _menu_ubl_tools);
   GCODES_ITEM(MSG_UBL_INFO_UBL, F("G29W"));

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -297,13 +297,15 @@ typedef struct SettingsDataStruct {
   //
   // AUTO_BED_LEVELING_BILINEAR
   //
-  uint8_t grid_max_x, grid_max_y;                       // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
-  uint16_t grid_check;                                  // Hash to check against X/Y
-  xy_pos_t bilinear_grid_spacing, bilinear_start;       // G29 L F
-  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-    bed_mesh_t z_values;                                // G29
-  #else
-    float z_values[3][3];
+  #if HAS_MESH_STORAGE
+    uint8_t grid_max_x, grid_max_y;                     // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
+    uint16_t grid_check;                                // Hash to check against X/Y
+    xy_pos_t bilinear_grid_spacing, bilinear_start;     // G29 L F
+    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      bed_mesh_t z_values;                              // G29
+    #else
+      float z_values[3][3];
+    #endif
   #endif
 
   //
@@ -318,8 +320,10 @@ typedef struct SettingsDataStruct {
   //
   // AUTO_BED_LEVELING_UBL
   //
-  bool planner_leveling_active;                         // M420 S  planner.leveling_active
-  int8_t ubl_storage_slot;                              // bedlevel.storage_slot
+  #if HAS_MESH_STORAGE
+    bool planner_leveling_active;                       // M420 S  planner.leveling_active
+    int8_t ubl_storage_slot;                            // bedlevel.storage_slot
+  #endif
 
   //
   // SERVO_ANGLES
@@ -751,7 +755,9 @@ void MarlinSettings::postprocess() {
 
   TERN_(ENABLE_LEVELING_FADE_HEIGHT, set_z_fade_height(new_z_fade_height, false)); // false = no report
 
-  TERN_(AUTO_BED_LEVELING_BILINEAR, bedlevel.refresh_bed_level());
+  #if ALL(AUTO_BED_LEVELING_BILINEAR, HAS_MESH_STORAGE)
+    bedlevel.refresh_bed_level();
+  #endif
 
   TERN_(HAS_MOTOR_CURRENT_PWM, stepper.refresh_motor_power());
 
@@ -1081,6 +1087,7 @@ void MarlinSettings::postprocess() {
     //
     // Bilinear Auto Bed Leveling
     //
+    #if HAS_MESH_STORAGE
     {
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
         static_assert(
@@ -1114,6 +1121,7 @@ void MarlinSettings::postprocess() {
         for (uint16_t q = grid_max_x * grid_max_y; q--;) EEPROM_WRITE(dummyf);
       #endif
     }
+    #endif // HAS_MESH_STORAGE
 
     //
     // X Axis Twist Compensation
@@ -1128,6 +1136,7 @@ void MarlinSettings::postprocess() {
     //
     // Unified Bed Leveling
     //
+    #if HAS_MESH_STORAGE
     {
       _FIELD_TEST(planner_leveling_active);
       const bool ubl_active = TERN(AUTO_BED_LEVELING_UBL, planner.leveling_active, false);
@@ -1135,6 +1144,7 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(ubl_active);
       EEPROM_WRITE(storage_slot);
     }
+    #endif
 
     //
     // Servo Angles
@@ -2151,6 +2161,7 @@ void MarlinSettings::postprocess() {
       //
       // Bilinear Auto Bed Leveling
       //
+      #if HAS_MESH_STORAGE
       {
         uint8_t grid_max_x, grid_max_y;
         EEPROM_READ_ALWAYS(grid_max_x);                // 1 byte
@@ -2184,6 +2195,7 @@ void MarlinSettings::postprocess() {
             for (uint16_t q = grid_max_x * grid_max_y; q--;) EEPROM_READ(dummyf);
           }
       }
+      #endif // HAS_MESH_STORAGE
 
       //
       // X Axis Twist Compensation
@@ -2198,6 +2210,7 @@ void MarlinSettings::postprocess() {
       //
       // Unified Bed Leveling active state
       //
+      #if HAS_MESH_STORAGE
       {
         _FIELD_TEST(planner_leveling_active);
         #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -2207,9 +2220,11 @@ void MarlinSettings::postprocess() {
           bool planner_leveling_active;
           int8_t ubl_storage_slot;
         #endif
+
         EEPROM_READ(planner_leveling_active);
         EEPROM_READ(ubl_storage_slot);
       }
+      #endif
 
       //
       // SERVO_ANGLES
@@ -3043,9 +3058,11 @@ void MarlinSettings::postprocess() {
             bedlevel.reset();
           }
 
-          if (bedlevel.storage_slot >= 0) {
-            load_mesh(bedlevel.storage_slot);
-            DEBUG_ECHOLNPGM("Mesh ", bedlevel.storage_slot, " loaded from storage.");
+          if (TERN0(HAS_MESH_STORAGE, bedlevel.storage_slot >= 0)) {
+            #if HAS_MESH_STORAGE
+              load_mesh(bedlevel.storage_slot);
+              DEBUG_ECHOLNPGM("Mesh ", bedlevel.storage_slot, " loaded from storage.");
+            #endif
           }
           else {
             bedlevel.reset();
@@ -3152,7 +3169,7 @@ void MarlinSettings::postprocess() {
     return false;
   }
 
-  #if ENABLED(AUTO_BED_LEVELING_UBL)
+  #if ALL(AUTO_BED_LEVELING_UBL, HAS_MESH_STORAGE)
 
     static void ubl_invalid_slot(const int s) {
       DEBUG_ECHOLN(F("?Invalid "), F("slot.\n"), s, F(" mesh slots available."));
@@ -3173,7 +3190,7 @@ void MarlinSettings::postprocess() {
     #define MESH_STORE_SIZE sizeof(TERN(OPTIMIZED_MESH_STORAGE, mesh_store_t, bedlevel.z_values))
 
     uint16_t MarlinSettings::calc_num_meshes() {
-      return (meshes_end - meshes_start_index()) / MESH_STORE_SIZE;
+      return MIN(MAX_SAVED_MESHES, (meshes_end - meshes_start_index()) / MESH_STORE_SIZE);
     }
 
     int MarlinSettings::mesh_slot_offset(const int8_t slot) {
@@ -3276,7 +3293,7 @@ void MarlinSettings::postprocess() {
     //void MarlinSettings::delete_mesh() { return; }
     //void MarlinSettings::defrag_meshes() { return; }
 
-  #endif // AUTO_BED_LEVELING_UBL
+  #endif // AUTO_BED_LEVELING_UBL && HAS_MESH_STORAGE
 
 #else // !EEPROM_SETTINGS
 
@@ -3959,8 +3976,10 @@ void MarlinSettings::reset() {
         if (!forReplay) {
           SERIAL_EOL();
           bedlevel.report_state();
-          SERIAL_ECHO_MSG("Active Mesh Slot ", bedlevel.storage_slot);
-          SERIAL_ECHO_MSG("EEPROM can hold ", calc_num_meshes(), " meshes.\n");
+          #if HAS_MESH_STORAGE
+            SERIAL_ECHO_MSG("Active Mesh Slot ", bedlevel.storage_slot);
+            SERIAL_ECHO_MSG("EEPROM can hold ", calc_num_meshes(), " meshes.\n");
+          #endif
         }
 
        //bedlevel.report_current_mesh();   // This is too verbose for large meshes. A better (more terse)

--- a/buildroot/tests/STM32F446VE_fysetc/config-02.ini
+++ b/buildroot/tests/STM32F446VE_fysetc/config-02.ini
@@ -17,6 +17,7 @@ sdsupport                                = on
 custom_menu_main                         = on
 fix_mounted_probe                        = on
 auto_bed_leveling_ubl                    = on
+max_saved_meshes                         = 0
 z_safe_homing                            = on
 eeprom_settings                          = on
 printcounter                             = on


### PR DESCRIPTION
As requested by @KillerBug in #27436 …

Add an option to limit the number of meshes that can be saved to EEPROM.
If `MAX_SAVED_MESHES` is set to 0 then no meshes will be saved to EEPROM, reducing firmware size a little.

No doubt incomplete. Will add CI testing and get this out the door … eventually!