### PR TITLE
UBL: Do not deploy probe until reaching first point

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -840,8 +840,10 @@ void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const float off
    *   This attempts to fill in locations closest to the nozzle's start location first.
    */
   void unified_bed_leveling::probe_entire_mesh(const xy_pos_t &nearby, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) {
-    probe.deploy(); // Deploy before ui.capture() to allow for PAUSE_BEFORE_DEPLOY_STOW
-
+    #ifdef PAUSE_BEFORE_DEPLOY_STOW 
+      probe.deploy(); // Deploy before ui.capture() to allow for PAUSE_BEFORE_DEPLOY_STOW
+    #endif
+    
     TERN_(HAS_MARLINUI_MENU, ui.capture());
     TERN_(EXTENSIBLE_UI, ExtUI::onLevelingStart());
 


### PR DESCRIPTION

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

UBL: When executing ```G29 P1``` the probe was deployed before reaching the first point of measurement. This commit prevents this dangerous behavior except for the case it is needed.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->  UBL, Z-Probe

### Benefits

<!-- What does this PR fix or improve? --> Driving with deployed probe can cause collisions. This PR prevents it for using "G29 P1" .

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->  

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. --> NO
