### PR TITLE
update I2C_EEPROM to use setSDA and setSCL to avoid begin() variable type issues. 

### DIFF
--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -40,11 +40,18 @@
 #endif
 
 void eeprom_init() {
+  #if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION >= ((2U << 24) | (1U << 16) | (0U << 8)))
+    #define I2C_PIN_TYPE uint32_t
+  #else
+    #define I2C_PIN_TYPE uint8_t
+  #endif
+
   eWire.begin(
     #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
-      uint8_t(I2C_SDA_PIN), uint8_t(I2C_SCL_PIN)
+      I2C_PIN_TYPE(I2C_SDA_PIN), I2C_PIN_TYPE(I2C_SCL_PIN)
     #endif
   );
+  #undef I2C_PIN_TYPE
 }
 
 #if ENABLED(USE_SHARED_EEPROM)

--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -40,18 +40,12 @@
 #endif
 
 void eeprom_init() {
-  #if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION >= ((2U << 24) | (1U << 16) | (0U << 8)))
-    #define I2C_PIN_TYPE uint32_t
-  #else
-    #define I2C_PIN_TYPE uint8_t
+  #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
+    eWire.setSDA(I2C_SDA_PIN);
+    eWire.setSCL(I2C_SCL_PIN);
   #endif
 
-  eWire.begin(
-    #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
-      I2C_PIN_TYPE(I2C_SDA_PIN), I2C_PIN_TYPE(I2C_SCL_PIN)
-    #endif
-  );
-  #undef I2C_PIN_TYPE
+  eWire.begin();
 }
 
 #if ENABLED(USE_SHARED_EEPROM)


### PR DESCRIPTION
### Description

On the STM32 Arduino core, the `TwoWire::begin(sda, scl)` function signature has changed over time:

* **1.9.x:** `void begin(uint8_t, uint8_t);`
* **2.1.x:** `void begin(uint32_t, uint32_t);`
* **3.x:** `void begin(pin_size_t, pin_size_t);`

With newer core versions, passing `uint8_t` arguments causes the compiler to select the wrong `begin()` overload (`void begin(uint8_t, bool generalCall = false, bool NoStretchMode = false)`), resulting in incorrect initialization.

My original solution used preprocessor checks to select the correct argument type based on the STM32 core version. On further review, I replaced that approach by configuring the pins with:

```cpp
eWire.setSDA(I2C_SDA_PIN);
eWire.setSCL(I2C_SCL_PIN);
eWire.begin();
```

This avoids depending on the changing `begin(sda, scl)` function signature altogether and lets the  ARDUINO core handle the pin type internally.

### Requirements

 ENABLED(I2C_EEPROM) on an STM32 target.

### Benefits

* Eliminates STM32 core version checks.
* Works regardless of whether the core uses `uint8_t`, `uint32_t`, or `pin_size_t` for I2C pin types.
* Uses the `TwoWire` API as intended by configuring the pins with `setSDA()` / `setSCL()` before calling `begin()`.

### Related Issues

<li>MarlinFirmware/Marlin#28494
