### PR TITLE
🩹 Fix LIST_28 typo

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -310,7 +310,7 @@
 #define LIST_31(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC,DD,EE,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC,DD,EE
 #define LIST_30(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC,DD,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC,DD
 #define LIST_29(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,CC
-#define LIST_28(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,TU,V,W,X,Y,Z,AA,BB
+#define LIST_28(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BB
 #define LIST_27(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA
 #define LIST_26(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
 #define LIST_25(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,...) A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y


### PR DESCRIPTION
### Description

`LIST_28` is missing a comma in its expansion, so `T,U` became the single token
`TU`:

```c
#define LIST_28(A,...,S,T,U,V,...,BB,...) A,...,S,TU,V,...,BB
```

The parameter list is correct; only the expansion is wrong. It yields 27 items
instead of 28, and `TU` is not a parameter, so it survives as a literal token.

Every other macro in the family is correct — verified by parsing all 32
comma-separated `LIST_*`/`ARRAY_*` definitions and comparing each expansion
against its own parameter list. `LIST_28` was the only mismatch.

### Requirements

None.

### Benefits

Correctness. `LIST_28` is currently unreachable, so nothing is broken today: the
largest counts passed to `LIST_N` are `NUM_AXES` (max 9) and `E_STEPPERS`
(max 8). The family is defined up to `LIST_32`, though, so the macro is there to
be used, and if it ever were the build would fail on an undeclared `TU` rather
than silently produce a short list.

### Configurations

No configuration changes.

### Testing

`mega2560` builds. Nothing else can change, as the fix only affects an expansion
that no current configuration reaches.

### Related Issues

Fixes #28559.
