### PR TITLE
FT_MOTION: fix disable FT_MOTION when CONSTANT_JOLT is current TrajectoryType

### DIFF
--- a/Marlin/src/module/ft_motion/constant_jolt_planner.cpp
+++ b/Marlin/src/module/ft_motion/constant_jolt_planner.cpp
@@ -367,7 +367,6 @@ float ConstantJoltBlockPlanner::maxReachableSpeed(float v_from, float dist_total
 
   if (constant_jolt::rampDistWithA(v_from, hi, j_max, a_max, a_entry) <= dist_total) return hi;
 
-  float v_lo;
   if (a_entry == 0.0f) {
     /**
      * Closed-form solutions for a_entry=0:

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1764,10 +1764,8 @@ bool Planner::_buffer_steps(const xyze_long_t &target
   // CJ planner ignores trapezoidal entry/exit speeds — it runs its own
   // jolt-aware passes via planNext(). Blocks are marked recalculate=false
   // above, so skip the expensive reverse/forward pass and trapezoid calc.
-  #if ENABLED(FTM_CONSTANT_JOLT)
-    if (!ftMotion.cfg.active || ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT)
-  #endif
-    recalculate(safe_exit_speed_sqr);
+  const bool is_jolt = TERN0(FTM_CONSTANT_JOLT, ftMotion.cfg.active && ftMotion.cfg.trajectory_type == TrajectoryType::CONSTANT_JOLT);
+  if (!is_jolt) recalculate(safe_exit_speed_sqr);
 
   // Movement successfully queued!
   return true;
@@ -2720,24 +2718,24 @@ bool Planner::_populate_block(
     #endif // HAS_ROUGH_LIN_ADVANCE
 
     xyze_float_t speed_diff = current_speed;
-    float vmax_junction;
+    float vmax_junc;
     if (!moves_queued || UNEAR_ZERO(previous_nominal_speed)) {
       // Limited by a jerk to/from full halt.
-      vmax_junction = block->nominal_speed;
+      vmax_junc = block->nominal_speed;
     }
     else {
       // Compute the maximum velocity allowed at a joint of two successive segments.
 
       // The junction velocity will be shared between successive segments. Limit the junction velocity to their minimum.
-      // Scale per-axis velocities for the same vmax_junction.
+      // Scale per-axis velocities for the same vmax_junc.
       if (block->nominal_speed < previous_nominal_speed) {
-        vmax_junction = block->nominal_speed;
-        const float previous_scale = vmax_junction / previous_nominal_speed;
+        vmax_junc = block->nominal_speed;
+        const float previous_scale = vmax_junc / previous_nominal_speed;
         LOOP_LOGICAL_AXES(i) speed_diff[i] -= previous_speed[i] * previous_scale;
       }
       else {
-        vmax_junction = previous_nominal_speed;
-        const float current_scale = vmax_junction / block->nominal_speed;
+        vmax_junc = previous_nominal_speed;
+        const float current_scale = vmax_junc / block->nominal_speed;
         LOOP_LOGICAL_AXES(i) speed_diff[i] = speed_diff[i] * current_scale - previous_speed[i];
       }
     }
@@ -2749,7 +2747,7 @@ bool Planner::_populate_block(
       const float jerk = ABS(speed_diff[i]), maxj = max_j[i];
       if (jerk * v_factor > maxj) v_factor = maxj / jerk;
     }
-    vmax_junction_sqr = sq(vmax_junction * v_factor);
+    vmax_junction_sqr = sq(vmax_junc * v_factor);
 
   #endif // CLASSIC_JERK
 
@@ -2759,10 +2757,14 @@ bool Planner::_populate_block(
 
   // Max entry speed of this block equals the max exit speed of the previous block.
   block->max_entry_speed_sqr = vmax_junction_sqr;
+
   #if ENABLED(FTM_CONSTANT_JOLT)
-    if (ftMotion.cfg.trajectory_type == TrajectoryType::CONSTANT_JOLT && ftMotion.cfg.active)
-      block->vmax_junction = SQRT(vmax_junction_sqr);
+    const bool is_jolt = ftMotion.cfg.active && ftMotion.cfg.trajectory_type == TrajectoryType::CONSTANT_JOLT;
+    if (is_jolt) block->vmax_junction = SQRT(vmax_junction_sqr);
+  #else
+    constexpr bool is_jolt = false;
   #endif
+
   // Set entry speed. The reverse and forward passes will optimize it later.
   block->entry_speed_sqr = minimum_planner_speed_sqr;
   // Set min entry speed. Rarely it could be higher than the previous nominal speed but that's ok.
@@ -2774,10 +2776,7 @@ bool Planner::_populate_block(
 
   // CJ planner runs its own jolt-aware passes — blocks are ready immediately.
   // recalculate() is also skipped below, so no code will re-set this flag.
-  #if ENABLED(FTM_CONSTANT_JOLT)
-    if (!ftMotion.cfg.active || ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT)
-  #endif
-  block->flag.recalculate = true;
+  block->flag.recalculate |= !is_jolt;
 
   // Update previous path unit_vector and nominal speed
   previous_speed = current_speed;

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1764,7 +1764,9 @@ bool Planner::_buffer_steps(const xyze_long_t &target
   // CJ planner ignores trapezoidal entry/exit speeds — it runs its own
   // jolt-aware passes via planNext(). Blocks are marked recalculate=false
   // above, so skip the expensive reverse/forward pass and trapezoid calc.
-  if (TERN1(FTM_CONSTANT_JOLT, ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT))
+  #if ENABLED(FTM_CONSTANT_JOLT)
+    if (!ftMotion.cfg.active || ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT)
+  #endif
     recalculate(safe_exit_speed_sqr);
 
   // Movement successfully queued!
@@ -2758,7 +2760,7 @@ bool Planner::_populate_block(
   // Max entry speed of this block equals the max exit speed of the previous block.
   block->max_entry_speed_sqr = vmax_junction_sqr;
   #if ENABLED(FTM_CONSTANT_JOLT)
-    if (ftMotion.cfg.trajectory_type == TrajectoryType::CONSTANT_JOLT)
+    if (ftMotion.cfg.trajectory_type == TrajectoryType::CONSTANT_JOLT && ftMotion.cfg.active)
       block->vmax_junction = SQRT(vmax_junction_sqr);
   #endif
   // Set entry speed. The reverse and forward passes will optimize it later.
@@ -2772,7 +2774,10 @@ bool Planner::_populate_block(
 
   // CJ planner runs its own jolt-aware passes — blocks are ready immediately.
   // recalculate() is also skipped below, so no code will re-set this flag.
-  block->flag.recalculate = TERN1(FTM_CONSTANT_JOLT, ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT);
+  #if ENABLED(FTM_CONSTANT_JOLT)
+    if (!ftMotion.cfg.active || ftMotion.cfg.trajectory_type != TrajectoryType::CONSTANT_JOLT)
+  #endif
+  block->flag.recalculate = true;
 
   // Update previous path unit_vector and nominal speed
   previous_speed = current_speed;


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
When `FT_MOTION` is enabled with` CONSTANT_JOLT` as trajectory type, if you send a `M493 S0`, `FT_MOTION` is disabled, but you can't move your printer head. If you change trajectory type (`M494 T0` for example) and then send `M493 S0`, everything is fine. The issue is related to conditionals regarding `TrajectoryType::CONSTANT_JOLT` in `planner.cpp`.
This PR restores the correct behavior.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
