### PR TITLE
🩹 Fix RP2040 sensorless homing, servos, and M997

### DIFF
--- a/Marlin/src/HAL/RP2040/AGENTS.md
+++ b/Marlin/src/HAL/RP2040/AGENTS.md
@@ -34,7 +34,7 @@ Because the framework is upstream, there is **no mirror-to-installed-package ste
 
 4. **`freeMemory()` relies on a linker symbol, not a stack probe.** It computes `(char*)&__StackLimit - (char*)_sbrk(0)` using the Pico linker-provided `__StackLimit` (`HAL.cpp`). Don't "fix" it with a local-variable subtraction as on single-stack chips — that is wrong on this core.
 
-5. **`flashFirmware()` (M997) reboots into the bootloader via the watchdog.** `flashFirmware()` → `hal.reboot()` → `watchdog_reboot(0,0,1)` (`HAL.cpp`). The `raspberrypi.ini` build flags include `-DPLATFORM_M997_SUPPORT` (also forced on in `HAL.h`). A UF2/picotool upload picks up the reset.
+5. **`flashFirmware()` (M997) reboots into the UF2 bootloader.** `flashFirmware()` → `reset_usb_boot(0,0)` (`HAL.cpp`); `hal.reboot()` would only restart the current firmware. The `raspberrypi.ini` build flags include `-DPLATFORM_M997_SUPPORT` (also forced on in `HAL.h`). The board re-enumerates as `RPI-RP2` for a UF2/picotool upload.
 
 6. **SPI uses the core's `<SPI.h>` directly; SOFTWARE_SPI path also exists.** `HAL_SPI.cpp` includes `<SPI.h>` and calls `spiBegin()`; a software-SPI fallback is compiled when `SOFTWARE_SPI` is enabled. There is no custom `SPI` global shim needed (unlike AT32). `spi_pins.h` pins live in `HAL/RP2040/`.
 

--- a/Marlin/src/HAL/RP2040/HAL.cpp
+++ b/Marlin/src/HAL/RP2040/HAL.cpp
@@ -281,8 +281,8 @@ uint16_t MarlinHAL::adc_value() {
   return adc_values[channel];
 }
 
-// Reset the system to initiate a firmware flash
-void flashFirmware(const int16_t) { hal.reboot(); }
+// Reboot into the UF2 bootloader to initiate a firmware flash
+void flashFirmware(const int16_t) { reset_usb_boot(0, 0); }
 
 extern "C" {
   void * _sbrk(int incr);

--- a/Marlin/src/HAL/RP2040/HAL.h
+++ b/Marlin/src/HAL/RP2040/HAL.h
@@ -28,6 +28,7 @@
 #endif
 
 #include "arduino_extras.h"
+#include "Servo.h"
 #include "../../core/macros.h"
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"

--- a/Marlin/src/HAL/RP2040/inc/Conditionals_type.h
+++ b/Marlin/src/HAL/RP2040/inc/Conditionals_type.h
@@ -20,3 +20,8 @@
  *
  */
 #pragma once
+
+// LOW / HIGH are PinStatus enumerators, so they evaluate to 0 in #if tests.
+// Define them here, after HAL.h has declared the enum, and no earlier.
+#define LOW  0
+#define HIGH 1

--- a/buildroot/tests/SKR_Pico/config-02.ini
+++ b/buildroot/tests/SKR_Pico/config-02.ini
@@ -1,0 +1,24 @@
+#
+# Marlin Firmware
+# Test: SKR_Pico/config-02.ini
+#
+# NeoPixel and servo with sensorless homing
+#
+
+[config:base]
+motherboard                              = BOARD_BTT_SKR_PICO
+x_driver_type                            = TMC2209
+y_driver_type                            = TMC2209
+z_driver_type                            = TMC2209
+e0_driver_type                           = TMC2209
+sensorless_homing                        = on
+x_stall_sensitivity                      = 8
+y_stall_sensitivity                      = 8
+num_servos                               = 1
+z_probe_servo_nr                         = on
+z_servo_angles                           = on
+z_safe_homing                            = on
+neopixel_led                             = on
+neopixel_type                            = NEO_GRB
+neopixel_pixels                          = 3
+led_control_menu                         = on


### PR DESCRIPTION
### Description

Three RP2040 fixes:

- `LOW` and `HIGH` are `PinStatus` enumerators on this core rather than macros, so the preprocessor evaluates both to 0 and every `*_ENDSTOP_HIT_STATE` check in `SanityCheck.h` fails regardless of the config. That breaks sensorless homing, BLTouch, and probe builds. The defines have to sit in `Conditionals_type.h` because it's included after `HAL.h`, once the enum exists.
- `HAL.h` forward-declares `libServo` without including `Servo.h`, so `PAUSE_SERVO_OUTPUT()` and `RESUME_SERVO_OUTPUT()` hit an incomplete type from `neopixel.h` and `eeprom_flash.cpp`. A servo on its own builds fine, which is why `config-01` never caught it.
- `flashFirmware()` rebooted through the watchdog, so M997 restarted Marlin instead of entering the bootloader.

`config-02.ini` covers the first two.

### Requirements

An RP2040 board. `M997` needs one that exposes USB, like the SKR Pico.

### Benefits

- Sensorless homing, BLTouch, and probe configs build on RP2040.
- Servos build alongside NeoPixels and flash EEPROM emulation.
- M997 reboots into the UF2 bootloader instead of back into Marlin.
- CI covers all three.

### Configurations

Default configuration with `MOTHERBOARD BOARD_BTT_SKR_PICO`. `buildroot/tests/SKR_Pico/config-02.ini` has the exact options.

### Related Issues

None.