### PR TITLE
🩹 Fix FTM_DYNAMIC_FREQ build error with FTM_SHAPER_Z/E

### DIFF
--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -138,28 +138,18 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
     , " H", c.axis_sync_enabled
   );
 
-  #if HAS_DYNAMIC_FREQ
-    #define _F_REPORT(A) , F(" F"), c.dynFreqK.A
-  #else
-    #define _F_REPORT(A)
-  #endif
   // Dynamic Frequency scaling (dynFreqK) is XY-only, so only report for X and Y.
-  #define F_REPORT_X _F_REPORT(X)
-  #define F_REPORT_Y _F_REPORT(Y)
+  #define F_REPORT_X F(" F"), c.dynFreqK.X
+  #define F_REPORT_Y F(" F"), c.dynFreqK.Y
   #define F_REPORT_Z
   #define F_REPORT_E
-  #if HAS_FTM_EI_SHAPING
-    #define Q_REPORT(A) , F(" Q"), c.vtol.A
-  #else
-    #define Q_REPORT(A)
-  #endif
   #define _REPORT_M493_AXIS(A) \
     SERIAL_ECHOLN(F("  M493 "), C(AXIS_CHAR(_AXIS(A))) \
       , F(" C"), c.shaper.A \
       , F(" A"), c.baseFreq.A \
-      F_REPORT_##A \
+      OPTARG(HAS_DYNAMIC_FREQ, F_REPORT_##A) \
       , F(" I"), c.zeta.A \
-      Q_REPORT(A) \
+      OPTARG(HAS_FTM_EI_SHAPING, F(" Q"), c.vtol.A) \
     );
   // Shaper type for each axis
   SHAPED_MAP(_REPORT_M493_AXIS);

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -140,17 +140,18 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
     , " H", c.axis_sync_enabled
   );
 
-  #if HAS_DYNAMIC_FREQ
-    #define F_REPORT(A) , F(" F"), c.dynFreqK.A
-  #else
-    #define F_REPORT(A)
-  #endif
   #if HAS_FTM_EI_SHAPING
     #define Q_REPORT(A) , F(" Q"), c.vtol.A
   #else
     #define Q_REPORT(A)
   #endif
-  #define _REPORT_M493_AXIS(A) \
+  // Dynamic Frequency scaling (dynFreqK) is XY-only, so only report it for X and Y.
+  #if HAS_DYNAMIC_FREQ
+    #define F_REPORT(A) , F(" F"), c.dynFreqK.A
+  #else
+    #define F_REPORT(A)
+  #endif
+  #define _REPORT_M493_AXIS_XY(A) \
     SERIAL_ECHOLN(F("  M493 "), C(AXIS_CHAR(_AXIS(A))) \
       , F(" C"), c.shaper.A \
       , F(" A"), c.baseFreq.A \
@@ -158,8 +159,22 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
       , F(" I"), c.zeta.A \
       Q_REPORT(A) \
     );
