### PR TITLE
✅ Cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -30,6 +30,11 @@ on:
     - Marlin/tests/**
     - '**/*.md'
 
+# Cancel PR runs superseded by a new push, so stacked runs don't queue up behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test_builds:
     name: Build Test

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -27,6 +27,11 @@ on:
     - docs/**
     - '**/*.md'
 
+# Cancel PR runs superseded by a new push, so stacked runs don't queue up behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # This runs all unit tests as a single job. While it should be possible to break this up into
   # multiple jobs, they currently run quickly and finish long before the compilation tests.

--- a/.github/workflows/ci-validate-boards.yml
+++ b/.github/workflows/ci-validate-boards.yml
@@ -18,6 +18,11 @@ on:
     paths:
       - "Marlin/src/core/boards.h"
 
+# Cancel PR runs superseded by a new push, so stacked runs don't queue up behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate_pins_files:
     name: Validate boards.h

--- a/.github/workflows/ci-validate-lines.yml
+++ b/.github/workflows/ci-validate-lines.yml
@@ -15,6 +15,11 @@ on:
       - bugfix-2.1.x
       - 2.1.x
 
+# Cancel PR runs superseded by a new push, so stacked runs don't queue up behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate_source_files:
     name: Validate Source Files

--- a/.github/workflows/ci-validate-pins.yml
+++ b/.github/workflows/ci-validate-pins.yml
@@ -21,6 +21,11 @@ on:
     paths:
       - "Marlin/src/pins/*/**"
 
+# Cancel PR runs superseded by a new push, so stacked runs don't queue up behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate_pins_files:
     name: Validate Pins Files


### PR DESCRIPTION
### Description

None of the workflows set `concurrency` right now, so every push queues a fresh run while the previous one is still going. `ci-build-tests.yml` is a 65-job matrix, so three pushes in a row leaves 195 jobs competing for the same runner pool.

`cancel-in-progress` is conditional instead of just `true` so only PR runs get cancelled. Pushes to `bugfix-2.1.x`, `2.1.x`, and `release-*` still finish, so if two merges land close together you can still tell which one broke the build.

Skipped `check-pr.yml` since it's a single job on `pull_request_target: [opened]` and there's nothing to supersede. Also skipped the scheduled and issue-driven ones (`lock-closed`, `close-stale`, `clean-closed`, `bump-date`, `auto-label`, `unlock-reopened`) since grouping those by PR ref would be wrong.

### Benefits

PRs stop queueing behind their own outdated runs.
