### PR TITLE
🔧 ESP32 TinyBee serial/timer fixes and platform bump

### DIFF
--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
@@ -22,7 +22,19 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
+#include "../../inc/MarlinConfig.h"
 #include "FlushableHardwareSerial.h"
+
+#if MB(MKS_TINYBEE)
+  // Emitted once per TinyBee build so the log shows which path was compiled in.
+  #ifndef MARLIN_ESP32_RX_QUEUE_LEN
+    #pragma message "TinyBee: UART0 RX buffer NOT resized (RX_BUFFER_SIZE <= 256 or MARLIN_ESP32_KEEP_STOCK_RX_BUFFER)"
+  #elif MARLIN_ESP32_CORE_MAJOR == 1
+    #pragma message "TinyBee: UART0 RX queue sized from RX_BUFFER_SIZE (arduino-esp32 1.0.x path, uartBegin)"
+  #else
+    #pragma message "TinyBee: UART0 RX buffer sized from RX_BUFFER_SIZE (arduino-esp32 2.0.x path, setRxBufferSize)"
+  #endif
+#endif
 
 Serial1Class<FlushableHardwareSerial> flushableSerial(false, 0);
 Serial1Class<FlushableHardwareSerial> flushableSerial2(false, 2);

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -26,9 +26,126 @@
 #include "../shared/Marduino.h"
 #include "../../core/serial_hook.h"
 
