### PR TITLE
🔨 Pins Debugging for ESP32

### DIFF
--- a/Marlin/src/HAL/ESP32/pinsDebug.h
+++ b/Marlin/src/HAL/ESP32/pinsDebug.h
@@ -21,8 +21,6 @@
  */
 #pragma once
 
-#error "PINS_DEBUGGING is not yet supported for ESP32!"
-
 /**
  * Pins Debugging for ESP32
  *
@@ -43,29 +41,68 @@
  *   - printPinAnalog(pin)
  */
 
+#include <driver/gpio.h>
+#include <soc/gpio_struct.h>
+#include <esp32-hal-ledc.h>
+
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
 #define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
 
 #define digitalRead_mod(P) extDigitalRead(P)
 #define printPinNameByIndex(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
 #define printPinNumber(P) do{ sprintf_P(buffer, PSTR("%02d"), P); SERIAL_ECHO(buffer); }while(0)
-#define printPinAnalog(P) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogIndex(P)); SERIAL_ECHO(buffer); }while(0)
 #define getPinByIndex(x) pin_array[x].pin
 #define getPinIsDigitalByIndex(x) pin_array[x].is_digital
-#define isValidPin(P) (P >= 0 && P < pin_t(NUMBER_PINS_TOTAL))
-#define digitalPinToAnalogIndex(P) int(P - analogInputToDigitalPin(0))
-#define isAnalogPin(P) WITHIN(P, pin_t(analogInputToDigitalPin(0)), pin_t(analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
-bool pwm_status(const pin_t) { return false; }
 
-void printPinPort(const pin_t) {}
+/**
+ * GPIO numbering is not contiguous. On the ESP32, GPIO 20, 24, and 28-31 don't
+ * exist, and 34-39 are input-only. SOC_GPIO_VALID_GPIO_MASK knows the gaps for
+ * whichever ESP32 variant is being built.
+ */
+#define isValidPin(P) (WITHIN(P, 0, pin_t(NUMBER_PINS_TOTAL - 1)) && GPIO_IS_VALID_GPIO(P))
 
+/**
+ * ADC channels are not a contiguous range of GPIOs, so the channel and the pin
+ * are different numbers. ESP32 analogRead() takes a GPIO, and the shared code
+ * passes it whatever this returns, so return the pin. printPinAnalog reports
+ * the actual channel.
+ */
+int8_t digitalPinToAnalogIndex(const pin_t pin) {
+  return (isValidPin(pin) && digitalPinToAnalogChannel(pin) >= 0) ? int8_t(pin) : -1;
+}
+
+bool isAnalogPin(const pin_t pin) {
+  return isValidPin(pin) && digitalPinToAnalogChannel(pin) >= 0;
+}
+
+#define printPinAnalog(P) do{ sprintf_P(buffer, PSTR(" (A%2d)  "), digitalPinToAnalogChannel(P)); SERIAL_ECHO(buffer); }while(0)
+
+/**
+ * True if the pin is currently an output. fastio's IS_OUTPUT is hardcoded to
+ * 'true' for this HAL, so read the GPIO output-enable registers instead.
+ */
 static bool getValidPinMode(const pin_t pin) {
-  return isValidPin(pin) && !IS_INPUT(pin);
+  if (!isValidPin(pin) || !GPIO_IS_VALID_OUTPUT_GPIO(pin)) return false; // 34-39 are input-only
+  return pin < 32 ? TEST32(GPIO.enable, pin) : TEST32(GPIO.enable1.val, pin - 32);
 }
 
