### PR TITLE
🐛 Fix ESP32 crash on endstop hit during homing

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3684,12 +3684,15 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
 
   ATOMIC_SECTION_START();   // Suspend the Stepper ISR on all platforms
 
-  float axis_pos = count_position[axis];
+  // Keep this integer-only. Called from an ISR, and on Xtensa (ESP32) any FPU
+  // access in interrupt context raises a Coprocessor exception. Step counts are
+  // int32 at both ends, so float gained nothing but lost exactness past 2^24.
+  int32_t axis_pos = count_position[axis];
   #if IS_CORE
     if (axis == CORE_AXIS_2)
-      axis_pos = CORESIGN(count_position[CORE_AXIS_1] - axis_pos) * 0.5f;
+      axis_pos = CORESIGN(count_position[CORE_AXIS_1] - axis_pos) / 2;
     else if (axis == CORE_AXIS_1)
-      axis_pos = (axis_pos + count_position[CORE_AXIS_2]) * 0.5f;
+      axis_pos = (axis_pos + count_position[CORE_AXIS_2]) / 2;
   #elif ENABLED(MARKFORGED_XY)
     if (axis == CORE_AXIS_1) axis_pos TERN(MARKFORGED_INVERSE, +=, -=) count_position[CORE_AXIS_2];
   #elif ENABLED(MARKFORGED_YX)


### PR DESCRIPTION
### Description

On ESP32, homing crashes and reboots the board the moment an endstop triggers.

`Stepper::endstop_triggered()` used a `float` local. That function runs in
interrupt context, and on Xtensa the FPU is a coprocessor whose state FreeRTOS
does not save for ISRs, so any FPU access there raises a Coprocessor exception.

Reproduced on an MKS TinyBee. The panic names the cause directly:

```
Guru Meditation Error: Core 1 panic'ed (Coprocessor exception)
EXCCAUSE: 0x00000004          <- Cp0Disabled, i.e. FPU access
Core 1 was running in ISR context
```

Backtrace, decoded against the matching ELF:

```
_xt_lowint1                                   Xtensa interrupt vector
 +- timer_isr()                   HAL/ESP32/timers.cpp:72
    +- Temperature::isr()         temperature.cpp:4616
       +- Endstops::poll()        endstops.cpp:233
          +- Endstops::update()   endstops.cpp:685
             +- Planner::endstop_triggered()   planner.cpp:1614
                +- Stepper::endstop_triggered()  stepper.cpp:3698   <- float
```

Note it is the **temperature ISR** that polls endstops, not the stepper ISR, so
this needs no `ENDSTOP_INTERRUPTS_FEATURE` and happens on a stock config. That
matches it being reported repeatedly by unrelated users.

The float was doing no work. `count_position` is `xyze_long_t`,
`endstops_trigsteps` is `xyz_long_t`, and `triggered_position()` returns
`int32_t` — int32 in, int32 out, with a float in the middle purely so the
`IS_CORE` branch could write `* 0.5f`. That becomes `/ 2`; both truncate toward
zero, so the result is unchanged.

### Requirements

None.

### Benefits

Homing no longer crashes the board on ESP32. On every other platform this
removes a latent precision loss — `float` has a 24-bit mantissa, so step counts
above 2^24 were being rounded in a value that is `int32_t` at both ends.

### Configurations

No configuration changes.

### Testing

Same board, same triggered-endstop conditions, same command:

| | before | after |
|---|---|---|
| `G28 X` | Coprocessor exception, reboot | `X:0.00 Y:0.00 Z:5.00 E:0.00`, `ok` |
| `G28` x3 | — | completes, no reboot |

`mega2560` builds clean, and again with `COREXY` enabled to compile the
`IS_CORE` branch that actually changed.

### Caveats

Reproduced with endstops reading triggered because nothing is wired to them,
which exercises the same code path but is not a physical switch closing
mid-move — worth one confirmation against a real endstop. Only the ESP32
symptom is proven here; on AVR/ARM this is a correctness improvement, not a
crash fix.

### Related Issues

Regression from `5b71e64a77` (2026-02-09, "🐛 Fix endstops_trigsteps value"),
which replaced the per-kinematics expression with a single `float` local.

Before that commit nothing here touched the ESP32's FPU, on any machine type:

| path | generated code | FPU |
|---|---|---|
| Cartesian (was `count_position[axis]`) | plain integer | no |
| `IS_CORE` (was `* double(0.5)`) | `__floatsidf`, `__muldf3`, `__fixdfsi` | no — soft-float calls |
| after the change (all kinematics) | `float.s`, `trunc.s` | **yes** |

The Xtensa LX6 FPU is single precision only, so `double` is emulated in
software. Moving to `float`/`0.5f` emitted real FPU instructions for the first
time, and those raise `Cp0Disabled` in ISR context. That matches the reports:
every ESP32 board was fine before February 2026 and broken after, regardless of
kinematics.

This fix is integer on all paths, so it also spares `IS_CORE` machines three
soft-float library calls inside an interrupt handler.

Fixes #28504 — "[BUG] homing makes mcu reboot" (MKS TinyBee / ESP32 WROOM,
Kossel mini). Same board and same panic text, "Guru meditation error: core 1
panic'ed (coprocessor exception)", on endstop hit during homing. That report was
closed by its author on 2026-07-29 without a cause being found; no ASCII dump or
ELF was ever supplied, so it was never decoded. It should be reopened or linked
to this PR.

Two details in it corroborate the diagnosis:

- The reporter disabled endstop interrupts and still crashed. Expected — the
  call reaches `Endstops::poll()` from `Temperature::isr()`, so
  `ENDSTOP_INTERRUPTS_FEATURE` is not involved either way.
- Their machine is a delta, mine was Cartesian. Neither is `IS_CORE`, so both
  used the pure-integer `#else` path before `5b71e64a77` and both moved to
  `float` after it — consistent with the same regression hitting unrelated
  machine types at once.

Driver type is also irrelevant: they saw it with TMC2209 and A4988 alike, which
fits a fault in position bookkeeping rather than in stepper output.