### PR TITLE
🔧 Correct USB host support for H723 Octopus Pro

### DIFF
--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -61,6 +61,10 @@
   #error "TEMP_SENSOR_SOC requires 'TEMP_SOC_PIN ATEMP' on STM32."
 #endif
 
+#if ENABLED(USE_OTG_USB_HOST) && !defined(USBHOST)
+  #error "USE_OTG_USB_HOST requires a '..._usb_flash_drive' PlatformIO environment."
+#endif
+
 /**
  * Check for common serial pin conflicts
  */

--- a/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_OCTOPUS_PRO_V1_common.h
@@ -23,7 +23,6 @@
 
 #include "env_validate.h"
 
-#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 #define USES_DIAG_JUMPERS
 
 // Onboard I2C EEPROM


### PR DESCRIPTION
### Description

Also adds a sanity check for `USE_OTG_USB_HOST` outside a `_usb_flash_drive` environment.

`HAS_OTG_USB_HOST_SUPPORT` came over with the H723 Octopus Pro pins in #26159, but the H723 can't do it. The USB-A port's D-/D+ go to `PB14`/`PB15`, which have no USB alternate function on that MCU. Its only USB peripheral, `OTG_HS`, is on `PA11`/`PA12`, which is the USB-C device port. The F429/F446 versions of the board do use `PB14`/`PB15` as `OTG_HS`, so they keep it.

The `*_usb_flash_drive` env requested in #26115 can't be added for STM32H7 either. `[stm_flash_drive]` pins the core to the `stm-flash-drive` branch of `MarlinFirmware/Arduino_Core_STM32`, which predates H723 variant support.

### Requirements

BTT Octopus Pro V1.0.1 / V1.1 (STM32H723ZE), or any STM32 board with `USB_FLASH_DRIVE_SUPPORT` + `USE_OTG_USB_HOST`.

### Benefits

Users get a build error explaining the problem instead of a link failure.

### Related Issues

- #26115
- #26159