### PR TITLE
Reject overflowing G-code subcodes

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -216,8 +216,14 @@ void GCodeParser::parse(char *p) {
       #if USE_GCODE_SUBCODES
         if (*p == '.') {
           p++;
-          while (NUMERIC(*p))
-            subcode = subcode * 10 + *p++ - '0';
+          while (NUMERIC(*p)) {
+            const uint8_t digit = *p++ - '0';
+            if (subcode > UINT8_MAX / 10 || (subcode == UINT8_MAX / 10 && digit > UINT8_MAX % 10)) {
+              command_letter = '?';
+              return;
+            }
+            subcode = subcode * 10 + digit;
+          }
         }
       #endif
 

--- a/Marlin/tests/gcode/test_gcode.cpp
+++ b/Marlin/tests/gcode/test_gcode.cpp
@@ -31,6 +31,27 @@ MARLIN_TEST(gcode, process_parsed_command) {
   suite.process_parsed_command(false);
 }
 
+#if USE_GCODE_SUBCODES
+
+MARLIN_TEST(gcode, parse_g_code_subcode_limit) {
+  char max_subcode[] = "G38.255";
+  parser.parse(max_subcode);
+  TEST_ASSERT_TRUE(parser.is_command('G', 38));
+  TEST_ASSERT_EQUAL(255, parser.subcode);
+
+  char overflow_subcode[] = "G38.256";
+  parser.parse(overflow_subcode);
+  TEST_ASSERT_EQUAL('?', parser.command_letter);
+}
+
+MARLIN_TEST(gcode, reject_g_code_subcode_overflow_alias) {
+  char alias_command[] = "G38.258";
+  parser.parse(alias_command);
+  TEST_ASSERT_FALSE(parser.is_command('G', 38) && parser.subcode == 2);
+}
+
+#endif
+
 MARLIN_TEST(gcode, parse_g1_xz) {
   char current_command[] = "G0 X10 Z30";
   parser.command_letter = -128;

--- a/test/004-gcode_subcodes.ini
+++ b/test/004-gcode_subcodes.ini
@@ -1,0 +1,12 @@
+#
+# Test configuration for G-code subcode parsing
+#
+
+[config:base]
+ini_use_config         = base
+
+# Unit tests must use BOARD_SIMULATED to run natively in Linux
+motherboard            = BOARD_SIMULATED
+
+# Enable USE_GCODE_SUBCODES without requiring physical probe hardware
+cnc_coordinate_systems = on


### PR DESCRIPTION
## Problem

With `USE_GCODE_SUBCODES`, the parser accumulates decimal subcode digits directly into `uint8_t`.

Values above 255 therefore wrap and can alias another valid subcode. For example:

```text
G38.258 -> G38.2
```

This is the corresponding subcode follow-up to #28497.

## Fix

Check the next digit before updating `subcode`. On overflow, mark the command as unknown and return.

The valid boundary remains unchanged:

```text
G38.255 is accepted.
G38.256 is rejected.
G38.258 does not alias G38.2.
```

## Validation

On the unpatched parser, the two added regression tests failed as expected, reproducing the missing boundary rejection and the G38.258 to G38.2 alias.

After the fix:

```text
gcode_subcodes:       147/147
default:              145/145
extruders_1_runout:   146/146
extruders_3_runout:   146/146
mega2560 matrix:      passed
DUE matrix:           passed
```

Validated with native tests and representative AVR and ARM builds. No device was accessed.

## Status

Kept as a draft for the **After 2.1.3** milestone.

Before marking it ready, update the branch against the current `bugfix-2.1.x` and rerun the focused tests and representative target builds.