### PR TITLE
🔨 Update STM32H7 (and FLY D5/D7) to framework-arduinoststm32 4.20600.231001

### DIFF
--- a/Marlin/src/HAL/STM32/sdio.cpp
+++ b/Marlin/src/HAL/STM32/sdio.cpp
@@ -52,6 +52,9 @@
   #include <stm32h7xx_hal_dma.h>
   #include <stm32h7xx_hal_gpio.h>
   #include <stm32h7xx_hal_sd.h>
+  // Arduino_Core_STM32 2.6.0 split PinMap_SD into per-signal maps and dropped this
+  // declaration from PeripheralPins.h, but Marlin's variants still define the combined map.
+  extern const PinMap PinMap_SD[];
 #else
   #error "SDIO is only supported with STM32F103xE, STM32F103xG, STM32F4xx, STM32F7xx, and STM32H7xx."
 #endif

--- a/ini/stm32f0.ini
+++ b/ini/stm32f0.ini
@@ -58,7 +58,7 @@ platform                = ststm32
 extends                 = stm32_variant
 board                   = marlin_STM32F072
 board_build.variant     = MARLIN_FLY_D5
-platform_packages       = framework-arduinoststm32@4.20500.230714
+platform_packages       = framework-arduinoststm32@~4.20600.231001
                           framework-cmsis@2.50700.210515
                           toolchain-gccarmnoneeabi@1.100301.220327
 build_flags             = ${stm32_variant.build_flags}
@@ -73,7 +73,7 @@ platform                = ststm32
 extends                 = stm32_variant
 board                   = marlin_STM32F072
 board_build.variant     = MARLIN_FLY_D7
-platform_packages       = framework-arduinoststm32@4.20500.230714
+platform_packages       = framework-arduinoststm32@~4.20600.231001
                           framework-cmsis@2.50700.210515
                           toolchain-gccarmnoneeabi@1.100301.220327
 build_flags             = ${stm32_variant.build_flags}

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -45,8 +45,9 @@ debug_tool         = cmsis-dap
 #
 [STM32H743Vx_btt]
 extends                     = stm32_variant
-platform                    = ststm32@15.4.1
-platform_packages           = framework-arduinoststm32@~4.20200.220530
+platform                    = ststm32@17.1.0
+platform_packages           = framework-arduinoststm32@~4.20600.231001
+                              toolchain-gccarmnoneeabi@1.120301.0
 board_build.offset          = 0x20000
 board_upload.offset_address = 0x08020000
 build_flags                 = ${stm32_variant.build_flags}
@@ -72,8 +73,9 @@ board                       = marlin_STM32H743VI
 #
 [STM32H723Vx_btt]
 extends                     = stm32_variant
-platform                    = ststm32@15.4.1
-platform_packages           = framework-arduinoststm32@~4.20200.220530
+platform                    = ststm32@17.1.0
+platform_packages           = framework-arduinoststm32@~4.20600.231001
+                              toolchain-gccarmnoneeabi@1.120301.0
 board_build.offset          = 0x20000
 board_upload.offset_address = 0x08020000
 build_flags                 = ${stm32_variant.build_flags}
@@ -104,8 +106,9 @@ board                       = marlin_STM32H723VG
 #
 [STM32H723Zx_common]
 extends                     = stm32_variant
-platform                    = ststm32@15.4.1
-platform_packages           = framework-arduinoststm32@~4.20200.220530
+platform                    = ststm32@17.1.0
+platform_packages           = framework-arduinoststm32@~4.20600.231001
+                              toolchain-gccarmnoneeabi@1.120301.0
 board_build.offset          = 0x20000
 board_upload.offset_address = 0x08020000
 build_flags                 = ${stm32_variant.build_flags}
@@ -143,8 +146,9 @@ board                       = marlin_STM32H723ZG
 #
 [env:FLY_D8_PRO]
 extends                     = stm32_variant
-platform                    = ststm32@15.4.1
-platform_packages           = framework-arduinoststm32@~4.20200.220530
+platform                    = ststm32@17.1.0
+platform_packages           = framework-arduinoststm32@~4.20600.231001
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32H723VG
 board_build.variant         = MARLIN_FLY_D8_PRO
 board_build.offset          = 0x0000
@@ -161,8 +165,9 @@ upload_protocol             = dfu
 #
 [env:FLY_SUPER8_PRO]
 extends                     = stm32_variant
-platform                    = ststm32@15.4.1
-platform_packages           = framework-arduinoststm32@~4.20200.220530
+platform                    = ststm32@17.1.0
+platform_packages           = framework-arduinoststm32@~4.20600.231001
+                              toolchain-gccarmnoneeabi@1.120301.0
 board                       = marlin_STM32H723ZG
 board_build.variant         = MARLIN_FLY_SUPER8_PRO
 board_build.offset          = 0x20000


