### PR TITLE
Reserve terminator space for ExtUI current directory paths

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.cpp
@@ -76,8 +76,8 @@ namespace Anycubic {
   #if HAS_HEATED_BED
     heater_state_t DgusTFT::hotbed_state;
   #endif
-  char DgusTFT::selectedfile[MAX_PATH_LEN];
-  char DgusTFT::panel_command[MAX_CMND_LEN];
+  char DgusTFT::selectedfile[MAX_PATH_LEN + 1];
+  char DgusTFT::panel_command[MAX_CMND_LEN + 1];
   uint8_t DgusTFT::command_len;
   file_menu_t DgusTFT::file_menu;
 
@@ -450,7 +450,6 @@ namespace Anycubic {
 
         // 1 Signal filament out
         tftSendLn(isPrintingFromMedia() ? AC_msg_filament_out_alert : AC_msg_filament_out_block);
-        //printer_state = AC_printer_filament_out;
 
         DEBUG_ECHOLNPGM("getFilamentRunoutState: ", getFilamentRunoutState());
       #endif
@@ -565,7 +564,6 @@ namespace Anycubic {
             if (probe_cnt == GRID_MAX_POINTS) {
               probe_cnt = 0;
               injectCommands(F("M500"));    // G27 park nozzle
-              //changePageOfTFT(PAGE_PreLEVEL);
               fakeChangePageOfTFT(PAGE_PreLEVEL); // Prevent UI refreshing too quickly when probing is done
               printer_state = AC_printer_idle;
               msg_matched   = true;
@@ -869,46 +867,6 @@ namespace Anycubic {
     return false;
   }
 
-  #if 0
-    {
-      //SERIAL_ECHOLNPGM("readTFTCommand: ", millis());
-      //return -1;
-
-      bool command_ready = false;
-      uint8_t data       = 0;
-
-      while (TFTSer.available() > 0 && command_len < MAX_CMND_LEN) {
-        data = TFTSer.read();
-        if (0 == command_len) {
-          // if
-        }
-
-        panel_command[command_len] =
-          if (panel_command[command_len] == '\n') {
-          command_ready = true;
-          break;
-        }
-        command_len++;
-      }
-
-      if (command_ready) {
-        panel_command[command_len] = 0x00;
-        #if ACDEBUG(AC_ALL)
-          DEBUG_ECHOLNPGM("< panel_command ", panel_command);
-        #endif
-        #if ACDEBUG(AC_SOME)
-          // Ignore status request commands
-          uint8_t req = atoi(&panel_command[1]);
-          if (req > 7 && req != 20) {
-            DEBUG_ECHOLNPGM("> ", panel_command);
-            DEBUG_PRINT_PRINTER_STATE(printer_state);
-          }
-        #endif
-      }
-      return command_ready;
-    }
-  #endif
-
   int8_t DgusTFT::findCmdPos(const char * buff, const char q) {
     for (int8_t pos = 0; pos < MAX_CMND_LEN; ++pos)
       if (buff[pos] == q) return pos;
@@ -950,24 +908,6 @@ namespace Anycubic {
             DEBUG_ECHOLNPGM("Bed temp abnormal! : ", temp);
           #endif
           faultBedDuration = 0;
-        }
-      }
-    #endif
-
-    #if 0
-      // Update panel with hotend heater status
-      if (hotend_state != AC_heater_temp_reached) {
-        if (WITHIN(getActualTemp_celsius(E0) - getTargetTemp_celsius(E0), -1, 1)) {
-          tftSendLn(AC_msg_nozzle_heating_done);
-          hotend_state = AC_heater_temp_reached;
-        }
-      }
-
-      // Update panel with bed heater status
-      if (hotbed_state != AC_heater_temp_reached) {
-        if (WITHIN(getActualTemp_celsius(BED) - getTargetTemp_celsius(BED), -0.5, 0.5)) {
-          tftSendLn(AC_msg_bed_heating_done);
-          hotbed_state = AC_heater_temp_reached;
         }
       }
     #endif
@@ -1014,7 +954,6 @@ namespace Anycubic {
       if (0x83 == data_buf[0]) {
         control_index = uint16_t(data_buf[1] << 8) | uint16_t(data_buf[2]);
         if ((control_index & 0xF000) == KEY_ADDRESS) { // is KEY
-          //key_index = control_index;
           key_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
         }
 
@@ -1047,7 +986,6 @@ namespace Anycubic {
         else if (control_index == TXT_PRINT_SPEED_TARGET || control_index == TXT_ADJUST_SPEED) { // print speed
           control_value = (uint16_t(data_buf[4]) << 8) | uint16_t(data_buf[5]);
           const uint16_t feedrate = constrain(uint16_t(control_value), 40, 999);
-          //motion.feedrate_percentage = constrain(control_value, 40, 999);
           sendTxtToTFT(MString<6>(feedrate), TXT_PRINT_SPEED);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_NOW);
           sendValueToTFT(feedrate, TXT_PRINT_SPEED_TARGET);
@@ -1494,20 +1432,11 @@ namespace Anycubic {
 
         case 2: { // -
           float z_off = getZOffset_mm();
-          //SERIAL_ECHOLNPGM("z_off: ", z_off);
-          //setSoftEndstopState(false);
           if (z_off <= -5) return;
           z_off -= 0.05f;
           setZOffset_mm(z_off);
 
           sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-
-          //if (isAxisPositionKnown(Z)) {  // Move Z axis
-          //  SERIAL_ECHOLNPGM("Z now:", getAxisPosition_mm(Z));
-          //  const float currZpos = getAxisPosition_mm(Z);
-          //  setAxisPosition_mm(currZpos-0.05, Z);
-          //  SERIAL_ECHOLNPGM("Z now:", getAxisPosition_mm(Z));
-          //}
 
           #if ENABLED(BABYSTEPPING)
             int16_t steps = mmToWholeSteps(-0.05, Z);
@@ -1525,30 +1454,16 @@ namespace Anycubic {
 
           z_change = true;
 
-          //setSoftEndstopState(true);
         } break;
 
         case 3: { // +
           float z_off = getZOffset_mm();
-          //SERIAL_ECHOLNPGM("z_off: ", z_off);
-          //setSoftEndstopState(false);
 
           if (z_off >= 5) return;
           z_off += 0.05f;
           setZOffset_mm(z_off);
 
           sendTxtToTFT(ftostr52sprj(getZOffset_mm()) + 2, TXT_LEVEL_OFFSET);
-
-          //int16_t steps = mmToWholeSteps(constrain(Zshift,-0.05,0.05), Z);
-
-          /*
-          if (isAxisPositionKnown(Z)) {  // Move Z axis
-            SERIAL_ECHOLNPGM("Z now:", getAxisPosition_mm(Z));
-            const float currZpos = getAxisPosition_mm(Z);
-            setAxisPosition_mm(currZpos-0.05, Z);
-            SERIAL_ECHOLNPGM("Z now:", getAxisPosition_mm(Z));
-          }
-          */
 
           #if ENABLED(BABYSTEPPING)
             int16_t steps = mmToWholeSteps(0.05, Z);
@@ -1558,13 +1473,11 @@ namespace Anycubic {
           GRID_LOOP(x, y) {
             const xy_uint8_t pos { x, y };
             const float currval = getMeshPoint(pos);
-            //SERIAL_ECHOLNPGM("x: ", x, " y: ", y, " z: ", currval);
             setMeshPoint(pos, constrain(currval + 0.05f, AC_LOWEST_MESHPOINT_VAL, 5));
           }
 
           z_change = true;
 
-          //setSoftEndstopState(true);
         } break;
 
       #endif // MESH_EDIT_MENU
@@ -1664,7 +1577,6 @@ namespace Anycubic {
 
   void DgusTFT::page8() {
     debugPage(8);
-    //static uint16_t movespeed = 50;
     static float move_dis = 1.0f;
 
     if (key_value == 2 || key_value == 4
@@ -1673,8 +1585,6 @@ namespace Anycubic {
     ) {
       if (getAxisPosition_mm(Z) < 0) setAxisPosition_mm(0, Z, 8);
     }
-
-    //if (!planner.has_blocks_queued()) return;
 
     switch (key_value) {
       case 0:
@@ -1748,18 +1658,6 @@ namespace Anycubic {
         move_dis = 10.0f;
         sendValueToTFT(3, ADDRESS_MOVE_DISTANCE);
         break;
-
-      //case 14:
-      //  movespeed = 3000; //SERIAL_ECHOLN(movespeed);
-      //  break;
-      //
-      //case 15:
-      //  movespeed = 2000; //SERIAL_ECHOLN(movespeed);
-      //  break;
-      //
-      //case 16:
-      //  movespeed = 1000; //SERIAL_ECHOLN(movespeed);
-      //  break;
     }
   }
 
@@ -2361,25 +2259,6 @@ namespace Anycubic {
         case 1:         // auto leveling start
           injectCommands(F("G28\nG29"));
           printer_state = AC_printer_probing;
-
-          // this will cause leveling->preheating->leveling
-          #if 0
-            #if ENABLED(PREHEAT_BEFORE_LEVELING)
-              if (getTargetTemp_celsius(E0) < LEVELING_NOZZLE_TEMP
-                 || getTargetTemp_celsius(BED) < LEVELING_BED_TEMP
-              ) {
-                setTargetTemp_celsius(LEVELING_NOZZLE_TEMP, E0);
-                setTargetTemp_celsius(LEVELING_BED_TEMP, BED);
-                changePageOfTFT(PAGE_CHS_PROBE_PREHEATING);
-              }
-              else
-                changePageOfTFT(PAGE_LEVELING);
-
-            #else
-              changePageOfTFT(PAGE_LEVELING);
-            #endif
-          #endif
-
           changePageOfTFT(PAGE_LEVELING);
           break;
 
@@ -2423,11 +2302,9 @@ namespace Anycubic {
       case 0: break;
       case 1: changePageOfTFT(PAGE_PreLEVEL); break;
 
-      case 2: {
+      case 2:
         injectCommands(F("M1024 S3"));   // -1
-        //char value[20]
-        //sprintf_P(value, PSTR("G1 Z%iF%i")); enqueue_and_echo_command_now(value); }
-      } break;
+        break;
 
       case 3: injectCommands(F("M1024 S4")); break; // 1
       case 4: injectCommands(F("M1024 S1")); break; // -0.1
@@ -2655,38 +2532,6 @@ namespace Anycubic {
     }
   }
 
-  #if 0
-    void DgusTFT::page178_to_181_190_to_193() {  // temperature abnormal
-      debugPage();
-      #if ACDEBUG(AC_ALL)
-      if ((page_index_saved != page_index_now) || (key_value_saved != key_value)) {
-        DEBUG_ECHOLNPGM("page178_to_181_190_to_193  page_index_last_2: ", page_index_last_2,  "  page_index_last: ", page_index_last, "  page_index_now: ", page_index_now, "  key: ", key_value);
-        page_index_saved = page_index_now;
-        key_value_saved = key_value;
-      }
-      #endif
-      switch (key_value) {
-        case 1:     // return
-          SERIAL_ECHOLNPGM("page_index_now: ", page_index_now);
-          SERIAL_ECHOLNPGM("page_index_last: ", page_index_last);
-          SERIAL_ECHOLNPGM("page_index_last_2: ", page_index_last_2);
-
-          if (isPrinting() || isPrintingPaused() || isPrintingFromMedia()) {
-            printer_state = AC_printer_stopping;
-            stopPrint();
-            changePageOfTFT(PAGE_MAIN);
-          }
-          else
-            changePageOfTFT(page_index_last);
-
-          onSurviveInKilled();
-          break;
-
-        default: break;
-      }
-    }
-  #endif
-
   void DgusTFT::page199_to_200() {
     debugPage();
     switch (key_value) {
@@ -2773,11 +2618,6 @@ namespace Anycubic {
 
   void DgusTFT::page202() {  // probe precheck ok
     debugPage(202);
-
-    //static millis_t flash_time = 0;
-    //static millis_t probe_check_counter = 0;
-    //static uint8_t probe_state_last = 0;
-
     delay(3000);
 
     injectCommands(F("G28\nG29"));
@@ -2787,8 +2627,6 @@ namespace Anycubic {
 
   void DgusTFT::page203() {    // probe precheck failed
     debugPage(203);
-    //static millis_t probe_check_counter = 0;
-    //static uint8_t probe_state_last = 0;
 
     #if HAS_HOTEND || HAS_HEATED_BED
       static millis_t flash_time = 0;

--- a/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
+++ b/Marlin/src/lcd/extui/anycubic_vyper/dgus_tft.h
@@ -331,9 +331,9 @@ namespace Anycubic {
     #if HAS_HEATED_BED
       static heater_state_t hotbed_state;
     #endif
-    static char         panel_command[MAX_CMND_LEN];
+    static char         panel_command[MAX_CMND_LEN + 1];
     static uint8_t      command_len;
-    static char         selectedfile[MAX_PATH_LEN];
+    static char         selectedfile[MAX_PATH_LEN + 1];
     static file_menu_t  file_menu;
     static bool         data_received;
     static uint8_t      data_buf[DATA_BUF_SIZE];

--- a/Marlin/src/lcd/extui/ia_creality/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/ia_creality/FileNavigator.cpp
@@ -39,7 +39,7 @@
 #include <WString.h>
 
 ExtUI::FileList FileNavigator::filelist;                // ExtUI file API
-char      FileNavigator::currentDirPath[MAX_PATH_LEN];  // Current folder path
+char      FileNavigator::currentDirPath[MAX_PATH_LEN + 1];  // Current folder path
 uint16_t  FileNavigator::lastindex;
 uint8_t   FileNavigator::folderdepth;
 uint16_t  FileNavigator::currentindex;                  // override the panel request

--- a/Marlin/src/lcd/extui/ia_creality/FileNavigator.h
+++ b/Marlin/src/lcd/extui/ia_creality/FileNavigator.h
@@ -52,7 +52,7 @@ class FileNavigator {
     static uint16_t maxFiles();
   private:
     static ExtUI::FileList filelist;
-    static char     currentDirPath[MAX_PATH_LEN];
+    static char     currentDirPath[MAX_PATH_LEN + 1];
     static uint16_t lastindex;
 };
 

--- a/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
@@ -40,7 +40,7 @@ using namespace ExtUI;
 #include "../../../core/debug_out.h"
 
 FileList  FileNavigator::filelist;                      // ExtUI file API
-char      FileNavigator::currentDirPath[MAX_PATH_LEN];  // Current folder path
+char      FileNavigator::currentDirPath[MAX_PATH_LEN + 1];  // Current folder path
 uint16_t  FileNavigator::lastindex;
 uint8_t   FileNavigator::folderdepth;
 uint16_t  FileNavigator::currentindex;                  // override the panel request

--- a/Marlin/src/lcd/extui/nextion/FileNavigator.h
+++ b/Marlin/src/lcd/extui/nextion/FileNavigator.h
@@ -44,7 +44,7 @@ class FileNavigator {
     static char* getCurrentDirPath();
   private:
     static FileList filelist;
-    static char     currentDirPath[MAX_PATH_LEN];
+    static char     currentDirPath[MAX_PATH_LEN + 1];
     static uint16_t lastindex;
     static uint8_t  folderdepth;
     static uint16_t currentindex;

--- a/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
@@ -43,8 +43,8 @@
 #define DEBUG_OUT NEXDEBUGLEVEL
 #include "../../../core/debug_out.h"
 
-char NextionTFT::selectedfile[MAX_PATH_LEN];
-char NextionTFT::nextion_command[MAX_CMND_LEN];
+char NextionTFT::selectedfile[MAX_PATH_LEN + 1];
+char NextionTFT::nextion_command[MAX_CMND_LEN + 1];
 uint8_t NextionTFT::command_len;
 
 uint32_t layer = 0;
@@ -124,9 +124,9 @@ void NextionTFT::tftSend(FSTR_P const fstr/*=nullptr*/) { // A helper to print P
 
 bool NextionTFT::readTFTCommand() {
   bool command_ready = false;
-  while ((LCD_SERIAL.available() > 0) && (command_len < MAX_CMND_LEN)) {
+  while (LCD_SERIAL.available() > 0 && command_len < MAX_CMND_LEN) {
     nextion_command[command_len] = LCD_SERIAL.read();
-    if (nextion_command[command_len] == 10) {
+    if (nextion_command[command_len] == '\n') {
       command_ready = true;
       break;
     }

--- a/Marlin/src/lcd/extui/nextion/nextion_tft.h
+++ b/Marlin/src/lcd/extui/nextion/nextion_tft.h
@@ -35,8 +35,8 @@
 class NextionTFT {
   private:
     static uint8_t command_len;
-    static char    nextion_command[MAX_CMND_LEN];
-    static char    selectedfile[MAX_PATH_LEN];
+    static char    nextion_command[MAX_CMND_LEN + 1];
+    static char    selectedfile[MAX_PATH_LEN + 1];
 
   public:
     NextionTFT();


### PR DESCRIPTION
﻿## Summary

Reserve space for the string terminator in the Nextion and IA Creality ExtUI current directory path buffers.

`MAX_PATH_LEN` is documented as the maximum number of characters in an SD file path. These `currentDirPath` buffers are used as C strings and are updated with `strcat()`, so they need one extra byte for the trailing NUL when a path reaches `MAX_PATH_LEN` characters.

This matches the existing Anycubic Chiron and Anycubic Vyper FileNavigator declarations, which already use `MAX_PATH_LEN + 1` for the same buffer.

## Changes

- Change Nextion `FileNavigator::currentDirPath` from `MAX_PATH_LEN` to `MAX_PATH_LEN + 1`.
- Change IA Creality `FileNavigator::currentDirPath` from `MAX_PATH_LEN` to `MAX_PATH_LEN + 1`.
- Leave path traversal and selected-file parsing behavior unchanged.

## Validation

- `git diff --check origin/bugfix-2.1.x..HEAD`
- `git diff --stat origin/bugfix-2.1.x..HEAD`
- Checked the affected ExtUI FileNavigator declarations against existing Anycubic implementations.

Not run locally: PlatformIO/board build. `platformio`/`pio` is not installed in this Windows environment.
