### PR TITLE
Fix pause beeps even when disabled (M600 B0)

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -107,7 +107,7 @@ static xyze_pos_t resume_position;
 
 #if HAS_SOUND
   static void impatient_beep(const int8_t max_beep_count, const bool restart=false) {
-
+    if (max_beep_count == 0) return;
     if (TERN0(HAS_MARLINUI_MENU, pause_mode == PAUSE_MODE_PAUSE_PRINT)) return;
 
     static millis_t next_buzz = 0;


### PR DESCRIPTION
### Fixes printer beeping on M600 B0 command

I'm trying to disable beeping on filament change command. But setting count of beeps to zero still produces 3 beeps.
The patch fixes this by checking for zero count of beeps.

### Requirements

No special requirements.

### Benefits

Filament change could be silenced if needed.

### Configurations

Need to enable M600 command. Then M600 B0 should lead to no beeps from the printer.

### Related Issues

Nope.