### PR TITLE
Clarify WIFISUPPORT and ESP3D_WIFISUPPORT wifi options

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4599,28 +4599,43 @@
 
 /**
  * Native ESP32 board with WiFi or add-on ESP32 WiFi-101 module
+ *
+ * Enable one or the other. The two are separate implementations sharing no code,
+ * and each has its own extras below.
+ *
+ * WIFISUPPORT covers both an add-on WiFi module wired to the controller and
+ * Marlin's own WiFi on an ESP32 build. ESP3D_WIFISUPPORT is ESP32 only.
  */
 //#define WIFISUPPORT         // Marlin embedded WiFi management. Not needed for simple WiFi serial port.
 //#define ESP3D_WIFISUPPORT   // ESP3D Library WiFi management (https://github.com/luc-github/ESP3DLib)
 
-/**
- * Extras for an ESP32-based motherboard with WIFISUPPORT
- * These options don't apply to add-on WiFi modules based on ESP32 WiFi101.
- */
-#if ANY(WIFISUPPORT, ESP3D_WIFISUPPORT)
+#if ENABLED(WIFISUPPORT)
+  /**
+   * Marlin's own webserver and OTA, implemented in HAL/ESP32/wifi/ and built
+   * only for an ESP32 build of Marlin. With an add-on WiFi module the module
+   * runs its own firmware, so neither option has any effect there.
+   */
   //#define WEBSUPPORT          // Start a webserver (which may include auto-discovery) using SPIFFS
   //#define OTASUPPORT          // Support over-the-air firmware updates
-  //#define WIFI_CUSTOM_COMMAND // Accept feature config commands (e.g., WiFi ESP3D) from the host
 
   /**
-   * To set a default WiFi SSID / Password, create a file called Configuration_Secure.h with
-   * the following defines, customized for your network. This specific file is excluded via
-   * .gitignore to prevent it from accidentally leaking to the public.
+   * The network is set at compile time. To set a default WiFi SSID / Password, create a file
+   * called Configuration_Secure.h with the following defines, customized for your network.
+   * This specific file is excluded via .gitignore to prevent it from accidentally leaking
+   * to the public.
    *
    *   #define WIFI_SSID "WiFi SSID"
    *   #define WIFI_PWD  "WiFi Password"
    */
   //#include "Configuration_Secure.h" // External file with WiFi SSID / Password
+
+#elif ENABLED(ESP3D_WIFISUPPORT)
+  /**
+   * ESP3D brings its own webserver and OTA, so WEBSUPPORT and OTASUPPORT don't apply here.
+   * The network is configured at runtime with '[ESP100]' / '[ESP101]' and stored on the ESP,
+   * so WIFI_SSID / WIFI_PWD don't apply either.
+   */
+  //#define WIFI_CUSTOM_COMMAND // Accept ESP3D '[ESP...]' commands from the host
 #endif
 
 // @section multi-material

--- a/Marlin/src/HAL/ESP32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/ESP32/inc/SanityCheck.h
@@ -40,10 +40,6 @@
   #error "TMC220x Software Serial is not supported on ESP32."
 #endif
 
