### PR TITLE
Reject overflowing G-code command numbers

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -207,7 +207,14 @@ void GCodeParser::parse(char *p) {
       // Get the code number - integer digits only
       codenum = 0;
 
-      do { codenum = codenum * 10 + *p++ - '0'; } while (NUMERIC(*p));
+      do {
+        const uint8_t digit = *p++ - '0';
+        if (codenum > UINT16_MAX / 10 || (codenum == UINT16_MAX / 10 && digit > UINT16_MAX % 10)) {
+          command_letter = '?';
+          return;
+        }
+        codenum = codenum * 10 + digit;
+      } while (NUMERIC(*p));
 
       // Apply the sign, if any
       TERN_(SIGNED_CODENUM, codenum *= sign);

--- a/Marlin/tests/gcode/test_gcode.cpp
+++ b/Marlin/tests/gcode/test_gcode.cpp
@@ -31,6 +31,23 @@ MARLIN_TEST(gcode, process_parsed_command) {
   suite.process_parsed_command(false);
 }
 
+MARLIN_TEST(gcode, parse_g_code_number_limit) {
+  char max_command[] = "G65535";
+  parser.parse(max_command);
+  TEST_ASSERT_TRUE(parser.is_command('G', UINT16_MAX));
+
+  char overflow_command[] = "G65536";
+  parser.parse(overflow_command);
+  TEST_ASSERT_EQUAL('?', parser.command_letter);
+}
+
+MARLIN_TEST(gcode, reject_m_code_overflow_alias) {
+  char current_command[] = "M65648";
+  parser.parse(current_command);
+  TEST_ASSERT_EQUAL('?', parser.command_letter);
+  TEST_ASSERT_FALSE(parser.is_command('M', 112));
+}
+
 MARLIN_TEST(gcode, parse_g1_xz) {
   char current_command[] = "G0 X10 Z30";
   parser.command_letter = -128;


### PR DESCRIPTION
## Problem

The G-code parser accumulates a command number directly into its `uint16_t`
storage. Values above `65535` wrap and can be parsed as a different valid
command number.

The native reproducer showed:

```text
G65536 parsed as G0
M65648 parsed as M112
```

This verifies parser aliasing only. It does not claim that either command was
dispatched to hardware.

## Root cause

The decimal accumulator multiplies and adds each digit without checking whether
the next value still fits in `uint16_t`.

## Change

Check the next digit before updating `codenum`. On overflow, leave the parser
with the normal unknown-command marker (`?`) and return.

The boundary remains unchanged:

```text
G65535 is accepted.
G65536 is rejected.
```

The patch does not impose a smaller command-number range and does not widen the
parser storage type.

## Reproduction before

Added focused native parser tests and ran:

```sh
make unit-test-single-local UNIT_TEST_CONFIG=default
```

Result:

```text
147 test cases: 2 failed, 145 succeeded
```

Both failures showed oversized command numbers aliasing valid lower numbers.

## Validation after

```sh
make unit-test-all-local
```

Results:

```text
marlin_default:             147/147
marlin_extruders_1_runout:  148/148
marlin_extruders_3_runout:  148/148
```

Representative target matrices:

```sh
make tests-single-local TEST_TARGET=mega2560
make tests-single-local TEST_TARGET=STM32F103RE_creality
```

All 10 `mega2560` configurations and all 6
`STM32F103RE_creality` configurations completed successfully.

## Hardware scope

Validated with native host tests and representative AVR and ARM target builds.

Not validated: upload, boot, serial communication, motion, heating, or printer
behavior. No hardware access is required for this parser fix.

## Non-goals

- No change to valid command numbers through `65535`
- No change to line-number parsing
- No parser storage-type change
- No command-dispatch or hardware-behavior change
