### PR TITLE
FTM : fix Dynamic Frequency Mode is only for X and Y axis in M493

### DIFF
--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -114,19 +114,13 @@ void say_shaping() {
     #endif
 
     #if ENABLED(FTM_SHAPER_Z)
-      if (ftMotion.cfg.shaper[Z_AXIS]) {
-        SERIAL_CHAR(STEPPER_C_NAME);
-        SERIAL_ECHO(" shaper frequency: ",_float_t(c.baseFreq.z, 2), F(" Hz"));
-        SERIAL_EOL();
-      }
+      if (ftMotion.cfg.shaper[Z_AXIS])
+        SERIAL_ECHOLN(C(STEPPER_C_NAME), F(" shaper frequency: "), p_float_t(c.baseFreq.z, 2), F(" Hz"));
     #endif
 
     #if ENABLED(FTM_SHAPER_E)
-      if (ftMotion.cfg.shaper[E_AXIS]) {
-        SERIAL_CHAR('E');
-        SERIAL_ECHO(" shaper frequency: ", p_float_t(c.baseFreq.e, 2), F(" Hz"));
-        SERIAL_EOL();
-      }
+      if (ftMotion.cfg.shaper[E_AXIS])
+        SERIAL_ECHOLN(C('E'), F(" shaper frequency: "), p_float_t(c.baseFreq.e, 2), F(" Hz"));
     #endif
   }
 }

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -113,11 +113,7 @@ void say_shaping() {
     #if ENABLED(FTM_SHAPER_Z)
       if (ftMotion.cfg.shaper[Z_AXIS]) {
         SERIAL_CHAR(STEPPER_C_NAME);
-          SERIAL_ECHO_TERNARY(dynamic, " ", "base dynamic", "static", " shaper frequency: ");
-        SERIAL_ECHO(p_float_t(c.baseFreq.z, 2), F(" Hz"));
-        #if HAS_DYNAMIC_FREQ
-          if (dynamic) SERIAL_ECHO(F(" scaling: "), p_float_t(c.dynFreqK.z, 2), F("Hz/"), z_based ? F("mm") : F("g"));
-        # endif
+        SERIAL_ECHO(" shaper frequency: ",_float_t(c.baseFreq.z, 2), F(" Hz"));
         SERIAL_EOL();
       }
     #endif
@@ -125,11 +121,7 @@ void say_shaping() {
     #if ENABLED(FTM_SHAPER_E)
       if (ftMotion.cfg.shaper[E_AXIS]) {
         SERIAL_CHAR('E');
-        SERIAL_ECHO_TERNARY(dynamic, " ", "base dynamic", "static", " shaper frequency: ");
-        SERIAL_ECHO(p_float_t(c.baseFreq.e, 2), F(" Hz"));
-        #if HAS_DYNAMIC_FREQ
-          if (dynamic) SERIAL_ECHO(F(" scaling: "), p_float_t(c.dynFreqK.e, 2), F("Hz/"), z_based ? F("mm") : F("g"));
-        #endif
+        SERIAL_ECHO(" shaper frequency: ", p_float_t(c.baseFreq.e, 2), F(" Hz"));
         SERIAL_EOL();
       }
     #endif
@@ -207,7 +199,7 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
  *       7: 3HEI  : 3-Hump Extra-Intensive
  *       8: MZV   : Mass-based Zero Vibration
  *
- *    A<Hz>     Set static/base frequency for the specified axes
+ *    A<Hz>     Set static/base frequency for the specified axes only X and Y axes
  *    I<flt>    Set damping ratio for the specified axes
  *    Q<flt>    Set vibration tolerance (vtol) for the specified axes
  *
@@ -270,7 +262,7 @@ void GcodeSuite::M493() {
 
     // Dynamic frequency mode parameter.
     if (parser.seenval('D')) {
-      if (AXIS_IS_SHAPING(X) || AXIS_IS_SHAPING(Y) || AXIS_IS_SHAPING(Z) || AXIS_IS_SHAPING(E)) {
+      if (AXIS_IS_SHAPING(X) || AXIS_IS_SHAPING(Y)) {
         switch (c.setDynFreqMode(parser.value_byte())) {
           case 0: break; // Same value, no update
           case 1: flag.report = true; break; // New value, updated
@@ -434,8 +426,8 @@ void GcodeSuite::M493() {
 
       #if HAS_DYNAMIC_FREQ
         // Parse Z frequency scaling parameter
-        if (seenF && c.setDynFreqK(Z_AXIS, baseDynFreqVal))
-          flag.report = true;
+        if (seenF)
+          SERIAL_ECHOLNPGM("?Wrong axis for (F)requency scaling.");
       #endif
 
       // Parse Z zeta parameter
@@ -482,8 +474,8 @@ void GcodeSuite::M493() {
 
       #if HAS_DYNAMIC_FREQ
         // Parse E frequency scaling parameter
-        if (seenF && c.setDynFreqK(E_AXIS, baseDynFreqVal))
-          flag.report = true;
+        if (seenF)
+          SERIAL_ECHOLNPGM("?Wrong axis for (F)requency scaling.");
       #endif
 
       // Parse E zeta parameter

--- a/Marlin/src/module/ft_motion.h
+++ b/Marlin/src/module/ft_motion.h
@@ -83,7 +83,7 @@ typedef struct FTConfig {
 
     #if HAS_DYNAMIC_FREQ
       dynFreqMode_t dynFreqMode = FTM_DEFAULT_DYNFREQ_MODE; // Dynamic frequency mode configuration.
-      ft_shaped_float_t dynFreqK = { 0.0f };                // Scaling / gain for dynamic frequency. [Hz/mm] or [Hz/g]
+      ft_shaped_xy_float_t dynFreqK = { 0.0f };             // Scaling / gain for dynamic frequency. [Hz/mm] or [Hz/g]
     #else
       static constexpr dynFreqMode_t dynFreqMode = dynFreqMode_DISABLED;
     #endif
@@ -173,14 +173,14 @@ typedef struct FTConfig {
     #if HAS_DYNAMIC_FREQ
 
       uint8_t setDynFreqMode(const uint8_t m) {
-        if (dynFreqMode_t(m) == dynFreqMode) return 0;
-        switch (dynFreqMode_t(m)) {
+        if ((dynFreqMode_t)m == dynFreqMode) return 0;
+        switch ((dynFreqMode_t)m) {
           default: return 2;
           TERN_(HAS_DYNAMIC_FREQ_MM, case dynFreqMode_Z_BASED:)
           TERN_(HAS_DYNAMIC_FREQ_G, case dynFreqMode_MASS_BASED:)
           case dynFreqMode_DISABLED:
             prep_for_shaper_change();
-            dynFreqMode = dynFreqMode_t(m);
+            dynFreqMode = (dynFreqMode_t)m;
             break;
         }
         update_shaping_params();
@@ -193,6 +193,7 @@ typedef struct FTConfig {
       }
 
       bool setDynFreqK(const AxisEnum a, const float k) {
+        //assert(a == X_AXIS || X == Y_AXIS, "Dynamic Frequency only applies to XY axes.");
         if (!modeUsesDynFreq()) return false;
         if (k == dynFreqK[a]) return false;
         prep_for_shaper_change();

--- a/Marlin/src/module/ft_motion/shaping.h
+++ b/Marlin/src/module/ft_motion/shaping.h
@@ -55,6 +55,10 @@ enum dynFreqMode_t : uint8_t {
   #define SHAPED_ARRAY(A,B,C,D) { SHAPED_LIST(A, B, C, D) }
   #define SHAPED_CODE(A,B,C,D)    XY_CODE(A, B) OPTCODE(FTM_SHAPER_Z, C) OPTCODE(FTM_SHAPER_E, D)
   #define SHAPED_MAP(F)           MAP(F, SHAPED_AXIS_NAMES)
+  #define NUM_XY_SHAPED           COUNT_ENABLED(HAS_X_AXIS, HAS_Y_AXIS)
+  #define SHAPED_XY_NAMES         XY_LIST(X, Y)
+  #define SHAPED_XY_LIST(A,B)     XY_LIST(A, B)
+  #define SHAPED_XY_MAP(F)        MAP(F, SHAPED_XY_NAMES)
 #else
   #define NUM_AXES_SHAPED 0
   #define SHAPED_AXIS_NAMES
@@ -63,6 +67,10 @@ enum dynFreqMode_t : uint8_t {
   #define SHAPED_ARRAY(...) {}
   #define SHAPED_CODE(...)
   #define SHAPED_MAP(...)
+  #define NUM_XY_SHAPED 0
+  #define SHAPED_XY_NAMES
+  #define SHAPED_XY_LIST(...)
+  #define SHAPED_XY_MAP(...)
 #endif
 
 template<typename T>
@@ -87,9 +95,29 @@ private:
   }
 };
 
+template<typename T>
+struct FTShapedAxesXY {
+  union {
+    struct { T SHAPED_XY_NAMES; };
+    struct { T SHAPED_XY_LIST(x, y); };
+    T val[NUM_XY_SHAPED];
+  };
+  T& operator[](const int axis) {
+    return val[axis_to_index(axis)];
+  }
+  void reset() { ZERO(val); }
+
+private:
+  static constexpr int axis_to_index(const int axis) {
+    if (TERN0(HAS_X_AXIS, axis == X_AXIS)) return 0;
+    if (TERN0(HAS_Y_AXIS, axis == Y_AXIS)) return 1;
+    return -1; // Invalid axis
+  }
+};
+
 typedef FTShapedAxes<float>            ft_shaped_float_t;
 typedef FTShapedAxes<ftMotionShaper_t> ft_shaped_shaper_t;
-typedef FTShapedAxes<dynFreqMode_t>    ft_shaped_dfm_t;
+typedef FTShapedAxesXY<float>          ft_shaped_xy_float_t;
 
 #define FTM_MAX_DAMPENING 0.25
 constexpr float ftm_max_dampening = float(FTM_MAX_DAMPENING),


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
The dynamic frequency mode is only intended to work with the X and Y axes.  In `ft_motion.cpp` computation is done when it's enabled only as expected for X and Y axes, but in `M493`, it could be set for other axes. This PR conforms `M493` to the attended behavior.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
