### PR TITLE
🐛 Fix ESP32 SD SPI pins being ignored

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/ESP32/HAL_SPI.cpp
@@ -72,7 +72,7 @@ void spiInit(uint8_t spiRate) {
   }
 
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
-  SPI.begin();
+  SPI.begin(SD_SCK_PIN, SD_MISO_PIN, SD_MOSI_PIN, SD_SS_PIN);
 }
 
 uint8_t spiRec() {

--- a/Marlin/src/pins/esp32/pins_E4D.h
+++ b/Marlin/src/pins/esp32/pins_E4D.h
@@ -92,7 +92,7 @@
 #define HEATER_BED_PIN                        15
 
 //
-// MicroSD card on SPI
+// MicroSD card on VSPI (bus 3)
 //
 #define SD_MOSI_PIN                           23
 #define SD_MISO_PIN                           19

--- a/Marlin/src/pins/esp32/pins_ESPA_common.h
+++ b/Marlin/src/pins/esp32/pins_ESPA_common.h
@@ -72,7 +72,7 @@
 #define HEATER_BED_PIN                         4
 
 //
-// MicroSD card
+// MicroSD card on VSPI (bus 3)
 //
 #define SD_MOSI_PIN                           23
 #define SD_MISO_PIN                           19

--- a/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
+++ b/Marlin/src/pins/esp32/pins_GODI_CONTROLLER_V1_0.h
@@ -86,7 +86,7 @@
 #define HEATER_BED_PIN                         2
 
 //
-// MicroSD card
+// MicroSD card on VSPI (bus 3)
 //
 #define SD_MOSI_PIN                           23
 #define SD_MISO_PIN                           19

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -166,7 +166,7 @@
 #define EXP_REVERSE_KEYED
 
 //
-// MicroSD card
+// MicroSD card on VSPI (bus 3)
 //
 //#define SD_MOSI_PIN                EXP2_06_PIN  // uses esp32 default 23
 //#define SD_MISO_PIN                EXP2_01_PIN  // uses esp32 default 19

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -113,7 +113,7 @@
 #define FAN1_PIN                             149
 
 //
-// MicroSD card
+// MicroSD card on VSPI (bus 3)
 //
 #define SD_MOSI_PIN                           23
 #define SD_MISO_PIN                           19

--- a/Marlin/src/pins/esp32/pins_PANDA_common.h
+++ b/Marlin/src/pins/esp32/pins_PANDA_common.h
@@ -105,7 +105,7 @@
 #define EXP2_07_PIN                            2  // ?
 
 //
-// SD Card
+// MicroSD Card on VSPI (3)
 //
 #if HAS_MEDIA
   #define SD_MOSI_PIN                EXP2_06_PIN


### PR DESCRIPTION
### Description

On ESP32 the SD card never uses the pins the board defines. `spiInit()` calls

```c
SPI.begin();
```

with no arguments, so the global `SPI` object falls back to its own defaults —
GPIO 18/19/23 — and `SD_SCK_PIN`, `SD_MISO_PIN` and `SD_MOSI_PIN` from the pins
file are ignored entirely.

Any board wired to those three pins works by coincidence. Any board that is not
fails to mount the card, with no hint as to why.

### Requirements

ESP32 with an SD card on pins other than 18/19/23.

### Benefits

The SD card works on boards that route it anywhere else. It also stops SD from
taking over pins another peripheral is using — on a board with an SPI TFT on the
default pins, SD init would silently reconfigure the display's bus.

### Configurations

No configuration changes. Boards already on 18/19/23 get the same pins they
were getting by default.

### Testing

MKS DLC32 V2.1 (SD on 14/12/13, SS 15):

| | before | after |
|---|---|---|
| `M21` | `echo:No SD card` / `SD Card Init Fail` | `echo:SD card ok` |
| `M20` | `echo:No media` | file list returned |

Verified with the display disabled as well, to confirm the failure was not
related to the TFT sharing the bus.

Boards already using the default pins are unaffected by inspection — the values
passed are identical to the library defaults:

| board | SD SCK / MISO / MOSI |
|---|---|
| E4D, ESPA, GODI, MM_JOKER, MRR_ESPE | 18 / 19 / 23 (unchanged) |
| MKS DLC32 | 14 / 12 / 13 (previously broken) |
| MKS TinyBee, PANDA | EXP2 pins (previously broken) |

### Related Issues

<li>https://github.com/MarlinFirmware/Marlin/pull/28551)