### PR TITLE
fix(resonance_generator): use last_target_traj as base to avoid Z spike on Y/X test start

### DIFF
--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -72,8 +72,12 @@ float ResonanceGenerator::fast_sin(float x) {
 }
 
 void ResonanceGenerator::fill_stepper_plan_buffer() {
-  xyze_float_t traj_coords = ftMotion.last_target_traj;
-  traj_coords[rt_params.axis] = rt_params.start_pos[rt_params.axis];
+  #if HAS_FTM_DIR_CHANGE_HOLD
+    xyze_float_t traj_coords = ftMotion.last_target_traj;
+    traj_coords[rt_params.axis] = rt_params.start_pos[rt_params.axis];
+  #else
+    xyze_float_t traj_coords = rt_params.start_pos;
+  #endif
 
   const float amplitude_precalc = (rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f) / sq(M_PI);
 

--- a/Marlin/src/module/ft_motion/resonance_generator.cpp
+++ b/Marlin/src/module/ft_motion/resonance_generator.cpp
@@ -72,7 +72,8 @@ float ResonanceGenerator::fast_sin(float x) {
 }
 
 void ResonanceGenerator::fill_stepper_plan_buffer() {
-  xyze_float_t traj_coords = rt_params.start_pos;
+  xyze_float_t traj_coords = ftMotion.last_target_traj;
+  traj_coords[rt_params.axis] = rt_params.start_pos[rt_params.axis];
 
   const float amplitude_precalc = (rt_params.amplitude_correction * rt_params.accel_per_hz * 0.25f) / sq(M_PI);
 


### PR DESCRIPTION
- Bug: traj_coords initialized from rt_params.start_pos on every fill_stepper_plan_buffer() call, snapping all non-tested axes to stale captured position

- Symptom: Hard position spike on non-tested axes at test start, particularly visible as Z skip/jump when testing X or Y

- Root cause: start_pos is captured once at test start but buffer refill calls repeatedly reset all axes to that snapshot rather than tracking current position

- Fix: Initialize traj_coords from ftMotion.last_target_traj then override only the tested axis to start_pos[axis] as oscillation center

- Tested on: Ender 3 V2, 4.2.2 board, STM32F103, Marlin 2.1.x bugfix