+#if MB(MKS_TINYBEE)
+
+  #if __has_include(<esp_arduino_version.h>)
+    #include <esp_arduino_version.h>   // Only exists from arduino-esp32 2.0.0
+  #endif
+
+  /**
+   * MKS TinyBee: Marlin's RX_BUFFER_SIZE never reaches the ESP32 host port (UART0).
+   *
+   * MYSERIAL1 is flushableSerial (HAL/ESP32/HAL.h), and MarlinCore calls
+   * MYSERIAL1.begin(BAUDRATE) without any buffer size, so whatever the Arduino
+   * core picks as its default is what the printer actually gets. Both core
+   * generations pick something too small and then drop the surplus silently:
+   *
+   *  - arduino-esp32 1.0.x: HardwareSerial::begin() hands a literal 256 to
+   *    uartBegin(), which does xQueueCreate(256, 1). When that queue is full the
+   *    RX ISR still drains the hardware FIFO and throws the byte away, with no
+   *    error flag and no counter.
+   *
+   *  - arduino-esp32 2.0.x: begin() passes the _rxBufferSize member (256 by
+   *    default) to uartBegin(), which becomes the IDF driver's ring buffer. The
+   *    IDF driver at least raises UART_BUFFER_FULL / UART_FIFO_OVF events, but
+   *    Marlin installs no onReceiveError() handler, so the loss is silent again.
+   *
+   * It can fill up because the I2S stepper task (HAL/ESP32/i2s.cpp) is pinned to
+   * the same core and the same priority (1) as the Arduino loopTask that runs
+   * GCodeQueue, and it spins through a whole DMA buffer (~4 ms) before it blocks
+   * again. On the host this surfaces as "Line Number is not Last Line Number+1",
+   * "checksum mismatch", "Resend:" and aborted prints.
+   *
+   * The two core generations need different fixes, see the class below.
+   */
+
+  // arduino-esp32 1.0.x has no esp_arduino_version.h, hence no version macros.
+  #ifdef ESP_ARDUINO_VERSION_MAJOR
+    #define MARLIN_ESP32_CORE_MAJOR ESP_ARDUINO_VERSION_MAJOR
+  #else
+    #define MARLIN_ESP32_CORE_MAJOR 1
+  #endif
+
+  #if defined(RX_BUFFER_SIZE) && RX_BUFFER_SIZE > 256 && DISABLED(MARLIN_ESP32_KEEP_STOCK_RX_BUFFER)
+    #define MARLIN_ESP32_RX_QUEUE_LEN RX_BUFFER_SIZE
+  #endif
+
+  #ifdef MARLIN_ESP32_RX_QUEUE_LEN
+
+    #if MARLIN_ESP32_CORE_MAJOR == 1
+
+      #include <esp32-hal-uart.h>
+
+      #if RX_BUFFER_SIZE > 65535
+        #error "RX_BUFFER_SIZE must be <= 65535 on arduino-esp32 1.0.x (uartBegin() takes a uint16_t queue length)."
+      #endif
+
+    #elif MARLIN_ESP32_CORE_MAJOR == 2
+
+      #include <soc/soc_caps.h>
+
+      #if RX_BUFFER_SIZE <= SOC_UART_FIFO_LEN
+        #error "RX_BUFFER_SIZE must be > SOC_UART_FIFO_LEN or setRxBufferSize() rejects it."
+      #endif
+      #if RX_BUFFER_SIZE > 65535
+        #error "RX_BUFFER_SIZE must be <= 65535 (uartBegin() takes a uint16_t rx_buffer_size)."
+      #endif
+
+    #else
+
+      // Never let this fail quietly: a silently ineffective RX_BUFFER_SIZE is the
+      // exact bug this file exists to fix.
+      #error "Untested arduino-esp32 major version. Verify how HardwareSerial::begin() sizes the RX buffer, then extend FlushableHardwareSerial. Define MARLIN_ESP32_KEEP_STOCK_RX_BUFFER to build without the fix."
+
+    #endif
+
+  #endif
+
+#endif // MARLIN_ESP32_TINYBEE_FIXES
+
 class FlushableHardwareSerial : public HardwareSerial {
 public:
   FlushableHardwareSerial(int uart_nr) : HardwareSerial(uart_nr) {}
+
+  #if MB(MKS_TINYBEE) && defined(MARLIN_ESP32_RX_QUEUE_LEN)
+    #if MARLIN_ESP32_CORE_MAJOR == 1
+
+      /**
+       * 1.0.x: the 256 is a literal inside begin(), and setRxBufferSize() maps to
+       * uartResizeRxBuffer(), which does vQueueDelete() + xQueueCreate() while the
+       * RX ISR is live and would dereference the freed handle. So run the stock
+       * begin() (it resolves the pins and, from 1.0.5 on, records _rx_pin/_tx_pin
+       * for a later end()), then tear it down through end() and re-run uartBegin()
+       * with the real size.
+       */
+      void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms=20000UL) {
+        HardwareSerial::begin(baud, config, rxPin, txPin, invert, timeout_ms);
+
+        // Baud detection (baud == 0) and the remapped UART1/UART2 (TMC UART) keep
+        // stock behavior. A failed begin() leaves _uart NULL; nothing to redo.
+        if (_uart_nr != 0 || !baud || !_uart) return;
+
+        if (rxPin < 0 && txPin < 0) { rxPin = 3; txPin = 1; }  // ESP32 UART0 default pads
+
+        HardwareSerial::end();
+        _uart = uartBegin(0, baud, config, rxPin, txPin, MARLIN_ESP32_RX_QUEUE_LEN, invert);
+      }
+
+    #else
+
+      /**
+       * 2.0.x: begin() forwards the _rxBufferSize member to uartBegin(), so the
+       * size only has to be recorded first. setRxBufferSize() refuses to run once
+       * the driver is installed (it returns 0 and logs), which is why it must come
+       * before begin() and not after.
+       */
+      void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms=20000UL, uint8_t rxfifo_full_thrhd=112) {
+        if (_uart_nr == 0 && !_uart) setRxBufferSize(MARLIN_ESP32_RX_QUEUE_LEN);
+        HardwareSerial::begin(baud, config, rxPin, txPin, invert, timeout_ms, rxfifo_full_thrhd);
+      }
+
+    #endif
+  #endif
 };
 
 extern Serial1Class<FlushableHardwareSerial> flushableSerial;

--- a/Marlin/src/HAL/ESP32/timers.cpp
+++ b/Marlin/src/HAL/ESP32/timers.cpp
@@ -29,6 +29,99 @@
 
 #include "../../inc/MarlinConfig.h"
 
