### PR TITLE
Fix SanityCheck for NEOPIXEL_BKGD_INDEX_FIRST == 0

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3139,7 +3139,7 @@ static_assert(NUM_SERVOS <= NUM_SERVO_PLUGS, "NUM_SERVOS (or some servo index) i
     #error "LCD_BACKLIGHT_TIMEOUT_MINS requires an LCD with encoder or keypad."
   #elif HAS_DISPLAY_SLEEP
     #error "LCD_BACKLIGHT_TIMEOUT_MINS and DISPLAY_SLEEP_MINUTES are not currently supported at the same time."
-  #elif ENABLED(NEOPIXEL_BKGD_INDEX_FIRST)
+  #elif defined(NEOPIXEL_BKGD_INDEX_FIRST)
     #if PIN_EXISTS(LCD_BACKLIGHT)
       #error "LCD_BACKLIGHT_PIN and NEOPIXEL_BKGD_INDEX_FIRST are not supported at the same time."
     #elif ENABLED(NEOPIXEL_BKGD_ALWAYS_ON)


### PR DESCRIPTION
### Description

Fixes an issue where `ENABLED()` evaluates to `false` when the NeoPixel index is `0`. This caused `LCD_BACKLIGHT_TIMEOUT_MINS` to fail to compile when the first LED was assigned index `0`.

The check has been changed from `ENABLED()` to `defined()` so configurations using a NeoPixel at index `0` compile correctly.

### Requirements

No specific hardware requirements. Applies to configurations where NeoPixel indexing may start at `0`.

### Benefits

* Fixes compilation failures for configurations using NeoPixel index `0`
* Ensures `LCD_BACKLIGHT_TIMEOUT_MINS` behaves correctly with valid zero-based LED indexing
* Improves compatibility with affected hardware configurations

### Configurations

No additional configuration files attached.

### Related Issues

Fixes a compilation issue affecting configurations where the first NeoPixel LED uses index `0`.