### PR DESCRIPTION
### Description

PlatformIO has removed several `framework-arduinoststm32` releases from its registry. Only four
versions remain published:

| Version | Released |
|---|---|
| `4.30000.0` | 2026-08-19 |
| `4.21200.0` | 2026-02-04 |
| `4.20600.231001` | 2023-10-02 |
| `4.10900.200819` | 2020-08-19 |

Marlin still requests two versions that are no longer published, across two config files, so
**9 build environments cannot be built at all** — PlatformIO fails during package resolution
before a single file is compiled:

- `ini/stm32h7.ini` — `framework-arduinoststm32@~4.20200.220530`, in 5 sections covering 7 environments
- `ini/stm32f0.ini` — `framework-arduinoststm32@4.20500.230714`, in 2 environments (FLY D5 / FLY D7)

```
UnknownPackageError: Could not find the package with
'platformio/framework-arduinoststm32 @ 4.20500.230714' requirements
```

This PR moves both to `~4.20600.231001` (Arduino_Core_STM32 2.6.0) — the same version
`ini/stm32f4.ini` and `ini/stm32g0.ini` already use. After this change the entire repo pins exactly
one framework version.

### Changes

#### `ini/stm32h7.ini`

Five sections updated — `[STM32H743Vx_btt]`, `[STM32H723Vx_btt]`, `[STM32H723Zx_common]`,
`[env:FLY_D8_PRO]`, `[env:FLY_SUPER8_PRO]`:

| Key | Before | After |
|---|---|---|
| `platform` | `ststm32@15.4.1` | `ststm32@17.1.0` |
| `platform_packages` | `framework-arduinoststm32@~4.20200.220530` | `framework-arduinoststm32@~4.20600.231001` |
| `platform_packages` | *(none)* | `toolchain-gccarmnoneeabi@1.120301.0` (added) |

- **Platform `15.4.1` → `17.1.0`** — 15.4.1's own manifest declares
  `framework-arduinoststm32 ~4.20200.0`. 17.1.0 is the platform release that pairs with `~4.20600.0`.
- **Toolchain pinned to `1.120301.0`** (GCC 12.3.1) — matching what `ini/stm32g0.ini` already does
  with this same platform/framework pair.

`[env:BTT_SKR_SE_BX]` is **not** touched — it builds against the `biqu-bx.zip` branch of
`MarlinFirmware/Arduino_Core_STM32`, not a registry package.

#### `ini/stm32f0.ini`

Both `[env:FLY_D5]` and `[env:FLY_D7]` change `platform_packages` from
`framework-arduinoststm32@4.20500.230714` to `framework-arduinoststm32@~4.20600.231001`. The
`framework-cmsis` and `toolchain-gccarmnoneeabi` pins in those environments are left as they are.

#### `Marlin/src/HAL/STM32/sdio.cpp`

Arduino_Core_STM32 2.6.0 split the combined `PinMap_SD[]` into per-signal maps
(`PinMap_SD_CMD`, `PinMap_SD_CK`, `PinMap_SD_DATA0`…`PinMap_SD_DATA7`, …) and removed the
`PinMap_SD` declaration from `PeripheralPins.h`:

```
sdio.cpp:91:26: error: 'PinMap_SD' was not declared in this scope; did you mean 'PinMap_USB'?
   91 |     pinmap_pinout(PC_12, PinMap_SD);
```

Marlin's own variant `PeripheralPins.c` files still **define** `WEAK const PinMap PinMap_SD[]`, so
only the declaration went missing. The fix is therefore a local `extern const PinMap PinMap_SD[];`
added to the `#elif defined(STM32H7xx)` include branch, alongside the existing `stm32h7xx_hal_*.h`
includes, with a two-line comment explaining why it is there. That keeps Marlin decoupled from the
core's header reshuffle and avoids regenerating every variant.

Only the `SDIO_FOR_STM32H7` path uses `PinMap_SD`, so F1 / F4 / F7 SDIO boards are unaffected.

### Affected Motherboards

Every board reachable from the five updated `ini/stm32h7.ini` sections and the two `ini/stm32f0.ini`
environments. Note that `[STM32H743Vx_btt]`, `[STM32H723Vx_btt]` and `[STM32H723Zx_common]` are
shared base sections, so the environments that `extend` them are affected as well —
e.g. `[env:STM32H723ZG_btt]` (BTT Kraken V1.0) inherits from `[STM32H723Zx_common]`.

#### `[STM32H743Vx_btt]` → `env:STM32H743VI_btt` (STM32H743VIT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_BTT_SKR_V3_0` | BigTreeTech SKR V3.0 |
| `BOARD_BTT_SKR_V3_0_EZ` | BigTreeTech SKR V3.0 EZ |