+#if MB(MKS_TINYBEE)
+
+  #if __has_include(<esp_arduino_version.h>)
+    #include <esp_arduino_version.h>   // Only exists from arduino-esp32 2.0.0
+  #endif
+
+  /**
+   * MKS TinyBee: with I2S_STEPPER_STREAM the step timer is read but never started.
+   *
+   * Stepping is produced by the I2S DMA stream, so Stepper::init() skips the only
+   * HAL_timer_start() the step timer ever gets:
+   *
+   *   Marlin/src/module/stepper.cpp:3258
+   *     #if DISABLED(I2S_STEPPER_STREAM)
+   *       HAL_timer_start(MF_TIMER_STEP, 122);
+   *
+   * Nothing stopped reading it though. Marlin 2.1.x replaced the multistepping
+   * heuristic with one that measures how long the ISR takes, and put the first
+   * measurement at the top of block_phase_isr():
+   *
+   *   Marlin/src/module/stepper.cpp:2397
+   *     hal_timer_t Stepper::block_phase_isr() {
+   *       #if DISABLED(OLD_ADAPTIVE_MULTISTEPPING)
+   *         const hal_timer_t time_spent = HAL_timer_get_count(MF_TIMER_STEP);
+   *
+   * In I2S mode block_phase_isr() is not driven by that timer at all, it is called
+   * from stepperTask (HAL/ESP32/i2s.cpp:171) which loops over the DMA buffer
+   * forever, so this read happens continuously from boot whether the printer moves
+   * or not. Marlin 2.0.9.2 (the MKS fork) has no such read - block_phase_isr()
+   * starts straight at "uint32_t interval" - which is why this is a 2.1.x
+   * regression and not something the MKS firmware ever hit.
+   *
+   * START_TIMED_PULSE() (stepper.cpp:524, used from pulse_phase_isr() whenever
+   * ISR_PULSE_CONTROL is on) reads the same timer, so movement adds a second
+   * source once the machine is actually stepping.
+   *
+   * Why it only became visible on espressif32@6.1.0:
+   *
+   *  - arduino-esp32 1.0.x (ESP-IDF 3.3): timer_get_counter_value() just reads the
+   *    register. A never-started timer reads 0 and nobody complains.
+   *
+   *  - arduino-esp32 2.0.x (ESP-IDF 4.4): the driver keeps a per-timer object that
+   *    timer_init() allocates, and every entry point asserts on it first:
+   *      TIMER_CHECK(p_timer_obj[group_num][timer_num] != NULL, TIMER_NEVER_INIT_ERROR, ESP_ERR_INVALID_ARG);
+   *    So the call logs "E (...) timer_group: timer_get_counter_value(54): HW
+   *    TIMER NEVER INIT ERROR", returns ESP_ERR_INVALID_ARG, and leaves the output
+   *    parameter untouched. Called in a tight loop that is one error line per
+   *    iteration; at 115200 baud a ~75 character line takes ~6.5 ms, which matches
+   *    the observed ~7 ms spacing exactly. Because uartWriteBuf() busy-waits on
+   *    the TX FIFO, the log traffic starves the loopTask and the host connection
+   *    dies.
+   *
+   * The repair is to give the step timer a real counter. In I2S mode the timer
+   * hardware (TIMERG0 timer 0) is otherwise completely idle, so it is started here
+   * as a plain free-running counter - no alarm, no interrupt, no ISR registered -
+   * ticking at STEPPER_TIMER_RATE, which is the unit every caller already assumes
+   * (calc_timer_interval() returns STEPPER_TIMER_RATE/step_rate, ns_to_pulse_timer_ticks()
+   * divides by 1e9/STEPPER_TIMER_RATE). HAL_timer_get_count() then means what its
+   * name says instead of erroring out.
+   *
+   * Returning a constant instead would have been shorter and is wrong: AWAIT_TIMED_PULSE()
+   * (stepper.cpp:525) spins on "PULSE_x_TICK_COUNT > count - start_pulse_count", so
+   * a value that never advances is an infinite loop in pulse_phase_isr() as soon as
+   * PULSE_HIGH_TICK_COUNT is non-zero. It happens to be 0 for TMC2209_STANDALONE
+   * (MINIMUM_STEPPER_PULSE_NS 100 is below the 4 µs tick), but that is a property
+   * of this config, not something to build a HAL on.
+   */
+
+  // arduino-esp32 1.0.x has no esp_arduino_version.h, hence no version macros.
+  #ifdef ESP_ARDUINO_VERSION_MAJOR
+    #define MARLIN_ESP32_CORE_MAJOR ESP_ARDUINO_VERSION_MAJOR
+  #else
+    #define MARLIN_ESP32_CORE_MAJOR 1
+  #endif
+
+  #if ENABLED(I2S_STEPPER_STREAM) && DISABLED(MARLIN_ESP32_KEEP_STOCK_STEP_TIMER)
+
+    #define MARLIN_ESP32_I2S_STEP_COUNTER 1
+
+    #if MARLIN_ESP32_CORE_MAJOR > 2
+      // Never let this fail quietly: a HAL that silently reads a dead timer is the
+      // exact bug this file exists to fix. ESP-IDF 5.x deprecated the legacy
+      // driver/timer.h API this file (and stock Marlin) is written against, so the
+      // free-running-counter setup has to be re-checked against gptimer first.
+      #error "Untested arduino-esp32 major version. Verify that driver/timer.h still starts a counter without an alarm, then extend timers.cpp. Define MARLIN_ESP32_KEEP_STOCK_STEP_TIMER to build without the fix (expect a HW TIMER NEVER INIT ERROR flood on the serial port)."
+    #endif
+
+    #pragma message "TinyBee: I2S step timer free-running counter active"
+
+  #endif
+
+#endif // MARLIN_ESP32_TINYBEE_FIXES
+
 // ------------------------
 // Local defines
 // ------------------------
