### PR TITLE
add SERIAL_PORT 2 support to ESP32 HAL for tinybee

### DIFF
--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
@@ -25,5 +25,6 @@
 #include "FlushableHardwareSerial.h"
 
 Serial1Class<FlushableHardwareSerial> flushableSerial(false, 0);
+Serial1Class<FlushableHardwareSerial> flushableSerial2(false, 2);
 
 #endif

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -32,3 +32,4 @@ public:
 };
 
 extern Serial1Class<FlushableHardwareSerial> flushableSerial;
+extern Serial1Class<FlushableHardwareSerial> flushableSerial2;

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -60,6 +60,17 @@
   #define MYSERIAL2 webSocketSerial
 #endif
 
+#if (SERIAL_PORT_2 == 2)
+  #define MYSERIAL2 flushableSerial2
+#endif
+
+#ifdef LCD_SERIAL_PORT
+  #if LCD_SERIAL_PORT==2
+    #define LCD_SERIAL flushableSerial2
+    #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+  #endif
+#endif
+
 #define CRITICAL_SECTION_START() portENTER_CRITICAL(&hal.spinlock)
 #define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&hal.spinlock)
 

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -60,15 +60,13 @@
   #define MYSERIAL2 webSocketSerial
 #endif
 
-#if (SERIAL_PORT_2 == 2)
+#if SERIAL_PORT_2 == 2
   #define MYSERIAL2 flushableSerial2
 #endif
 
-#ifdef LCD_SERIAL_PORT
-  #if LCD_SERIAL_PORT==2
-    #define LCD_SERIAL flushableSerial2
-    #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
-  #endif
+#if LCD_SERIAL_PORT == 2
+  #define LCD_SERIAL flushableSerial2
+  #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
 #endif
 
 #define CRITICAL_SECTION_START() portENTER_CRITICAL(&hal.spinlock)


### PR DESCRIPTION
### Description

User wants to use #define SERIAL_PORT_2 2  but MarlinFirmware did not support this.
But the original makerbase-mks firmware did. https://github.com/makerbase-mks/MKS-TinyBee/blob/main/firmware/mks%20tinybee%20marlin/Marlin/src/HAL/ESP32/HAL.h#L71-L80 

I ported over the changes to modern Marlin. 

### Requirements

SERIAL_PORT_2 2  on a ESP32 eg MKS_TINYBEE

### Benefits

Builds as expected

### Configurations
From the issue
[Configuration.zip](https://github.com/user-attachments/files/30759673/Configuration.zip)

### Related Issues

<li>MarlinFirmware/Marlin/issues/28516