### PR TITLE
use _MIN in settings,cpp

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3190,7 +3190,7 @@ void MarlinSettings::postprocess() {
     #define MESH_STORE_SIZE sizeof(TERN(OPTIMIZED_MESH_STORAGE, mesh_store_t, bedlevel.z_values))
 
     uint16_t MarlinSettings::calc_num_meshes() {
-      return MIN(MAX_SAVED_MESHES, (meshes_end - meshes_start_index()) / MESH_STORE_SIZE);
+      return _MIN(uint16_t(MAX_SAVED_MESHES), uint16_t((meshes_end - meshes_start_index()) / MESH_STORE_SIZE));
     }
 
     int MarlinSettings::mesh_slot_offset(const int8_t slot) {


### PR DESCRIPTION
### Description

PR https://github.com/MarlinFirmware/Marlin/pull/28436 added 
```
return MIN(MAX_SAVED_MESHES, (meshes_end - meshes_start_index()) / MESH_STORE_SIZE);
``` 
To Marlin/src/module/settings.cpp. But MIN is not a standard macro

It errors with

```
Marlin/src/module/settings.cpp: In static member function 'static uint16_t MarlinSettings::calc_num_meshes()':
Marlin/src/module/settings.cpp:3193:14: error: 'MIN' was not declared in this scope
       return MIN(MAX_SAVED_MESHES, (meshes_end - meshes_start_index()) / MESH_STORE_SIZE);

```
This PR converts it to use _MIN

### Benefits

No longer errors

### Configurations

Stock with the following added
AUTO_BED_LEVELING_UBL
EEPROM_SETTINGS

