### PR TITLE
🔧 Enable HOST_ACTION_COMMANDS by default

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -584,7 +584,7 @@
  * Part Cooling Fan Pins
  * Override the default part cooling fan pins for each fan index.
  * Allows remapping which physical fan pin is used for part cooling.
- * By default: FAN0 → FAN0_PIN, FAN1 → FAN1_PIN, etc.
+ * By default: FAN0 -> FAN0_PIN, FAN1 -> FAN1_PIN, etc.
  */
 //#define PART_COOLING_FAN0_PIN   FAN0_PIN
 //#define PART_COOLING_FAN1_PIN   FAN1_PIN
@@ -4339,12 +4339,12 @@
  * Host Prompt Support enables Marlin to use the host for user prompts so
  * filament runout and other processes can be managed from the host side.
  */
-//#define HOST_ACTION_COMMANDS
+#define HOST_ACTION_COMMANDS
 #if ENABLED(HOST_ACTION_COMMANDS)
   //#define HOST_PAUSE_M76                // Tell the host to pause in response to M76
-  //#define HOST_PROMPT_SUPPORT           // Initiate host prompts to get user feedback
+  #define HOST_PROMPT_SUPPORT             // Initiate host prompts to get user feedback
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    //#define HOST_STATUS_NOTIFICATIONS   // Send some status messages to the host as notifications
+    #define HOST_STATUS_NOTIFICATIONS     // Send some status messages to the host as notifications
   #endif
   //#define HOST_START_MENU_ITEM          // Add a menu item that tells the host to start
   //#define HOST_SHUTDOWN_MENU_ITEM       // Add a menu item that tells the host to shut down

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4398,6 +4398,13 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
 #endif
 
 /**
+ * Sanity Check for Host Start/Shutdown menu items
+ */
+#if ANY(HOST_START_MENU_ITEM, HOST_SHUTDOWN_MENU_ITEM) && !HAS_MARLINUI_MENU
+  #error "HOST_START_MENU_ITEM and HOST_SHUTDOWN_MENU_ITEM require MarlinUI."
+#endif
+
+/**
  * Sanity Check for MEATPACK and BINARY_FILE_TRANSFER Features
  */
 #if ALL(HAS_MEATPACK, BINARY_FILE_TRANSFER)


### PR DESCRIPTION
Requested in #25907

A useful feature to have enabled. Of course, so is `SDSUPPORT` but we have that disabled by default.

But our default is a Mega2560 which has the space, so why not?

The hardest part is meaningfully updating all the configs that are amenable to the change.

So… I had a helpful agent put together a script that allows me to build all example configurations in parallel batches while responding to the build results with changes to the original config. The parallel batching reduces the build time for all config examples from 120 minutes down to 30 minutes.

For faster builds I can augment the workflow to distribute builds across multiple machines. With a desktop machine and three laptops each running multiple builds in parallel, I should be able reduce the build time for all config examples from 120 minutes down to 8 minutes.