#### `[STM32H723Vx_btt]` → `env:STM32H723VG_btt` (STM32H723VGT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_BTT_SKR_V3_0` | BigTreeTech SKR V3.0 |
| `BOARD_BTT_SKR_V3_0_EZ` | BigTreeTech SKR V3.0 EZ |

#### `[STM32H723Zx_common]` → `env:STM32H723ZE_btt` (STM32H723ZET6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_BTT_OCTOPUS_PRO_V1_0` | BigTreeTech Octopus Pro V1.0 (H723 chip variant) |
| `BOARD_BTT_OCTOPUS_PRO_V1_0_1` | BigTreeTech Octopus Pro V1.0.1 |
| `BOARD_BTT_OCTOPUS_PRO_V1_1` | BigTreeTech Octopus Pro V1.1 |
| `BOARD_BTT_OCTOPUS_MAX_EZ_V1_0` | BigTreeTech Octopus Max EZ V1.0 |
| `BOARD_BTT_MANTA_M8P_V2_0` | BigTreeTech Manta M8P V2.0 |

#### `[STM32H723Zx_common]` → `env:STM32H723ZG_btt` (STM32H723ZGT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_BTT_KRAKEN_V1_0` | BigTreeTech Kraken V1.0 |

#### `[STM32H723Zx_common]` → `env:STM32H723ZG_fysetc` (STM32H723ZGT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_FYSETC_SPIDER_KING_V1_H723` | FYSETC Spider King V1.0 |
| `BOARD_FYSETC_SPIDER_KING_V1_1_H723` | FYSETC Spider King V1.1 |

#### `[env:FLY_D8_PRO]` (STM32H723VGT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_FLY_D8_PRO` | FLY D8 Pro |

#### `[env:FLY_SUPER8_PRO]` (STM32H723ZGT6)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_FLY_SUPER8_PRO` | FLY Super8 Pro |

#### `[env:FLY_D5]` (STM32F072RB)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_FLY_D5` | FLY D5 |
| `BOARD_FLY_DP5` | FLY DP5 |

#### `[env:FLY_D7]` (STM32F072RB)

| MOTHERBOARD | Board |
|---|---|
| `BOARD_FLY_D7` | FLY D7 |

**15 motherboards across 9 build environments.**

### Testing

Every affected environment was built locally (PlatformIO Core 6.1.19, Linux) using stock
`Configuration.h` / `Configuration_adv.h` with only `MOTHERBOARD`, `SERIAL_PORT` and — for the
Kraken — the required `TMC2160` driver types and `0.022` RSENSE values set:

| Environment | Board built | Result |
|---|---|---|
| `STM32H743VI_btt` | `BOARD_BTT_SKR_V3_0` | ✅ |
| `STM32H723VG_btt` | `BOARD_BTT_SKR_V3_0` | ✅ |
| `STM32H723ZE_btt` | `BOARD_BTT_OCTOPUS_PRO_V1_1` | ✅ |
| `STM32H723ZG_btt` | `BOARD_BTT_KRAKEN_V1_0` | ✅ |
| `STM32H723ZG_fysetc` | `BOARD_FYSETC_SPIDER_KING_V1_H723` | ✅ |
| `FLY_D8_PRO` | `BOARD_FLY_D8_PRO` | ✅ |
| `FLY_SUPER8_PRO` | `BOARD_FLY_SUPER8_PRO` | ✅ |
| `FLY_D5` | `BOARD_FLY_D5` | ✅ |
| `FLY_D7` | `BOARD_FLY_D7` | ✅ |
| `BTT_SKR_SE_BX` | `BOARD_BTT_SKR_SE_BX_V3` | ✅ (unchanged, regression check) |

Resolved packages for the H7 environments:

```
PLATFORM: ST STM32 (17.1.0)
 - framework-arduinoststm32 @ 4.20600.231001 (2.6.0)
 - framework-cmsis @ 2.50700.210515 (5.7.0)
 - toolchain-gccarmnoneeabi @ 1.120301.0 (12.3.1)
```

⚠️ **Not flashed to hardware.** These are compile-only results. Testing on real SKR V3.0 / Octopus /
Kraken / Manta / FLY boards — in particular onboard **SDIO SD card access**, which is the one code
path this PR touches — would be very welcome.

### Why not `4.21200.0` or `4.30000.0`?

Those need platform `ststm32@17.6+` / `@19.0`, and the framework versions those platforms default to
(`~4.20801.0`, `~4.20900.0`) have *also* been delisted, so moving there means untangling further
version mismatches for no immediate benefit. `4.20600.231001` is the newest still-published release that
the rest of Marlin already builds against, which makes it the low-risk landing spot. A later jump
to 2.12.0 / 3.0.0 can be its own PR.
