### PR TITLE
🐛 Fix PID_OPENLOOP build error (MAX_POW out of scope)

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1725,7 +1725,7 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
     float get_pid_output(const uint8_t extr=0) {
       #if ENABLED(PID_OPENLOOP)
 
-        return constrain(tempinfo.target, 0, MAX_POW);
+        return constrain(tempinfo.target, 0, tempinfo.pid.high());
 
       #else // !PID_OPENLOOP
 


### PR DESCRIPTION
When `PID_OPENLOOP` is enabled, the firmware fails to compile in `PIDRunner<TT>::get_pid_output()`

Marlin/src/module/temperature.cpp:
```
error: 'MAX_POW' was not declared in this scope
     return constrain(tempinfo.target, 0, MAX_POW);
```
`MAX_POW` is a template parameter of `PID_t<MIN_POW, MAX_POW>` (temperature.h), so it isn't a visible identifier inside the generic PIDRunner class — the `PID_OPENLOOP` code path has never compiled. Since `PID_OPENLOOP` is disabled by default, regular CI builds don't catch it.

The fix uses the existing public accessor `PID_t::high()` (`int high() const { return MAX_POW; }`), which returns the correct per-heater max power (hotend / bed / chamber each resolve to their own value):
```c
return constrain(tempinfo.target, 0, tempinfo.pid.high());
```

### Description

When `PID_OPENLOOP` is enabled, the firmware fails to compile in `PIDRunner<TT>::get_pid_output()` (`Marlin/src/module/temperature.cpp`):
```
error: 'MAX_POW' was not declared in this scope
     return constrain(tempinfo.target, 0, MAX_POW);
```

`MAX_POW` is a template parameter of `PID_t<MIN_POW, MAX_POW>` (`temperature.h`), so it isn't a visible identifier inside the generic `PIDRunner` class — the `PID_OPENLOOP` code path has never compiled. Since `PID_OPENLOOP` is disabled by default, regular CI builds don't catch it.

The fix uses the existing public accessor `PID_t::high()` (`int high() const { return MAX_POW; }`), which returns the correct per-heater max power (hotend / bed / chamber each resolve to their own value):
```c
return constrain(tempinfo.target, 0, tempinfo.pid.high());
```

### Requirements

 No special hardware. Affects only firmware built with `PID_OPENLOOP` enabled in `Configuration_adv.h`.

### Benefits

- Restores the ability to compile with `PID_OPENLOOP` enabled.
- No functional change for the default (closed-loop) path; tempinfo.pid.high() returns the same MAX_POW constant the code intended to use.

### Configurations

To reproduce: enable #define `PID_OPENLOOP` in `Configuration_adv.h` and build any environment: e.g. pio run -e esp32.

### Related Issues

None.
