### PR TITLE
Fix TMC current step-down underflow

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -335,7 +335,7 @@
     template<typename TMC>
     void step_current_down(TMC &st) {
       if (st.isEnabled()) {
-        const uint16_t I_rms = st.getMilliamps() - (CURRENT_STEP_DOWN);
+        const int32_t I_rms = int32_t(st.getMilliamps()) - int32_t(CURRENT_STEP_DOWN);
         if (I_rms > 50) {
           st.rms_current(I_rms);
           #if ENABLED(REPORT_CURRENT_CHANGE)


### PR DESCRIPTION
### Description

`step_current_down()` subtracts `CURRENT_STEP_DOWN` before checking the
50 mA lower limit. Because the result is stored as `uint16_t`, a step larger
than the current wraps around (for example, 100 - 200 becomes 65,436) and the
wrapped value passes the lower-limit check.

Compute the subtraction with signed 32-bit operands so a negative result stays
negative and the existing lower-limit check skips the current update. Valid
decrements retain the existing behavior.

### Requirements

This affects Trinamic drivers configured with `MONITOR_DRIVER_STATUS` and a
positive `CURRENT_STEP_DOWN`.

### Benefits

Prevents repeated over-temperature warnings from wrapping a low driver current
to a very high value instead of stopping the automatic step-down.

### Configurations

- `LPC1769`, test config 03: TMC2130 with `MONITOR_DRIVER_STATUS` — build passed,
  12,188 bytes RAM and 123,648 bytes flash (no flash-size change from baseline).
- `mega2560ext`, test config 06: TMC2160/TMC5160/TMC2130 with
  `MONITOR_DRIVER_STATUS` — build passed, 3,896 bytes RAM and 144,506 bytes flash.
- Boundary harness covered normal decrements, the 50 mA cutoff, current below
  the configured step, zero current, and the `uint16_t` upper boundary.

### Related Issues

Fixes #27102.
