### PR TITLE
🚸 Report material presets with bare M145

### DIFF
--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -41,6 +41,8 @@
  *   F<fan speed>
  */
 void GcodeSuite::M145() {
+  if (!parser.seen("SHBCF")) return M145_report();
+
   const uint8_t material = (uint8_t)parser.byteval('S');
   if (material >= PREHEAT_COUNT)
     SERIAL_ERROR_MSG(STR_ERR_MATERIAL_INDEX);


### PR DESCRIPTION
### Description

Bare `M145` currently does nothing even though `M145_report()` already emits the configured material presets for `M503`.

Call the existing report when no supported `M145` parameters are supplied.

### Requirements

`HAS_PREHEAT`

### Benefits

Material presets can be queried directly without changing any settings.

### Configurations

- `mega2560`

### Related Issues

None.
