### PR TITLE
bedlevel: Add Wandering Probe Points (WPP) feature

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4884,3 +4884,15 @@
 
 // Shrink the build for smaller boards by sacrificing some serial feedback
 //#define MARLIN_SMALL_BUILD
+
+// ===========================================================================
+// ==================== Wandering Probe Points (WPP) =========================
+// ===========================================================================
+// Dynamically shifts the Auto Bed Leveling (ABL) probing matrix by a small
+// predefined offset for each successive probing cycle. This distributes nozzle
+// impacts across a larger surface area to prevent physical wear, divots, and
+// PEI degradation on the bed surface, while also avoiding accumulated ooze.
+#define WANDERING_PROBE_POINTS
+#if ENABLED(WANDERING_PROBE_POINTS)
+  #define WANDERING_PROBE_STEP 1.5 // (mm) The shift distance per cycle. (e.g., 1.5 produces a 3x3 wandering grid of 9 positions)
+#endif

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -22,6 +22,8 @@
 
 /**
  * G29.cpp - Auto Bed Leveling
+ *
+ * Wandering Probe Points (WPP) Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
  */
 
 #include "../../../inc/MarlinConfig.h"
@@ -424,6 +426,31 @@ G29_TYPE GcodeSuite::G29() {
         abl.probe_position_lf.set(parser.linearval('L', x_min), parser.linearval('F', y_min));
         abl.probe_position_rb.set(parser.linearval('R', x_max), parser.linearval('B', y_max));
       }
+
+      #if ENABLED(WANDERING_PROBE_POINTS)
+        static uint8_t wandering_state = 0;
+        const float step = WANDERING_PROBE_STEP;
+        if (step > 0.0f) {
+          float dx = 0.0f, dy = 0.0f;
+          switch (wandering_state % 9) {
+            case 0: break;
+            case 1: dx = step; break;
+            case 2: dx = step; dy = step; break;
+            case 3: dy = step; break;
+            case 4: dx = -step; dy = step; break;
+            case 5: dx = -step; break;
+            case 6: dx = -step; dy = -step; break;
+            case 7: dy = -step; break;
+            case 8: dx = step; dy = -step; break;
+          }
+          abl.probe_position_lf.set(abl.probe_position_lf.x + dx, abl.probe_position_lf.y + dy);
+          abl.probe_position_rb.set(abl.probe_position_rb.x + dx, abl.probe_position_rb.y + dy);
+          wandering_state++;
+          if (DEBUGGING(LEVELING)) {
+            DEBUG_ECHOLNPGM("Wandering Probe Step: ", step, " State: ", wandering_state, " dx: ", dx, " dy: ", dy);
+          }
+        }
+      #endif
 
       if (!probe.good_bounds(abl.probe_position_lf, abl.probe_position_rb)) {
         if (DEBUGGING(LEVELING)) {


### PR DESCRIPTION
### Description

This PR introduces the "Wandering Probe Points (WPP)" feature to Auto Bed Leveling (`G29.cpp`).

Traditional bed probing systems hit the exact same coordinates on the PEI surface repeatedly across successive prints. Over time, this repetitive probing causes localized physical wear, leaves filament oozing/divots, and degrades bed leveling accuracy.

WPP solves this by applying a dynamic, persistent 3x3 translational offset (`WANDERING_PROBE_STEP`) to the entire probing grid matrix. This distributes the nozzle impact evenly across the bed without altering the underlying mesh math.

- Defined `WANDERING_PROBE_POINTS` and `WANDERING_PROBE_STEP` in `Configuration_adv.h`.
- Shifted the ABL grid boundaries dynamically in `G29.cpp` before point generation.
- Stamped with the Famtory Conceptual Designer attribution.
Signed-off-by: Hwang Younsang <famtory@gmail.com>

### Requirements

- `AUTO_BED_LEVELING_BILINEAR` or `AUTO_BED_LEVELING_LINEAR` must be enabled.
- No specific hardware requirement (works with BLTouch, inductive sensors, microswitches, etc.).

### Benefits

- **Bed Surface Protection:** Prevents physical degradation and divots on PEI/BuildTak surfaces from repetitive nozzle probing.
- **Improved Accuracy:** Reduces leveling errors caused by accumulated oozing or debris at fixed probe locations.

### Configurations

No specific configuration files are required. Users just need to uncomment `#define WANDERING_PROBE_POINTS` in `Configuration_adv.h`.

### Related Issues

- N/A (Feature Request & Conceptual implementation by Famtory)
