### PR TITLE
Validate DGUS read variable lengths

### DIFF
--- a/Marlin/src/lcd/extui/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSDisplay.cpp
@@ -203,6 +203,18 @@ void DGUSDisplay::processRx() {
         |     DatagramLen  /  VPAdr  |
         |           Command          DataLen (in Words) */
         if (command == DGUS_CMD_READVAR) {
+          if (rx_datagram_len < 4) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
+          const uint16_t dlen = uint16_t(tmp[2]) << 1,
+                         payload_len = rx_datagram_len - 4;
+          if (dlen < 2 || dlen != payload_len) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
           const uint16_t vp = tmp[0] << 8 | tmp[1];
           DGUS_VP_Variable ramcopy;
           if (populate_VPVar(vp, &ramcopy)) {

--- a/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_e3s1pro/DGUSDisplay.cpp
@@ -259,8 +259,19 @@ void DGUSDisplay::processRx() {
          *           Command          DataLen (in Words)
          */
         if (command == DGUS_READVAR) {
+          if (rx_datagram_len < 4) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
+          const uint16_t dlen = uint16_t(tmp[2]) << 1,  // Convert to Bytes. (Display works with words)
+                         payload_len = rx_datagram_len - 4;
+          if (dlen != payload_len) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
           const uint16_t addr = Endianness::fromBE_P<uint16_t>(tmp);
-          const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
           if (addr == DGUS_VERSION && dlen == 2) {
             gui_version = tmp[3];
             os_version = tmp[4];
@@ -297,7 +308,7 @@ void DGUSDisplay::processRx() {
             unsigned char buffer[vp.size];
             memset(buffer, 0, vp.size);
 
-            for (uint8_t i = 0; i < dlen; i++) {
+            for (uint16_t i = 0; i < dlen; i++) {
               if (i >= vp.size) break;
 
               if (i + 1 < dlen && tmp[i + 3] == 0xFF && tmp[i + 4] == 0xFF)

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
@@ -264,8 +264,19 @@ void DGUSDisplay::processRx() {
         |     DatagramLen  /  VPAdr  |
         |           Command          DataLen (in Words) */
         if (command == DGUS_READVAR) {
+          if (rx_datagram_len < 4) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
+          const uint16_t dlen = uint16_t(tmp[2]) << 1,  // Convert to Bytes. (Display works with words)
+                         payload_len = rx_datagram_len - 4;
+          if (dlen != payload_len) {
+            rx_datagram_state = DGUS_IDLE;
+            break;
+          }
+
           const uint16_t addr = tmp[0] << 8 | tmp[1];
-          const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
           if (addr == DGUS_VERSION && dlen == 2) {
             gui_version = tmp[3];
             os_version = tmp[4];
@@ -298,7 +309,7 @@ void DGUSDisplay::processRx() {
             unsigned char buffer[vp.size];
             memset(buffer, 0, vp.size);
 
-            for (uint8_t i = 0; i < dlen; i++) {
+            for (uint16_t i = 0; i < dlen; i++) {
               if (i >= vp.size) break;
 
               if (i + 1 < dlen && tmp[i + 3] == 0xFF && tmp[i + 4] == 0xFF)


### PR DESCRIPTION
## Problem

The DGUS `READVAR` handlers could access the VP address, word count, or payload before confirming that those bytes were present. Truncated or over-declared frames could therefore read beyond the received datagram in the Classic, E3S1Pro, and Reloaded implementations.

## Fix

Require `READVAR` frames to contain the VP address and word count, and require the declared payload length to match the received payload before accessing it.

The E3S1Pro and Reloaded string paths now keep the payload length wide enough for the declared word count. Valid three-byte `0x82` / `OK` acknowledgements are unchanged.

## Validation

Malformed and over-declared `READVAR` frames reproduced out-of-bounds reads before the fix and are rejected after it.

* `mega2560ext`, test 2 (DGUS MKS): passed
* `mega2560ext`, test 3 (DGUS Reloaded): passed
* `STM32F401RC_creality`, test 99 (DGUS E3S1Pro): passed
* Flash: +48 bytes Classic, +40 bytes Reloaded, +24 bytes E3S1Pro
* RAM: unchanged

No device was accessed.
