### PR TITLE
fix workspace offsets after G28

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -310,6 +310,10 @@ void GcodeSuite::G28() {
     // Potentially disable Fixed-Time Motion for homing
     TERN_(FT_MOTION, FTM_DISABLE_IN_SCOPE());
 
+    #if ENABLED(CNC_COORDINATE_SYSTEMS)
+      const bool old_coordinate_system = active_coordinate_system;
+    #endif
+
     // Always home with tool 0 active
     #if HAS_MULTI_HOTEND
       #if DISABLED(DELTA) || ENABLED(DELTA_HOME_TO_SAFE_ZONE)
@@ -560,6 +564,12 @@ void GcodeSuite::G28() {
       SERIAL_ECHOLNPGM(STR_Z_MOVE_COMP);
 
   #endif // NUM_AXES
+
+  // Reload workspace offsets
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    bool workspace_update = select_coordinate_system(-1);  
+    workspace_update = select_coordinate_system(old_coordinate_system);  
+  #endif
 
   ui.refresh();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -311,7 +311,8 @@ void GcodeSuite::G28() {
     TERN_(FT_MOTION, FTM_DISABLE_IN_SCOPE());
 
     #if ENABLED(CNC_COORDINATE_SYSTEMS)
-      const bool old_coordinate_system = active_coordinate_system;
+      const int8_t old_coordinate_system = active_coordinate_system;
+      (void)select_coordinate_system(-1);
     #endif
 
     // Always home with tool 0 active
@@ -560,16 +561,13 @@ void GcodeSuite::G28() {
 
     motion.restore_feedrate_and_scaling();
 
+    // Reload workspace offsets
+    TERN_(CNC_COORDINATE_SYSTEMS, (void)select_coordinate_system(old_coordinate_system));
+
     if (ENABLED(NANODLP_Z_SYNC) && (ENABLED(NANODLP_ALL_AXIS) || TERN0(HAS_Z_AXIS, doZ)))
       SERIAL_ECHOLNPGM(STR_Z_MOVE_COMP);
 
   #endif // NUM_AXES
-
-  // Reload workspace offsets
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    bool workspace_update = select_coordinate_system(-1);  
-    workspace_update = select_coordinate_system(old_coordinate_system);  
-  #endif
 
   ui.refresh();
 

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -62,11 +62,20 @@ enum CalEnum : char {                        // The 7 main calibration points - 
 float lcd_probe_pt(const xy_pos_t &xy);
 
 void ac_home() {
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    //temporarily switch to native machine coordinate system for homing
+    old_coordinate_system = active_coordinate_system;
+    select_coordinate_system(-1);
+  #endif
   endstops.enable(true);
   TERN_(IMPROVE_HOMING_RELIABILITY, planner.enable_stall_prevention(true));
   home_delta();
   TERN_(IMPROVE_HOMING_RELIABILITY, planner.enable_stall_prevention(false));
   endstops.not_homing();
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    //Restore old cooridnate system after homing
+    select_coordinate_system(old_coordinate_system);
+  #endif
 }
 
 void ac_setup(const bool reset_bed) {

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -63,19 +63,19 @@ float lcd_probe_pt(const xy_pos_t &xy);
 
 void ac_home() {
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    //temporarily switch to native machine coordinate system for homing
+    // Temporarily switch to native machine coordinate system for homing
     old_coordinate_system = active_coordinate_system;
     select_coordinate_system(-1);
   #endif
+
   endstops.enable(true);
   TERN_(IMPROVE_HOMING_RELIABILITY, planner.enable_stall_prevention(true));
   home_delta();
   TERN_(IMPROVE_HOMING_RELIABILITY, planner.enable_stall_prevention(false));
   endstops.not_homing();
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    //Restore old cooridnate system after homing
-    select_coordinate_system(old_coordinate_system);
-  #endif
+
+  // Restore old coordinate system after homing
+  TERN_(CNC_COORDINATE_SYSTEMS, select_coordinate_system(old_coordinate_system));
 }
 
 void ac_setup(const bool reset_bed) {


### PR DESCRIPTION
### Description

I had a coordinate system selected (e.g. G55) and workspace offsets set. After a G28 the workspace offset was not applied anymore. It seems to be a known issue: https://forum.v1e.com/t/marlin-workspaces-and-homing/35876. Thhis is now fixed.

### Requirements

CNC_COORDINATE_SYSTEMS

### Benefits

Positions with coordinate systems other than the native machine coordinate system remain intact after G28. No unexpected moves and less chance of running into endstops which currently can cause additional position corruption and crashes.

### Configurations

None
 
### Related Issues

https://forum.v1e.com/t/marlin-workspaces-and-homing/35876. 
