### PR TITLE
Fix native unit test source filter

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -29,7 +29,7 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/LINUX>
 extends          = env:linux_native
 extra_scripts    = ${common.extra_scripts}
                    post:buildroot/share/PlatformIO/scripts/collect-code-tests.py
-build_src_filter = ${env:linux_native.build_src_filter} +<test>
+build_src_filter = ${env:linux_native.build_src_filter} +<tests>
 lib_deps         = throwtheswitch/Unity@^2.6.0
 test_build_src   = true
 build_flags      = ${env:linux_native.build_flags} -Werror -DNO_USER_FEEDBACK_WARNING


### PR DESCRIPTION
### Description

Follow-up to #28490.

The `linux_native_test` environment uses `build_src_filter` to add the Marlin unit-test source files to the native test build.

Marlin sets:

```ini
src_dir = Marlin
```

Therefore this filter:

```ini
+<test>
```

refers to `Marlin/test`, which does not exist.

The project-level `test/` directory remains PlatformIO's test harness and contains the unit-test runner and configuration files. The C++ unit-test sources are stored separately in `Marlin/tests/`.

This PR changes only the source filter:

```diff
- build_src_filter = ${env:linux_native.build_src_filter} +<test>
+ build_src_filter = ${env:linux_native.build_src_filter} +<tests>
```

### Requirements

No printer hardware or board-specific environment is required.

The existing native unit-test command is sufficient:

```sh
make unit-test-all-local
```

### Benefits

The final CI run for #28490, with `+<test>`, completed successfully while executing zero registered Marlin test cases for all three configurations:

```text
marlin_default:             0 test cases, 0 succeeded
marlin_extruders_1_runout:  0 test cases, 0 succeeded
marlin_extruders_3_runout:  0 test cases, 0 succeeded
```

Each run reported `Collected 1 tests`, then skipped the test entry and finished with `0 test cases: 0 succeeded`.

With this one-line source-filter correction, the existing suites execute their registered Marlin tests:

```text
marlin_default:             145 test cases, 145 succeeded
marlin_extruders_1_runout:  146 test cases, 146 succeeded
marlin_extruders_3_runout:  146 test cases, 146 succeeded
```

### Configurations

Tested with the existing unit-test configurations:

- `test/001-default.ini`
- `test/002-extruders_1_runout.ini`
- `test/003-extruders_3_runout.ini`

### Scope

- One changed line
- One changed file: `ini/native.ini`
- No production firmware code changes
- No test-content changes

### Related Issues

- Follow-up to #28490