-  // Shaper type for each axis
-  SHAPED_MAP(_REPORT_M493_AXIS);
+  #define _REPORT_M493_AXIS_OTHER(A) \
+    SERIAL_ECHOLN(F("  M493 "), C(AXIS_CHAR(_AXIS(A))) \
+      , F(" C"), c.shaper.A \
+      , F(" A"), c.baseFreq.A \
+      , F(" I"), c.zeta.A \
+      Q_REPORT(A) \
+    );
+  // Shaper type for X and Y (with Dynamic Frequency scaling, if applicable)
+  SHAPED_XY_MAP(_REPORT_M493_AXIS_XY);
+  // Shaper type for Z and E, if enabled (no Dynamic Frequency scaling support)
+  #if ENABLED(FTM_SHAPER_Z)
+    _REPORT_M493_AXIS_OTHER(Z);
+  #endif
+  #if ENABLED(FTM_SHAPER_E)
+    _REPORT_M493_AXIS_OTHER(E);
+  #endif
 }
 
 /**

--- a/Marlin/src/gcode/feature/ft_motion/M493.cpp
+++ b/Marlin/src/gcode/feature/ft_motion/M493.cpp
@@ -133,48 +133,36 @@ void GcodeSuite::M493_report(const bool forReplay/*=true*/) {
 
   SERIAL_ECHOLNPGM(
     "  M493 S", c.active
-    #if HAS_DYNAMIC_FREQ
-      , " D", c.dynFreqMode
-    #endif
+    OPTARG(HAS_DYNAMIC_FREQ, " D", c.dynFreqMode)
     // Axis Synchronization
     , " H", c.axis_sync_enabled
   );
 
+  #if HAS_DYNAMIC_FREQ
+    #define _F_REPORT(A) , F(" F"), c.dynFreqK.A
+  #else
+    #define _F_REPORT(A)
+  #endif
+  // Dynamic Frequency scaling (dynFreqK) is XY-only, so only report for X and Y.
+  #define F_REPORT_X _F_REPORT(X)
+  #define F_REPORT_Y _F_REPORT(Y)
+  #define F_REPORT_Z
+  #define F_REPORT_E
   #if HAS_FTM_EI_SHAPING
     #define Q_REPORT(A) , F(" Q"), c.vtol.A
   #else
     #define Q_REPORT(A)
   #endif
-  // Dynamic Frequency scaling (dynFreqK) is XY-only, so only report it for X and Y.
-  #if HAS_DYNAMIC_FREQ
-    #define F_REPORT(A) , F(" F"), c.dynFreqK.A
-  #else
-    #define F_REPORT(A)
-  #endif
-  #define _REPORT_M493_AXIS_XY(A) \
+  #define _REPORT_M493_AXIS(A) \
     SERIAL_ECHOLN(F("  M493 "), C(AXIS_CHAR(_AXIS(A))) \
       , F(" C"), c.shaper.A \
       , F(" A"), c.baseFreq.A \
-      F_REPORT(A) \
+      F_REPORT_##A \
       , F(" I"), c.zeta.A \
       Q_REPORT(A) \
     );
-  #define _REPORT_M493_AXIS_OTHER(A) \
-    SERIAL_ECHOLN(F("  M493 "), C(AXIS_CHAR(_AXIS(A))) \
-      , F(" C"), c.shaper.A \
-      , F(" A"), c.baseFreq.A \
-      , F(" I"), c.zeta.A \
-      Q_REPORT(A) \
-    );
-  // Shaper type for X and Y (with Dynamic Frequency scaling, if applicable)
-  SHAPED_XY_MAP(_REPORT_M493_AXIS_XY);
-  // Shaper type for Z and E, if enabled (no Dynamic Frequency scaling support)
-  #if ENABLED(FTM_SHAPER_Z)
-    _REPORT_M493_AXIS_OTHER(Z);
-  #endif
-  #if ENABLED(FTM_SHAPER_E)
-    _REPORT_M493_AXIS_OTHER(E);
-  #endif
+  // Shaper type for each axis
+  SHAPED_MAP(_REPORT_M493_AXIS);
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes #28548. `M493_report()` used the generic `SHAPED_MAP` (which iterates all shaped axes: X, Y, Z, E) to print each axis's Dynamic Frequency scaling value (`c.dynFreqK.A`). PR #28509 made `dynFreqK` XY-only (`ft_shaped_xy_float_t`), so this now fails to compile whenever `FTM_DYNAMIC_FREQ` is combined with `FTM_SHAPER_Z` and/or `FTM_SHAPER_E`, since `FTShapedAxesXY` has no `Z` or `E` member:

```
error: 'const ft_shaped_xy_float_t {aka const struct FTShapedAxesXY<float>}' has no member named 'Z'
error: 'const ft_shaped_xy_float_t {aka const struct FTShapedAxesXY<float>}' has no member named 'E'
```

### Fix

Split the M493 report into `SHAPED_XY_MAP` for X/Y (which may include Dynamic Frequency scaling) and a separate, explicit path for Z/E (which never had Dynamic Frequency scaling support — matching the rest of `M493.cpp`, which already treats Z/E individually).

### Testing

Verified locally with `mftest`/`pio` on `mega2560` for all relevant combinations, before and after the fix:

| Config | Before | After |
|---|---|---|
| `FTM_DYNAMIC_FREQ` + `FTM_SHAPER_Z` + `FTM_SHAPER_E` (reported combo) | fails | builds |
| `FTM_DYNAMIC_FREQ` only (XY) | builds | builds |
| `FTM_DYNAMIC_FREQ` + `FTM_SHAPER_Z` only | builds | builds |
| `FTM_DYNAMIC_FREQ` + `FTM_SHAPER_E` only | builds | builds |
| `FTM_DYNAMIC_FREQ` disabled + Z/E enabled | builds | builds |
| Default config (`FT_MOTION` disabled) | builds | builds |

### Requirements

N/A — bug fix only, no new config options.

### Benefits

Restores the ability to build with `FTM_DYNAMIC_FREQ` alongside `FTM_SHAPER_Z`/`FTM_SHAPER_E`, a regression introduced by #28509.

### Related Issues

Fixes #28548
