### PR TITLE
🔨 Fix RWX segment warning, drop stale I2C flags (STM32H7)

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_FLY_D8_PRO/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FLY_D8_PRO/ldscript.ld
@@ -95,14 +95,15 @@ SECTIONS
     __exidx_end = .;
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))

--- a/buildroot/share/PlatformIO/variants/MARLIN_FLY_SUPER8_PRO/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FLY_SUPER8_PRO/ldscript.ld
@@ -95,14 +95,15 @@ SECTIONS
     __exidx_end = .;
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))

--- a/buildroot/share/PlatformIO/variants/MARLIN_H723VG/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H723VG/ldscript.ld
@@ -95,14 +95,15 @@ SECTIONS
     __exidx_end = .;
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))

--- a/buildroot/share/PlatformIO/variants/MARLIN_H723ZE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H723ZE/ldscript.ld
@@ -95,14 +95,15 @@ SECTIONS
     __exidx_end = .;
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))

--- a/buildroot/share/PlatformIO/variants/MARLIN_H723ZG/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H723ZG/ldscript.ld
@@ -95,14 +95,15 @@ SECTIONS
     __exidx_end = .;
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))

--- a/buildroot/share/PlatformIO/variants/MARLIN_H743VI/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_H743VI/ldscript.ld
@@ -124,7 +124,8 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .preinit_array     :
+  /* (READONLY) keeps these out of the RWX LOAD segment. Requires GCC 11+ / binutils 2.35+ */
+  .preinit_array (READONLY) :
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -133,7 +134,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .init_array :
+  .init_array (READONLY) :
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
@@ -143,7 +144,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .fini_array :
+  .fini_array (READONLY) :
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -87,10 +87,8 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM5 -DTIMER_TONE=TIM2
                               -DSTEP_TIMER_IRQ_PRIO=0
-                              -DRCC_PERIPHCLK_I2C35=RCC_PERIPHCLK_I2C5
                               -DUSE_USB_HS -DUSE_USB_HS_IN_FS
                               -DD_CACHE_DISABLED
-                              -UI2C5_BASE
 upload_protocol             = cmsis-dap
 debug_tool                  = cmsis-dap
 
@@ -120,10 +118,8 @@ build_flags                 = ${stm32_variant.build_flags}
                               -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                               -DTIMER_SERVO=TIM5 -DTIMER_TONE=TIM2
                               -DSTEP_TIMER_IRQ_PRIO=0
-                              -DRCC_PERIPHCLK_I2C35=RCC_PERIPHCLK_I2C5
                               -DUSE_USB_HS -DUSE_USB_HS_IN_FS
                               -DD_CACHE_DISABLED
-                              -UI2C5_BASE
 upload_protocol             = cmsis-dap
 debug_tool                  = cmsis-dap
 
@@ -154,7 +150,6 @@ board_build.variant         = MARLIN_FLY_D8_PRO
 board_build.offset          = 0x0000
 board_upload.offset_address = 0x08000000
 build_flags                 = ${stm32_variant.build_flags}
-                              -DRCC_PERIPHCLK_I2C35=RCC_PERIPHCLK_I2C5
                               -DTIMER_SERVO=TIM5 -DTIMER_TONE=TIM2
                               -DUSE_USB_HS -DUSE_USB_HS_IN_FS
                               -DD_CACHE_DISABLED
@@ -173,7 +168,6 @@ board_build.variant         = MARLIN_FLY_SUPER8_PRO
 board_build.offset          = 0x20000
 board_upload.offset_address = 0x08020000
 build_flags                 = ${stm32_variant.build_flags}
-                              -DRCC_PERIPHCLK_I2C35=RCC_PERIPHCLK_I2C5
                               -DUSE_USB_HS -DUSE_USB_HS_IN_FS
                               -DD_CACHE_DISABLED
 upload_protocol             = dfu


### PR DESCRIPTION
### Description

Follow-up cleanup to #28534 (framework bump for STM32H7 to `ststm32@17.1.0` / `framework-arduinoststm32@~4.20600.231001` / `toolchain-gccarmnoneeabi@1.120301.0`).

**1. Fix `LOAD segment with RWX permissions` linker warning**

Every STM32H7 env now emits:

```
ld: warning: firmware.elf has a LOAD segment with RWX permissions
```

The cause is not the `MEMORY` region attributes — it's that `.init_array` / `.fini_array` carry `SHF_WRITE`, so the linker merged them into the same `PT_LOAD` as `.text` and marked the whole segment RWX:

```
LOAD  0x08000000 ... RWE    <- .isr_vector .text .rodata .ARM .init_array .fini_array
```

Adding the `(READONLY)` output-section attribute to `.preinit_array`, `.init_array` and `.fini_array` puts them in the read-only segment where they belong. This matches what current STM32CubeIDE linker script templates generate.

`(READONLY)` needs binutils 2.35+, which the newly pinned GCC 12.3 toolchain provides. Only the six H7 variants used by envs pinned to `toolchain-gccarmnoneeabi@1.120301.0` are touched.

After:

```
LOAD  0x08000000 ... R E
```

**2. Drop two stale I2C workarounds from `ini/stm32h7.ini`**

- `-DRCC_PERIPHCLK_I2C35=RCC_PERIPHCLK_I2C5` (H723Vx_btt, H723Zx_common, FLY_D8_PRO, FLY_SUPER8_PRO)
- `-UI2C5_BASE` (H723Vx_btt, H723Zx_common)

Both are no-ops with the new framework:

- `stm32h7xx_hal_rcc_ex.h` now defines `RCC_PERIPHCLK_I2C3` and `RCC_PERIPHCLK_I2C5` natively under `#if defined(I2C5)`, which H723 satisfies. `Wire/utility/twi.c` only falls back to `RCC_PERIPHCLK_I2C35` when those are missing, and `RCC_PERIPHCLK_I2C35` is an STM32MP1-only macro to begin with.
- `-UI2C5_BASE` was already inert: `stm32h723xx.h` defines `I2C5_BASE` unconditionally, i.e. after the command line is processed.

`STM32H743Vx_btt` never carried these flags (H743 has no I2C5) and is unaffected.

### Requirements

Any STM32H7 board: BTT SKR V3.0 / Octopus Pro / Octopus Max EZ / Manta M8P / Kraken, FYSETC Spider King, FLY D8 PRO, FLY SUPER8 PRO.

### Benefits

- Clean build output — no more RWX warning on H7 builds.
- The firmware image no longer maps a writable+executable segment.
- Removes two build flags that no longer do anything, so the next person doesn't have to work out why they're there.

### Configurations

No configuration changes required. Verified with `BOARD_FLY_D8_PRO` / `env:FLY_D8_PRO`:

- RWX warning gone, segment flags now `R E`.
- Flash and RAM totals unchanged (113648 / 11156 bytes).
- `libWire.a` (i.e. `twi.c`) is in the build, so the I2C flag removal is genuinely exercised. The resulting binary is byte-identical to the pre-removal build apart from the 4 bytes of embedded build timestamp.

### Related Issues

<li>MarlinFirmware/Marlin/pull/28534