-void printPinPWM(const int32_t pin) {
-  if (pwm_status(pin)) {
-    //uint32_t chan = g_APinDescription[pin].ulPWMChannel TODO when fast pwm is operative;
-    //SERIAL_ECHOPGM("PWM = ", duty);
-  }
+// Defined by the HAL. Returns the LEDC channel driving the pin, or -1. Unlike
+// get_pwm_channel it never allocates, so it's safe to call just to look.
+int8_t channel_for_pin(const uint8_t pin);
+
+bool pwm_status(const pin_t pin) {
+  // chan_pin[] is zero-initialized, so channel_for_pin() would match GPIO 0
+  // against an unallocated channel. get_pwm_channel skips pin 0 for the same
+  // reason, so no PWM is ever assigned to it.
+  if (!WITHIN(pin, 1, pin_t(MAX_PWM_IOPIN))) return false;
+  return channel_for_pin(uint8_t(pin)) >= 0;
 }
+
+void printPinPWM(const pin_t pin) {
+  if (!pwm_status(pin)) return;
+  const uint8_t chan = uint8_t(channel_for_pin(uint8_t(pin)));
+  SERIAL_ECHOPGM("  LEDC chan: ", chan, "  duty: ", uint32_t(ledcRead(chan)), "  freq: ", uint32_t(ledcReadFreq(chan)));
+}
+
+// ESP32 GPIOs are not grouped into named ports, so there is nothing to report.
+void printPinPort(const pin_t) {}


### PR DESCRIPTION
### Description

`PINS_DEBUGGING` was a hard `#error` on ESP32. A skeleton sat below it, unused
and never compiled, and three parts of it were wrong for this platform:

- `getValidPinMode()` tested `IS_INPUT(pin)`, but ESP32 `fastio.h` hardcodes
  `_IS_INPUT`/`_IS_OUTPUT` to `true` (there is a TODO to that effect), so every
  pin would have reported as an input. It now reads the GPIO output-enable
  registers — `GPIO.enable` for 0-31, `GPIO.enable1` for 32-39 — and reports
  34-39 as input-only.
- `isValidPin()` was a plain range check, but ESP32 GPIO numbering has holes:
  20, 24 and 28-31 do not exist. Now uses `GPIO_IS_VALID_GPIO()`, which knows
  the gaps for the variant being built.
- `digitalPinToAnalogIndex()` used a linear `P - analogInputToDigitalPin(0)`
  borrowed from DUE. ESP32 ADC channels are not contiguous with GPIO numbers, so
  that was arithmetic on unrelated quantities. It now returns the pin, since
  ESP32 `analogRead()` takes a GPIO, and `printPinAnalog` reports the real
  channel via `digitalPinToAnalogChannel()` — the same split `GD32_MFL` uses.

`pwm_status()`/`printPinPWM()` were stubs. They now report the LEDC channel,
duty and frequency using the HAL's `channel_for_pin()`, which is a passive
lookup — deliberately not `get_pwm_channel()`, which *allocates* a channel and
would have made M43 change hardware state just by reporting on it.

### Requirements

None. ESP32 only.

### Benefits

`M43` works on ESP32 instead of refusing to compile.

### Testing

Verified on MKS TinyBee hardware, not just built:

- GPIO gaps absent from the report, as expected
- ADC channels correct — GPIO36→A0, 39→A3, 32→A4, 33→A5 (ADC1); 0→A11, 4→A10,
  2→A12, 25→A18 (ADC2, offset by 10)
- Pin direction reflects real state — some pins report `Output`, most `Input`
- `M42 P2 S128` then `M43 P2` gives `LEDC chan: 0  duty: 514  freq: 1000`.
  514 is 128/255 of the 10-bit range, and 1000 matches `PWM_FREQUENCY`.

Also builds for `esp32` and `mks_tinybee` (the latter exercises
`I2S_STEPPER_STREAM`, whose expander pins are numbered above 127).

### Note for reviewers

Editing any HAL `pinsDebug.h` does **not** rebuild `M43.cpp`. It is reached via
`#include HAL_PATH(.., pinsDebug.h)`, and SCons cannot follow a macro-expanded
include, so the object file goes stale and the change silently does nothing.
Delete `.pio/build/<env>/src/src/gcode/config/M43.cpp.o` when testing.

### Related Issues

None.

