### PR TITLE
Fix native unit test source wiring

### DIFF
--- a/Marlin/tests/core/test_macros.cpp
+++ b/Marlin/tests/core/test_macros.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include <vector>
+#include <array>
 #include "../test/unit_tests.h"
 #include "src/core/macros.h"
 

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -29,10 +29,9 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/LINUX>
 extends          = env:linux_native
 extra_scripts    = ${common.extra_scripts}
                    post:buildroot/share/PlatformIO/scripts/collect-code-tests.py
-build_src_filter = ${env:linux_native.build_src_filter} +<test>
+build_src_filter = ${env:linux_native.build_src_filter} +<tests>
 lib_deps         = throwtheswitch/Unity@^2.6.0
 test_build_src   = true
-build_unflags    =
 build_flags      = ${env:linux_native.build_flags} -Werror -DNO_USER_FEEDBACK_WARNING
 
 #

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -29,7 +29,7 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/LINUX>
 extends          = env:linux_native
 extra_scripts    = ${common.extra_scripts}
                    post:buildroot/share/PlatformIO/scripts/collect-code-tests.py
-build_src_filter = ${env:linux_native.build_src_filter} +<tests>
+build_src_filter = ${env:linux_native.build_src_filter} +<test>
 lib_deps         = throwtheswitch/Unity@^2.6.0
 test_build_src   = true
 build_flags      = ${env:linux_native.build_flags} -Werror -DNO_USER_FEEDBACK_WARNING


### PR DESCRIPTION
### Description

The `linux_native_test` environment currently adds `+<test>` to `build_src_filter`. Because `src_dir` is `Marlin`, this resolves to `Marlin/test`, while the registered Marlin unit test sources are stored in `Marlin/tests`.

As a result, `make unit-test-all-local` completes successfully while executing zero registered Marlin tests.

This change:

- updates the source filter from `+<test>` to `+<tests>`;
- adds the direct standard-library includes required by `test_macros.cpp` once that source is compiled;
- removes the empty `build_unflags` override so `linux_native_test` inherits the native environment's removal of `-fsingle-precision-constant`.

Without the inherited `build_unflags`, the `SString` test evaluates unsuffixed floating-point constants as `float` and produces `2895645.75` instead of the expected `2895645.67`.

### Requirements

No printer hardware or board-specific environment is required. The tests run in the existing `linux_native_test` PlatformIO environment.

Validated with:

- Linux Mint 22.3
- GCC / G++ host toolchain
- Python 3.12.3
- PlatformIO Core 6.1.19
- base commit `250a3ed74eb2a29da3764428bf09f3a69c191c69`

### Benefits

`make unit-test-all-local` now compiles and executes the registered Marlin unit tests instead of reporting success with zero test cases.

Before:

    linux_native_test  SUCCESS
    0 test cases: 0 succeeded

After:

    marlin_default:             145 test cases, 145 succeeded
    marlin_extruders_1_runout:  146 test cases, 146 succeeded
    marlin_extruders_3_runout:  146 test cases, 146 succeeded

The complete three-configuration run exits with status 0.

### Configurations

Tested with the existing unit-test configurations:

- `test/001-default.ini`
- `test/002-extruders_1_runout.ini`
- `test/003-extruders_3_runout.ini`

Command used:

    make unit-test-all-local

### Related Issues

None known.
