### PR TITLE
Fix SERIAL_DMA for new Arduino framework-arduinoststm32@~4.20600.231001

### DIFF
--- a/Marlin/src/HAL/STM32/HardwareSerial.cpp
+++ b/Marlin/src/HAL/STM32/HardwareSerial.cpp
@@ -234,8 +234,11 @@ void HAL_HardwareSerial::init(PinName _rx, PinName _tx) {
   _serial.tx_buff = _tx_buffer;
   _serial.tx_head = _serial.tx_tail = 0;
 
-  _serial.pin_rts = NC;
-  _serial.pin_cts = NC;
+  // RTS/CTS were added to serial_t in STM32 core 2.3.0 and must be initialized
+  #if defined(STM32_CORE_VERSION) && STM32_CORE_VERSION >= 0x02030000
+    _serial.pin_rts = NC;
+    _serial.pin_cts = NC;
+  #endif
 }
 
 // Actual interrupt handlers //////////////////////////////////////////////////////////////

--- a/Marlin/src/HAL/STM32/HardwareSerial.cpp
+++ b/Marlin/src/HAL/STM32/HardwareSerial.cpp
@@ -233,6 +233,9 @@ void HAL_HardwareSerial::init(PinName _rx, PinName _tx) {
   _serial.pin_tx  = _tx;
   _serial.tx_buff = _tx_buffer;
   _serial.tx_head = _serial.tx_tail = 0;
+
+  _serial.pin_rts = NC;
+  _serial.pin_cts = NC;
 }
 
 // Actual interrupt handlers //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix SERIAL_DMA for new Arduino framework-arduinoststm32@~4.20600.231001

### Description
#28534 updated the Arduino framework for the STM32H7xx boards, this caused some issues for the SERIAL_DMA of this board, which resulted in the serial communication not working anymore.
The new framework added serial RTS and CTS pin support, which are not initialized, this causes the issue.
This PR adds the initialization for these pins. 

### Requirements
STM32H7xx based board.

### Benefits
SERIAL_DMA works again on the STM32H7xx boards.