@@ -47,6 +140,20 @@ const tTimerConfig timer_config[NUM_HARDWARE_TIMERS] = {
   { TIMER_GROUP_1, TIMER_0,     PWM_TIMER_PRESCALE, pwmTC_Handler  }, // 2 - PWM
   { TIMER_GROUP_1, TIMER_1,    TONE_TIMER_PRESCALE, toneTC_Handler }, // 3 - Tone
 };
+
+#if MB(MKS_TINYBEE)
+
+  /**
+   * Timers that have been through timer_init(), i.e. the ones the ESP-IDF driver
+   * will accept. MF_TIMER_PWM is only started when the first PWM pin is attached
+   * (HAL.cpp:398) and MF_TIMER_TONE only while a tone plays (Tone.cpp:41), so this
+   * is not exclusively about the step timer.
+   */
+  static uint8_t timer_started = 0;
+
+  #define TIMER_IS_STARTED(N) TEST(timer_started, N)
+
+#endif
 
 // ------------------------
 // Public functions
@@ -75,6 +182,63 @@ void IRAM_ATTR timer_isr(void *para) {
   // Enable it again so it gets triggered the next time
   TG[timer.group]->hw_timer[timer.idx].config.alarm_en = TIMER_ALARM_EN;
 }
+
+#if ENABLED(MARLIN_ESP32_I2S_STEP_COUNTER)
+
+  /**
+   * A tick of the step timer is 1/STEPPER_TIMER_RATE of a second to every caller,
+   * so that is what the counter has to run at. STEPPER_TIMER_PRESCALE is 1 under
+   * I2S_STEPPER_STREAM (timers.h:54) and describes the I2S word clock, not a
+   * timer divider, so it cannot be reused here.
+   */
+  constexpr uint32_t step_counter_divider = (HAL_TIMER_RATE) / (STEPPER_TIMER_RATE);
+
+  static_assert(step_counter_divider * uint32_t(STEPPER_TIMER_RATE) == uint32_t(HAL_TIMER_RATE),
+    "STEPPER_TIMER_RATE must divide HAL_TIMER_RATE exactly, or the step counter drifts against the tick unit every caller assumes.");
+  static_assert(step_counter_divider >= 2 && step_counter_divider <= 65536,
+    "The step counter divider is outside the ESP32 timer's 2..65536 range.");
+
+  /**
+   * The pulse-timing macros read MF_TIMER_PULSE and everything else reads
+   * MF_TIMER_STEP. Only the latter is given a counter below, so a build that
+   * splits the two would put the pulse waits back on a dead timer.
+   */
+  static_assert(MF_TIMER_PULSE == MF_TIMER_STEP,
+    "MF_TIMER_PULSE is no longer MF_TIMER_STEP. Give MF_TIMER_PULSE a counter too before building this.");
+
+  static void start_step_counter() {
+    const tTimerConfig timer = timer_config[MF_TIMER_STEP];
+
+    // Zero-initialized on purpose: stock HAL_timer_start() leaves any member it
+    // does not know about (clk_src on the SoCs that have it) holding stack junk.
+    timer_config_t config = {};
+    config.divider     = step_counter_divider;
+    config.counter_dir = TIMER_COUNT_UP;
+    config.counter_en  = TIMER_PAUSE;
+    config.alarm_en    = TIMER_ALARM_DIS;    // No alarm and no timer_isr_register():
+    config.intr_type   = TIMER_INTR_LEVEL;   // stepTC_Handler() must never run in I2S mode,
+    config.auto_reload = TIMER_AUTORELOAD_DIS;  // the DMA stream owns the stepping.
+
+    timer_init(timer.group, timer.idx, &config);
+    timer_set_counter_value(timer.group, timer.idx, 0x00000000ULL);
+    timer_start(timer.group, timer.idx);
+  }
+
+  /**
+   * stepperTask reaches this within microseconds of i2s_init(), long before
+   * anything else reads the step timer, so in practice the first call is alone
+   * here. The flag is still raised before the setup rather than after: a second
+   * caller then reads a counter that is mid-configuration (0, or a value that
+   * jumps once) instead of running timer_init() a second time. Both callers only
+   * ever use differences of this value, and both tolerate a single jump.
+   */
+  static void ensure_step_counter() {
+    if (TIMER_IS_STARTED(MF_TIMER_STEP)) return;
+    SBI(timer_started, MF_TIMER_STEP);
+    start_step_counter();
+  }
+
+#endif // MARLIN_ESP32_I2S_STEP_COUNTER
 
 /**
  * Enable and initialize the timer
@@ -106,6 +270,10 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
   timer_isr_register(timer.group, timer.idx, timer_isr, (void*)(uint32_t)timer_num, 0, nullptr);
 
   timer_start(timer.group, timer.idx);
+
+  #if MB(MKS_TINYBEE)
+    SBI(timer_started, timer_num);
+  #endif
 }
 
 /**
@@ -116,6 +284,9 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
  */
 void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
   const tTimerConfig timer = timer_config[timer_num];
