### PR TITLE
Fix I2C encoder report loop

### DIFF
--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -648,7 +648,7 @@ void I2CPositionEncodersMgr::report_position(const int8_t idx, const bool units,
     const int32_t raw_count = encoders[idx].get_raw_count();
     SERIAL_CHAR(AXIS_CHAR(encoders[idx].get_axis()), ' ');
 
-    for (uint8_t j = 31; j >= 0; j--)
+    for (uint8_t j = 32; j--;)
       SERIAL_ECHO(TEST32(raw_count, j));
 
     SERIAL_ECHOLN(C(' '), raw_count);


### PR DESCRIPTION
## Problem

`report_position()` counts down with a `uint8_t` and the condition `j >= 0`.
After bit 0, the index wraps to 255, so the loop never terminates. The
regression was introduced by cleanup commit
`c173ecd89ae636c2deaf7310a626569b6a6c4797`.

## Fix

Use `for (uint8_t j = 32; j--;)`, which emits bit indices 31 through 0 exactly
once.

## Validation

```sh
make tests-single-local TEST_TARGET=mega2560 ONLY_TEST=2
```

```text
Passed
All tests completed successfully
```