-#if ALL(WIFISUPPORT, ESP3D_WIFISUPPORT)
-  #error "Only enable one WiFi option, either WIFISUPPORT or ESP3D_WIFISUPPORT."
-#endif
-
 #if ENABLED(POSTMORTEM_DEBUGGING)
   #error "POSTMORTEM_DEBUGGING is not yet supported on ESP32."
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4350,16 +4350,23 @@ static_assert(_PLUS_TEST(3), "DEFAULT_MAX_ACCELERATION values must be positive."
   #error "Enable only one of WIFISUPPORT or ESP3D_WIFISUPPORT."
 #elif ENABLED(ESP3D_WIFISUPPORT) && DISABLED(ARDUINO_ARCH_ESP32)
   #error "ESP3D_WIFISUPPORT requires an ESP32 motherboard."
-#elif ALL(ARDUINO_ARCH_ESP32, WIFISUPPORT)
-  #if !(defined(WIFI_SSID) && defined(WIFI_PWD))
-    #error "ESP32 motherboard with WIFISUPPORT requires WIFI_SSID and WIFI_PWD."
+#endif
+
+// Only the native ESP32 WiFi needs credentials at compile time. An add-on module
+// on another board is brought up by esp_wifi_init() and configures itself.
+#if ALL(ARDUINO_ARCH_ESP32, WIFISUPPORT) && !(defined(WIFI_SSID) && defined(WIFI_PWD))
+  #error "ESP32 motherboard with WIFISUPPORT requires WIFI_SSID and WIFI_PWD."
+#endif
+
+// With no WiFi at all these can do nothing whatsoever.
+#if NONE(WIFISUPPORT, ESP3D_WIFISUPPORT)
+  #if ANY(WEBSUPPORT, OTASUPPORT)
+    #error "WEBSUPPORT and OTASUPPORT require WIFISUPPORT."
+  #elif ENABLED(WIFI_CUSTOM_COMMAND)
+    #error "WIFI_CUSTOM_COMMAND requires ESP3D_WIFISUPPORT."
+  #elif defined(WIFI_SSID) || defined(WIFI_PWD)
+    #error "WIFI_SSID and WIFI_PWD require WIFISUPPORT."
   #endif
-#elif ENABLED(WIFI_CUSTOM_COMMAND) && NONE(ESP3D_WIFISUPPORT, WIFISUPPORT)
-  #error "WIFI_CUSTOM_COMMAND requires an ESP32 motherboard and WIFISUPPORT."
-#elif ENABLED(OTASUPPORT) && NONE(ESP3D_WIFISUPPORT, WIFISUPPORT)
-  #error "OTASUPPORT requires an ESP32 motherboard and WIFISUPPORT."
-#elif (defined(WIFI_SSID) || defined(WIFI_PWD)) && NONE(ESP3D_WIFISUPPORT, WIFISUPPORT)
-  #error "WIFI_SSID and WIFI_PWD only apply to ESP32 motherboard with WIFISUPPORT."
 #endif
 
 /**

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -79,6 +79,36 @@
   #warning "Rename 'Config-export.h' to 'Config.h' to override Configuration.h and Configuration_adv.h."
 #endif
 
+/**
+ * The two ESP32 WiFi implementations each ignore the other's options.
+ * These do nothing where they are, but they don't stop anything working.
+ */
+#if ENABLED(ESP3D_WIFISUPPORT)
+  #if ENABLED(WEBSUPPORT)
+    #warning "WEBSUPPORT does nothing with ESP3D_WIFISUPPORT, which starts its own webserver. Remove it."
+  #endif
+  #if ENABLED(OTASUPPORT)
+    #warning "OTASUPPORT does nothing with ESP3D_WIFISUPPORT, which provides its own OTA. Remove it."
+  #endif
+  #if defined(WIFI_SSID) || defined(WIFI_PWD)
+    #warning "WIFI_SSID and WIFI_PWD do nothing with ESP3D_WIFISUPPORT. Set the network with '[ESP100]' and '[ESP101]'."
+  #endif
+#elif ENABLED(WIFISUPPORT)
+  #if ENABLED(WIFI_CUSTOM_COMMAND)
+    #warning "WIFI_CUSTOM_COMMAND does nothing with WIFISUPPORT. It applies to ESP3D_WIFISUPPORT."
+  #endif
+  #if DISABLED(ARDUINO_ARCH_ESP32)
+    // WIFISUPPORT on another board only powers up an add-on module (esp_wifi_init).
+    // Marlin's own webserver, OTA and credentials are all native-ESP32 only.
+    #if ANY(WEBSUPPORT, OTASUPPORT)
+      #warning "WEBSUPPORT and OTASUPPORT need a native ESP32 motherboard. They do nothing with an add-on WiFi module."
+    #endif
+    #if defined(WIFI_SSID) || defined(WIFI_PWD)
+      #warning "WIFI_SSID and WIFI_PWD need a native ESP32 motherboard. An add-on WiFi module configures itself."
+    #endif
+  #endif
+#endif
+
 #if DISABLED(DEBUG_FLAGS_GCODE)
   #warning "DEBUG_FLAGS_GCODE is recommended if you have space. Some hosts rely on it."
 #endif

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.h
@@ -45,6 +45,12 @@
   #define HAS_SAVED_POSITIONS
 #endif
 
+// WiFi libraries are only needed where Marlin itself drives the radio. On other
+// platforms WIFISUPPORT just powers up an add-on module running its own firmware.
+#if defined(ARDUINO_ARCH_ESP32) && ANY(WIFISUPPORT, ESP3D_WIFISUPPORT)
+  #define HAS_ESP32_WIFI
+#endif
+
 #if ENABLED(DUET_SMART_EFFECTOR) && PIN_EXISTS(SMART_EFFECTOR_MOD)
   #define HAS_SMART_EFF_MOD
 #endif

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -16,7 +16,7 @@
 platform          = espressif32@2.1.0
 platform_packages = espressif/toolchain-xtensa-esp32s3
 board             = esp32dev
-build_flags       = ${common.build_flags} -DCORE_DEBUG_LEVEL=0 -std=gnu++17
+build_flags       = ${common.build_flags} -DCORE_DEBUG_LEVEL=0 -std=gnu++17 -DARDUINO_ARCH_ESP32
 build_unflags     = -std=gnu11 -std=gnu++11 -fsingle-precision-constant -Wno-register
 build_src_filter  = ${common.default_src_filter} +<src/HAL/ESP32>
 lib_ignore        = NativeEthernet, AsyncTCP_RP2040W

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -385,7 +385,7 @@ IS_SCARA                               = build_src_filter=+<src/module/scara.cpp
 HAS_SERVOS                             = build_src_filter=+<src/module/servo.cpp> +<src/gcode/control/M280.cpp>
 SCARA_CALIBRATION                      = build_src_filter=+<src/gcode/scara>
 HAS_MICROSTEPS                         = build_src_filter=+<src/gcode/control/M350_M351.cpp>
-(ESP3D_)?WIFISUPPORT                   = esp32async/AsyncTCP@3.3.3, mathieucarbou/ESP Async WebServer@3.0.6
+HAS_ESP32_WIFI                         = esp32async/AsyncTCP@3.3.3, mathieucarbou/ESP Async WebServer@3.0.6
                                          ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/6d62f76c3f.zip
                                          arduinoWebSockets=links2004/WebSockets@2.3.4
                                          luc-github/ESP32SSDP@1.1.1


### PR DESCRIPTION
### Description

The  WiFi block groups four options under one condition:

```c
#if ANY(WIFISUPPORT, ESP3D_WIFISUPPORT)
  //#define WEBSUPPORT
  //#define OTASUPPORT
  //#define WIFI_CUSTOM_COMMAND
  ...
  //#include "Configuration_Secure.h"
#endif
```

which reads as though all four apply to both implementations. None of them do:

- **`WEBSUPPORT` / `OTASUPPORT`** are only acted on in the `WIFISUPPORT` branch of
  `HAL.cpp:124-134`. Enabling them alongside `ESP3D_WIFISUPPORT` does nothing —
  ESP3D starts its own webserver and OTA regardless.
- **`WIFI_SSID` / `WIFI_PWD` / `Configuration_Secure.h`** are read only by
  `wifi/wifi.cpp`, which is `#if ENABLED(WIFISUPPORT)`. ESP3D keeps credentials on
  the ESP, set at runtime with `[ESP100]` / `[ESP101]`.
- **`WIFI_CUSTOM_COMMAND`** is the opposite way round. It is implemented only in
  `HAL/ESP32/HAL.cpp:94`, and returns `false` unless `ESP3D_WIFISUPPORT` is set,
  so it does nothing for `WIFISUPPORT`.

So every option in that block belongs to one implementation or the other, and the
one shared condition tells the user the opposite. This splits them into
`#if ENABLED(WIFISUPPORT)` / `#elif ENABLED(ESP3D_WIFISUPPORT)` and notes on the
ESP3D side which options are handled by the library instead.

Worth stating plainly, because the option name hides it: **an ESP32 board can use
either implementation.** `WIFISUPPORT` is not the "other boards" option.

`WIFISUPPORT` arrived with the ESP32 HAL itself — `e2aeda61ed`, "HAL for Espressif
ESP32 Wifi" (2017) — as Marlin's own WiFi using the ESP32's radio, and it still
does that today via `HAL/ESP32/wifi/`. Three years later `f5d809f366`, "SKR Pro
1.1 WiFi and LCD SD card support" (#17531), reused the same flag on non-ESP32
boards to power up an add-on WiFi module's pins (`HAL/shared/esp_wifi.cpp`).

So the flag means two different things depending on platform:

| Platform | `WIFISUPPORT` does | `ESP3D_WIFISUPPORT` |
|---|---|---|
| ESP32 | Marlin's own WiFi: STA connect, mDNS, websocket serial, optional webserver and OTA | available — ESP3D WebUI |
| anything else | brings up an add-on module's pins; the module runs its own firmware | not available |

`WEBSUPPORT` and `OTASUPPORT` belong to the first row only, which is what the
regrouping and the new comments say.

The sanity checks had the same problem, plus a structural one. They were a single
`#if`/`#elif` chain, so an earlier branch matching stopped the rest being
evaluated — with `ESP32 + WIFISUPPORT` the third branch matches and the
`WIFI_CUSTOM_COMMAND`, `OTASUPPORT` and `WIFI_SSID` checks below it were never
reached at all. The conditions were also wrong in both directions:

```c
#elif ENABLED(WIFI_CUSTOM_COMMAND) && NONE(ESP3D_WIFISUPPORT, WIFISUPPORT)
  #error "WIFI_CUSTOM_COMMAND requires an ESP32 motherboard and WIFISUPPORT."
#elif ENABLED(OTASUPPORT) && NONE(ESP3D_WIFISUPPORT, WIFISUPPORT)
  #error "OTASUPPORT requires an ESP32 motherboard and WIFISUPPORT."
```

Each only complains when *neither* implementation is enabled, so `OTASUPPORT`
with ESP3D and `WIFI_CUSTOM_COMMAND` with `WIFISUPPORT` both passed silently
while doing nothing.

These are now split by severity:

- **`SanityCheck.h`** keeps errors for configurations that cannot work — both
  implementations at once, `ESP3D_WIFISUPPORT` off an ESP32, a native ESP32 with
  `WIFISUPPORT` but no credentials, and any of these options with no WiFi enabled
  at all. The architecture and credential conditions are unchanged from upstream:
  `WIFISUPPORT` also covers an add-on WiFi module on a non-ESP32 board
  (`HAL/shared/esp_wifi.cpp`), which needs neither.
- **`Warnings.cpp`** gets the "enabled but ignored here" cases. Marlin already
  uses that file for advisory notices, and it emits them once per build.

An option that merely does nothing should not stop the build, so those warn and
carry on.

### Requirements

None for a configuration that was already correct.

### Migration

None — no configuration that builds today stops building. Configurations with an
inert option now emit a warning naming it, for example:

```
warning: #warning "OTASUPPORT does nothing with ESP3D_WIFISUPPORT, which provides its own OTA. Remove it."
```

### Benefits

The block stops implying that four options work with both implementations when
each works with exactly one.

### Configurations

No option added, removed or re-defaulted. Existing configurations are unaffected:
anything previously enabled inside the old block is still enabled, and the two
options that silently did nothing still do nothing — they are just no longer
offered where they don't apply.

### Testing

`mks_tinybee`, except the last which is `mega2560`:

| Config | Result |
|---|---|
| `ESP3D_WIFISUPPORT` + `WIFI_CUSTOM_COMMAND` | builds |
| `WIFISUPPORT` + `WEBSUPPORT` + `OTASUPPORT` + credentials | builds |
| neither | builds |
| ESP3D + `WEBSUPPORT` + `OTASUPPORT` | builds, warns on both |
| `WIFISUPPORT` + `WIFI_CUSTOM_COMMAND` | builds, warns |
| ESP3D + `WIFI_SSID` / `WIFI_PWD` | builds, warns |
| no WiFi + `OTASUPPORT` | errors — nothing to attach to |
| both implementations at once | errors |
| ESP32 + `WIFISUPPORT`, no credentials | errors, as before |
| ESP32 + `WIFISUPPORT` + credentials | builds |
| ESP32, no WiFi | builds, WiFi libraries not pulled |
| **non-ESP32 + `WIFISUPPORT`** (add-on module) | **builds** — failed on `bugfix-2.1.x` |

The last row shows the structural fix working: the old chain would have stopped
at the first match and reported only one of the two real problems.

The `WIFISUPPORT` case also needs `TX_BUFFER_SIZE` non-zero, which
`WebSocketSerial.h:37` enforces with an `#error`. That is pre-existing and
unrelated; `buildroot/tests/mks_tinybee/config-01.ini` sets `tx_buffer_size = 64`
for the same reason.

### Related Issues

None.

The second commit fixes two things found while checking the first:

**The add-on WiFi module case did not build at all.** `ini/features.ini` attached
the ESP32 WiFi libraries to `(ESP3D_)?WIFISUPPORT` on every platform, so enabling
`WIFISUPPORT` on an STM32 board with an ESP01 module pulled AsyncTCP, the async
webserver and ESP3DLib and failed with `Ethernet.h: No such file or directory`.
The documented configuration was unusable.

The libraries are now attached to a new `HAS_ESP32_WIFI`, defined in
`common-dependencies.h` — the file that exists for exactly this, "conditionals
only used for [features]":

```c
#if defined(ARDUINO_ARCH_ESP32) && ANY(WIFISUPPORT, ESP3D_WIFISUPPORT)
  #define HAS_ESP32_WIFI
#endif
```

The dependency scanner runs the preprocessor with only the project's own
`build_flags`, so framework defines are not visible to it and `ARDUINO_ARCH_ESP32`
alone would never be true there. `ini/esp32.ini` now states it explicitly in
`build_flags`, which changes nothing at compile time — the framework defines it
anyway — but makes it visible to the scanner.

**Duplicate error removed.** `HAL/ESP32/inc/SanityCheck.h` repeated the "enable
only one" check that `inc/SanityCheck.h` already makes, so that mistake reported
twice.
