### PR TITLE
Make auto calibration of unknown hotend offset possible

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1433,10 +1433,17 @@
   //#define CALIBRATION_SCRIPT_PRE  "M117 Starting Auto-Calibration\nT0\nG28\nG12\nM117 Calibrating..."
   //#define CALIBRATION_SCRIPT_POST "M500\nM117 Calibration data saved"
 
-  // Uncertainty of hotend offset. This defines, how far away from the 
-  // calibration object the measurment starts. Can be overridden by parameter U.
-  #define CALIBRATION_MEASUREMENT_UNKNOWN   5.0 // (mm) Default for fast measurement with G425
-  #define CALIBRATION_MEASUREMENT_UNCERTAIN 1.0 // mm Default for slow measurement (default for G425 T... or G425 B)
+  // Uncertainty of hotend z offset. This defines, how far away in z from the 
+  // calibration object the measurment starts. Can be overridden by parameter L.
+  #define CALIBRATION_MEASUREMENT_TOOL_LENGTH 5.0 // (mm)
+
+  // Uncertainty of hotend xy offset for G425. This defines, how far away in in xy from the 
+  // calibration object the measurment starts for hotend offset calibration. Can be overridden by parameter U.
+  #define CALIBRATION_MEASUREMENT_UNKNOWN   5.0 // (mm)
+
+  // Uncertainty of hotend xy offset for G425 T... and of backlash. This defines, how far away from the 
+  // calibration object the measurment starts for backlash- and xy hotend offset calibration. Can be overridden by parameter U.
+  #define CALIBRATION_MEASUREMENT_UNCERTAIN 1.0 // (mm)
 
   #define CALIBRATION_FEEDRATE_SLOW             60    // (mm/min)
   #define CALIBRATION_FEEDRATE_FAST           1200    // (mm/min)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1416,16 +1416,21 @@
 /**
  * Automatic backlash, position, and hotend offset calibration
  *
- * Enable G425 to run automatic calibration using an electrically-
- * conductive cube, bolt, or washer mounted on the bed.
+ * Enable G425 to run automatic calibration using a calibration object that is mounted to the frame or bed.
  *
- * G425 uses the probe to touch the top and sides of the calibration object
- * on the bed and measures and/or correct positional offsets, axis backlash
- * and hotend offsets.
+ * G425 moves the toolhead to touch the top and sides of the calibration object
+ * on the bed and measures and/or correct positional offsets and axis backlash. 
+ * It requires a calibration object and an electrical circuit that ensures that the voltage between ground and the 
+ * PROBE_PIN or CALIBRATION_PIN changes, when the nozzle touches the trigger point. Examples:
+ * - A grounded nozzle and a conductive calibration object like a cube, a bolt or washer that is connected to the CALIBRATION_PIN (requires CALIBRATION_PIN with a pull up resistor)
+ * - A nozzle with a load cell that serves as a touch probe (see NOZZLE_AS_PROBE).
+ * - A tool setter that is electrically connected to the PROBE_PIN or CALIBRATION_PIN is used as the calibration object.
+ * - A toolhead-mounted probe and a calibration object. This only works for backlash calibration using G425 B.
  *
- * Note: HOTEND_OFFSET and CALIBRATION_OBJECT_CENTER must be set to within
- * ±(CALIBRATION_MEASUREMENT_UNCERTAIN) of true values for G425 T... 
- * and within ±(CALIBRATION_MEASUREMENT_UNKNOWN) for full calibration (G425).
+ * Note: The deviation of HOTEND_OFFSET and CALIBRATION_OBJECT_CENTER xy values from true values 
+ *      must be smaller than half the length of the calibration object along the x or y axis, respectively.
+ *      If Z_HOME_DIR is -1, HOTEND_OFFSET and CALIBRATION_OBJECT_CENTER z values must be set to within 
+ *      ±(CALIBRATION_MEASUREMENT_TOOL_LENGTH) of true values for G425 or G425 T... to succeed.
  */
 //#define CALIBRATION_GCODE
 #if ENABLED(CALIBRATION_GCODE)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1424,13 +1424,19 @@
  * and hotend offsets.
  *
  * Note: HOTEND_OFFSET and CALIBRATION_OBJECT_CENTER must be set to within
- *       ±5mm of true values for G425 to succeed.
+ * ±(CALIBRATION_MEASUREMENT_UNCERTAIN) of true values for G425 T... 
+ * and within ±(CALIBRATION_MEASUREMENT_UNKNOWN) for full calibration (G425).
  */
 //#define CALIBRATION_GCODE
 #if ENABLED(CALIBRATION_GCODE)
 
   //#define CALIBRATION_SCRIPT_PRE  "M117 Starting Auto-Calibration\nT0\nG28\nG12\nM117 Calibrating..."
   //#define CALIBRATION_SCRIPT_POST "M500\nM117 Calibration data saved"
+
+  // Uncertainty of hotend offset. This defines, how far away from the 
+  // calibration object the measurment starts. Can be overridden by parameter U.
+  #define CALIBRATION_MEASUREMENT_UNKNOWN   5.0 // (mm) Default for fast measurement with G425
+  #define CALIBRATION_MEASUREMENT_UNCERTAIN 1.0 // mm Default for slow measurement (default for G425 T... or G425 B)
 
   #define CALIBRATION_FEEDRATE_SLOW             60    // (mm/min)
   #define CALIBRATION_FEEDRATE_FAST           1200    // (mm/min)

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -203,7 +203,7 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
   #if Z_HOME_TO_MAX
     const float limit_z = fast ? ((Z_HOME_POS) - calibration_center.z  + 50) : ((Z_MAX_POS) - calibration_center.z + 5);
   #else
-    const float limit_z = fast ? (uncertainty_tool_length + 50) : (uncertainty_tool_length + 5);
+    const float limit_z = fast ? (2 * uncertainty_tool_length + 50) : (2 * uncertainty_tool_length + 5);
   #endif
   motion.destination = motion.position;
   if (axis == Z_AXIS) {

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -61,8 +61,12 @@
  *   UNKNOWN   - No real notion on where the calibration object is on the bed
  *   UNCERTAIN - Measurement may be uncertain due to backlash
  *   CERTAIN   - Measurement obtained with backlash compensation
+ *   TOOL_LENGTH  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
 
+ #ifndef CALIBRATION_MEASUREMENT_TOOL_LENGTH
+  #define CALIBRATION_MEASUREMENT_TOOL_LENGTH   5.0 // mm
+#endif
 #ifndef CALIBRATION_MEASUREMENT_UNKNOWN
   #define CALIBRATION_MEASUREMENT_UNKNOWN   5.0 // mm
 #endif
@@ -192,12 +196,18 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
  *   stop_state   in - Move until probe pin becomes this value
  *   fast         in - Fast vs. precise measurement
  */
-float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty) {
+float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty, const bool uncertainty_tool_length) {
   const feedRate_t mms = fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
   const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
+  const float limit_z = fast ? (uncertainty_tool_length + 50) : (uncertainty_tool_length + 5);
 
   motion.destination = motion.position;
-  motion.destination[axis] += dir * limit;
+  if (axis == Z_AXIS) {
+    motion.destination[axis] += dir * limit_z;
+  }
+  else {
+    motion.destination[axis] += dir * limit;
+  }
   endstops.enable_calibration_probe(true, stop_state);
   motion.blocking_move((xyz_pos_t)motion.destination, mms);
   endstops.enable_calibration_probe(false);
@@ -216,19 +226,20 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
  *   stop_state         in     - Move until probe pin becomes this value
  *   backlash_ptr       in/out - When not nullptr, measure and record axis backlash
  *   uncertainty        in     - If uncertainty is CALIBRATION_MEASUREMENT_UNKNOWN, do a fast probe.
+ *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
-inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty) {
+inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty, const float uncertainty_tool_length) {
   const bool fast = uncertainty == CALIBRATION_MEASUREMENT_UNKNOWN;
 
   // Save the current position of the specified axis
   const float start_pos = motion.position[axis];
 
   // Take a measurement. Only the specified axis will be affected.
-  const float measured_pos = measuring_movement(axis, dir, stop_state, fast, uncertainty);
+  const float measured_pos = measuring_movement(axis, dir, stop_state, fast, uncertainty, uncertainty_tool_length);
 
   // Measure backlash
   if (backlash_ptr && !fast) {
-    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast, uncertainty);
+    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast, uncertainty, uncertainty_tool_length);
     *backlash_ptr = ABS(release_pos - measured_pos);
   }
 
@@ -244,11 +255,12 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
  *
  *   m                  in/out - Measurement record, m.obj_center and m.obj_side will be updated.
  *   uncertainty        in     - How far away from the calibration object to begin probing
+ *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  *   side               in     - Side of probe where probe will occur
  *   probe_top_at_edge  in     - When probing sides, probe top of calibration object nearest edge
  *                               to find out height of edge
  */
-inline void probe_side(measurements_t &m, const float uncertainty, const side_t side, const bool probe_top_at_edge=false) {
+inline void probe_side(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const side_t side, const bool probe_top_at_edge=false) {
   const xyz_float_t dimensions = CALIBRATION_OBJECT_DIMENSIONS;
   AxisEnum axis;
   float dir = 1;
@@ -267,7 +279,7 @@ inline void probe_side(measurements_t &m, const float uncertainty, const side_t 
     #endif
     #if AXIS_CAN_CALIBRATE(Z)
       case TOP: {
-        const float measurement = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty);
+        const float measurement = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length);
         m.obj_center.z = measurement - dimensions.z / 2;
         m.obj_side[TOP] = measurement;
         return;
@@ -299,7 +311,7 @@ inline void probe_side(measurements_t &m, const float uncertainty, const side_t 
       // Probe top nearest the side we are probing
       motion.position[axis] = m.obj_center[axis] + (-dir) * (dimensions[axis] / 2 - m.nozzle_outer_dimension[axis]);
       calibration_move();
-      m.obj_side[TOP] = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty);
+      m.obj_side[TOP] = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length);
       m.obj_center.z = m.obj_side[TOP] - dimensions.z / 2;
     #endif
   }
@@ -312,7 +324,7 @@ inline void probe_side(measurements_t &m, const float uncertainty, const side_t 
     // Plunge below the side of the calibration object and measure
     motion.position.z = m.obj_side[TOP] - (CALIBRATION_NOZZLE_TIP_HEIGHT) * 0.7f;
     calibration_move();
-    const float measurement = measure(axis, dir, true, &m.backlash[side], uncertainty);
+    const float measurement = measure(axis, dir, true, &m.backlash[side], uncertainty, uncertainty_tool_length);
     m.obj_center[axis] = measurement + dir * (dimensions[axis] / 2 + m.nozzle_outer_dimension[axis] / 2);
     m.obj_side[side] = measurement;
   }
