### PR TITLE
Fix signed G-code command prefixes

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -187,7 +187,12 @@ void GCodeParser::parse(char *p) {
       #endif
 
       // Bail if there's no command code number
-      if (!TERN(SIGNED_CODENUM, NUMERIC_SIGNED(*p), NUMERIC(*p))) {
+      bool valid_codenum = NUMERIC(*p);
+      #if ENABLED(SIGNED_CODENUM)
+        if (!valid_codenum && (*p == '-' || *p == '+'))
+          valid_codenum = NUMERIC(p[1]);
+      #endif
+      if (!valid_codenum) {
         if (E_TERN0(letter == 'T')) {
           p[0] = '*'; p[1] = '\0'; string_arg = p; // Convert 'T' alone into 'T*'
           command_letter = letter;
@@ -200,8 +205,11 @@ void GCodeParser::parse(char *p) {
       command_letter = letter;
 
       #if ENABLED(SIGNED_CODENUM)
-        int sign = 1; // Allow for a negative code like D-1 or T-1
-        if (*p == '-') { sign = -1; ++p; }
+        int sign = 1; // Allow for a signed code like D-1 or T+1
+        if (*p == '-' || *p == '+') {
+          if (*p == '-') sign = -1;
+          ++p;
+        }
       #endif
 
       // Get the code number - integer digits only

--- a/Marlin/tests/gcode/test_gcode.cpp
+++ b/Marlin/tests/gcode/test_gcode.cpp
@@ -31,6 +31,36 @@ MARLIN_TEST(gcode, process_parsed_command) {
   suite.process_parsed_command(false);
 }
 
+#if ANY(SWITCHING_TOOLHEAD, MAGNETIC_SWITCHING_TOOLHEAD, ELECTROMAGNETIC_SWITCHING_TOOLHEAD)
+
+MARLIN_TEST(gcode, parse_explicit_positive_signed_code) {
+  char explicit_positive[] = "T+1";
+  parser.parse(explicit_positive);
+  TEST_ASSERT_EQUAL('T', parser.command_letter);
+  TEST_ASSERT_EQUAL(1, int16_t(parser.codenum));
+}
+
+MARLIN_TEST(gcode, parse_negative_signed_code) {
+  char negative[] = "T-1";
+  parser.parse(negative);
+  TEST_ASSERT_EQUAL('T', parser.command_letter);
+  TEST_ASSERT_EQUAL(-1, int16_t(parser.codenum));
+}
+
+MARLIN_TEST(gcode, reject_negative_sign_without_digits) {
+  char missing_digits[] = "M-";
+  parser.parse(missing_digits);
+  TEST_ASSERT_EQUAL('?', parser.command_letter);
+}
+
+MARLIN_TEST(gcode, reject_positive_sign_without_digits) {
+  char missing_digits[] = "M+";
+  parser.parse(missing_digits);
+  TEST_ASSERT_EQUAL('?', parser.command_letter);
+}
+
+#endif
+
 MARLIN_TEST(gcode, parse_g1_xz) {
   char current_command[] = "G0 X10 Z30";
   parser.command_letter = -128;

--- a/test/005-signed_codenum.ini
+++ b/test/005-signed_codenum.ini
@@ -1,0 +1,10 @@
+[config:base]
+ini_use_config = base
+
+# Unit tests must use BOARD_SIMULATED to run natively in Linux
+motherboard = BOARD_SIMULATED
+
+# Enable the production feature path that allows signed T codes.
+extruders                     = 2
+temp_sensor_1                 = 1
+magnetic_switching_toolhead   = on


### PR DESCRIPTION
## Context

This is an independent parser-contract fix found while reviewing signed G-code
command-number handling.

It is intentionally separate from #28497 and #28499. Those changes address
numeric overflow; this one addresses disagreement between signed-prefix
admission and signed-prefix consumption.

The pull request is opened as a draft because the adjacent parser pull requests
are still under review, and maintainers may prefer a particular sequence or
grouping. The patch itself is locally complete and green.

## Problem

When `SIGNED_CODENUM` is enabled, the parser's initial admission check accepts
both `+` and `-` through `NUMERIC_SIGNED`.

The parsing code then consumes only `-`.

As a result, an explicit positive sign is treated as a decimal digit. In the
native reproducer:

```text
T+1 parsed with command number -49
```

The same admission rule also accepts a standalone sign even though no decimal
digit follows it.

## Parser contract

A signed command number has this grammar:

```text
optional '+' or '-'
followed by at least one decimal digit
```

Admission, prefix consumption, and numeric accumulation must apply that same
grammar.

## Root cause

Two adjacent parser decisions disagree:

- admission accepts `+` and `-`;
- prefix consumption handles only `-`;
- admission does not require a digit after a sign.

The decimal accumulator therefore receives input that is not a decimal digit.

## Change

- Require a sign to be followed by a decimal digit before accepting the command
  number.
- Consume both explicit positive and negative signs.
- Preserve unsigned command numbers and existing negative signed command
  numbers.
- Keep the correction inside `GCodeParser::parse` without adding a new parser
  abstraction or changing storage types.

The small diff is deliberate: the defect is a local grammar mismatch, so a
broader refactor would add review surface without improving the contract.

## Regression coverage

A focused native configuration enables the production
`MAGNETIC_SWITCHING_TOOLHEAD` path that activates signed tool numbers.

The tests cover:

```text
T+1 -> command T, number 1
T-1 -> command T, number -1
M-  -> rejected as an unknown command
M+  -> rejected as an unknown command
```

The `M-` and `M+` cases avoid the existing special `T*` fallback for
non-numeric tool-selection input.

## Validation

Base:

```text
8f2968f16a4435762213028acc98f3adc750b2db
```

Focused signed native suite:

```sh
make unit-test-single-local UNIT_TEST_CONFIG=signed_codenum
```

```text
149 test cases: 149 succeeded
```

Default native suite:

```sh
make unit-test-single-local UNIT_TEST_CONFIG=default
```

```text
145 test cases: 145 succeeded
```

Representative production-feature target build:

```sh
make tests-single-local TEST_TARGET=BTT_GTR_V1_0 ONLY_TEST=3
```

```text
BigTreeTech GTR | MPC | Switching Toolhead | Tool Sensors
Passed
All tests completed successfully
```

## Hardware scope

Validated with native host tests and one STM32 target build.

Proof level: build only.

Not validated:

- upload or boot
- serial communication
- physical tool changing
- motion or heating
- printer behavior

No device was accessed.

## Non-goals

- No change to unsigned command-number parsing
- No change to valid negative tool numbers
- No change to command-number storage types
- No change to command dispatch
- No physical hardware behavior claim

