### PR TITLE
✨ Katapult bootloader entry (M997) and upload

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -179,7 +179,7 @@ extern "C" {
    * request key written here. If no (or an unexpected) bootloader is installed
    * this reduces to a plain reboot.
    */
-  void flashFirmware(const int16_t) {
+  WEAK void flashFirmware(const int16_t) {
     static constexpr uint64_t KATAPULT_SIGNATURE = 0x21746F6F426E6143ULL, // "CanBoot!"
                               KATAPULT_REQUEST   = 0x5984E3FA6CA1589BULL;
     const uint32_t * const bl_vectors = (uint32_t*)FLASH_BASE;

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -167,7 +167,38 @@ extern "C" {
 }
 
 // Reset the system to initiate a firmware flash
-WEAK void flashFirmware(const int16_t) { hal.reboot(); }
+#ifdef BOOTLOADER_KATAPULT
+
+  /**
+   * Request the Katapult bootloader (https://github.com/Arksine/katapult) to stay
+   * resident on reboot so new firmware can be flashed (e.g., with Katapult's
+   * flashtool.py) without pressing any BOOT / RESET buttons.
+   *
+   * Katapult stores the signature "CanBoot!" in the 8 bytes preceding its reset
+   * handler and on startup checks the 8 bytes at its initial stack pointer for the
+   * request key written here. If no (or an unexpected) bootloader is installed
+   * this reduces to a plain reboot.
+   */
+  void flashFirmware(const int16_t) {
+    static constexpr uint64_t KATAPULT_SIGNATURE = 0x21746F6F426E6143ULL, // "CanBoot!"
+                              KATAPULT_REQUEST   = 0x5984E3FA6CA1589BULL;
+    const uint32_t * const bl_vectors = (uint32_t*)FLASH_BASE;
+    uint64_t * const boot_sig = (uint64_t*)(bl_vectors[1] - 9),  // 8 bytes before the (Thumb) reset handler
+             * const req_sig  = (uint64_t*)bl_vectors[0];        // Top of the bootloader stack
+    if (!((uintptr_t)boot_sig & 0x7) && !((uintptr_t)req_sig & 0x7) && *boot_sig == KATAPULT_SIGNATURE) {
+      __disable_irq();
+      *req_sig = KATAPULT_REQUEST;
+      #if __CORTEX_M == 7
+        SCB_CleanDCache_by_Addr((uint32_t*)req_sig, sizeof(*req_sig));
+      #endif
+      NVIC_SystemReset();
+    }
+    hal.reboot();
+  }
+
+#else
+  WEAK void flashFirmware(const int16_t) { hal.reboot(); }
+#endif
 
 // Maple Compatibility
 volatile uint32_t systick_uptime_millis = 0;

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -167,19 +167,20 @@ extern "C" {
 }
 
 // Reset the system to initiate a firmware flash
-#ifdef BOOTLOADER_KATAPULT
+WEAK void flashFirmware(const int16_t) {
 
-  /**
-   * Request the Katapult bootloader (https://github.com/Arksine/katapult) to stay
-   * resident on reboot so new firmware can be flashed (e.g., with Katapult's
-   * flashtool.py) without pressing any BOOT / RESET buttons.
-   *
-   * Katapult stores the signature "CanBoot!" in the 8 bytes preceding its reset
-   * handler and on startup checks the 8 bytes at its initial stack pointer for the
-   * request key written here. If no (or an unexpected) bootloader is installed
-   * this reduces to a plain reboot.
-   */
-  WEAK void flashFirmware(const int16_t) {
+  #ifdef BOOTLOADER_KATAPULT
+
+    /**
+     * Request the Katapult bootloader (https://github.com/Arksine/katapult) to stay
+     * resident on reboot so new firmware can be flashed (e.g., with Katapult's
+     * flashtool.py) without pressing any BOOT / RESET buttons.
+     *
+     * Katapult stores the signature "CanBoot!" in the 8 bytes preceding its reset
+     * handler and on startup checks the 8 bytes at its initial stack pointer for the
+     * request key written here. If no (or an unexpected) bootloader is installed
+     * this reduces to a plain reboot.
+     */
     static constexpr uint64_t KATAPULT_SIGNATURE = 0x21746F6F426E6143ULL, // "CanBoot!"
                               KATAPULT_REQUEST   = 0x5984E3FA6CA1589BULL;
     const uint32_t * const bl_vectors = (uint32_t*)FLASH_BASE;
@@ -193,12 +194,11 @@ extern "C" {
       #endif
       NVIC_SystemReset();
     }
-    hal.reboot();
-  }
 
-#else
-  WEAK void flashFirmware(const int16_t) { hal.reboot(); }
-#endif
+  #endif // BOOTLOADER_KATAPULT
+
+  hal.reboot();
+}
 
 // Maple Compatibility
 volatile uint32_t systick_uptime_millis = 0;

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -737,11 +737,11 @@
 #elif MB(BTT_GTR_V1_0)
   #include "stm32f4/pins_BTT_GTR_V1_0.h"            // STM32F4                              env:BTT_GTR_V1_0 env:BTT_GTR_V1_0_usb_flash_drive
 #elif MB(BTT_OCTOPUS_V1_0)
-  #include "stm32f4/pins_BTT_OCTOPUS_V1_0.h"        // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive
+  #include "stm32f4/pins_BTT_OCTOPUS_V1_0.h"        // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive env:STM32F446ZE_btt_katapult
 #elif MB(BTT_OCTOPUS_V1_1)
-  #include "stm32f4/pins_BTT_OCTOPUS_V1_1.h"        // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive env:STM32F429ZG_btt env:STM32F429ZG_btt_usb_flash_drive env:STM32F407ZE_btt env:STM32F407ZE_btt_usb_flash_drive
+  #include "stm32f4/pins_BTT_OCTOPUS_V1_1.h"        // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive env:STM32F446ZE_btt_katapult env:STM32F429ZG_btt env:STM32F429ZG_btt_usb_flash_drive env:STM32F429ZG_btt_katapult env:STM32F407ZE_btt env:STM32F407ZE_btt_usb_flash_drive
 #elif MB(BTT_OCTOPUS_PRO_V1_0)
-  #include "stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h"    // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive env:STM32F429ZG_btt env:STM32F429ZG_btt_usb_flash_drive env:STM32H723ZE_btt
+  #include "stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h"    // STM32F4                              env:STM32F446ZE_btt env:STM32F446ZE_btt_usb_flash_drive env:STM32F446ZE_btt_katapult env:STM32F429ZG_btt env:STM32F429ZG_btt_usb_flash_drive env:STM32F429ZG_btt_katapult env:STM32H723ZE_btt env:STM32H723ZE_btt_katapult
 #elif MB(LERDGE_K)
   #include "stm32f4/pins_LERDGE_K.h"                // STM32F4                              env:LERDGEK env:LERDGEK_usb_flash_drive
 #elif MB(LERDGE_S)
@@ -857,13 +857,13 @@
 #elif MB(BTT_SKR_V3_0_EZ)
   #include "stm32h7/pins_BTT_SKR_V3_0_EZ.h"              // STM32H7                         env:STM32H743VI_btt env:STM32H723VG_btt
 #elif MB(BTT_OCTOPUS_MAX_EZ_V1_0)
-  #include "stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h"           // STM32H7                         env:STM32H723ZE_btt
+  #include "stm32h7/pins_BTT_OCTOPUS_MAX_EZ.h"           // STM32H7                         env:STM32H723ZE_btt env:STM32H723ZE_btt_katapult
 #elif MB(BTT_OCTOPUS_PRO_V1_0_1)
-  #include "stm32h7/pins_BTT_OCTOPUS_PRO_V1_0_1.h"       // STM32H7                         env:STM32H723ZE_btt
+  #include "stm32h7/pins_BTT_OCTOPUS_PRO_V1_0_1.h"       // STM32H7                         env:STM32H723ZE_btt env:STM32H723ZE_btt_katapult
 #elif MB(BTT_OCTOPUS_PRO_V1_1)
-  #include "stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h"         // STM32H7                         env:STM32H723ZE_btt
+  #include "stm32h7/pins_BTT_OCTOPUS_PRO_V1_1.h"         // STM32H7                         env:STM32H723ZE_btt env:STM32H723ZE_btt_katapult
 #elif MB(BTT_MANTA_M8P_V2_0)
-  #include "stm32h7/pins_BTT_MANTA_M8P_V2_0.h"           // STM32H7                         env:STM32H723ZE_btt
+  #include "stm32h7/pins_BTT_MANTA_M8P_V2_0.h"           // STM32H7                         env:STM32H723ZE_btt env:STM32H723ZE_btt_katapult
 #elif MB(BTT_KRAKEN_V1_0)
   #include "stm32h7/pins_BTT_KRAKEN_V1_0.h"              // STM32H7                         env:STM32H723ZG_btt
 #elif MB(TEENSY40)

--- a/buildroot/share/scripts/katapult_upload.py
+++ b/buildroot/share/scripts/katapult_upload.py
@@ -1,0 +1,156 @@
+#
+# katapult_upload.py
+# Upload firmware over USB serial via the Katapult bootloader (https://github.com/Arksine/katapult)
+# without pressing any BOOT / RESET buttons.
+#
+# If the board is running Marlin with BOOTLOADER_KATAPULT, 'M997' is sent to reboot it
+# into Katapult. If the board is already in Katapult mode (e.g., a first install or a
+# previous incomplete flash) that step is skipped. Katapult's own 'flashtool.py' then
+# uploads and SHA-verifies the firmware and jumps to the application.
+#
+# flashtool.py is fetched once from the Katapult repository (pinned commit, checksum
+# verified) and cached in the PlatformIO build folder. To use a local copy instead
+# (e.g., from an existing Katapult checkout) set the KATAPULT_FLASHTOOL environment
+# variable to its path.
+#
+# Note: flashtool.py requires a POSIX system (Linux / macOS / WSL).
+#
+import os, time, hashlib, subprocess
+from SCons.Script import DefaultEnvironment
+env = DefaultEnvironment()
+
+# Katapult USB CDC identity (OpenMoko VID)
+KATAPULT_USB_VID = 0x1D50
+KATAPULT_USB_PID = 0x6177
+
+# STMicroelectronics VID, as used by the STM32 core's USB CDC
+STM32_USB_CDC_VID = 0x0483
+
+# Pinned flashtool.py from the Katapult repository (GPLv3, same license as Marlin)
+FLASHTOOL_COMMIT = '509acf4b90260851e0199f1ac7ca7b6ff5dc188b'
+FLASHTOOL_URL    = f'https://raw.githubusercontent.com/Arksine/katapult/{FLASHTOOL_COMMIT}/scripts/flashtool.py'
+FLASHTOOL_SHA256 = '918de11f9310d434e32aeb0020a767f7900e9ba703a7f26f44874d8de1d0c126'
+
+#-----------------#
+# Upload Callback #
+#-----------------#
+def Upload(source, target, env):
+    import serial
+    from serial.tools import list_ports
+
+    #----------------#
+    # Port functions #
+    #----------------#
+    def _KatapultPorts():
+        return [ p.device for p in list_ports.comports() if p.vid == KATAPULT_USB_VID and p.pid == KATAPULT_USB_PID ]
+
+    def _GetUploadPort(env):
+        # An explicitly configured 'upload_port' always wins
+        portName = env.subst('$UPLOAD_PORT')
+        if not portName:
+            # Autodetection can land on an unrelated port (e.g., a Bluetooth device), so
+            # look for a USB CDC device first and only fall back to PlatformIO's guess
+            usb_ports = [ p for p in list_ports.comports() if p.vid is not None ]
+            stm_ports = [ p.device for p in usb_ports if p.vid == STM32_USB_CDC_VID ]
+            if len(stm_ports) == 1:
+                portName = stm_ports[0]
+            elif len(usb_ports) == 1:
+                portName = usb_ports[0].device
+            else:
+                env.AutodetectUploadPort(env)
+                portName = env.subst('$UPLOAD_PORT')
+                if portName and portName not in [ p.device for p in usb_ports ]:
+                    raise Exception(
+                        f"Autodetected '{portName}', which is not a USB serial device.\n"
+                        "Set 'upload_port' to the board's port and try again."
+                    )
+        if not portName:
+            raise Exception('Error detecting the upload port.')
+        return portName
+
+    def _RequestBootloader(portName):
+        # Send M997 so Marlin (with BOOTLOADER_KATAPULT) reboots into Katapult
+        print(f"Sending M997 to '{portName}'...")
+        upload_speed = env['UPLOAD_SPEED'] if 'UPLOAD_SPEED' in env else 250000
+        port = serial.Serial(portName, baudrate=upload_speed, write_timeout=2, timeout=0.1)
+        try:
+            port.reset_input_buffer()
+            port.write(b'\nM997\n')
+            port.flush()
+        finally:
+            try:
+                port.close()
+            except serial.SerialException:
+                pass  # The board may reset before the port is released
+
+    def _WaitForKatapult(timeout=30):
+        print('Waiting for Katapult to enumerate...')
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            ports = _KatapultPorts()
+            if ports: return ports[0]
+            time.sleep(0.5)
+        raise Exception(
+            'Timed out waiting for the Katapult bootloader device (USB ID '
+            f'{KATAPULT_USB_VID:04x}:{KATAPULT_USB_PID:04x}).\n'
+            'Make sure Katapult is installed on the board and the running Marlin '
+            'was built with BOOTLOADER_KATAPULT.'
+        )
+
+    #---------------------#
+    # flashtool functions #
+    #---------------------#
+    def _GetFlashtool():
+        # A user-provided flashtool (e.g., from a local Katapult checkout)
+        localtool = os.environ.get('KATAPULT_FLASHTOOL')
+        if localtool:
+            if not os.path.isfile(localtool):
+                raise Exception(f"KATAPULT_FLASHTOOL is set but '{localtool}' was not found")
+            return localtool
+
+        # Otherwise download once and cache in the build folder
+        cached = os.path.join(env.subst('$PROJECT_BUILD_DIR'), 'katapult', f'flashtool-{FLASHTOOL_COMMIT[:8]}.py')
+        if not os.path.isfile(cached):
+            print(f'Downloading Katapult flashtool ({FLASHTOOL_URL})...')
+            import requests
+            response = requests.get(FLASHTOOL_URL, timeout=30)
+            response.raise_for_status()
+            data = response.content
+            checksum = hashlib.sha256(data).hexdigest()
+            if checksum != FLASHTOOL_SHA256:
+                raise Exception(f'flashtool.py checksum mismatch (expected {FLASHTOOL_SHA256}, got {checksum})')
+            os.makedirs(os.path.dirname(cached), exist_ok=True)
+            with open(cached, 'wb') as f: f.write(data)
+        return cached
+
+    #---------------------#
+    # Callback Entrypoint #
+    #---------------------#
+    if os.name == 'nt':
+        raise Exception("Katapult's flashtool.py requires a POSIX system. On Windows, upload from WSL or use another upload method.")
+
+    upload_firmware_source_path = os.path.join(env['PROJECT_BUILD_DIR'], env['PIOENV'], f"{env['PROGNAME']}.bin") if 'PROGNAME' in env else str(source[0])
+    if not os.path.isfile(upload_firmware_source_path):
+        raise Exception(f"Firmware file '{upload_firmware_source_path}' not found")
+
+    flashtool = _GetFlashtool()
+
+    # Skip the M997 handshake if the board is already sitting in Katapult
+    katapult_ports = _KatapultPorts()
+    if katapult_ports:
+        katapult_port = katapult_ports[0]
+        print(f"Katapult bootloader already active on '{katapult_port}'")
+    else:
+        _RequestBootloader(_GetUploadPort(env))
+        katapult_port = _WaitForKatapult()
+
+    print(f"Uploading '{os.path.basename(upload_firmware_source_path)}' via Katapult on '{katapult_port}'")
+    result = subprocess.call([ env.subst('$PYTHONEXE'), flashtool, '-d', katapult_port, '-f', upload_firmware_source_path ])
+    if result != 0:
+        raise Exception('Katapult flash failed. The board may still be in Katapult mode; fix the issue and upload again.')
+
+    print('Firmware update completed')
+    return 0
+
+# Attach custom upload callback
+env.Replace(UPLOADCMD=Upload)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -366,6 +366,22 @@ build_flags       = ${env:STM32F446ZE_btt.build_flags} ${stm_flash_drive.build_f
                     ${USB_HS_IN_FS.build_flags} -DUSBD_USE_CDC_MSC
 
 #
+# BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)
+# Direct USB upload via the Katapult bootloader (https://github.com/Arksine/katapult)
+# Requires Katapult installed with application offset 0x8000. With Marlin running,
+# 'pio run -t upload' sends M997 (BOOTLOADER_KATAPULT) to enter the bootloader and
+# then flashes over USB with no BOOT / RESET button presses. Also works with the
+# board already in Katapult mode, e.g., for a first install.
+# The upload requires a POSIX system (Linux / macOS / WSL).
+#
+[env:STM32F446ZE_btt_katapult]
+extends         = env:STM32F446ZE_btt
+build_flags     = ${env:STM32F446ZE_btt.build_flags} -DBOOTLOADER_KATAPULT
+extra_scripts   = ${env:STM32F446ZE_btt.extra_scripts}
+                  pre:buildroot/share/scripts/katapult_upload.py
+upload_protocol = custom
+
+#
 # BigTreeTech Octopus V1.1 / Octopus Pro V1.0 (STM32F429ZGT6 ARM Cortex-M4)
 #
 [env:STM32F429ZG_btt]
@@ -387,6 +403,18 @@ platform_packages = ${stm_flash_drive.platform_packages}
 build_unflags     = -DUSBD_USE_CDC
 build_flags       = ${env:STM32F429ZG_btt.build_flags} ${stm_flash_drive.build_flags}
                     ${USB_HS_IN_FS.build_flags} -DUSBD_USE_CDC_MSC
+
+#
+# BigTreeTech Octopus V1.1 / Octopus Pro V1.0 (STM32F429ZGT6 ARM Cortex-M4)
+# Direct USB upload via the Katapult bootloader. See 'STM32F446ZE_btt_katapult' above.
+# Requires Katapult installed with application offset 0x8000.
+#
+[env:STM32F429ZG_btt_katapult]
+extends         = env:STM32F429ZG_btt
+build_flags     = ${env:STM32F429ZG_btt.build_flags} -DBOOTLOADER_KATAPULT
+extra_scripts   = ${env:STM32F429ZG_btt.extra_scripts}
+                  pre:buildroot/share/scripts/katapult_upload.py
+upload_protocol = custom
 
 #
 # BigTreeTech Octopus / Octopus Pro (STM32F407ZET6 ARM Cortex-M4)

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -135,6 +135,18 @@ extends                     = STM32H723Zx_common
 board                       = marlin_STM32H723ZE
 
 #
+# BigTreeTech Octopus Pro V1.0.1/1.1 / Octopus Max EZ V1.0 / Manta M8P V2.0 (STM32H723ZET6 ARM Cortex-M7)
+# Direct USB upload via the Katapult bootloader. See 'STM32F446ZE_btt_katapult' in stm32f4.ini.
+# Requires Katapult installed with application offset 0x20000, matching this board's flash sector size.
+#
+[env:STM32H723ZE_btt_katapult]
+extends         = env:STM32H723ZE_btt
+build_flags     = ${env:STM32H723ZE_btt.build_flags} -DBOOTLOADER_KATAPULT
+extra_scripts   = ${env:STM32H723ZE_btt.extra_scripts}
+                  pre:buildroot/share/scripts/katapult_upload.py
+upload_protocol = custom
+
+#
 # BigTreeTech Kraken V1.0 (STM32H723ZGT6 ARM Cortex-M7)
 #
 [env:STM32H723ZG_btt]


### PR DESCRIPTION
### Description

Add opt-in [Katapult](https://github.com/Arksine/katapult) support for STM32: bootloader entry from `M997`, plus a PlatformIO upload target that flashes through Katapult from VSCode or `pio run -t upload`.

Katapult is the standard bootloader in the Klipper ecosystem, and several boards Marlin supports ship with it or have vendor instructions to install it (BTT Manta and Octopus, LDO Leviathan). Marlin already honors its flash offset through the `board_build.offset` envs, but getting into the bootloader still takes a BOOT/RESET press, and boards without an SD socket have no card flashing to fall back on.

#### `M997`

With `BOOTLOADER_KATAPULT` defined, the STM32 HAL's `flashFirmware()` requests the bootloader the way Klipper's `armcm_reset.c` does: check Katapult's `"CanBoot!"` signature, stored 8 bytes before its reset handler and located through the vector table at `FLASH_BASE`, write the request key `0x5984E3FA6CA1589B` to the 8 bytes at the bootloader's initial stack pointer, then reset. Katapult sees the key and stays resident, so firmware can be flashed with no button presses. On Cortex-M7 the write is followed by `SCB_CleanDCache_by_Addr()` so it lands in SRAM before the reset.

If no bootloader is installed or something else occupies `FLASH_BASE`, the signature check fails and `M997` falls back to `hal.reboot()`, so the define is harmless on a bare board.

Boards opt in per env with `-DBOOTLOADER_KATAPULT` on the env whose `board_build.offset` matches the installed Katapult's offset, and `build_unflags` it in `no_bootloader` variants. Any stock Katapult build works.

#### Upload

`buildroot/share/scripts/katapult_upload.py` registers an upload callback, same pattern as the `_xfer` envs' `upload.py`:

1. If a Katapult device (USB ID `1d50:6177`) is already enumerated, from a first install or an interrupted flash, flash it directly.
2. Otherwise autodetect the running Marlin's port, send `M997`, and wait for the board to come back as Katapult.
3. Run Katapult's `flashtool.py` to upload and SHA-verify, after which Katapult jumps to the new firmware.

`flashtool.py` is downloaded once from a pinned Katapult commit, SHA-256 verified (Katapult is GPLv3 like Marlin), and cached under `.pio/`. Set `KATAPULT_FLASHTOOL` to use a local checkout instead.

Three envs are included for the boards most often shipped with Katapult, each keeping its parent's existing `board_build.offset`:

| Env | Board | Offset |
| --- | --- | --- |
| `STM32F446ZE_btt_katapult` | Octopus V1.0/1.1, Octopus Pro V1.0 (F446ZE) | `0x8000` |
| `STM32F429ZG_btt_katapult` | Octopus V1.1, Octopus Pro V1.0 (F429ZG) | `0x8000` |
| `STM32H723ZE_btt_katapult` | Octopus Pro V1.0.1/1.1, Octopus Max EZ, Manta M8P V2.0 (H723ZE) | `0x20000` |

Other boards need the same three lines: `-DBOOTLOADER_KATAPULT`, the `pre:` script, and `upload_protocol = custom`.

#### Notes

- `flashtool.py` imports `termios`/`fcntl`, so uploads need POSIX (Linux / macOS / WSL). The script errors out early on native Windows.
- The H723 envs build with `-DD_CACHE_DISABLED`, so `SCB_CleanDCache_by_Addr()` is a no-op there. It's in for anyone running with the cache on.

Tested on a handful of boards with stock Katapult at 0x0 and Marlin at 0x8000:

| Board | MCU | Env |
| --- | --- | --- |
| BTT Octopus V1.0 | STM32F446ZET6 | `STM32F446ZE_btt_katapult` |
| BTT Octopus Pro V1.0 | STM32F446ZET6 | `STM32F446ZE_btt_katapult` |
| BTT Octopus Pro V1.0 | STM32F429ZGT6 | `STM32F429ZG_btt_katapult` |
| BTT Octopus Pro V1.1 | STM32H723ZET6 | `STM32H723ZE_btt_katapult` |
| LDO Leviathan V1.2 | STM32F446ZET6 | (custom env) |

On the four Octopus boards with Katapult built for a matching offset (32KiB on F4, 128KiB on H7) and USB on PA11/PA12:

- `M997` over USB CDC drops the board from `0483:5740` to Katapult's `1d50:6177` in ~0.3s on every board, no button presses.
- `pio run -t upload` with the board already in Katapult flashes and SHA-verifies in ~6-11s.
- `pio run -t upload` with Marlin running does the `M997` handshake and completes in ~7-9s. Katapult reports `Application Start: 0x8008000` on F4 and `0x8020000` on H7, matching each env's `board_build.offset`.
- Marlin boots after each upload and answers `M115` with the timestamp of the build just flashed.

> [!TIP]
> The crystal differs per board (12MHz on F446, 8MHz on F429, 25MHz on H723), so Katapult has to be configured to match.
> 
> For anyone testing over SWD: Marlin uses PA13/PA14 (SWDIO/SWCLK) for `LED_PIN` and `E3_DIR_PIN` on the Octopus family, so an ST-Link has to connect under reset once firmware is running.

### Requirements

An STM32 board with Katapult installed at an offset matching the env's `board_build.offset`.

### Benefits

Reflash a Katapult board over USB without opening the case to press BOOT / RESET.

### Configurations

Stock configs with two changes, built against `env:STM32F446ZE_btt_katapult` (swap the board for the other two envs):

```cpp
#define MOTHERBOARD BOARD_BTT_OCTOPUS_PRO_V1_0
#define SERIAL_PORT -1  // USB CDC, for M997 and the upload script
```
#### Bootloader Backups

These exist elsewhere, but I dumped BTT's stock SD card bootloaders just in case:

- [octopus-v1.0-STM32F446ZET6-bootloader.bin.zip](https://github.com/user-attachments/files/31350917/octopus-v1.0-STM32F446ZET6-bootloader.bin.zip)
- [octopus-pro-v1.0-STM32F446ZET6-bootloader.bin.zip](https://github.com/user-attachments/files/31350915/octopus-pro-v1.0-STM32F446ZET6-bootloader.bin.zip)
- [octopus-pro-v1.0-STM32F429ZGT6-bootloader.bin.zip](https://github.com/user-attachments/files/31350914/octopus-pro-v1.0-STM32F429ZGT6-bootloader.bin.zip)
- [octopus-pro-v1.1-STM32H723ZET6-bootloader.bin.zip](https://github.com/user-attachments/files/31350916/octopus-pro-v1.1-STM32H723ZET6-bootloader.bin.zip)
- [skr-3-STM32H723VG-bootloader.bin.zip](https://github.com/user-attachments/files/31402142/skr-3-STM32H723VG-bootloader.bin.zip)
- [skr-3-ez-STM32H743VI-bootloader.bin.zip](https://github.com/user-attachments/files/31402470/skr-3-ez-STM32H743VI-bootloader.bin.zip)

### Related Issues

- #28563
- https://github.com/Arksine/katapult/issues/172