### PR TITLE
HASH_ADD_STR use struct field name

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
@@ -270,7 +270,7 @@ static FSTR_P const assets[] = {
       // Add to hash table, don't save "bmp_"
       strncpy(entry->name, pname + PIC_NAME_OFFSET, sizeof(entry->name));
       entry->addr = addr;
-      HASH_ADD_STR(pic_hash, pname, entry);
+      HASH_ADD_STR(pic_hash, name, entry);
 
       // Next tft internal flash addr
       addr += tsiz;


### PR DESCRIPTION
### Description

The HASH_ADD_STR macro expects the name of the struct's key field as its second parameter. 

```cpp
typedef struct {
  uint8_t name[PIC_NAME_MAX_LEN];
  union union32 size;
} pic_msg_t;

```

The commit [8a2e89eb0fb56644d3af08864e66b97d6c157052](https://github.com/MarlinFirmware/Marlin/commit/8a2e89eb0fb56644d3af08864e66b97d6c157052) mistakenly changed name to pname, but:

name is the field name in the PicHashEntry struct (the hash key field)
pname is a local variable holding the full picture name with "bmp_" prefix

This caused

```
Marlin/src/lcd/extui/mks_ui/pic_manager.cpp:273:30: error: 'struct PicHashEntry' has no member named 'pname'; did you mean 'name'?
  273 |       HASH_ADD_STR(pic_hash, pname, entry);

```

This PR reverts to 'HASH_ADD_STR(pic_hash, name, entry);'

### Requirements

mks_ui

### Benefits

Builds as expected

