### PR TITLE
preserve spaces in SRCHOME  (esp3dlib uses this) 

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -389,4 +389,4 @@ HAS_MICROSTEPS                         = build_src_filter=+<src/gcode/control/M3
                                          arduinoWebSockets=links2004/WebSockets@2.3.4
                                          luc-github/ESP32SSDP@1.1.1
                                          lib_ignore=ESPAsyncTCP
-                                         build_flags=-DSRCHOME=${platformio.src_dir}/src -DHALHOME=SRCHOME
+                                         build_flags=-DSRCHOME="${platformio.src_dir}/src" -DHALHOME=SRCHOME


### PR DESCRIPTION
### Description

While looking at an issue on a MKS_TINYBEE I noted that if there  was a space in the path, it would break compiling in ESP3DLib/src/command.cpp

The error is 
fatal error: /home/user/code/Marlin/inc/MarlinConfigPre.h: No such file or directory, which was accurate as the path was truncated.

If you pio run -v, the log clearly shows
-DSRCHOME=/home/user/Marlin

when it should have been in this case
"-DSRCHOME=/home/user/Marlin mks tinybee/Marlin/src"

I tracked the issue down to features.ini

build_flags=-DSRCHOME=${platformio.src_dir}/src -DHALHOME=SRCHOME
SRCHOME was dropping anything after a space

updating this to the following resolves this issue
build_flags=-DSRCHOME="${platformio.src_dir}/src" -DHALHOME=SRCHOME

### Requirements

ESP3DLib and a path with spaces

### Benefits

Builds as expected

