### PR TITLE
add LEVELING_HEAT_SOAK_TIME

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2218,8 +2218,9 @@
  */
 //#define PREHEAT_BEFORE_LEVELING
 #if ENABLED(PREHEAT_BEFORE_LEVELING)
-  #define LEVELING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
-  #define LEVELING_BED_TEMP     50
+  #define LEVELING_NOZZLE_TEMP     120   // (°C) Only applies to E0 at this time
+  #define LEVELING_BED_TEMP         50
+  //#define LEVELING_HEAT_SOAK_TIME 60   // (s) Time to wait for heat soak after heaters reach temperature
 #endif
 
 /**

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -706,6 +706,7 @@ namespace LanguageNarrow_en {
   LSTR MSG_ERR_COOLING_FAILED             = _UxGT("Cooling Failed");
   LSTR MSG_PLEASE_WAIT                    = _UxGT("Please wait...");
   LSTR MSG_PREHEATING                     = _UxGT("Preheating...");
+  LSTR MSG_HEAT_SOAK                      = _UxGT("Heat Soak");
   LSTR MSG_PROBE_HEATING                  = _UxGT("Probe Heating...");
   LSTR MSG_PROBE_COOLING                  = _UxGT("Probe Cooling...");
   LSTR MSG_LASER_COOLING                  = _UxGT("Laser Cooling...");

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -504,11 +504,18 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       }
     #endif
 
+    #ifdef LEVELING_HEAT_SOAK_TIME
+      DEBUG_ECHOPGM(" and soak for ", LEVELING_HEAT_SOAK_TIME, "s");
+    #endif
+
     DEBUG_EOL();
 
     if (!early) {
       TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotend_temp > thermalManager.wholeDegHotend(0) + (TEMP_WINDOW)) thermalManager.wait_for_hotend(0));
       TERN_(WAIT_FOR_BED_HEAT,    if (bed_temp    > thermalManager.wholeDegBed() + (TEMP_BED_WINDOW)) thermalManager.wait_for_bed_heating());
+      #ifdef LEVELING_HEAT_SOAK_TIME
+        thermalManager.wait_for_heat_soak(LEVELING_HEAT_SOAK_TIME);
+      #endif
     }
   }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -5092,6 +5092,48 @@ void Temperature::isr() {
 
   #endif // HAS_HEATED_BED
 
+  #ifdef LEVELING_HEAT_SOAK_TIME
+    void Temperature::wait_for_heat_soak(const uint16_t seconds) {
+      if (!seconds) return;
+
+      SERIAL_ECHOLNPGM("Heat soak for ", seconds, "s");
+
+      #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
+        KEEPALIVE_STATE(NOT_BUSY);
+      #endif
+
+      const millis_t soak_ms = SEC_TO_MS(seconds);
+      const millis_t soak_start = millis();
+      millis_t now = soak_start, next_temp_ms = soak_start;
+
+      marlin.heatup_start();
+      while (marlin.is_heating() && PENDING(now, soak_start, soak_ms)) {
+        now = millis();
+        if (ELAPSED(now, next_temp_ms)) {
+          next_temp_ms = now + 1000UL;
+
+          print_heater_states(motion.extruder);
+          const millis_t elapsed = now - soak_start;
+          const millis_t remaining = elapsed >= soak_ms ? 0 : soak_ms - elapsed;
+          SString<24> s(F(" W:"));
+          s += long((remaining + 999UL) / 1000UL);
+          s.echo();
+          SERIAL_EOL();
+
+          TERN_(HAS_STATUS_MESSAGE, ui.status_printf(0, F(S_FMT " %lus"), GET_TEXT(MSG_HEAT_SOAK), long((remaining + 999UL) / 1000UL)));
+        }
+
+        marlin.idle();
+        gcode.reset_stepper_timeout(); // Keep steppers powered
+      }
+
+      if (marlin.is_heating()) {
+        marlin.heatup_done();
+        ui.reset_status();
+      }
+    }
+  #endif
+
   #if HAS_TEMP_PROBE
 
     #ifndef MIN_DELTA_SLOPE_DEG_PROBE

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -1137,6 +1137,10 @@ class Temperature {
 
       static void wait_for_bed_heating();
 
+      #ifdef LEVELING_HEAT_SOAK_TIME
+        static void wait_for_heat_soak(const uint16_t seconds);
+      #endif
+
       static void manage_heated_bed(const millis_t &ms);
 
     #endif // HAS_HEATED_BED


### PR DESCRIPTION
### Description

Wanted a heat soak option for PREHEAT_BEFORE_LEVELING to make sure everything is well stabilized. 

So I added a completely optional LEVELING_HEAT_SOAK_TIME 

Might have gone OTT with the user notification side of it.

### Requirements

A probe and PREHEAT_BEFORE_LEVELING 

### Benefits

Give the machine time to heat soak before leveling.

### Configurations

[Configuration eg.zip](https://github.com/user-attachments/files/30828225/Configuration.eg.zip)

### Related Issues

Prompted by <li>MarlinFirmware/Marlin/issues/28489
