### PR TITLE
use  CHAMBER_HYSTERESIS in CHAMBER_LIMIT_SWITCHING

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -831,7 +831,7 @@
 
   // FIND YOUR OWN: "M303 E-1 C8 S90" to run autotune on the bed at 90 degreesC for 8 cycles.
 #else
-  //#define BED_LIMIT_SWITCHING   // Keep the bed temperature within BED_HYSTERESIS of the target
+  //#define BED_LIMIT_SWITCHING   // Keep the bed temperature within BED_LIMIT_HYSTERESIS of the target
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -204,9 +204,9 @@
 // Heated Bed Bang-Bang options
 //
 #if DISABLED(PIDTEMPBED)
-  #define BED_CHECK_INTERVAL 5000   // (ms) Interval between checks in bang-bang control
+  #define BED_CHECK_INTERVAL  5000  // (ms) Interval between checks in bang-bang control
   #if ANY(BED_LIMIT_SWITCHING, PELTIER_BED)
-    #define BED_HYSTERESIS 2        // (°C) Only set the relevant heater state when ABS(T-target) > BED_HYSTERESIS
+    #define BED_LIMIT_HYSTERESIS 2  // (°C) Only set the relevant heater state when ABS(T-target) > BED_LIMIT_HYSTERESIS
   #endif
 #endif
 
@@ -220,9 +220,9 @@
   //#define FAN1_PIN                   -1   // Remove the fan signal on pin P2_04 (example: SKR 1.4 Turbo HE1 plug)
 
   #if DISABLED(PIDTEMPCHAMBER)
-    #define CHAMBER_CHECK_INTERVAL 5000   // (ms) Interval between checks in bang-bang control
+    #define CHAMBER_CHECK_INTERVAL  5000  // (ms) Interval between checks in bang-bang control
     #if ENABLED(CHAMBER_LIMIT_SWITCHING)
-      #define CHAMBER_HYSTERESIS 2        // (°C) Only set the relevant heater state when ABS(T-target) > CHAMBER_HYSTERESIS
+      #define CHAMBER_LIMIT_HYSTERESIS 2  // (°C) Only set the relevant heater state when ABS(T-target) > CHAMBER_LIMIT_HYSTERESIS
     #endif
   #endif
 

--- a/Marlin/src/inc/Changes.h
+++ b/Marlin/src/inc/Changes.h
@@ -765,6 +765,10 @@
   #error "MP_SCARA is now just SCARA."
 #elif defined(HAS_PIN_27_BOARD)
   #error "HAS_PIN_27_BOARD is now USE_PIN_27_BOARD."
+#elif defined(BED_HYSTERESIS)
+  #error "BED_HYSTERESIS is now BED_LIMIT_HYSTERESIS."
+#elif defined(CHAMBER_HYSTERESIS)
+  #error "CHAMBER_HYSTERESIS is now CHAMBER_LIMIT_HYSTERESIS."
 #endif
 
 // SDSS renamed to SD_SS_PIN

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2080,23 +2080,23 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
            * Peltier bang-bang maintains max bed power but changes
            * current direction to switch between heating/cooling.
            */
-          if (temp_bed.target && temp_bed.is_above_target(BED_HYSTERESIS)) {  // Fast Cooling
+          if (temp_bed.target && temp_bed.is_above_target(BED_LIMIT_HYSTERESIS)) { // Fast Cooling
             temp_bed.soft_pwm_amount = MAX_BED_POWER;
             temp_bed.peltier_dir_heating = false;
           }
-          else if (temp_bed.is_below_target(BED_HYSTERESIS)) {                // Heating
+          else if (temp_bed.is_below_target(BED_LIMIT_HYSTERESIS)) {  // Heating
             temp_bed.soft_pwm_amount = MAX_BED_POWER;
             temp_bed.peltier_dir_heating = true;
           }
           else
-            temp_bed.soft_pwm_amount = 0;                                     // Off (ambient cooling)
+            temp_bed.soft_pwm_amount = 0;                             // Off (ambient cooling)
 
         #else // !PELTIER_BED
 
           #if ENABLED(BED_LIMIT_SWITCHING)
-            if (temp_bed.is_above_target(BED_HYSTERESIS))       // Cooling (implicit off)
+            if (temp_bed.is_above_target(BED_LIMIT_HYSTERESIS))       // Cooling (implicit off)
               temp_bed.soft_pwm_amount = 0;
-            else if (temp_bed.is_below_target(BED_HYSTERESIS))  // Heating
+            else if (temp_bed.is_below_target(BED_LIMIT_HYSTERESIS))  // Heating
               temp_bed.soft_pwm_amount = MAX_BED_POWER >> 1;
           #else                                                 // Not bed limit switching
             temp_bed.soft_pwm_amount = temp_bed.is_below_target() ? MAX_BED_POWER >> 1 : 0;
@@ -2223,9 +2223,9 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
           }
           else {
             #if ENABLED(CHAMBER_LIMIT_SWITCHING)
-              if (temp_chamber.is_above_target(CHAMBER_HYSTERESIS))
+              if (temp_chamber.is_above_target(CHAMBER_LIMIT_HYSTERESIS))
                 temp_chamber.soft_pwm_amount = 0;
-              else if (temp_chamber.is_below_target(CHAMBER_HYSTERESIS))
+              else if (temp_chamber.is_below_target(CHAMBER_LIMIT_HYSTERESIS))
                 temp_chamber.soft_pwm_amount = (MAX_CHAMBER_POWER) >> 1;
             #else
               temp_chamber.soft_pwm_amount = temp_chamber.is_below_target() ? (MAX_CHAMBER_POWER) >> 1 : 0;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2223,9 +2223,9 @@ void Temperature::mintemp_error(const heater_id_t heater_id OPTARG(ERR_INCLUDE_T
           }
           else {
             #if ENABLED(CHAMBER_LIMIT_SWITCHING)
-              if (temp_chamber.is_above_target(TEMP_CHAMBER_HYSTERESIS))
+              if (temp_chamber.is_above_target(CHAMBER_HYSTERESIS))
                 temp_chamber.soft_pwm_amount = 0;
-              else if (temp_chamber.is_below_target(TEMP_CHAMBER_HYSTERESIS))
+              else if (temp_chamber.is_below_target(CHAMBER_HYSTERESIS))
                 temp_chamber.soft_pwm_amount = (MAX_CHAMBER_POWER) >> 1;
             #else
               temp_chamber.soft_pwm_amount = temp_chamber.is_below_target() ? (MAX_CHAMBER_POWER) >> 1 : 0;


### PR DESCRIPTION
### Description

Issue https://github.com/MarlinFirmware/Marlin/issues/28514 noticed that CHAMBER_HYSTERESIS in 
CHAMBER_LIMIT_SWITCHING was not working. 

The issue is the CHAMBER_LIMIT_SWITCHING code incorrectly used TEMP_CHAMBER_HYSTERESIS
No code used CHAMBER_HYSTERESIS at all other than it being in the Coonfiguration_adv.h.

Been this way since the configuration option CHAMBER_HYSTERESIS was added: https://github.com/MarlinFirmware/Marlin/commit/a3a10b62f21cfbedfd001746faa46ac55d248b36 

### Requirements

Attempt to use CHAMBER_HYSTERESIS

### Benefits

Works as expected

### Related Issues

<li>MarlinFirmware/Marlin/issues/28514
