### PR TITLE
patch DGUSScreenHandler::init() to handle REINIT_NOISY_LCD

### DIFF
--- a/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSScreenHandler.cpp
@@ -70,7 +70,10 @@ millis_t DGUSScreenHandler::eeprom_save = 0;
 
 void DGUSScreenHandler::init() {
   dgus.init();
-  moveToScreen(DGUS_ScreenID::BOOT, true);
+  if (booted)
+    triggerFullUpdate(); // Reinit LCD hardware then refresh current screen
+  else
+    moveToScreen(DGUS_ScreenID::BOOT, true);
 }
 
 void DGUSScreenHandler::ready() {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -72,7 +72,10 @@ millis_t DGUSScreenHandler::eeprom_save = 0;
 void DGUSScreenHandler::init() {
   dgus.init();
 
-  moveToScreen(DGUS_ScreenID::BOOT, true);
+  if (booted)
+    triggerFullUpdate(); // Reinit LCD hardware then refresh current screen
+  else
+    moveToScreen(DGUS_ScreenID::BOOT, true);
 }
 
 void DGUSScreenHandler::ready() {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -71,7 +71,6 @@ millis_t DGUSScreenHandler::eeprom_save = 0;
 
 void DGUSScreenHandler::init() {
   dgus.init();
-
   if (booted)
     triggerFullUpdate(); // Reinit LCD hardware then refresh current screen
   else


### PR DESCRIPTION
### Description

With REINIT_NOISY_LCD enabled, removing the sdcard on dgus_e3s1pro or dgus_reloaded resulted in the boot screen being redisplayed with no way out of it. 

The same bug was in both user interfaces.

Updated DGUSScreenHandler.cpp to check for booted flag and, after 'booted' is true, call triggerFullUpdate() 

### Requirements

REINIT_NOISY_LCD, SDSUPPORT with RELOADED or E3S1PRO UI

### Benefits

Works as expected; can remove and insert the SD card without getting the boot screen. 

### Configurations

Eg from the issue
[Configuration Files E5Plus SD Card Bug.zip](https://github.com/user-attachments/files/26198130/Configuration.Files.E5Plus.SD.Card.Bug.zip)

### Related Issues

<li>MarlinFirmware/Marlin/issues/28370