### PR TITLE
Enable Z-Probe for Lerdge K board

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -57,9 +57,9 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-//#ifndef Z_MIN_PROBE_PIN
-//  #define Z_MIN_PROBE_PIN                 PG6
-//#endif
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PG6
+#endif
 
 //
 // Filament runout


### PR DESCRIPTION
### Description
A tiny change, that enables the Z-Probe pin of Lerdge K boards.

#### Problem: 
_"#define Z_MIN_PROBE_PIN"_ was commented out in _Marlin/src/pins/stm32f4/pins_LERDGE_K.h_, causing error _"Z_MIN_PROBE_PIN must be defined if Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN is not enabled."_ in _SanityCheck.h_

In the history of file _pins_LERDGE_K.h_ I saw, that it was like that since the beginning, only the pin name was corrected after a while.  So, probably it was not commented out because of a problem. It seems, that I am simply the first one, who wants to use this feature on a Lerdge K board.

#### Tests:
I did not provide a test case in buildroot/tests because that would require real hardware.
So, I ran the tests on my Lerdge K board: attached wires to the "Probe" connector and sent command M119 via USB serial.
**Successfully tested with branches Marlin bugfix-2.1.x and Marlin 2.1.2.7.**


### Requirements
Hardware: 

- Lerdge K board
- Z-Probe (or simply a DuPont wire for testing) 


### Benefits

Marlin Firmware can be built for a Lerdge K board with Z-Probe enabled.

### Configurations
[config_for_2.1.2.7.zip](https://github.com/user-attachments/files/28974030/config_for_2.1.2.7.zip)
[config_for_bugfix-2.1.x.zip](https://github.com/user-attachments/files/28974031/config_for_bugfix-2.1.x.zip)

#### Build command:
platformio run -e LERDGEK_usb_flash_drive

### Related Issues

None found.
