### PR TITLE
🐛 Fix macOS simulator build on Homebrew + Xcode CLT

### DIFF
--- a/buildroot/share/PlatformIO/scripts/simulator.py
+++ b/buildroot/share/PlatformIO/scripts/simulator.py
@@ -41,16 +41,47 @@ if pioutil.is_pio_build():
             #
             env['RANLIBFLAGS'] += [ "-no_warning_for_no_symbols" ]
 
+            import os.path, subprocess
+
+            #
+            # Find the package-manager prefix (Homebrew or MacPorts) so SDL2, glm,
+            # and freetype headers/libs are found regardless of install location.
+            #
+            prefix = ''
+            brew = shutil.which('brew')
+            if brew:
+                try: prefix = subprocess.check_output([ brew, '--prefix' ], text=True).strip()
+                except Exception: prefix = ''
+            if not prefix and os.path.exists('/opt/local'):
+                prefix = '/opt/local'   # MacPorts
+
+            if prefix:
+                env['BUILD_FLAGS'] += [ '-I' + prefix + '/include',
+                                        '-I' + prefix + '/include/freetype2',
+                                        '-I' + prefix + '/include/SDL2',
+                                        '-L' + prefix + '/lib' ]
+
             # Default paths for Xcode and a lucky GL/gl.h dropped by Mesa
             xcode_path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
             mesa_path = "/opt/local/include/GL/gl.h"
 
-            import os.path
+            # Command Line Tools SDK frameworks (no full Xcode.app required)
+            clt_fw = ''
+            try:
+                sdk = subprocess.check_output([ 'xcrun', '--show-sdk-path' ], text=True).strip()
+                if sdk: clt_fw = sdk + "/System/Library/Frameworks"
+            except Exception:
+                pass
 
             if os.path.exists(xcode_path):
 
                 env['BUILD_FLAGS'] += [ "-F" + xcode_path ]
                 emsg = "\u001b[33mUsing OpenGL framework headers from Xcode.app"
+
+            elif clt_fw and os.path.exists(clt_fw + "/OpenGL.framework/Headers/gl.h"):
+
+                env['BUILD_FLAGS'] += [ "-F" + clt_fw ]
+                emsg = "\u001b[33mUsing OpenGL framework headers from the Command Line Tools SDK"
 
             elif os.path.exists(mesa_path):
 
@@ -59,7 +90,7 @@ if pioutil.is_pio_build():
 
             else:
 
-                emsg = "\u001b[31mNo OpenGL headers found. Install Xcode for matching headers, or use 'sudo port install mesa' to get a GL/gl.h."
+                emsg = "\u001b[31mNo OpenGL headers found. Install the Command Line Tools (xcode-select --install) or Mesa."
                 fatal = 1
 
     # Print error message, if any

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -114,10 +114,6 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 build_unflags     = -g3 -lGL -fstack-protector-strong -fsingle-precision-constant
 build_flags       = -g2
   -DHAS_LIBBSD
-  -I/opt/local/include
-  -I/opt/local/include/freetype2
-  -I/opt/local/include/SDL2
-  -L/opt/local/lib
   -Wl,-framework,OpenGl
   -Wl,-framework,CoreFoundation
   -lSDL2


### PR DESCRIPTION
### Description

Fix the native macOS simulator build. The PlatformIO pre-script failed with `No OpenGL headers found ...` on a machine that had the Xcode Command Line Tools (no full `Xcode.app`) and Homebrew (no MacPorts).

Two hardcoded macOS assumptions caused this:

- `simulator.py` looked for OpenGL headers only under a full `Xcode.app` or under MacPorts Mesa at `/opt/local/include/GL/gl.h`. It never checked the Command Line Tools SDK, which does ship a valid `gl.h` reachable via `xcrun --show-sdk-path`.
- `[simulator_macos]` in `ini/native.ini` hardcoded MacPorts include and lib paths (`/opt/local/...`) for SDL2, glm, and freetype. Those paths don't exist under Homebrew.

### Requirements

macOS with either Homebrew or MacPorts, plus the Xcode Command Line Tools (`xcode-select --install`). A full `Xcode.app` is no longer required. Build with `pio run -e simulator_macos_debug` or `simulator_macos_release`.

### Benefits

- Builds and runs with only the minimal Command Line Tools installed.
- Supports Homebrew, including Apple Silicon at `/opt/homebrew`, not just MacPorts.
- Drops the machine-specific paths from `native.ini` and detects them at runtime instead.

### Configurations

Uses the standard `simulator_macos_debug` environment. No configuration ZIP is needed to reproduce.
