### PR TITLE
🔧 Enable BTT SKRat TMC UART drivers

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKRAT_V1_0.h
@@ -266,18 +266,16 @@
   //
   // Software serial
   //
-  //#define X_SERIAL_TX_PIN                 PF10
-  //#define Y_SERIAL_TX_PIN                 PD4
-  //#define Z_SERIAL_TX_PIN                 PC8
-  //#define E0_SERIAL_TX_PIN                PD8
-  //#define E1_SERIAL_TX_PIN                PB11
+  #define X_SERIAL_TX_PIN                   PF10
+  #define Y_SERIAL_TX_PIN                   PD4
+  #define Z_SERIAL_TX_PIN                   PC8
+  #define E0_SERIAL_TX_PIN                  PD8
+  #define E1_SERIAL_TX_PIN                  PB11
 
   // Reduce baud rate to improve software serial reliability
-  //#ifndef TMC_BAUD_RATE
-  //  #define TMC_BAUD_RATE                19200
-  //#endif
-
-  #error "UART-based drivers are not supported on this board."
+  #ifndef TMC_BAUD_RATE
+    #define TMC_BAUD_RATE                  19200
+  #endif
 
 #endif
 


### PR DESCRIPTION
### Description

Re-enable UART-based TMC drivers on the BigTreeTech SKRat V1.0.

Support was disabled in #27639 after all register reads returned `ALL LOW` with the TMCStepper version used by #27361. [MarlinFirmware/TMCStepper#5](https://github.com/MarlinFirmware/TMCStepper/pull/5) fixed software UART read timing in v0.8.6.

### Requirements

BigTreeTech SKRat V1.0 with UART-based TMC drivers and the socket jumpers set for UART mode.

### Benefits

UART-based TMC drivers work on the SKRat.

### Configurations

Built with `STM32G0B1VE_btt` and tested on an SKRat V1.0 with external 24V power and TMC2209 drivers. `M122` returned valid register data and all connection tests passed.

- [btt-skrat-tmc2209-test.zip](https://github.com/user-attachments/files/30883914/btt-skrat-tmc2209-test.zip)

### Related Issues

- #27361
- #27639
- https://github.com/MarlinFirmware/TMCStepper/pull/5
