### PR TITLE
Fix DWIN handshake response handling

### DIFF
--- a/Marlin/src/lcd/dwin/common/dwin_api.cpp
+++ b/Marlin/src/lcd/dwin/common/dwin_api.cpp
@@ -46,7 +46,6 @@ void dwinSend(size_t &i) {
 
 // Handshake (1: Success, 0: Fail)
 bool dwinHandshake() {
-  static int recnum = 0;
   #ifndef LCD_BAUDRATE
     #define LCD_BAUDRATE 115200
   #endif
@@ -58,21 +57,22 @@ bool dwinHandshake() {
   dwinByte(i, 0x00);
   dwinSend(i);
 
-  while (LCD_SERIAL.available() > 0 && recnum < (signed)sizeof(databuf)) {
-    databuf[recnum] = LCD_SERIAL.read();
-    // ignore the invalid data
-    if (databuf[0] != FHONE) { // prevent the program from running.
-      if (recnum > 0) {
-        recnum = 0;
-        ZERO(databuf);
-      }
+  constexpr uint8_t handshake_len = 4;
+  uint8_t recnum = 0;
+  ZERO(databuf);
+  const millis_t response_timeout = millis() + 1000UL;
+  while (recnum < handshake_len && PENDING(millis(), response_timeout)) {
+    if (!LCD_SERIAL.available()) {
+      delay(1);
       continue;
     }
-    delay(10);
-    recnum++;
+
+    const uint8_t received = LCD_SERIAL.read();
+    if (!recnum && received != FHONE) continue;
+    databuf[recnum++] = received;
   }
 
-  return ( recnum >= 3
+  return ( recnum == handshake_len
         && databuf[0] == FHONE
         && databuf[1] == '\0'
         && databuf[2] == 'O'


### PR DESCRIPTION
## Problem

`dwinHandshake()` kept its receive count across calls and only consumed bytes already available immediately after sending the request.

A partial response could therefore leave parser state for a later call, while a delayed or fragmented response could be missed.

## Fix

Keep the receive count local to each handshake, clear the handshake data buffer, and wait up to one second for the complete four-byte `AA 00 4F 4B` response.

Leading noise before `AA` remains ignored.

## Validation

The receive logic produced the expected result for immediate, delayed, fragmented, truncated, repeated-call, invalid, and timed-out responses.

`STM32F103RE_creality` build tests 1–4 passed for CrealityUI, JyersUI, MarlinUI, and ProUI.

No device was accessed.