@@ -324,14 +336,14 @@ inline void probe_side(measurements_t &m, const float uncertainty, const side_t 
  *   m                  in/out - Measurement record: center, backlash and error values be updated.
  *   uncertainty        in     - How far away from the calibration object to begin probing
  */
-inline void probe_sides(measurements_t &m, const float uncertainty) {
+inline void probe_sides(measurements_t &m, const float uncertainty, const float uncertainty_tool_length) {
   #if ENABLED(CALIBRATION_MEASURE_AT_TOP_EDGES)
     constexpr bool probe_top_at_edge = true;
   #else
     // Probing at the exact center only works if the center is flat. Probing on a washer
     // or bolt will require probing the top near the side edges, away from the center.
     constexpr bool probe_top_at_edge = false;
-    probe_side(m, uncertainty, TOP);
+    probe_side(m, uncertainty, uncertainty_tool_length, TOP);
   #endif
 
   /**
@@ -340,28 +352,28 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
    * values where the nozzle was catching on the edges of the cube, and this was intended to help
    * ensure the probe object remained centered.
    */
-  TERN_(CALIBRATION_MEASURE_FRONT, probe_side(m, uncertainty, FRONT,    probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_BACK,  probe_side(m, uncertainty, BACK,     probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_FRONT, probe_side(m, uncertainty, uncertainty_tool_length, FRONT,    probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_BACK,  probe_side(m, uncertainty, uncertainty_tool_length, BACK,     probe_top_at_edge));
 
   #if HAS_Y_CENTER
     m.obj_center.y = (m.obj_side[FRONT] + m.obj_side[BACK]) / 2;
     m.nozzle_outer_dimension.y = m.obj_side[BACK] - m.obj_side[FRONT] - dimensions.y;
   #endif
 
-  TERN_(CALIBRATION_MEASURE_LEFT,  probe_side(m, uncertainty, LEFT,     probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_RIGHT, probe_side(m, uncertainty, RIGHT,    probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_IMIN,  probe_side(m, uncertainty, IMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_IMAX,  probe_side(m, uncertainty, IMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_JMIN,  probe_side(m, uncertainty, JMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_JMAX,  probe_side(m, uncertainty, JMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_KMIN,  probe_side(m, uncertainty, KMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_KMAX,  probe_side(m, uncertainty, KMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_UMIN,  probe_side(m, uncertainty, UMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_UMAX,  probe_side(m, uncertainty, UMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_VMIN,  probe_side(m, uncertainty, VMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_VMAX,  probe_side(m, uncertainty, VMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_WMIN,  probe_side(m, uncertainty, WMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_WMAX,  probe_side(m, uncertainty, WMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_LEFT,  probe_side(m, uncertainty, uncertainty_tool_length, LEFT,     probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_RIGHT, probe_side(m, uncertainty, uncertainty_tool_length, RIGHT,    probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_IMIN,  probe_side(m, uncertainty, uncertainty_tool_length, IMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_IMAX,  probe_side(m, uncertainty, uncertainty_tool_length, IMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_JMIN,  probe_side(m, uncertainty, uncertainty_tool_length, JMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_JMAX,  probe_side(m, uncertainty, uncertainty_tool_length, JMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_KMIN,  probe_side(m, uncertainty, uncertainty_tool_length, KMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_KMAX,  probe_side(m, uncertainty, uncertainty_tool_length, KMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_UMIN,  probe_side(m, uncertainty, uncertainty_tool_length, UMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_UMAX,  probe_side(m, uncertainty, uncertainty_tool_length, UMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_VMIN,  probe_side(m, uncertainty, uncertainty_tool_length, VMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_VMAX,  probe_side(m, uncertainty, uncertainty_tool_length, VMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_WMIN,  probe_side(m, uncertainty, uncertainty_tool_length, WMINIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_WMAX,  probe_side(m, uncertainty, uncertainty_tool_length, WMAXIMUM, probe_top_at_edge));
 
   // Compute the measured center of the calibration object.
   TERN_(HAS_X_CENTER, m.obj_center.x = (m.obj_side[LEFT]     + m.obj_side[RIGHT])    / 2);
@@ -579,6 +591,8 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
  *
  *   m              in/out - Measurement record, updated with new readings
  *   uncertainty    in     - How far away from the object to begin probing
+ *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
+
  */
 inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
   // Backlash compensation should be off while measuring backlash
@@ -588,7 +602,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
     TEMPORARY_BACKLASH_CORRECTION(backlash.all_off);
     TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
-    probe_sides(m, uncertainty);
+    probe_sides(m, uncertainty, uncertainty);
 
     #if ENABLED(BACKLASH_GCODE)
 
@@ -691,18 +705,19 @@ inline void update_measurements(measurements_t &m, const AxisEnum axis) {
  *
  *   m              in/out - Measurement record, updated with new readings
  *   uncertainty    in     - How far away from the object to begin probing
+ *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  *   extruder       in     - What extruder to probe
  *
  * Prerequisites:
  *    - Call calibrate_backlash() beforehand for best accuracy
  */
-inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const uint8_t extruder) {
+inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const uint8_t extruder) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   TERN(HAS_MULTI_HOTEND, set_nozzle(m, extruder), UNUSED(extruder));
 
-  probe_sides(m, uncertainty);
+  probe_sides(m, uncertainty, uncertainty_tool_length);
 
   // Adjust the hotend offset
   #if HAS_HOTEND_OFFSET
@@ -736,12 +751,13 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
  *
  *   m              in/out - Measurement record, updated with new readings
  *   uncertainty    in     - How far away from the object to begin probing
+ *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
-inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty) {
+inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, const float uncertainty_tool_length) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
-  HOTEND_LOOP() calibrate_toolhead(m, uncertainty, e);
+  HOTEND_LOOP() calibrate_toolhead(m, uncertainty, uncertainty_tool_length, e);
 
   TERN_(HAS_HOTEND_OFFSET, normalize_hotend_offsets());
 
@@ -768,7 +784,7 @@ inline void calibrate_all() {
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   // Do a fast and rough calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN, CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   TERN_(BACKLASH_GCODE, calibrate_backlash(m, CALIBRATION_MEASUREMENT_UNCERTAIN));
 
@@ -778,7 +794,7 @@ inline void calibrate_all() {
   #endif
 
   // Do a slow and precise calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   motion.position.x = X_CENTER;
   calibration_move();         // Park nozzle away from calibration object
@@ -790,7 +806,8 @@ inline void calibrate_all() {
  *   B           - Perform calibration of backlash only.
  *   T<extruder> - Perform calibration of toolhead only.
  *   V           - Probe object and print position, error, backlash and hotend offset.
- *   U           - Uncertainty, how far to start probe away from the object (mm)
+ *   U           - Uncertainty, how far inxy to start probe away from the object (mm)
+ *   L           - Tool length uncertainty, how far in z to start probe away from the object (mm)
  *
  *   no args     - Perform entire calibration sequence (backlash + position on all toolheads)
  */
@@ -807,11 +824,12 @@ void GcodeSuite::G425() {
 
   measurements_t m;
   const float uncertainty = parser.floatval('U', CALIBRATION_MEASUREMENT_UNCERTAIN);
+  const float uncertainty_tool_length = parser.floatval('L', CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   if (parser.seen_test('B'))
     calibrate_backlash(m, uncertainty);
   else if (parser.seen_test('T'))
-    calibrate_toolhead(m, uncertainty, parser.intval('T', motion.extruder));
+    calibrate_toolhead(m, uncertainty, uncertainty_tool_length, parser.intval('T', motion.extruder));
   #if ENABLED(CALIBRATION_REPORTING)
     else if (parser.seen('V')) {
       probe_sides(m, uncertainty);

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -405,15 +405,15 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
   // The difference between the known and the measured location
   // of the calibration object is the positional error
   NUM_AXIS_CODE(
-    m.pos_error.x = TERN0(HAS_X_CENTER, motion.calibrationcenter.x - m.obj_center.x),
-    m.pos_error.y = TERN0(HAS_Y_CENTER, motion.calibrationcenter.y - m.obj_center.y),
-    m.pos_error.z = motion.calibrationcenter.z - m.obj_center.z,
-    m.pos_error.i = TERN0(HAS_I_CENTER, motion.calibrationcenter.i - m.obj_center.i),
-    m.pos_error.j = TERN0(HAS_J_CENTER, motion.calibrationcenter.j - m.obj_center.j),
-    m.pos_error.k = TERN0(HAS_K_CENTER, motion.calibrationcenter.k - m.obj_center.k),
-    m.pos_error.u = TERN0(HAS_U_CENTER, motion.calibrationcenter.u - m.obj_center.u),
-    m.pos_error.v = TERN0(HAS_V_CENTER, motion.calibrationcenter.v - m.obj_center.v),
-    m.pos_error.w = TERN0(HAS_W_CENTER, motion.calibrationcenter.w - m.obj_center.w)
+    m.pos_error.x = TERN0(HAS_X_CENTER, motion.calibration_center.x - m.obj_center.x),
+    m.pos_error.y = TERN0(HAS_Y_CENTER, motion.calibration_center.y - m.obj_center.y),
+    m.pos_error.z = motion.calibration_center.z - m.obj_center.z,
+    m.pos_error.i = TERN0(HAS_I_CENTER, motion.calibration_center.i - m.obj_center.i),
+    m.pos_error.j = TERN0(HAS_J_CENTER, motion.calibration_center.j - m.obj_center.j),
+    m.pos_error.k = TERN0(HAS_K_CENTER, motion.calibration_center.k - m.obj_center.k),
+    m.pos_error.u = TERN0(HAS_U_CENTER, motion.calibration_center.u - m.obj_center.u),
+    m.pos_error.v = TERN0(HAS_V_CENTER, motion.calibration_center.v - m.obj_center.v),
+    m.pos_error.w = TERN0(HAS_W_CENTER, motion.calibration_center.w - m.obj_center.w)
   );
 }
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -719,6 +719,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
 }
 
 inline void update_measurements(measurements_t &m, const AxisEnum axis) {
+  motion.position[axis] += m.pos_error[axis];
   m.obj_center[axis] = motion.calibration_center[axis];
   m.pos_error[axis] = 0;
 }
@@ -747,9 +748,9 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
   // Adjust the hotend offset
   #if HAS_HOTEND_OFFSET
     xyz_pos_t &hotoff = motion.active_hotend_offset();
-    if (ENABLED(HAS_X_CENTER) && AXIS_CAN_CALIBRATE(X)) hotoff.x = m.pos_error.x;
-    if (ENABLED(HAS_Y_CENTER) && AXIS_CAN_CALIBRATE(Y)) hotoff.y = m.pos_error.y;
-                             if (AXIS_CAN_CALIBRATE(Z)) hotoff.z = m.pos_error.z;
+    if (ENABLED(HAS_X_CENTER) && AXIS_CAN_CALIBRATE(X)) hotoff.x += m.pos_error.x;
+    if (ENABLED(HAS_Y_CENTER) && AXIS_CAN_CALIBRATE(Y)) hotoff.y += m.pos_error.y;
+                             if (AXIS_CAN_CALIBRATE(Z)) hotoff.z += m.pos_error.z;
     normalize_hotend_offsets();
   #endif
 
@@ -917,14 +918,6 @@ void GcodeSuite::G425() {
 
   if (motion.homing_needed_error()) return;
 
-  #if HAS_TOOL_CENTERPOINT_CONTROL
-    const bool old_tcpc = motion.tool_centerpoint_control;
-  #endif
-  #if HAS_TOOL_LENGTH_COMPENSATION
-    const bool old_tool_length_compensation = motion.simple_tool_length_compensation;
-    process_subcommands_now(F("G49"));
-  #endif
-
   #if HAS_LEVELING
     TEMPORARY_BED_LEVELING_STATE(false);
   #endif
@@ -966,12 +959,6 @@ void GcodeSuite::G425() {
     calibrate_all();
 
   motion.set_soft_endstop_loose(false);
-  #if HAS_TOOL_LENGTH_COMPENSATION
-    if (old_tool_length_compensation) process_subcommands_now(F("G43"));
-  #endif
-  #if HAS_TOOL_CENTERPOINT_CONTROL
-    if (old_tcpc) process_subcommands_now(F("G43.4"));
-  #endif
 
   #ifdef CALIBRATION_SCRIPT_POST
     process_subcommands_now(F(CALIBRATION_SCRIPT_POST));

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -34,7 +34,9 @@
 #include "../../module/motion.h"
 #include "../../module/planner.h"
 #include "../../module/endstops.h"
-#include "../../feature/bedlevel/bedlevel.h"
+#if HAS_LEVELING
+  #include "../../feature/bedlevel/bedlevel.h"
+#endif
 
 #if HAS_MULTI_HOTEND
   #include "../../module/tool_change.h"
@@ -109,12 +111,11 @@ enum side_t : uint8_t {
     UMINIMUM, UMAXIMUM, VMINIMUM, VMAXIMUM, WMINIMUM, WMAXIMUM)
 };
 
-static constexpr xyz_pos_t true_center = motion.calibration_center;
-static constexpr xyz_float_t dimensions CALIBRATION_OBJECT_DIMENSIONS;
+static constexpr xyz_float_t dimensions = CALIBRATION_OBJECT_DIMENSIONS;
 static constexpr xy_float_t nod = { CALIBRATION_NOZZLE_OUTER_DIAMETER, CALIBRATION_NOZZLE_OUTER_DIAMETER };
 
 struct measurements_t {
-  xyz_pos_t obj_center = true_center; // Non-static must be assigned from xyz_pos_t
+  xyz_pos_t obj_center = motion.calibration_center; // Non-static must be assigned from xyz_pos_t
 
   float obj_side[NUM_SIDES], backlash[NUM_SIDES];
   xyz_float_t pos_error;
@@ -160,8 +161,10 @@ inline void calibration_move() {
  */
 inline void park_above_object(measurements_t &m, const float uncertainty_tool_length) {
   // Move to safe distance above calibration object
-  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
-    gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
+  #if defined(Z_HOME_DIR) && Z_HOME_DIR == 1
+    if (uncertainty_tool_length > CALIBRATION_MEASUREMENT_UNCERTAIN)
+      gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
+    else
   #else
     motion.position.z = m.obj_center.z + dimensions.z / 2 + uncertainty_tool_length;
   #endif
@@ -201,7 +204,7 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
   const feedRate_t mms = fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
   const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
   #if Z_HOME_TO_MAX
-    const float limit_z = fast ? ((Z_HOME_POS) - calibration_center.z  + 50) : ((Z_MAX_POS) - calibration_center.z + 5);
+    const float limit_z = fast ? ((Z_HOME_POS) - motion.calibration_center.z  + 50) : ((Z_MAX_POS) - motion.calibration_center.z + 5);
   #else
     const float limit_z = fast ? (2 * uncertainty_tool_length + 50) : (2 * uncertainty_tool_length + 5);
   #endif
@@ -233,7 +236,7 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
  *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
 inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty, const float uncertainty_tool_length) {
-  const bool fast = uncertainty == CALIBRATION_MEASUREMENT_UNKNOWN;
+  const bool fast = (uncertainty == CALIBRATION_MEASUREMENT_UNKNOWN || uncertainty_tool_length == CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   // Save the current position of the specified axis
   const float start_pos = motion.position[axis];
@@ -249,7 +252,12 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
 
   // Move back to the starting position
   motion.destination = motion.position;
-  motion.destination[axis] = start_pos;
+  #if Z_HOME_TO_MAX
+    if (axis == Z_AXIS)
+      motion.destination[axis] = motion.position.z + CALIBRATION_MEASUREMENT_UNCERTAIN;
+    else
+  #endif
+  motion.destination = start_pos;
   motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
   return measured_pos;
 }
@@ -265,7 +273,7 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
  *                               to find out height of edge
  */
 inline void probe_side(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const side_t side, const bool probe_top_at_edge=false) {
-  const xyz_float_t dimensions = CALIBRATION_OBJECT_DIMENSIONS;
+  const xyz_float_t dimensions = dimensions;
   AxisEnum axis;
   float dir = 1;
 
@@ -392,20 +400,20 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
   // at which it makes contact with the calibration object
   TERN_(HAS_X_CENTER, m.nozzle_outer_dimension.x = m.obj_side[RIGHT] - m.obj_side[LEFT] - dimensions.x);
 
-  park_above_object(m, uncertainty_tool_length);
+  park_above_object(m, CALIBRATION_MEASUREMENT_UNCERTAIN);
 
   // The difference between the known and the measured location
   // of the calibration object is the positional error
   NUM_AXIS_CODE(
-    m.pos_error.x = TERN0(HAS_X_CENTER, true_center.x - m.obj_center.x),
-    m.pos_error.y = TERN0(HAS_Y_CENTER, true_center.y - m.obj_center.y),
-    m.pos_error.z = true_center.z - m.obj_center.z,
-    m.pos_error.i = TERN0(HAS_I_CENTER, true_center.i - m.obj_center.i),
-    m.pos_error.j = TERN0(HAS_J_CENTER, true_center.j - m.obj_center.j),
-    m.pos_error.k = TERN0(HAS_K_CENTER, true_center.k - m.obj_center.k),
-    m.pos_error.u = TERN0(HAS_U_CENTER, true_center.u - m.obj_center.u),
-    m.pos_error.v = TERN0(HAS_V_CENTER, true_center.v - m.obj_center.v),
-    m.pos_error.w = TERN0(HAS_W_CENTER, true_center.w - m.obj_center.w)
+    m.pos_error.x = TERN0(HAS_X_CENTER, motion.calibrationcenter.x - m.obj_center.x),
+    m.pos_error.y = TERN0(HAS_Y_CENTER, motion.calibrationcenter.y - m.obj_center.y),
+    m.pos_error.z = motion.calibrationcenter.z - m.obj_center.z,
+    m.pos_error.i = TERN0(HAS_I_CENTER, motion.calibrationcenter.i - m.obj_center.i),
+    m.pos_error.j = TERN0(HAS_J_CENTER, motion.calibrationcenter.j - m.obj_center.j),
+    m.pos_error.k = TERN0(HAS_K_CENTER, motion.calibrationcenter.k - m.obj_center.k),
+    m.pos_error.u = TERN0(HAS_U_CENTER, motion.calibrationcenter.u - m.obj_center.u),
+    m.pos_error.v = TERN0(HAS_V_CENTER, motion.calibrationcenter.v - m.obj_center.v),
+    m.pos_error.w = TERN0(HAS_W_CENTER, motion.calibrationcenter.w - m.obj_center.w)
   );
 }
 
@@ -688,8 +696,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
       TEMPORARY_BACKLASH_SMOOTHING(0.0f);
       const xyz_float_t move = NUM_AXIS_ARRAY(
         AXIS_CAN_CALIBRATE(X) * 3, AXIS_CAN_CALIBRATE(Y) * 3, AXIS_CAN_CALIBRATE(Z) * 3,
-        AXIS_CAN_CALIBRATE(I) * 3, AXIS_CAN_CALIBRATE(J) * 3, AXIS_CAN_CALIBRATE(K) * 3,
-        AXIS_CAN_CALIBRATE(U) * 3, AXIS_CAN_CALIBRATE(V) * 3, AXIS_CAN_CALIBRATE(W) * 3
+        0, 0, 0, 0, 0, 0
       );
       motion.position += move; calibration_move();
       motion.position -= move; calibration_move();
@@ -760,7 +767,7 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
 inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, const float uncertainty_tool_length) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
-
+ 
   HOTEND_LOOP() calibrate_toolhead(m, uncertainty, uncertainty_tool_length, e);
 
   TERN_(HAS_HOTEND_OFFSET, normalize_hotend_offsets());
@@ -794,17 +801,17 @@ inline void calibrate_all() {
 
   // Cycle the toolheads so the servos settle into their "natural" positions
   #if HAS_MULTI_HOTEND
-    HOTEND_LOOP() set_nozzle(m, e);
+    HOTEND_LOOP() set_nozzle(m, e, CALIBRATION_MEASUREMENT_UNCERTAIN);
   #endif
 
   // Do a slow and precise calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_TOOL_LENGTH);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN);
 
   motion.position.x = X_CENTER;
   calibration_move();         // Park nozzle away from calibration object
 }
 
-calibrate_toolhead_Z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
+inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
@@ -848,14 +855,14 @@ calibrate_toolhead_Z_only(measurements_t &m, const float uncertainty, const uint
   // at which it makes contact with the calibration object
   TERN_(HAS_X_CENTER, m.nozzle_outer_dimension.x = m.obj_side[RIGHT] - m.obj_side[LEFT] - dimensions.x);
 
-  park_above_object(m, uncertainty);
+  park_above_object(m, CALIBRATION_MEASUREMENT_UNCERTAIN);
 
   // The difference between the known and the measured location
   // of the calibration object is the positional error
   NUM_AXIS_CODE(
-    m.pos_error.x = TERN0(HAS_X_CENTER, true_center.x - m.obj_center.x),
-    m.pos_error.y = TERN0(HAS_Y_CENTER, true_center.y - m.obj_center.y),
-    m.pos_error.z = true_center.z - m.obj_center.z,
+    m.pos_error.x = TERN0(HAS_X_CENTER, motion.calibration_center.x - m.obj_center.x),
+    m.pos_error.y = TERN0(HAS_Y_CENTER, motion.calibration_center.y - m.obj_center.y),
+    m.pos_error.z = motion.calibration_center.z - m.obj_center.z,
     m.pos_error.i = 0,
     m.pos_error.j = 0,
     m.pos_error.k = 0,
@@ -864,141 +871,6 @@ calibrate_toolhead_Z_only(measurements_t &m, const float uncertainty, const uint
     m.pos_error.w = 0
   );
 }
-
-
-
-/**
-// ====================================================================
-// HÀM ĐO CHIỀU DÀI DAO Z (CNC STYLE) - BẢN SỬA CHUẨN CÚ PHÁP MARLIN 2.1.X BUGFIX
-// ====================================================================
-inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
-  TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
-  TEMPORARY_BACKLASH_SMOOTHING(0.0f);
-
-  float saved_hotend_offset_z = 0.0f;
-  #if HAS_HOTEND_OFFSET
-    saved_hotend_offset_z = motion.hotend_offset[extruder].z; // Lưu lại offset cũ để dự phòng
-    motion.hotend_offset[extruder].z = 0.0f;                  // Xóa trắng offset dao chuẩn bị đo
-  #endif
-
-  // Đồng bộ hóa Planner đưa tất cả bộ đệm di chuyển về trạng thái thực tế của phần cứng
-  planner.synchronize();
-  motion.set_current_from_steppers_for_axis(Z_AXIS);
-  motion.sync_plan_position();
-
-  // BƯỚC 1: KHỞI TẠO TỌA ĐỘ XY CỦA CỤC CALIP TỪ CONFIGURATION
-  const xyz_float_t obj_center_array = CALIBRATION_OBJECT_CENTER;
-  m.obj_center.x = obj_center_array[X_AXIS]; // 264.0
-  m.obj_center.y = obj_center_array[Y_AXIS]; // -22.0
-  m.obj_center.z = obj_center_array[Z_AXIS]; 
-  m.pos_error.x = 0.0f; m.pos_error.y = 0.0f; m.pos_error.z = 0.0f;
-
-  // ====================================================================
-  // BƯỚC 2: RÚT TRỤC Z LÊN ĐỈNH TRẦN BẰNG CHU TRÌNH G28 Z LÕI HỆ THỐNG
-  // Sửa chính xác cú pháp API v2 của nhánh Marlin 2.1.x Bugfix
-  // ====================================================================
-  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
-    gcode.process_subcommands_now(F("G28 Z")); // Gọi chu trình Home cứng trục Z thông qua hàng đợi lệnh lõi
-  #else
-    motion.destination = motion.position;
-    motion.destination.z = _MIN(motion.position.z + CALIBRATION_MEASUREMENT_UNKNOWN, (float)Z_MAX_POS);
-    motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
-  #endif
-  planner.synchronize();  
-
-  // BƯỚC 3: ĐỔI DAO VÀ DI CHUYỂN XY ĐẾN THÁP ĐO CỐ ĐỊNH
-  #if HAS_TOOLCHANGE
-    set_nozzle(m, extruder, uncertainty);
-    planner.synchronize();
-  #endif
-
-  // DI CHUYỂN XY: Đưa đầu dao đến vị trí cục Calip cố định
-  motion.destination = motion.position;
-  motion.destination.x = m.obj_center.x; 
-  motion.destination.y = m.obj_center.y; 
-  motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
-  planner.synchronize();
-
-  // BƯỚC 4: CHU TRÌNH DÒ XUỐNG SÂU (PROBE CÓ CẢM BIẾN CHẶN)
-  motion.destination = motion.position;
-  motion.destination.z = 0.0f; // Điểm đích sát đáy máy để ép máy chịu dò xuống sâu
-
-  motion.set_soft_endstop_loose(true);
-  endstops.enable_calibration_probe(true, true);
-  motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST));
-  endstops.enable_calibration_probe(false);
-  endstops.hit_on_purpose();
-  motion.set_soft_endstop_loose(false);
-
-  // ĐỒNG BỘ TOÀN CỤC: Cập nhật lại số xung bước từ Driver vào hệ thống ngay khi chạm cảm biến
-  motion.set_current_from_steppers_for_axis(Z_AXIS);
-  motion.sync_plan_position();
-
-  // Ghi nhận cao độ LÀM VIỆC (Dành cho việc lưu thông tin Object nếu cần)
-  const float measurement = motion.position.z;
-  m.obj_side[TOP] = measurement;
-  m.obj_center.z = measurement - dimensions.z / 2;
-
-  // ------------------------------------------------------------------
-  // BƯỚC 5: TÍNH TOÁN HOTEND OFFSET Z - THUẬT TOÁN ĐỒNG BỘ MỚI (Marlin 2.1.x)
-  // ------------------------------------------------------------------
-  #if HAS_HOTEND_OFFSET
-    static float z_calip_machine_raw[TOOLS] = { };
-    planner.synchronize();
-    motion.set_current_from_steppers_for_axis(Z_AXIS);
-    motion.sync_plan_position();
-    planner.synchronize();
-    const float z_trigger_machine_absolute = planner.get_axis_position_mm(Z_AXIS); 
-
-    if (extruder < TOOLS) {
-      z_calip_machine_raw[extruder] = z_trigger_machine_absolute;
-    }
-    // 2. THUẬT TOÁN TÍNH TOÁN RA SỐ DƯƠNG (+) ĐỂ ĐỒNG BỘ VỚI TOÁN TỬ G43/G43.4 (+=)
-    if (z_calip_machine_raw[REFERENCE_TOOL] > 0.0f) {
-      float cnc_calculated_offset_z = 0.0f;
-      if (extruder == REFERENCE_TOOL) {
-        motion.hotend_offset[REFERENCE_TOOL].z = 0.0f; // Đầu Master Probe luôn bằng 0
-      }
-      else if (z_calip_machine_raw[extruder] > 0.0f) {
-        cnc_calculated_offset_z = z_calip_machine_raw[REFERENCE_TOOL] - z_calip_machine_raw[extruder];
-        motion.hotend_offset[extruder].z = cnc_calculated_offset_z;
-      }
-
-      // SAU KHI NẠP OFFSET MỚI: Bắt buộc phải đồng bộ lại toàn cục để áp dụng ma trận mới
-      planner.synchronize();
-      motion.set_current_from_steppers_for_axis(Z_AXIS);
-      motion.sync_plan_position();
-      planner.synchronize();
-    }
-    // Khôi phục lại offset cũ để an toàn nếu đo lỗi bộ đệm
-    else if (extruder != REFERENCE_TOOL && extruder != 0 && z_calip_machine_raw[REFERENCE_TOOL] == 0.0f) {
-      motion.hotend_offset[extruder].z = saved_hotend_offset_z;
-      planner.synchronize();
-      motion.sync_plan_position();
-      planner.synchronize();
-    }
-  #endif
-
-  // ====================================================================
-  // BƯỚC 6: RÚT DAO LÊN LẠI ĐỈNH CAO AN TOÀN BẰNG CHU TRÌNH G28 Z LÕI HỆ THỐNG
-  // Sửa chính xác cú pháp API v2 của nhánh Marlin 2.1.x Bugfix
-  // ====================================================================
-  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
-    gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
-  #else
-    motion.destination = motion.position;
-    motion.destination.z = _MIN(motion.position.z + 20.0f, (float)Z_MAX_POS);
-    motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
-  #endif
-  
-  planner.synchronize();
-
-  if (AXIS_CAN_CALIBRATE(Z)) {
-    update_measurements(m, Z_AXIS);
-  }
-  motion.sync_plan_position();
-}
-*/
 
 /**
  * G425: Perform calibration with calibration object.
@@ -1020,11 +892,13 @@ void GcodeSuite::G425() {
 
   if (motion.homing_needed_error()) return;
 
-  TEMPORARY_BED_LEVELING_STATE(false);
+  #if HAS_LEVELING
+    TEMPORARY_BED_LEVELING_STATE(false);
+  #endif
   motion.set_soft_endstop_loose(true);
 
   measurements_t m;
-  const float uncertainty = parser.floatval('U', CALIBRATION_MEASUREMENT_UNCERTAIN);
+  const float uncertainty = parser.floatval('U', CALIBRATION_MEASUREMENT_UNKNOWN);
   const float uncertainty_tool_length = parser.floatval('L', CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   if (parser.seen_test('B'))
@@ -1036,10 +910,12 @@ void GcodeSuite::G425() {
     // Nếu gõ G425 T1 Z hoặc G425 T1 Z0 -> Kích hoạt chế độ đo chiều dài Z nhanh CNC style
     if (parser.seen('Z')) {
       calibrate_toolhead_z_only(m, uncertainty_tool_length, target_tool);
+      calibrate_toolhead_z_only(m, CALIBRATION_MEASUREMENT_UNCERTAIN, target_tool); 
     } 
     // Nếu chỉ gõ G425 T1 -> Chạy chế độ mặc định đo toàn diện X Y Z
     else {
-      calibrate_toolhead(m, uncertainty, uncertainty_tool_length, parser.intval('T', motion.extruder));
+      calibrate_toolhead(m, uncertainty, uncertainty_tool_length, target_tool);
+      calibrate_toolhead(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN, target_tool);
     }
   }
   #if ENABLED(CALIBRATION_REPORTING)

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -706,7 +706,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
 
 inline void update_measurements(measurements_t &m, const AxisEnum axis) {
   motion.position[axis] += m.pos_error[axis];
-  m.obj_center[axis] = true_center[axis];
+  m.obj_center[axis] = motion.calibration_center[axis];
   m.pos_error[axis] = 0;
 }
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -163,7 +163,7 @@ inline void park_above_object(measurements_t &m, const float uncertainty_tool_le
   // Move to safe distance above calibration object
   #if defined(Z_HOME_DIR) && Z_HOME_DIR == 1
     if (uncertainty_tool_length > CALIBRATION_MEASUREMENT_UNCERTAIN)
-      gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
+      gcode.process_subcommands_now(F("G28 Z"));
     else
   #else
     motion.position.z = m.obj_center.z + dimensions.z / 2 + uncertainty_tool_length;
@@ -195,13 +195,25 @@ inline void park_above_object(measurements_t &m, const float uncertainty_tool_le
  * Move along axis in the specified dir until the probe value becomes stop_state,
  * then return the axis value.
  *
- *   axis         in - Axis along which the measurement will take place
- *   dir          in - Direction along that axis (-1 or 1)
- *   stop_state   in - Move until probe pin becomes this value
- *   fast         in - Fast vs. precise measurement
+ *   axis                     in - Axis along which the measurement will take place
+ *   dir                      in - Direction along that axis (-1 or 1)
+ *   stop_state               in - Move until probe pin becomes this value
+ *   fast                     in - Fast vs. precise measurement
+ *   uncertainty              in - How far away from the calibration object to start probing
+ *   uncertainty_tool_length  in - How far away in Z direction from the calibration object to start probing
+ *   feedrate                 in - Feedrate for the measurement move
  */
 float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty, const bool uncertainty_tool_length, const feedRate_t feedrate) {
-  const feedRate_t mms = (feedrate != MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW)) ? feedrate : (fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW));
+  feedRate_t mms = feedrate;
+  if (feedrate == MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW)) {
+    if (fast) {
+      mms = MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST);
+    }
+    else {
+      mms = MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
+    }
+  }
+
   const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
   #if Z_HOME_TO_MAX
     const float limit_z = fast ? ((Z_HOME_POS) - motion.calibration_center.z  + 50) : ((Z_MAX_POS) - motion.calibration_center.z + 5);
@@ -228,12 +240,13 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
  * Move along axis until the probe is triggered. Move toolhead to its starting
  * point and return the measured value.
  *
- *   axis               in     - Axis along which the measurement will take place
- *   dir                in     - Direction along that axis (-1 or 1)
- *   stop_state         in     - Move until probe pin becomes this value
- *   backlash_ptr       in/out - When not nullptr, measure and record axis backlash
- *   uncertainty        in     - If uncertainty is CALIBRATION_MEASUREMENT_UNKNOWN, do a fast probe.
- *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
+ *   axis                     in     - Axis along which the measurement will take place
+ *   dir                      in     - Direction along that axis (-1 or 1)
+ *   stop_state               in     - Move until probe pin becomes this value
+ *   backlash_ptr             in/out - When not nullptr, measure and record axis backlash
+ *   uncertainty              in     - If uncertainty is CALIBRATION_MEASUREMENT_UNKNOWN, do a fast probe.
+ *   uncertainty_tool_length  in     - How far away in Z direction from the calibration object to start probing
+ *   feedrate                 in     - Feedrate for the measurement move
  */
 inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   const bool fast = (uncertainty == CALIBRATION_MEASUREMENT_UNKNOWN || uncertainty_tool_length == CALIBRATION_MEASUREMENT_TOOL_LENGTH);
@@ -265,12 +278,13 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
 /**
  * Probe one side of the calibration object
  *
- *   m                  in/out - Measurement record, m.obj_center and m.obj_side will be updated.
- *   uncertainty        in     - How far away from the calibration object to begin probing
- *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
- *   side               in     - Side of probe where probe will occur
- *   probe_top_at_edge  in     - When probing sides, probe top of calibration object nearest edge
- *                               to find out height of edge
+ *   m                        in/out - Measurement record, m.obj_center and m.obj_side will be updated.
+ *   uncertainty              in     - How far away from the calibration object to begin probing
+ *   uncertainty_tool_length  in     - How far away in Z direction from the calibration object to start probing
+ *   side                     in     - Side of probe where probe will occur
+ *   probe_top_at_edge        in     - When probing sides, probe top of calibration object nearest edge
+ *                                     to find out height of edge
+ *   feedrate                 in     - Feedrate for the measurement move
  */
 inline void probe_side(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const side_t side, const bool probe_top_at_edge=false, const feedRate_t feedrate=MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW)) {
   const xyz_float_t dims = dimensions;
@@ -345,8 +359,10 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
 /**
  * Probe all sides of the calibration calibration object
  *
- *   m                  in/out - Measurement record: center, backlash and error values be updated.
- *   uncertainty        in     - How far away from the calibration object to begin probing
+ *   m                       in/out - Measurement record: center, backlash and error values be updated.
+ *   uncertainty             in     - How far away from the calibration object to begin probing
+ *   uncertainty_tool_length in     - How far away in Z direction from the calibration object to begin probing
+ *   feedrate                in     - Feedrate for the measurement
  */
 inline void probe_sides(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   #if ENABLED(CALIBRATION_MEASURE_AT_TOP_EDGES)
@@ -355,7 +371,7 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
     // Probing at the exact center only works if the center is flat. Probing on a washer
     // or bolt will require probing the top near the side edges, away from the center.
     constexpr bool probe_top_at_edge = false;
-    probe_side(m, uncertainty, uncertainty_tool_length, TOP, feedrate);
+    probe_side(m, uncertainty, uncertainty_tool_length, TOP, probe_top_at_edge, feedrate);
   #endif
 
   /**
@@ -603,8 +619,6 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
  *
  *   m              in/out - Measurement record, updated with new readings
  *   uncertainty    in     - How far away from the object to begin probing
- *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
-
  */
 inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
   // Backlash compensation should be off while measuring backlash
@@ -713,10 +727,11 @@ inline void update_measurements(measurements_t &m, const AxisEnum axis) {
  * Probe around the calibration object. Adjust the position and toolhead offset
  * using the deviation from the known position of the calibration object.
  *
- *   m              in/out - Measurement record, updated with new readings
- *   uncertainty    in     - How far away from the object to begin probing
- *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
- *   extruder       in     - What extruder to probe
+ *   m                        in/out - Measurement record, updated with new readings
+ *   uncertainty              in     - How far away from the object to begin probing
+ *   uncertainty_tool_length  in     - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
+ *   extruder                 in     - What extruder to probe
+ *   feedrate                 in     - Feedrate for the measurement move
  *
  * Prerequisites:
  *    - Call calibrate_backlash() beforehand for best accuracy
@@ -759,9 +774,10 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
  * Probe around the calibration object for all toolheads, adjusting the coordinate
  * system for the first nozzle and the nozzle offset for subsequent nozzles.
  *
- *   m              in/out - Measurement record, updated with new readings
- *   uncertainty    in     - How far away from the object to begin probing
- *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
+ *   m                        in/out - Measurement record, updated with new readings
+ *   uncertainty              in     - How far away from the object to begin probing
+ *   uncertainty_tool_length  in     - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
+ *   feedrate                 in     - Feedrate for the measurement move
  */
 inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
@@ -794,7 +810,7 @@ inline void calibrate_all() {
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   // Do a fast and rough calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN, CALIBRATION_MEASUREMENT_TOOL_LENGTH, CALIBRATION_FEEDRATE_FAST);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN, CALIBRATION_MEASUREMENT_TOOL_LENGTH, MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST));
 
   TERN_(BACKLASH_GCODE, calibrate_backlash(m, CALIBRATION_MEASUREMENT_UNCERTAIN));
 
@@ -804,7 +820,7 @@ inline void calibrate_all() {
   #endif
 
   // Do a slow and precise calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_FEEDRATE_SLOW);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN, MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW));
 
   motion.position.x = X_CENTER;
   calibration_move();         // Park nozzle away from calibration object
@@ -822,7 +838,7 @@ inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty
     // Probing at the exact center only works if the center is flat. Probing on a washer
     // or bolt will require probing the top near the side edges, away from the center.
     constexpr bool probe_top_at_edge = false;
-  probe_side(m, uncertainty, uncertainty, TOP, feedrate);
+    probe_side(m, uncertainty, uncertainty, TOP, false, feedrate);
   #endif
 
   park_above_object(m, CALIBRATION_MEASUREMENT_UNCERTAIN);
@@ -889,6 +905,7 @@ inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty
  *   U           - Uncertainty, how far in xy to start probe away from the object (mm)
  *   L           - Tool length uncertainty, how far in z to start probe away from the object (mm)
  *   Z           - With parameter T: Calibrate Z hotend offset only
+ *   F           - With parameter T: Feedrate for the measurement move
  *
  *   no args     - Perform entire calibration sequence (backlash + position on all toolheads)
  */
@@ -919,22 +936,20 @@ void GcodeSuite::G425() {
   const feedRate_t measurement_feedrate = parser.seenval('F') ? MMM_TO_MMS(parser.value_linear_units()) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
   if (parser.seen_test('B'))
     calibrate_backlash(m, uncertainty);
-  // --- ĐOẠN ĐIỀU HƯỚNG MỚI ĐÃ ĐƯỢC CHUẨN HÓA ---
+
   else if (parser.seen_test('T')) {
     const uint8_t target_tool = parser.intval('T', motion.extruder);
     
-    // Nếu gõ G425 T1 Z hoặc G425 T1 Z0 -> Kích hoạt chế độ đo chiều dài Z nhanh CNC style
     if (parser.seen('Z')) {
       calibrate_toolhead_z_only(m, uncertainty_tool_length, target_tool, measurement_feedrate);
     } 
-    // Nếu chỉ gõ G425 T1 -> Chạy chế độ mặc định đo toàn diện X Y Z
     else {
       calibrate_toolhead(m, uncertainty, uncertainty_tool_length, target_tool, measurement_feedrate);
     }
   }
   #if ENABLED(CALIBRATION_REPORTING)
     else if (parser.seen('V')) {
-      probe_sides(m, uncertainty);
+      probe_sides(m, uncertainty, uncertainty_tool_length, measurement_feedrate);
       SERIAL_EOL();
       report_measured_faces(m);
       report_measured_center(m);

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -200,8 +200,8 @@ inline void park_above_object(measurements_t &m, const float uncertainty_tool_le
  *   stop_state   in - Move until probe pin becomes this value
  *   fast         in - Fast vs. precise measurement
  */
-float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty, const bool uncertainty_tool_length) {
-  const feedRate_t mms = fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
+float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty, const bool uncertainty_tool_length, const feedRate_t feedrate) {
+  const feedRate_t mms = (feedrate != MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW)) ? feedrate : (fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW));
   const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
   #if Z_HOME_TO_MAX
     const float limit_z = fast ? ((Z_HOME_POS) - motion.calibration_center.z  + 50) : ((Z_MAX_POS) - motion.calibration_center.z + 5);
@@ -235,18 +235,18 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
  *   uncertainty        in     - If uncertainty is CALIBRATION_MEASUREMENT_UNKNOWN, do a fast probe.
  *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
-inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty, const float uncertainty_tool_length) {
+inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   const bool fast = (uncertainty == CALIBRATION_MEASUREMENT_UNKNOWN || uncertainty_tool_length == CALIBRATION_MEASUREMENT_TOOL_LENGTH);
 
   // Save the current position of the specified axis
   const float start_pos = motion.position[axis];
 
   // Take a measurement. Only the specified axis will be affected.
-  const float measured_pos = measuring_movement(axis, dir, stop_state, fast, uncertainty, uncertainty_tool_length);
+  const float measured_pos = measuring_movement(axis, dir, stop_state, fast, uncertainty, uncertainty_tool_length, feedrate);
 
   // Measure backlash
   if (backlash_ptr && !fast) {
-    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast, uncertainty, uncertainty_tool_length);
+    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast, uncertainty, uncertainty_tool_length, feedrate);
     *backlash_ptr = ABS(release_pos - measured_pos);
   }
 
@@ -272,8 +272,8 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
  *   probe_top_at_edge  in     - When probing sides, probe top of calibration object nearest edge
  *                               to find out height of edge
  */
-inline void probe_side(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const side_t side, const bool probe_top_at_edge=false) {
-  const xyz_float_t dimensions = dimensions;
+inline void probe_side(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const side_t side, const bool probe_top_at_edge=false, const feedRate_t feedrate=MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW)) {
+  const xyz_float_t dims = dimensions;
   AxisEnum axis;
   float dir = 1;
 
@@ -291,8 +291,8 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
     #endif
     #if AXIS_CAN_CALIBRATE(Z)
       case TOP: {
-        const float measurement = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length);
-        m.obj_center.z = measurement - dimensions.z / 2;
+        const float measurement = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length, feedrate);
+        m.obj_center.z = measurement - dims.z / 2;
         m.obj_side[TOP] = measurement;
         return;
       }
@@ -323,8 +323,8 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
       // Probe top nearest the side we are probing
       motion.position[axis] = m.obj_center[axis] + (-dir) * (dimensions[axis] / 2 - m.nozzle_outer_dimension[axis]);
       calibration_move();
-      m.obj_side[TOP] = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length);
-      m.obj_center.z = m.obj_side[TOP] - dimensions.z / 2;
+      m.obj_side[TOP] = measure(Z_AXIS, -1, true, &m.backlash[TOP], uncertainty, uncertainty_tool_length, feedrate);
+      m.obj_center.z = m.obj_side[TOP] - dims.z / 2;
     #endif
   }
 
@@ -336,8 +336,8 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
     // Plunge below the side of the calibration object and measure
     motion.position.z = m.obj_side[TOP] - (CALIBRATION_NOZZLE_TIP_HEIGHT) * 0.7f;
     calibration_move();
-    const float measurement = measure(axis, dir, true, &m.backlash[side], uncertainty, uncertainty_tool_length);
-    m.obj_center[axis] = measurement + dir * (dimensions[axis] / 2 + m.nozzle_outer_dimension[axis] / 2);
+    const float measurement = measure(axis, dir, true, &m.backlash[side], uncertainty, uncertainty_tool_length, feedrate);
+    m.obj_center[axis] = measurement + dir * (dims[axis] / 2 + m.nozzle_outer_dimension[axis] / 2);
     m.obj_side[side] = measurement;
   }
 }
@@ -348,14 +348,14 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
  *   m                  in/out - Measurement record: center, backlash and error values be updated.
  *   uncertainty        in     - How far away from the calibration object to begin probing
  */
-inline void probe_sides(measurements_t &m, const float uncertainty, const float uncertainty_tool_length) {
+inline void probe_sides(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   #if ENABLED(CALIBRATION_MEASURE_AT_TOP_EDGES)
     constexpr bool probe_top_at_edge = true;
   #else
     // Probing at the exact center only works if the center is flat. Probing on a washer
     // or bolt will require probing the top near the side edges, away from the center.
     constexpr bool probe_top_at_edge = false;
-    probe_side(m, uncertainty, uncertainty_tool_length, TOP);
+    probe_side(m, uncertainty, uncertainty_tool_length, TOP, feedrate);
   #endif
 
   /**
@@ -364,28 +364,28 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
    * values where the nozzle was catching on the edges of the cube, and this was intended to help
    * ensure the probe object remained centered.
    */
-  TERN_(CALIBRATION_MEASURE_FRONT, probe_side(m, uncertainty, uncertainty_tool_length, FRONT,    probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_BACK,  probe_side(m, uncertainty, uncertainty_tool_length, BACK,     probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_FRONT, probe_side(m, uncertainty, uncertainty_tool_length, FRONT,    probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_BACK,  probe_side(m, uncertainty, uncertainty_tool_length, BACK,     probe_top_at_edge, feedrate));
 
   #if HAS_Y_CENTER
     m.obj_center.y = (m.obj_side[FRONT] + m.obj_side[BACK]) / 2;
     m.nozzle_outer_dimension.y = m.obj_side[BACK] - m.obj_side[FRONT] - dimensions.y;
   #endif
 
-  TERN_(CALIBRATION_MEASURE_LEFT,  probe_side(m, uncertainty, uncertainty_tool_length, LEFT,     probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_RIGHT, probe_side(m, uncertainty, uncertainty_tool_length, RIGHT,    probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_IMIN,  probe_side(m, uncertainty, uncertainty_tool_length, IMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_IMAX,  probe_side(m, uncertainty, uncertainty_tool_length, IMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_JMIN,  probe_side(m, uncertainty, uncertainty_tool_length, JMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_JMAX,  probe_side(m, uncertainty, uncertainty_tool_length, JMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_KMIN,  probe_side(m, uncertainty, uncertainty_tool_length, KMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_KMAX,  probe_side(m, uncertainty, uncertainty_tool_length, KMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_UMIN,  probe_side(m, uncertainty, uncertainty_tool_length, UMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_UMAX,  probe_side(m, uncertainty, uncertainty_tool_length, UMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_VMIN,  probe_side(m, uncertainty, uncertainty_tool_length, VMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_VMAX,  probe_side(m, uncertainty, uncertainty_tool_length, VMAXIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_WMIN,  probe_side(m, uncertainty, uncertainty_tool_length, WMINIMUM, probe_top_at_edge));
-  TERN_(CALIBRATION_MEASURE_WMAX,  probe_side(m, uncertainty, uncertainty_tool_length, WMAXIMUM, probe_top_at_edge));
+  TERN_(CALIBRATION_MEASURE_LEFT,  probe_side(m, uncertainty, uncertainty_tool_length, LEFT,     probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_RIGHT, probe_side(m, uncertainty, uncertainty_tool_length, RIGHT,    probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_IMIN,  probe_side(m, uncertainty, uncertainty_tool_length, IMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_IMAX,  probe_side(m, uncertainty, uncertainty_tool_length, IMAXIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_JMIN,  probe_side(m, uncertainty, uncertainty_tool_length, JMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_JMAX,  probe_side(m, uncertainty, uncertainty_tool_length, JMAXIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_KMIN,  probe_side(m, uncertainty, uncertainty_tool_length, KMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_KMAX,  probe_side(m, uncertainty, uncertainty_tool_length, KMAXIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_UMIN,  probe_side(m, uncertainty, uncertainty_tool_length, UMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_UMAX,  probe_side(m, uncertainty, uncertainty_tool_length, UMAXIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_VMIN,  probe_side(m, uncertainty, uncertainty_tool_length, VMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_VMAX,  probe_side(m, uncertainty, uncertainty_tool_length, VMAXIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_WMIN,  probe_side(m, uncertainty, uncertainty_tool_length, WMINIMUM, probe_top_at_edge, feedrate));
+  TERN_(CALIBRATION_MEASURE_WMAX,  probe_side(m, uncertainty, uncertainty_tool_length, WMAXIMUM, probe_top_at_edge, feedrate));
 
   // Compute the measured center of the calibration object.
   TERN_(HAS_X_CENTER, m.obj_center.x = (m.obj_side[LEFT]     + m.obj_side[RIGHT])    / 2);
@@ -614,7 +614,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
     TEMPORARY_BACKLASH_CORRECTION(backlash.all_off);
     TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
-    probe_sides(m, uncertainty, uncertainty);
+    probe_sides(m, uncertainty, uncertainty, CALIBRATION_FEEDRATE_SLOW);
 
     #if ENABLED(BACKLASH_GCODE)
 
@@ -705,7 +705,6 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
 }
 
 inline void update_measurements(measurements_t &m, const AxisEnum axis) {
-  motion.position[axis] += m.pos_error[axis];
   m.obj_center[axis] = motion.calibration_center[axis];
   m.pos_error[axis] = 0;
 }
@@ -722,20 +721,20 @@ inline void update_measurements(measurements_t &m, const AxisEnum axis) {
  * Prerequisites:
  *    - Call calibrate_backlash() beforehand for best accuracy
  */
-inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const uint8_t extruder) {
+inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const uint8_t extruder, const feedRate_t feedrate) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   TERN(HAS_MULTI_HOTEND, set_nozzle(m, extruder, uncertainty_tool_length), UNUSED(extruder));
 
-  probe_sides(m, uncertainty, uncertainty_tool_length);
+  probe_sides(m, uncertainty, uncertainty_tool_length, feedrate);
 
   // Adjust the hotend offset
   #if HAS_HOTEND_OFFSET
     xyz_pos_t &hotoff = motion.active_hotend_offset();
-    if (ENABLED(HAS_X_CENTER) && AXIS_CAN_CALIBRATE(X)) hotoff.x += m.pos_error.x;
-    if (ENABLED(HAS_Y_CENTER) && AXIS_CAN_CALIBRATE(Y)) hotoff.y += m.pos_error.y;
-                             if (AXIS_CAN_CALIBRATE(Z)) hotoff.z += m.pos_error.z;
+    if (ENABLED(HAS_X_CENTER) && AXIS_CAN_CALIBRATE(X)) hotoff.x = m.pos_error.x;
+    if (ENABLED(HAS_Y_CENTER) && AXIS_CAN_CALIBRATE(Y)) hotoff.y = m.pos_error.y;
+                             if (AXIS_CAN_CALIBRATE(Z)) hotoff.z = m.pos_error.z;
     normalize_hotend_offsets();
   #endif
 
@@ -764,11 +763,11 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
  *   uncertainty    in     - How far away from the object to begin probing
  *   uncertainty_tool_length  in  - How far away from the object to begin probing for hotend Z offset calibration with G425 T...
  */
-inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, const float uncertainty_tool_length) {
+inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, const float uncertainty_tool_length, const feedRate_t feedrate) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
  
-  HOTEND_LOOP() calibrate_toolhead(m, uncertainty, uncertainty_tool_length, e);
+  HOTEND_LOOP() calibrate_toolhead(m, uncertainty, uncertainty_tool_length, e, feedrate);
 
   TERN_(HAS_HOTEND_OFFSET, normalize_hotend_offsets());
 
@@ -795,7 +794,7 @@ inline void calibrate_all() {
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   // Do a fast and rough calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN, CALIBRATION_MEASUREMENT_TOOL_LENGTH);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNKNOWN, CALIBRATION_MEASUREMENT_TOOL_LENGTH, CALIBRATION_FEEDRATE_FAST);
 
   TERN_(BACKLASH_GCODE, calibrate_backlash(m, CALIBRATION_MEASUREMENT_UNCERTAIN));
 
@@ -805,13 +804,13 @@ inline void calibrate_all() {
   #endif
 
   // Do a slow and precise calibration of the toolheads
-  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN);
+  calibrate_all_toolheads(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_FEEDRATE_SLOW);
 
   motion.position.x = X_CENTER;
   calibration_move();         // Park nozzle away from calibration object
 }
 
-inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
+inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty, const uint8_t extruder, const feedRate_t feedrate) {
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
@@ -823,15 +822,10 @@ inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty
     // Probing at the exact center only works if the center is flat. Probing on a washer
     // or bolt will require probing the top near the side edges, away from the center.
     constexpr bool probe_top_at_edge = false;
-    probe_side(m, uncertainty, uncertainty, TOP);
+  probe_side(m, uncertainty, uncertainty, TOP, feedrate);
   #endif
 
-  // Adjust the hotend offset
-  #if HAS_HOTEND_OFFSET
-    xyz_pos_t &hotoff = motion.active_hotend_offset();
-    if (AXIS_CAN_CALIBRATE(Z)) hotoff.z += m.pos_error.z;
-    normalize_hotend_offsets();
-  #endif
+  park_above_object(m, CALIBRATION_MEASUREMENT_UNCERTAIN);
 
   // Correct for positional error, so the object
   // is at the known actual spot
@@ -860,8 +854,8 @@ inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty
   // The difference between the known and the measured location
   // of the calibration object is the positional error
   NUM_AXIS_CODE(
-    m.pos_error.x = TERN0(HAS_X_CENTER, motion.calibration_center.x - m.obj_center.x),
-    m.pos_error.y = TERN0(HAS_Y_CENTER, motion.calibration_center.y - m.obj_center.y),
+    m.pos_error.x = 0,
+    m.pos_error.y = 0,
     m.pos_error.z = motion.calibration_center.z - m.obj_center.z,
     m.pos_error.i = 0,
     m.pos_error.j = 0,
@@ -870,6 +864,20 @@ inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty
     m.pos_error.v = 0,
     m.pos_error.w = 0
   );
+
+  // Adjust the hotend offset
+  #if HAS_HOTEND_OFFSET
+    xyz_pos_t &hotoff = motion.active_hotend_offset();
+    if (AXIS_CAN_CALIBRATE(Z)) hotoff.z = m.pos_error.z;
+    normalize_hotend_offsets();
+  #endif
+
+  // Correct for positional error, so the object
+  // is at the known actual spot
+  planner.synchronize();
+  if (AXIS_CAN_CALIBRATE(Z)) update_measurements(m, Z_AXIS);
+
+  motion.sync_plan_position();
 }
 
 /**
@@ -892,6 +900,14 @@ void GcodeSuite::G425() {
 
   if (motion.homing_needed_error()) return;
 
+  #if HAS_TOOL_CENTERPOINT_CONTROL
+    const bool old_tcpc = motion.tool_centerpoint_control;
+  #endif
+  #if HAS_TOOL_LENGTH_COMPENSATION
+    const bool old_tool_length_compensation = motion.simple_tool_length_compensation;
+    process_subcommands_now(F("G49"));
+  #endif
+
   #if HAS_LEVELING
     TEMPORARY_BED_LEVELING_STATE(false);
   #endif
@@ -900,7 +916,7 @@ void GcodeSuite::G425() {
   measurements_t m;
   const float uncertainty = parser.floatval('U', CALIBRATION_MEASUREMENT_UNKNOWN);
   const float uncertainty_tool_length = parser.floatval('L', CALIBRATION_MEASUREMENT_TOOL_LENGTH);
-
+  const feedRate_t measurement_feedrate = parser.seenval('F') ? MMM_TO_MMS(parser.value_linear_units()) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
   if (parser.seen_test('B'))
     calibrate_backlash(m, uncertainty);
   // --- ĐOẠN ĐIỀU HƯỚNG MỚI ĐÃ ĐƯỢC CHUẨN HÓA ---
@@ -909,13 +925,11 @@ void GcodeSuite::G425() {
     
     // Nếu gõ G425 T1 Z hoặc G425 T1 Z0 -> Kích hoạt chế độ đo chiều dài Z nhanh CNC style
     if (parser.seen('Z')) {
-      calibrate_toolhead_z_only(m, uncertainty_tool_length, target_tool);
-      calibrate_toolhead_z_only(m, CALIBRATION_MEASUREMENT_UNCERTAIN, target_tool); 
+      calibrate_toolhead_z_only(m, uncertainty_tool_length, target_tool, measurement_feedrate);
     } 
     // Nếu chỉ gõ G425 T1 -> Chạy chế độ mặc định đo toàn diện X Y Z
     else {
-      calibrate_toolhead(m, uncertainty, uncertainty_tool_length, target_tool);
-      calibrate_toolhead(m, CALIBRATION_MEASUREMENT_UNCERTAIN, CALIBRATION_MEASUREMENT_UNCERTAIN, target_tool);
+      calibrate_toolhead(m, uncertainty, uncertainty_tool_length, target_tool, measurement_feedrate);
     }
   }
   #if ENABLED(CALIBRATION_REPORTING)
@@ -937,6 +951,12 @@ void GcodeSuite::G425() {
     calibrate_all();
 
   motion.set_soft_endstop_loose(false);
+  #if HAS_TOOL_LENGTH_COMPENSATION
+    if (old_tool_length_compensation) process_subcommands_now(F("G43"));
+  #endif
+  #if HAS_TOOL_CENTERPOINT_CONTROL
+    if (old_tcpc) process_subcommands_now(F("G43.4"));
+  #endif
 
   #ifdef CALIBRATION_SCRIPT_POST
     process_subcommands_now(F(CALIBRATION_SCRIPT_POST));

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -192,9 +192,9 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
  *   stop_state   in - Move until probe pin becomes this value
  *   fast         in - Fast vs. precise measurement
  */
-float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast) {
+float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty) {
   const feedRate_t mms = fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
-  const float limit    = fast ? 50 : 5;
+  const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
 
   motion.destination = motion.position;
   motion.destination[axis] += dir * limit;
@@ -224,11 +224,11 @@ inline float measure(const AxisEnum axis, const int dir, const bool stop_state, 
   const float start_pos = motion.position[axis];
 
   // Take a measurement. Only the specified axis will be affected.
-  const float measured_pos = measuring_movement(axis, dir, stop_state, fast);
+  const float measured_pos = measuring_movement(axis, dir, stop_state, fast, uncertainty);
 
   // Measure backlash
   if (backlash_ptr && !fast) {
-    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast);
+    const float release_pos = measuring_movement(axis, -dir, !stop_state, fast, uncertainty);
     *backlash_ptr = ABS(release_pos - measured_pos);
   }
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -109,7 +109,7 @@ enum side_t : uint8_t {
     UMINIMUM, UMAXIMUM, VMINIMUM, VMAXIMUM, WMINIMUM, WMAXIMUM)
 };
 
-static constexpr xyz_pos_t true_center CALIBRATION_OBJECT_CENTER;
+static constexpr xyz_pos_t true_center = motion.calibration_center;
 static constexpr xyz_float_t dimensions CALIBRATION_OBJECT_DIMENSIONS;
 static constexpr xy_float_t nod = { CALIBRATION_NOZZLE_OUTER_DIAMETER, CALIBRATION_NOZZLE_OUTER_DIAMETER };
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -158,21 +158,22 @@ inline void calibration_move() {
  *   m                  in     - Measurement record
  *   uncertainty        in     - How far away from the object top to park
  */
-inline void park_above_object(measurements_t &m, const float uncertainty) {
+inline void park_above_object(measurements_t &m, const float uncertainty_tool_length) {
   // Move to safe distance above calibration object
-  motion.position.z = m.obj_center.z + dimensions.z / 2 + uncertainty;
-  calibration_move();
-
-  // Move to center of calibration object in XY
+  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
+    gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
+  #else
+    motion.position.z = m.obj_center.z + dimensions.z / 2 + uncertainty_tool_length;
+  #endif
   motion.position = xy_pos_t(m.obj_center);
   calibration_move();
 }
 
 #if HAS_MULTI_HOTEND
-  inline void set_nozzle(measurements_t &m, const uint8_t extruder) {
+  inline void set_nozzle(measurements_t &m, const uint8_t extruder, const bool uncertainty_tool_length) {
     if (extruder != motion.extruder) {
-      park_above_object(m, CALIBRATION_MEASUREMENT_UNKNOWN);
       tool_change(extruder);
+      park_above_object(m, uncertainty_tool_length);
     }
   }
 #endif
@@ -199,8 +200,11 @@ inline void park_above_object(measurements_t &m, const float uncertainty) {
 float measuring_movement(const AxisEnum axis, const int dir, const bool stop_state, const bool fast, const bool uncertainty, const bool uncertainty_tool_length) {
   const feedRate_t mms = fast ? MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST) : MMM_TO_MMS(CALIBRATION_FEEDRATE_SLOW);
   const float limit    = fast ? (uncertainty + 50) : (uncertainty + 5);
-  const float limit_z = fast ? (uncertainty_tool_length + 50) : (uncertainty_tool_length + 5);
-
+  #if Z_HOME_TO_MAX
+    const float limit_z = fast ? ((Z_HOME_POS) - calibration_center.z  + 50) : ((Z_MAX_POS) - calibration_center.z + 5);
+  #else
+    const float limit_z = fast ? (uncertainty_tool_length + 50) : (uncertainty_tool_length + 5);
+  #endif
   motion.destination = motion.position;
   if (axis == Z_AXIS) {
     motion.destination[axis] += dir * limit_z;
@@ -265,7 +269,7 @@ inline void probe_side(measurements_t &m, const float uncertainty, const float u
   AxisEnum axis;
   float dir = 1;
 
-  park_above_object(m, uncertainty);
+  park_above_object(m, uncertainty_tool_length);
 
   #define _ACASE(N,A,B) case A: dir = -1; case B: axis = N##_AXIS; break
   #define _PCASE(N) _ACASE(N, N##MINIMUM, N##MAXIMUM)
@@ -388,7 +392,7 @@ inline void probe_sides(measurements_t &m, const float uncertainty, const float 
   // at which it makes contact with the calibration object
   TERN_(HAS_X_CENTER, m.nozzle_outer_dimension.x = m.obj_side[RIGHT] - m.obj_side[LEFT] - dimensions.x);
 
-  park_above_object(m, uncertainty);
+  park_above_object(m, uncertainty_tool_length);
 
   // The difference between the known and the measured location
   // of the calibration object is the positional error
@@ -715,7 +719,7 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
   TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
-  TERN(HAS_MULTI_HOTEND, set_nozzle(m, extruder), UNUSED(extruder));
+  TERN(HAS_MULTI_HOTEND, set_nozzle(m, extruder, uncertainty_tool_length), UNUSED(extruder));
 
   probe_sides(m, uncertainty, uncertainty_tool_length);
 
@@ -761,7 +765,7 @@ inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty, 
 
   TERN_(HAS_HOTEND_OFFSET, normalize_hotend_offsets());
 
-  TERN_(HAS_MULTI_HOTEND, set_nozzle(m, 0));
+  TERN_(HAS_MULTI_HOTEND, set_nozzle(m, 0, uncertainty_tool_length));
 }
 
 /**
@@ -800,14 +804,211 @@ inline void calibrate_all() {
   calibration_move();         // Park nozzle away from calibration object
 }
 
+calibrate_toolhead_Z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
+  TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
+  TEMPORARY_BACKLASH_SMOOTHING(0.0f);
+
+  TERN(HAS_MULTI_HOTEND, set_nozzle(m, extruder, uncertainty), UNUSED(extruder));
+
+  #if ENABLED(CALIBRATION_MEASURE_AT_TOP_EDGES)
+    constexpr bool probe_top_at_edge = true;
+  #else
+    // Probing at the exact center only works if the center is flat. Probing on a washer
+    // or bolt will require probing the top near the side edges, away from the center.
+    constexpr bool probe_top_at_edge = false;
+    probe_side(m, uncertainty, uncertainty, TOP);
+  #endif
+
+  // Adjust the hotend offset
+  #if HAS_HOTEND_OFFSET
+    xyz_pos_t &hotoff = motion.active_hotend_offset();
+    if (AXIS_CAN_CALIBRATE(Z)) hotoff.z += m.pos_error.z;
+    normalize_hotend_offsets();
+  #endif
+
+  // Correct for positional error, so the object
+  // is at the known actual spot
+  planner.synchronize();
+  if (AXIS_CAN_CALIBRATE(Z)) update_measurements(m, Z_AXIS);
+
+  motion.sync_plan_position();
+
+  // Compute the measured center of the calibration object.
+  TERN_(HAS_X_CENTER, m.obj_center.x = (m.obj_side[LEFT]     + m.obj_side[RIGHT])    / 2);
+  SECONDARY_AXIS_CODE(
+    m.obj_center.i = 0,
+    m.obj_center.j = 0,
+    m.obj_center.k = 0,
+    m.obj_center.u = 0,
+    m.obj_center.v = 0,
+    m.obj_center.w = 0
+  );
+
+  // Compute the outside diameter of the nozzle at the height
+  // at which it makes contact with the calibration object
+  TERN_(HAS_X_CENTER, m.nozzle_outer_dimension.x = m.obj_side[RIGHT] - m.obj_side[LEFT] - dimensions.x);
+
+  park_above_object(m, uncertainty);
+
+  // The difference between the known and the measured location
+  // of the calibration object is the positional error
+  NUM_AXIS_CODE(
+    m.pos_error.x = TERN0(HAS_X_CENTER, true_center.x - m.obj_center.x),
+    m.pos_error.y = TERN0(HAS_Y_CENTER, true_center.y - m.obj_center.y),
+    m.pos_error.z = true_center.z - m.obj_center.z,
+    m.pos_error.i = 0,
+    m.pos_error.j = 0,
+    m.pos_error.k = 0,
+    m.pos_error.u = 0,
+    m.pos_error.v = 0,
+    m.pos_error.w = 0
+  );
+}
+
+
+
+/**
+// ====================================================================
+// HÀM ĐO CHIỀU DÀI DAO Z (CNC STYLE) - BẢN SỬA CHUẨN CÚ PHÁP MARLIN 2.1.X BUGFIX
+// ====================================================================
+inline void calibrate_toolhead_z_only(measurements_t &m, const float uncertainty, const uint8_t extruder) {
+  TEMPORARY_BACKLASH_CORRECTION(backlash.all_on);
+  TEMPORARY_BACKLASH_SMOOTHING(0.0f);
+
+  float saved_hotend_offset_z = 0.0f;
+  #if HAS_HOTEND_OFFSET
+    saved_hotend_offset_z = motion.hotend_offset[extruder].z; // Lưu lại offset cũ để dự phòng
+    motion.hotend_offset[extruder].z = 0.0f;                  // Xóa trắng offset dao chuẩn bị đo
+  #endif
+
+  // Đồng bộ hóa Planner đưa tất cả bộ đệm di chuyển về trạng thái thực tế của phần cứng
+  planner.synchronize();
+  motion.set_current_from_steppers_for_axis(Z_AXIS);
+  motion.sync_plan_position();
+
+  // BƯỚC 1: KHỞI TẠO TỌA ĐỘ XY CỦA CỤC CALIP TỪ CONFIGURATION
+  const xyz_float_t obj_center_array = CALIBRATION_OBJECT_CENTER;
+  m.obj_center.x = obj_center_array[X_AXIS]; // 264.0
+  m.obj_center.y = obj_center_array[Y_AXIS]; // -22.0
+  m.obj_center.z = obj_center_array[Z_AXIS]; 
+  m.pos_error.x = 0.0f; m.pos_error.y = 0.0f; m.pos_error.z = 0.0f;
+
+  // ====================================================================
+  // BƯỚC 2: RÚT TRỤC Z LÊN ĐỈNH TRẦN BẰNG CHU TRÌNH G28 Z LÕI HỆ THỐNG
+  // Sửa chính xác cú pháp API v2 của nhánh Marlin 2.1.x Bugfix
+  // ====================================================================
+  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
+    gcode.process_subcommands_now(F("G28 Z")); // Gọi chu trình Home cứng trục Z thông qua hàng đợi lệnh lõi
+  #else
+    motion.destination = motion.position;
+    motion.destination.z = _MIN(motion.position.z + CALIBRATION_MEASUREMENT_UNKNOWN, (float)Z_MAX_POS);
+    motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
+  #endif
+  planner.synchronize();  
+
+  // BƯỚC 3: ĐỔI DAO VÀ DI CHUYỂN XY ĐẾN THÁP ĐO CỐ ĐỊNH
+  #if HAS_TOOLCHANGE
+    set_nozzle(m, extruder, uncertainty);
+    planner.synchronize();
+  #endif
+
+  // DI CHUYỂN XY: Đưa đầu dao đến vị trí cục Calip cố định
+  motion.destination = motion.position;
+  motion.destination.x = m.obj_center.x; 
+  motion.destination.y = m.obj_center.y; 
+  motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
+  planner.synchronize();
+
+  // BƯỚC 4: CHU TRÌNH DÒ XUỐNG SÂU (PROBE CÓ CẢM BIẾN CHẶN)
+  motion.destination = motion.position;
+  motion.destination.z = 0.0f; // Điểm đích sát đáy máy để ép máy chịu dò xuống sâu
+
+  motion.set_soft_endstop_loose(true);
+  endstops.enable_calibration_probe(true, true);
+  motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_FAST));
+  endstops.enable_calibration_probe(false);
+  endstops.hit_on_purpose();
+  motion.set_soft_endstop_loose(false);
+
+  // ĐỒNG BỘ TOÀN CỤC: Cập nhật lại số xung bước từ Driver vào hệ thống ngay khi chạm cảm biến
+  motion.set_current_from_steppers_for_axis(Z_AXIS);
+  motion.sync_plan_position();
+
+  // Ghi nhận cao độ LÀM VIỆC (Dành cho việc lưu thông tin Object nếu cần)
+  const float measurement = motion.position.z;
+  m.obj_side[TOP] = measurement;
+  m.obj_center.z = measurement - dimensions.z / 2;
+
+  // ------------------------------------------------------------------
+  // BƯỚC 5: TÍNH TOÁN HOTEND OFFSET Z - THUẬT TOÁN ĐỒNG BỘ MỚI (Marlin 2.1.x)
+  // ------------------------------------------------------------------
+  #if HAS_HOTEND_OFFSET
+    static float z_calip_machine_raw[TOOLS] = { };
+    planner.synchronize();
+    motion.set_current_from_steppers_for_axis(Z_AXIS);
+    motion.sync_plan_position();
+    planner.synchronize();
+    const float z_trigger_machine_absolute = planner.get_axis_position_mm(Z_AXIS); 
+
+    if (extruder < TOOLS) {
+      z_calip_machine_raw[extruder] = z_trigger_machine_absolute;
+    }
+    // 2. THUẬT TOÁN TÍNH TOÁN RA SỐ DƯƠNG (+) ĐỂ ĐỒNG BỘ VỚI TOÁN TỬ G43/G43.4 (+=)
+    if (z_calip_machine_raw[REFERENCE_TOOL] > 0.0f) {
+      float cnc_calculated_offset_z = 0.0f;
+      if (extruder == REFERENCE_TOOL) {
+        motion.hotend_offset[REFERENCE_TOOL].z = 0.0f; // Đầu Master Probe luôn bằng 0
+      }
+      else if (z_calip_machine_raw[extruder] > 0.0f) {
+        cnc_calculated_offset_z = z_calip_machine_raw[REFERENCE_TOOL] - z_calip_machine_raw[extruder];
+        motion.hotend_offset[extruder].z = cnc_calculated_offset_z;
+      }
+
+      // SAU KHI NẠP OFFSET MỚI: Bắt buộc phải đồng bộ lại toàn cục để áp dụng ma trận mới
+      planner.synchronize();
+      motion.set_current_from_steppers_for_axis(Z_AXIS);
+      motion.sync_plan_position();
+      planner.synchronize();
+    }
+    // Khôi phục lại offset cũ để an toàn nếu đo lỗi bộ đệm
+    else if (extruder != REFERENCE_TOOL && extruder != 0 && z_calip_machine_raw[REFERENCE_TOOL] == 0.0f) {
+      motion.hotend_offset[extruder].z = saved_hotend_offset_z;
+      planner.synchronize();
+      motion.sync_plan_position();
+      planner.synchronize();
+    }
+  #endif
+
+  // ====================================================================
+  // BƯỚC 6: RÚT DAO LÊN LẠI ĐỈNH CAO AN TOÀN BẰNG CHU TRÌNH G28 Z LÕI HỆ THỐNG
+  // Sửa chính xác cú pháp API v2 của nhánh Marlin 2.1.x Bugfix
+  // ====================================================================
+  #if defined(Z_HOME_DIR) && Z_HOME_DIR > 0
+    gcode.process_subcommands_now(F("G28 Z")); // Ép trục Z chạy Home Max cơ khí thực tế tại điểm 380mm để làm sạch mốc tọa độ
+  #else
+    motion.destination = motion.position;
+    motion.destination.z = _MIN(motion.position.z + 20.0f, (float)Z_MAX_POS);
+    motion.blocking_move((xyz_pos_t)motion.destination, MMM_TO_MMS(CALIBRATION_FEEDRATE_TRAVEL));
+  #endif
+  
+  planner.synchronize();
+
+  if (AXIS_CAN_CALIBRATE(Z)) {
+    update_measurements(m, Z_AXIS);
+  }
+  motion.sync_plan_position();
+}
+*/
+
 /**
  * G425: Perform calibration with calibration object.
  *
  *   B           - Perform calibration of backlash only.
  *   T<extruder> - Perform calibration of toolhead only.
  *   V           - Probe object and print position, error, backlash and hotend offset.
- *   U           - Uncertainty, how far inxy to start probe away from the object (mm)
+ *   U           - Uncertainty, how far in xy to start probe away from the object (mm)
  *   L           - Tool length uncertainty, how far in z to start probe away from the object (mm)
+ *   Z           - With parameter T: Calibrate Z hotend offset only
  *
  *   no args     - Perform entire calibration sequence (backlash + position on all toolheads)
  */
@@ -828,8 +1029,19 @@ void GcodeSuite::G425() {
 
   if (parser.seen_test('B'))
     calibrate_backlash(m, uncertainty);
-  else if (parser.seen_test('T'))
-    calibrate_toolhead(m, uncertainty, uncertainty_tool_length, parser.intval('T', motion.extruder));
+  // --- ĐOẠN ĐIỀU HƯỚNG MỚI ĐÃ ĐƯỢC CHUẨN HÓA ---
+  else if (parser.seen_test('T')) {
+    const uint8_t target_tool = parser.intval('T', motion.extruder);
+    
+    // Nếu gõ G425 T1 Z hoặc G425 T1 Z0 -> Kích hoạt chế độ đo chiều dài Z nhanh CNC style
+    if (parser.seen('Z')) {
+      calibrate_toolhead_z_only(m, uncertainty_tool_length, target_tool);
+    } 
+    // Nếu chỉ gõ G425 T1 -> Chạy chế độ mặc định đo toàn diện X Y Z
+    else {
+      calibrate_toolhead(m, uncertainty, uncertainty_tool_length, parser.intval('T', motion.extruder));
+    }
+  }
   #if ENABLED(CALIBRATION_REPORTING)
     else if (parser.seen('V')) {
       probe_sides(m, uncertainty);

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -126,7 +126,7 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading_etc(forReplay, F(STR_BACKLASH_COMPENSATION));
-  SERIAL_ECHOPGM_P(PSTR("  M425"));
+  SERIAL_ECHOPGM("  M425");
   #if ENABLED(BACKLASH_GCODE)
     SERIAL_ECHOPGM_P(PSTR("  F"), backlash.get_correction()
     #ifdef BACKLASH_SMOOTHING_MM
@@ -151,10 +151,13 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   #endif
   #endif
   #if ENABLED(CALIBRATION_GCODE)
-  SERIAL_ECHOPGM_P(
-    , PSTR("O"), LINEAR_UNIT(motion.calibration_center.x)
-    , PSTR("P"), LINEAR_UNIT(motion.calibration_center.y)
-    , PSTR("Q"), LINEAR_UNIT(motion.calibration_center.z)
+  SERIAL_ECHOPGM_P(PSTR("O"), LINEAR_UNIT(motion.calibration_center.x)
+    #if HAS_Y_AXIS
+      , PSTR("P"), LINEAR_UNIT(motion.calibration_center.y)
+    #endif
+    #if HAS_Z_AXIS
+      , PSTR("Q"), LINEAR_UNIT(motion.calibration_center.z)
+    #endif
   );
   #endif
   SERIAL_EOL();

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -24,7 +24,9 @@
 
 #if ANY(BACKLASH_GCODE, CALIBRATION_GCODE)
 
-#include "../../feature/backlash.h"
+#if ENABLED(BACKLASH_GCODE)
+  #include "../../feature/backlash.h"
+#endif
 #include "../../module/planner.h"
 
 #include "../gcode.h"

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -47,7 +47,7 @@
 void GcodeSuite::M425() {
   bool noArgs = true;
 
-  #if ENABLED(CALIBRATION_CODE)
+  #if ENABLED(CALIBRATION_GCODE)
     if (parser.seen('O')) {
       motion.calibration_center[0] = parser.value_linear_units();
       noArgs = false;
@@ -61,7 +61,7 @@ void GcodeSuite::M425() {
       noArgs = false;
     };
   #endif
-  #if ENABLED(BACKLASH_CODE)
+  #if ENABLED(BACKLASH_GCODE)
   auto axis_can_calibrate = [](const uint8_t a) -> bool {
     #define _CAN_CASE(N) case N##_AXIS: return bool(AXIS_CAN_CALIBRATE(N));
     switch (a) {
@@ -93,8 +93,6 @@ void GcodeSuite::M425() {
     }
   #endif
 
-  #endif
-
   if (noArgs) {
     SERIAL_ECHOPGM("Backlash Correction ");
     if (!backlash.get_correction_uint8()) SERIAL_ECHOPGM("in");
@@ -121,20 +119,22 @@ void GcodeSuite::M425() {
       SERIAL_EOL();
     #endif
   }
-  #endif //BACKLASH_CODE
+  #endif //BACKLASH_GCODE
 }
 
 void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading_etc(forReplay, F(STR_BACKLASH_COMPENSATION));
-  SERIAL_ECHOPGM_P(
-  #if ENABLED(BACKLASH_CODE)
-    PSTR("  M425 F"), backlash.get_correction()
+  SERIAL_ECHOPGM_P(PSTR("  M425")
+  #if ENABLED(BACKLASH_GCODE)
+    , PSTR("  F"), backlash.get_correction()
     #ifdef BACKLASH_SMOOTHING_MM
       , PSTR(" S"), LINEAR_UNIT(backlash.get_smoothing_mm())
     #endif
+  #endif
   );
+  #if ENABLED(BACKLASH_GCODE)
   #if NUM_AXES
     SERIAL_ECHOPGM_P(NUM_AXIS_PAIRED_LIST(
       SP_X_STR, LINEAR_UNIT(backlash.get_distance_mm(X_AXIS)),
@@ -148,8 +148,8 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
       SP_W_STR, W_AXIS_UNIT(backlash.get_distance_mm(W_AXIS))
     ));
   #endif
-
-  #if ENABLED(CALIBRATION_CODE)
+  #endif
+  #if ENABLED(CALIBRATION_GCODE)
   SERIAL_ECHOPGM_P(
     , PSTR("O"), LINEAR_UNIT(calibration_center_x)
     , PSTR("P"), LINEAR_UNIT(calibration_center_y)
@@ -159,4 +159,4 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   SERIAL_EOL();
 }
 
-#endif // BACKLASH_GCODE
+#endif // ANY(BACKLASH_GCODE, CALIBRATION_GCODE)

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -152,9 +152,9 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   #endif
   #if ENABLED(CALIBRATION_GCODE)
   SERIAL_ECHOPGM_P(
-    , PSTR("O"), LINEAR_UNIT(calibration_center_x)
-    , PSTR("P"), LINEAR_UNIT(calibration_center_y)
-    , PSTR("Q"), LINEAR_UNIT(calibration_center_z)
+    , PSTR("O"), LINEAR_UNIT(motion.calibration_center.x)
+    , PSTR("P"), LINEAR_UNIT(motion.calibration_center.y)
+    , PSTR("Q"), LINEAR_UNIT(motion.calibration_center.z)
   );
   #endif
   SERIAL_EOL();

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(BACKLASH_GCODE)
+#if ANY(BACKLASH_GCODE, CALIBRATION_GCODE)
 
 #include "../../feature/backlash.h"
 #include "../../module/planner.h"
@@ -39,13 +39,29 @@
  *   Z<length>                          ... on Z
  *   X            If a backlash measurement was done on X, copy that value
  *   Y                                           ... on Y
- *   Z                                           ... on Z
- *
+ *   O            Set the Calibration object center X                                         ... on Z
+ *   P            Set the Calibration object center Y
+ *   Q            Set the Calibration object center Z
  * Type M425 without any arguments to show active values.
  */
 void GcodeSuite::M425() {
   bool noArgs = true;
 
+  #if ENABLED(CALIBRATION_CODE)
+    if (parser.seen('O')) {
+      motion.calibration_center[0] = parser.value_linear_units();
+      noArgs = false;
+    };
+    if (parser.seen('P')) {
+      motion.calibration_center[1] = parser.value_linear_units();
+      noArgs = false;
+    };
+    if (parser.seen('Q')) {
+      motion.calibration_center[2] = parser.value_linear_units();
+      noArgs = false;
+    };
+  #endif
+  #if ENABLED(BACKLASH_CODE)
   auto axis_can_calibrate = [](const uint8_t a) -> bool {
     #define _CAN_CASE(N) case N##_AXIS: return bool(AXIS_CAN_CALIBRATE(N));
     switch (a) {
@@ -68,13 +84,15 @@ void GcodeSuite::M425() {
     backlash.set_correction(parser.value_float());
     noArgs = false;
   }
-
+  
   #ifdef BACKLASH_SMOOTHING_MM
     if (parser.seen('S')) {
       planner.synchronize();
       backlash.set_smoothing_mm(parser.value_linear_units());
       noArgs = false;
     }
+  #endif
+
   #endif
 
   if (noArgs) {
@@ -103,6 +121,7 @@ void GcodeSuite::M425() {
       SERIAL_EOL();
     #endif
   }
+  #endif //BACKLASH_CODE
 }
 
 void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
@@ -110,6 +129,7 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
 
   report_heading_etc(forReplay, F(STR_BACKLASH_COMPENSATION));
   SERIAL_ECHOPGM_P(
+  #if ENABLED(BACKLASH_CODE)
     PSTR("  M425 F"), backlash.get_correction()
     #ifdef BACKLASH_SMOOTHING_MM
       , PSTR(" S"), LINEAR_UNIT(backlash.get_smoothing_mm())
@@ -127,6 +147,14 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
       SP_V_STR, V_AXIS_UNIT(backlash.get_distance_mm(V_AXIS)),
       SP_W_STR, W_AXIS_UNIT(backlash.get_distance_mm(W_AXIS))
     ));
+  #endif
+
+  #if ENABLED(CALIBRATION_CODE)
+  SERIAL_ECHOPGM_P(
+    , PSTR("O"), LINEAR_UNIT(calibration_center_x)
+    , PSTR("P"), LINEAR_UNIT(calibration_center_y)
+    , PSTR("Q"), LINEAR_UNIT(calibration_center_z)
+  );
   #endif
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -126,14 +126,15 @@ void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   TERN_(MARLIN_SMALL_BUILD, return);
 
   report_heading_etc(forReplay, F(STR_BACKLASH_COMPENSATION));
-  SERIAL_ECHOPGM_P(PSTR("  M425")
+  SERIAL_ECHOPGM_P(PSTR("  M425"));
   #if ENABLED(BACKLASH_GCODE)
-    , PSTR("  F"), backlash.get_correction()
+    SERIAL_ECHOPGM_P(PSTR("  F"), backlash.get_correction()
     #ifdef BACKLASH_SMOOTHING_MM
       , PSTR(" S"), LINEAR_UNIT(backlash.get_smoothing_mm())
     #endif
+    );
   #endif
-  );
+
   #if ENABLED(BACKLASH_GCODE)
   #if NUM_AXES
     SERIAL_ECHOPGM_P(NUM_AXIS_PAIRED_LIST(

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -41,6 +41,7 @@
  *   Z<length>                          ... on Z
  *   X            If a backlash measurement was done on X, copy that value
  *   Y                                           ... on Y
+ *   Z                                           ... on Z
  *   O            Set the Calibration object center X                                         ... on Z
  *   P            Set the Calibration object center Y
  *   Q            Set the Calibration object center Z

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -246,7 +246,7 @@
  * M420 - Enable/Disable Leveling (with current values) S1=enable S0=disable (Requires MESH_BED_LEVELING or ABL)
  * M421 - Set a single Z coordinate in the Mesh Leveling grid. X<units> Y<units> Z<units> (Requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BILINEAR, or AUTO_BED_LEVELING_UBL)
  * M422 - Set Z Stepper automatic alignment position using probe. X<units> Y<units> A<axis> (Requires Z_STEPPER_AUTO_ALIGN)
- * M425 - Enable/Disable and tune backlash correction. (Requires BACKLASH_COMPENSATION and BACKLASH_GCODE)
+ * M425 - Enable/Disable and tune backlash correction. (Requires BACKLASH_COMPENSATION and BACKLASH_GCODE) and calibration (requires CALIBRATION_GCODE)
  * M428 - Set the home_offset based on the position. Nearest edge applies. (Disabled by NO_WORKSPACE_OFFSETS or DELTA)
  * M430 - Read the system current, voltage, and power (Requires POWER_MONITOR_CURRENT, POWER_MONITOR_VOLTAGE, or POWER_MONITOR_FIXED_VOLTAGE)
  * M485 - Send RS485 packets (Requires RS485_SERIAL_PORT)
@@ -1098,7 +1098,7 @@ private:
     static void M421();
   #endif
 
-  #if ENABLED(BACKLASH_GCODE)
+  #if ANY(BACKLASH_GCODE, CALIBRATION_GCODE)
     static void M425();
     static void M425_report(const bool forReplay=true);
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -161,7 +161,7 @@ xyz_pos_t Motion::cartes;
 #endif
 
 #if ENABLED(CALIBRATION_GCODE)
-  xyz_pos_t calibration_center = CALIBRATION_OBJECT_CENTER;
+  xyz_pos_t Motion::calibration_center = CALIBRATION_OBJECT_CENTER;
 #endif
 
 // The feedrate for the current move, often used as the default if

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -160,6 +160,10 @@ xyz_pos_t Motion::cartes;
   constexpr xyz_pos_t Motion::hotend_offset[1];
 #endif
 
+#if ENABLED(CALIBRATION_GCODE)
+  xyz_pos_t calibration_center = CALIBRATION_OBJECT_CENTER;
+#endif
+
 // The feedrate for the current move, often used as the default if
 // no other feedrate is specified. Overridden for special moves.
 // Set by the last G0 through G5 command's "F" parameter.

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -302,6 +302,10 @@ public:
 
   #endif // NUM_AXES
 
+  #if ENABLED(CALIBRATION_GCODE)
+    static xyz_pos_t calibration_center;
+  #endif
+
   //
   // Workspace offsets
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3403,8 +3403,12 @@ void MarlinSettings::reset() {
   //
   // Calibration Center
   //
-  TERN_(CALIBRATION_GCODE, motion.calibration_center = CALIBRATION_OBJECT_CENTER)
-  
+  #if ENABLED(CALIBRATION_GCODE)
+    constexpr float calib_center[] = NOZZLE_TO_PROBE_OFFSET;
+    static_assert(COUNT(calib_center) == NUM_AXES, "CALIBRATION_CENTER must contain offsets for each axis X, Y, Z....");
+    LOOP_NUM_AXES(a) motion.calibration_center[a] = calib_center[a];
+  #endif
+
   //
   // Spindle Acceleration
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3403,7 +3403,7 @@ void MarlinSettings::reset() {
   //
   // Calibration Center
   //
-  TERN(CALIBRATION_GCODE, calibration_center = CALIBRATION_OBJECT_CENTER)
+  TERN_(CALIBRATION_GCODE, calibration_center = CALIBRATION_OBJECT_CENTER)
   
   //
   // Spindle Acceleration

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3404,8 +3404,8 @@ void MarlinSettings::reset() {
   // Calibration Center
   //
   #if ENABLED(CALIBRATION_GCODE)
-    constexpr float calib_center[] = NOZZLE_TO_PROBE_OFFSET;
-    static_assert(COUNT(calib_center) == NUM_AXES, "CALIBRATION_CENTER must contain offsets for each axis X, Y, Z....");
+    constexpr float calib_center[] = CALIBRATION_OBJECT_CENTER;
+    static_assert(COUNT(calib_center) == NUM_AXES, "CALIBRATION_OBJECT_CENTER must contain offsets for each axis X, Y, Z....");
     LOOP_NUM_AXES(a) motion.calibration_center[a] = calib_center[a];
   #endif
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -247,6 +247,10 @@ typedef struct SettingsDataStruct {
     xyz_pos_t hotend_offset[HOTENDS - 1];               // M218 XYZ
   #endif
 
+  #if ENABLED(CALIBRATION_GCODE)
+    xyz_pos_t calibration_center;               // M425 OPQ
+  #endif
+
   //
   // Spindle Acceleration
   //
@@ -964,6 +968,16 @@ void MarlinSettings::postprocess() {
       #endif
     }
 
+    //
+    // Calibration Center
+    //
+    {
+      #if ENABLED(CALIBRATION_GCODE)
+        _FIELD_TEST(calibration_center);
+        EEPROM_WRITE(motion.calibration_center);
+      #endif
+    }
+  
     //
     // Spindle Acceleration
     //
@@ -2034,6 +2048,16 @@ void MarlinSettings::postprocess() {
             EEPROM_READ(motion.hotend_offset[e]);
         #endif
       }
+
+    //
+    // Calibration Center
+    //
+    {
+      #if ENABLED(CALIBRATION_GCODE)
+        _FIELD_TEST(calibration_center);
+        EEPROM_WRITE(motion.calibration_center);
+      #endif
+    }
 
       //
       // Spindle Acceleration
@@ -3375,6 +3399,12 @@ void MarlinSettings::reset() {
   //
   TERN_(HAS_HOTEND_OFFSET, motion.reset_hotend_offsets());
 
+  
+  //
+  // Calibration Center
+  //
+  TERN(CALIBRATION_GCODE, calibration_center = CALIBRATION_OBJECT_CENTER)
+  
   //
   // Spindle Acceleration
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3403,7 +3403,7 @@ void MarlinSettings::reset() {
   //
   // Calibration Center
   //
-  TERN_(CALIBRATION_GCODE, calibration_center = CALIBRATION_OBJECT_CENTER)
+  TERN_(CALIBRATION_GCODE, motion.calibration_center = CALIBRATION_OBJECT_CENTER)
   
   //
   // Spindle Acceleration

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -281,7 +281,7 @@ MECHANICAL_GANTRY_CAL.+                = build_src_filter=+<src/gcode/calibrate/
 Z_MULTI_ENDSTOPS|Z_STEPPER_AUTO_ALIGN  = build_src_filter=+<src/gcode/calibrate/G34_M422.cpp>
 Z_STEPPER_AUTO_ALIGN                   = build_src_filter=+<src/feature/z_stepper_align.cpp>
 DELTA_AUTO_CALIBRATION                 = build_src_filter=+<src/gcode/calibrate/G33.cpp>
-CALIBRATION_GCODE                      = build_src_filter=+<src/gcode/calibrate/G425.cpp> +<src/gcode/calibrate/M425.cpp
+CALIBRATION_GCODE                      = build_src_filter=+<src/gcode/calibrate/G425.cpp> +<src/gcode/calibrate/M425.cpp>
 Z_MIN_PROBE_REPEATABILITY_TEST         = build_src_filter=+<src/gcode/calibrate/M48.cpp>
 M100_FREE_MEMORY_WATCHER               = build_src_filter=+<src/gcode/calibrate/M100.cpp>
 BACKLASH_GCODE                         = build_src_filter=+<src/gcode/calibrate/M425.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -281,7 +281,7 @@ MECHANICAL_GANTRY_CAL.+                = build_src_filter=+<src/gcode/calibrate/
 Z_MULTI_ENDSTOPS|Z_STEPPER_AUTO_ALIGN  = build_src_filter=+<src/gcode/calibrate/G34_M422.cpp>
 Z_STEPPER_AUTO_ALIGN                   = build_src_filter=+<src/feature/z_stepper_align.cpp>
 DELTA_AUTO_CALIBRATION                 = build_src_filter=+<src/gcode/calibrate/G33.cpp>
-CALIBRATION_GCODE                      = build_src_filter=+<src/gcode/calibrate/G425.cpp>
+CALIBRATION_GCODE                      = build_src_filter=+<src/gcode/calibrate/G425.cpp> +<src/gcode/calibrate/M425.cpp
 Z_MIN_PROBE_REPEATABILITY_TEST         = build_src_filter=+<src/gcode/calibrate/M48.cpp>
 M100_FREE_MEMORY_WATCHER               = build_src_filter=+<src/gcode/calibrate/M100.cpp>
 BACKLASH_GCODE                         = build_src_filter=+<src/gcode/calibrate/M425.cpp>


### PR DESCRIPTION
### Description

- Previously, for hotend offset calibration using G425 or G425 T..., the hotend offset had to be known and set to +/- 5 mm of real values. This somewhat defeated the purpose of G425 or G425 T....
With my changes, fully automatic tool length setting (hotend offset calibration) is now possible. 

- Add G425 F~ parameter to provide an intuitive way to set the feedrate for the hotend offset measurement. Without the F parameter, fall back to the old behaviour where the feedrate is dependent on the uncertainty.

- Make CALIBRATION_OBJECT_CENTER editable at runtime with M425 O~ P~ Q~ where O, P, Q are the X, Y and Z coordinates of the calibration object center, respectively, in the currently active coordinate system. 

- Exposes existing constants as config options, so the user can define the default uncertainty (CALIBRATION_MEASUREMENT_UNKNOWN defines the maximum tool width).

- Add a config option CALIBRATION_MEASUREMENT_TOOL_LENGTH which defines the maximum tool length. This can be overridden with the new G425 L~ parameter

- If the machine can home to Z max, home the Z axis at the beginning of the calibration and start measuring from the Z home to minimize risk of crashes with overly long tools.

### Requirements

You need a calibration object that is mounted at a fixed position on the frame / base plate / print bed. The calibration object is electrically connected to  a digital input pin of the mainboard which is defined as the CALIBRATION_PIN. Ideally, the pin is interrupt-capable so you can use ENDSTOPS_INTERRUPT_FEATURE. Any of the following setups is possible:
- A professional tool setter is the recommended calibration object: It minimizes the risk of damaging the tool during measurement. 
- The toolhead is equipped witth a load cell that changes the voltage at the PROBE_PIN or CALIBRATION_PIN when the tool touches a surface (see NOZZLE_AS_PROBE). In this case the calibration object does not need to be conductive. 
- If you do not worry about damage,  and if you have an electrically grounded tool/nozzle, the calibration object can be a conductive cube or a simple bolt / washer, connected to the CALIBRATION_PIN with internal pullup resistor (enable CALIBRATION_PIN_PULLUP).

### Benefits

Fully automatic tool length setting using G425 T..., which is especially useful for general purpose CNC machines. 

### Configurations

Assuming you have max. 250 mm long tools and a contact tool setter with a 10x10mm touch plate at native machine coordinates X300, Y300 that triggers in Z direction at Z100:

```
#define EXTRUDERS 2
#define HOTEND_OFFSET_Z { 0.0, 0.0 }
#define CALIBRATION_GCODE
#define CALIBRATION_SCRIPT_PRE "G53\nG1Z355\nG1X300Y300"
#define CALIBRATION_OBJECT_CENTER {300, 300, 50}
#define CALIBRATION_OBJECT_DIMENSIONS {10, 10, 100}
#define CALIBRATION_MEASUREMENT_TOOL_LENGTH 251 // (mm) Default uncertainty for hotend z offset measurement with G425 T... or G425
#define CALIBRATION_MEASUREMENT_UNKNOWN 51 // (mm) Default uncertainty for fast hotend xy-offset measurement with G425 or G425 T...
#define CALIBRATION_MEASUREMENT_UNCERTAIN 5 // (mm) Default for slow measurement with G425 or G425 B)
#define CALIBRATION_PIN X_MAX_PIN // or any other unused input pin.
```

### Related Issues
- https://github.com/MarlinFirmware/Marlin/issues/27857
- https://github.com/MarlinFirmware/Marlin/issues/26887
- https://github.com/MarlinFirmware/Marlin/issues/18305
- This was discussed in the issues of my fork