### PR TITLE
🔧 Require pins as macros

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/inc/SanityCheck.h
+++ b/Marlin/src/HAL/GD32_MFL/inc/SanityCheck.h
@@ -21,6 +21,13 @@
  */
 #pragma once
 
+/**
+ * Require pins to be defined as macros with numerical values
+ */
+#ifndef PA0
+  #error "Your ARM platform pins are not defined as macros, only as enums! Provide pins_arduino.h and/or 'buildroot/share/PlatformIO/variants/*/variant.h' to define the pins."
+#endif
+
 // Test MFL GD32 specific configuration values for errors at compile-time.
 #if ENABLED(SDCARD_EEPROM_EMULATION) && !HAS_MEDIA
   #undef SDCARD_EEPROM_EMULATION  // avoid additional error noise

--- a/Marlin/src/HAL/HC32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HC32/inc/SanityCheck.h
@@ -22,6 +22,13 @@
 #pragma once
 #include <core_util.h>
 
+/**
+ * Require pins to be defined as macros with numerical values
+ */
+#ifndef PA0
+  #error "Your ARM platform pins are not defined as macros, only as enums! Provide pins_arduino.h and/or 'buildroot/share/PlatformIO/variants/*/variant.h' to define the pins."
+#endif
+
 #if !defined(ARDUINO_CORE_VERSION_INT) || !defined(GET_VERSION_INT)
   // version macros were introduced in arduino core version 1.1.0
   // below that version, we polyfill them

--- a/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
@@ -29,6 +29,13 @@
 #endif
 
 /**
+ * Require pins to be defined as macros with numerical values
+ */
+#ifndef P1_01
+  #error "Your ARM platform pins are not defined as macros, only as enums! Provide pins_arduino.h to define the pins."
+#endif
+
+/**
  * Detect an old pins file by checking for old ADC pins values.
  */
 #define _OLD_TEMP_PIN(P) PIN_EXISTS(P) && _CAT(P,_PIN) <= 7 && !WITHIN(_CAT(P,_PIN), TERN(LPC1768_IS_SKRV1_3, 0, 2), 3)  // Include P0_00 and P0_01 for SKR V1.3 board

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -22,6 +22,13 @@
 #pragma once
 
 /**
+ * Require pins to be defined as macros with numerical values
+ */
+#ifndef PA0
+  #error "Your ARM platform pins are not defined as macros, only as enums! Provide pins_arduino.h and/or 'buildroot/share/PlatformIO/variants/*/variant.h' to define the pins."
+#endif
+
+/**
  * Test STM32-specific configuration values for errors at compile-time.
  */
 //#if ENABLED(SPINDLE_LASER_USE_PWM) && !(SPINDLE_LASER_PWM_PIN == 4 || SPINDLE_LASER_PWM_PIN == 6 || SPINDLE_LASER_PWM_PIN == 11)

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -25,6 +25,13 @@
  * Test STM32F1-specific configuration values for errors at compile-time.
  */
 
+/**
+ * Require pins to be defined as macros with numerical values
+ */
+#ifndef PA0
+  #error "Your ARM platform pins are not defined as macros, only as enums! Provide pins_arduino.h and/or 'buildroot/share/PlatformIO/variants/*/variant.h' to define the pins."
+#endif
+
 #if ENABLED(SDCARD_EEPROM_EMULATION) && !HAS_MEDIA
   #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise
   #if USE_FALLBACK_EEPROM


### PR DESCRIPTION
### Description

Add sanity check for platform / variant pins that must be defined as macros to catch broken variants and platform headers. New HALs should adopt this check.