### PR TITLE
🐛 Prevent unwanted downward move after motor-off

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -750,8 +750,9 @@ class Stepper {
       CBI(axis_enabled.bits, INDEX_OF_AXIS(axis, eindex));
       #if HAS_Z_AXIS
         if (TERN0(Z_CAN_FALL_DOWN, axis == Z_AXIS)) {
-          motion.z_min_trusted = false;
-          motion.position.z = 0;
+          motion.set_all_unhomed();     // Re-homing required before any motion
+          motion.position.z = 0;        // Assume the head has fallen to the bed
+          motion.sync_plan_position();  // Sync planner step counts to match
         }
       #endif
       // TODO: DELTA should have "Z" state affect all (ABC) motors and treat "XY" on/off as meaningless


### PR DESCRIPTION
On `DELTA` (and `AXEL_TPARA`), disabling the Z stepper correctly clears `z_min_trusted`, but also reset `motion.position.z` to 0. This caused subsequent moves (`G28`, `G33`, `M48`, etc.) to command a high-speed plunge to Z0, risking a bed crash.

Clearing `z_min_trusted` is sufficient — the last-known position remains the best reference for any move that follows. The `G28` code already handles the untrusted-Z case by treating z_homing_height as a relative offset when z_min_trusted is false.

Fixes #28426
Fixes #28430
