### PR TITLE
menu items out of position

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -543,7 +543,7 @@ void MarlinUI::clear_for_drawing() {
     uint8_t n = LCD_WIDTH - 1;
     n -= lcd_put_u8str(ftpl, itemIndex, itemStringC, itemStringF, n);
     for (; n; --n) lcd_put_u8str(F(" "));
-    lcd_put_lchar(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH), row_y2, post_char);
+    lcd_put_lchar(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH), row_y2 - MENU_FONT_DESCENT, post_char);
     lcd_put_u8str(F(" "));
   }
 
@@ -560,7 +560,7 @@ void MarlinUI::clear_for_drawing() {
     if (vallen) {
       lcd_put_u8str(F(":"));
       for (; n; --n) lcd_put_u8str(F(" "));
-      lcd_moveto(LCD_PIXEL_WIDTH - _MAX((MENU_FONT_WIDTH) * vallen, pixelwidth + 2), row_y2);
+      lcd_moveto(LCD_PIXEL_WIDTH - _MAX((MENU_FONT_WIDTH) * vallen, pixelwidth + 2), row_y2 - MENU_FONT_DESCENT);
       if (pgm) lcd_put_u8str_P(inStr); else lcd_put_u8str(inStr);
     }
   }


### PR DESCRIPTION
### Description

It was noticed in discord that the values and characters were not centred on marlinui menus

eg

<img width="647" height="324" alt="Screenshot from 2026-06-20 05-07-13" src="https://github.com/user-attachments/assets/110eab0e-3def-4a30-b972-bbb042da8daf" />

and

<img width="647" height="324" alt="Screenshot from 2026-06-20 05-08-26" src="https://github.com/user-attachments/assets/a0d5158f-8e43-4ca6-a2a6-9d3071b61363" />

Traced the issue back to https://github.com/MarlinFirmware/Marlin/commit/da7cfd1551ba66ba83de4889e0da2a5ef2b158df#diff-51ebd64e573552bacb27fd55fc4ed2c67f3a3f2741d0033e0aaff402d629b152 

the issue is the new row_y2 value is used elsewhere in the code.

Changing 
`lcd_put_lchar(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH), row_y2, post_char);`
to
`lcd_put_lchar(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH), row_y2 - MENU_FONT_DESCENT, post_char);`
Fixes the -> position

<img width="647" height="324" alt="Screenshot from 2026-06-20 05-15-09" src="https://github.com/user-attachments/assets/adc7a942-62b1-4444-84cc-45cacbfef144" />

and 

changing
`lcd_moveto(LCD_PIXEL_WIDTH - _MAX((MENU_FONT_WIDTH) * vallen, pixelwidth + 2), row_y2);`
to
`lcd_moveto(LCD_PIXEL_WIDTH - _MAX((MENU_FONT_WIDTH) * vallen, pixelwidth + 2), row_y2 - MENU_FONT_DESCENT);`

fixes the values position

<img width="647" height="324" alt="Screenshot from 2026-06-20 05-12-45" src="https://github.com/user-attachments/assets/89698aae-d4d2-4a09-85fd-0916dfa8966b" />

### Requirements

A display that uses marlinui and menus

### Benefits

Displays correctly

### Configurations

I used stock simulator configs