+  #if MB(MKS_TINYBEE)
+    if (!TIMER_IS_STARTED(timer_num)) return;
+  #endif
   timer_set_alarm_value(timer.group, timer.idx, compare);
 }
 
@@ -127,8 +298,16 @@ void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
 hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   const tTimerConfig timer = timer_config[timer_num];
 
-  uint64_t alarm_value;
-  timer_get_alarm_value(timer.group, timer.idx, &alarm_value);
+  #if MB(MKS_TINYBEE)
+    // Zeroed because the driver leaves it untouched when it rejects the call, and
+    // stock returns that indeterminate value.
+    uint64_t alarm_value = 0;
+    if (TIMER_IS_STARTED(timer_num))
+      timer_get_alarm_value(timer.group, timer.idx, &alarm_value);
+  #else
+    uint64_t alarm_value;
+    timer_get_alarm_value(timer.group, timer.idx, &alarm_value);
+  #endif
 
   return alarm_value;
 }
@@ -140,8 +319,20 @@ hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
  */
 hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig timer = timer_config[timer_num];
-  uint64_t counter_value;
-  timer_get_counter_value(timer.group, timer.idx, &counter_value);
+
+  #if ENABLED(MARLIN_ESP32_I2S_STEP_COUNTER)
+    if (timer_num == MF_TIMER_STEP) ensure_step_counter();
+  #endif
+
+  #if MB(MKS_TINYBEE)
+    uint64_t counter_value = 0;
+    if (TIMER_IS_STARTED(timer_num))
+      timer_get_counter_value(timer.group, timer.idx, &counter_value);
+  #else
+    uint64_t counter_value;
+    timer_get_counter_value(timer.group, timer.idx, &counter_value);
+  #endif
+
   return counter_value;
 }
 

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -43,7 +43,7 @@ monitor_speed          = 115200
 [env:mks_tinybee]
 extends                = env:esp32
 board                  = marlin_MKS_TinyBee
-platform               = espressif32@~3.5.0
+platform               = espressif32@6.1.0
 board_build.partitions = default_8MB.csv
 build_src_flags        = -O3
 monitor_filters        = esp32_exception_decoder


### PR DESCRIPTION
- Size UART0 RX buffer from RX_BUFFER_SIZE for arduino-esp32 1.0.x and 2.0.x
- Initialize the step timer so HAL_timer_get_count works with I2S stepping
- Bump mks_tinybee environment to espressif32@6.1.0

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

There is a hidden/muted error in the serial communication stack on the ESP based (MKS Tinybee) boards. There is a clue that octoprint catch a "Serial status mismatch" error, and the print halt. (https://github.com/MarlinFirmware/Marlin/issues/27450) 

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
MKS Tinybee (and other ESP32 based board?)

### Benefits

<!-- What does this PR fix or improve? -->
Marlin relies on Arduino based serial communicaion stack, but esp-idf has different stack implemented. This fix enables serial G-code streaming for the printer (Eg. From Octoprint) without SD card.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

ESP32 (MKS Tinybee) with serial streaming on ESP-IDF based serial protocol stack.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
https://github.com/MarlinFirmware/Marlin/issues/27450
https://github.com/MarlinFirmware/Marlin/issues/21010