### PR TITLE
🐛 Fix BTT Manta M4P SD, LCD, and TMC pins

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
+++ b/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if ALL(HAS_MARLINUI_U8GLIB, LCD_USE_SOFT_SPI)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -125,5 +125,5 @@ uint8_t u8g_com_HAL_MFL_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && LCD_USE_SOFT_SPI
 #endif // ARDUINO_ARCH_MFL

--- a/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
+++ b/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if ALL(HAS_MARLINUI_U8GLIB, LCD_USE_SOFT_SPI)
 
 #warning "Software SPI for U8Glib is experimental on HC32F460. Please share your experiences at https://github.com/shadow578/Marlin-H32/issues/35"
 
@@ -159,5 +159,5 @@ uint8_t u8g_com_HAL_HC32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, voi
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && LCD_USE_SOFT_SPI
 #endif // ARDUINO_ARCH_HC32

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -124,6 +124,9 @@ uint8_t MarlinHAL::get_reset_source() {
     #ifdef RCC_FLAG_IWDG2RST
       RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDG2RST) ? RST_WATCHDOG :
     #endif
+    #ifdef RCC_FLAG_WWDGRST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)  ? RST_WATCHDOG :
+    #endif
     #ifdef RCC_FLAG_SFTRST
       RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)   ? RST_SOFTWARE :
     #endif
@@ -132,6 +135,9 @@ uint8_t MarlinHAL::get_reset_source() {
     #endif
     #ifdef RCC_FLAG_PORRST
       RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PORRST)   ? RST_POWER_ON :
+    #endif
+    #ifdef RCC_FLAG_PWRRST // STM32G0/G4/L4/... combine BOR and POR/PDR in one flag
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PWRRST)   ? RST_POWER_ON :
     #endif
     0
   );

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if ALL(HAS_MARLINUI_U8GLIB, LCD_USE_SOFT_SPI)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -132,5 +132,5 @@ uint8_t u8g_com_HAL_STM32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, vo
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && LCD_USE_SOFT_SPI
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -130,7 +130,7 @@ const XrefInfo pin_xref[] PROGMEM = {
 #ifndef NUM_ANALOG_LAST
   #define NUM_ANALOG_LAST ((NUM_ANALOG_FIRST) + (NUM_ANALOG_INPUTS) - 1)
 #endif
-#define NUMBER_PINS_TOTAL ((NUM_DIGITAL_PINS) + TERN0(HAS_HIGH_ANALOG_PINS, NUM_ANALOG_INPUTS))
+#define NUMBER_PINS_TOTAL COUNT(pin_xref)  // All consumers index pin_xref[]
 #define isValidPin(P) (WITHIN(P, 0, (NUM_DIGITAL_PINS) - 1) || TERN0(HAS_HIGH_ANALOG_PINS, WITHIN(P, NUM_ANALOG_FIRST, NUM_ANALOG_LAST)))
 #define digitalRead_mod(A) extDigitalRead(A)  // must use Arduino pin numbers when doing reads
 #define printPinNumber(Q)
@@ -146,8 +146,44 @@ const XrefInfo pin_xref[] PROGMEM = {
 //
 #define GET_PIN_MAP_PIN_M43(x) pin_xref[x].Ard_num
 
+//
+// Pins that will cause a hang / reset / disconnect in M43 Toggle and Watch utils
+//
 #ifndef M43_NEVER_TOUCH
-  #define _M43_NEVER_TOUCH(x) WITHIN(x, 9, 12) // SERIAL/USB pins: PA9(TX) PA10(RX) PA11(USB_DM) PA12(USB_DP)
+
+  // Set these as GPIO and the crystal stops. Boards clocked from HSE hang.
+  #if defined(STM32F1xx)
+    #if defined(PD0) && defined(PD1)
+      #define OSC_IN_PIN                      PD0
+      #define OSC_OUT_PIN                     PD1
+    #endif
+  #elif defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32G4xx)
+    #if defined(PF0) && defined(PF1)
+      #define OSC_IN_PIN                      PF0
+      #define OSC_OUT_PIN                     PF1
+    #endif
+  #elif defined(PH0) && defined(PH1)                // F2/F4/F7/H7/L4/...
+    #define OSC_IN_PIN                        PH0
+    #define OSC_OUT_PIN                       PH1
+  #endif
+
+  // Only skip them while HSE is running. On HSI boards these are normal pins.
+  #ifdef OSC_IN_PIN
+    #define IS_OSC_PIN(P) (((P) == OSC_IN_PIN || (P) == OSC_OUT_PIN) && __HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY))
+  #else
+    #define IS_OSC_PIN(P) false
+  #endif
+
+  // Reset pin on variants that expose it
+  #if defined(STM32G0xx) && defined(PF2)
+    #define IS_NRST_PIN(P) ((P) == PF2)
+  #else
+    #define IS_NRST_PIN(P) false
+  #endif
+
+  // 'x' indexes pin_xref[]. It's not a pin number.
+  #define _M43_NEVER_TOUCH(x) ( WITHIN(x, 9, 12)    /* SERIAL/USB pins: PA9(TX) PA10(RX) PA11(USB_DM) PA12(USB_DP) */ \
+                             || IS_OSC_PIN(GET_PIN_MAP_PIN_M43(x)) || IS_NRST_PIN(GET_PIN_MAP_PIN_M43(x)) )
   #if PIN_EXISTS(KILL)
     #define M43_NEVER_TOUCH(x) m43_never_touch(x)
 
@@ -206,7 +242,7 @@ void printPinPort(const pin_t pin) {
   for (index = 0; index < NUMBER_PINS_TOTAL; index++)
     if (pin == GET_PIN_MAP_PIN_M43(index)) break;
 
-  const char * ppa = pin_xref[index].Port_pin_alpha;
+  const char * ppa = index < NUMBER_PINS_TOTAL ? pin_xref[index].Port_pin_alpha : "?";
   sprintf_P(buffer, PSTR("%s"), ppa);
   SERIAL_ECHO(buffer);
   if (ppa[3] == '\0') SERIAL_CHAR(' ');
@@ -222,11 +258,10 @@ void printPinPort(const pin_t pin) {
     SERIAL_ECHO_SP(7);
 
   // Print number to be used with M42
+  // The digital pins these map to aren't contiguous. Deriving one from the
+  // analog index gives the wrong pin.
   int calc_p = pin;
-  if (pin > NUM_DIGITAL_PINS) {
-    calc_p -= NUM_ANALOG_FIRST;
-    if (calc_p > 7) calc_p += 8;
-  }
+  if (pin > NUM_DIGITAL_PINS) calc_p = digitalPinFirstOccurence(pin);
   SERIAL_ECHO(F(" M42 P"), calc_p, C(' '));
   if (calc_p < 100) {
     SERIAL_CHAR(' ');

--- a/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if ALL(HAS_MARLINUI_U8GLIB, LCD_USE_SOFT_SPI)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -166,5 +166,5 @@ uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && LCD_USE_SOFT_SPI
 #endif // __STM32F1__

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -480,6 +480,12 @@
   #define MAX_AUTORETRACT 99
 #endif
 
+// FORCE_SOFT_SPI bit-bangs the SD card too. Use LCD_FORCE_SOFT_SPI instead when the
+// panel has its own pins. Soft SPI disables interrupts per byte and breaks TMC serial.
+#if ANY(FORCE_SOFT_SPI, LCD_FORCE_SOFT_SPI)
+  #define LCD_USE_SOFT_SPI 1
+#endif
+
 /**
  * LCD Contrast for Graphical Displays
  */

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.h
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.h
@@ -246,8 +246,12 @@
 
 #endif
 
-#if defined(DOGM_FORCE_SOFT_SPI) && !defined(FORCE_SOFT_SPI)
+// Some displays require soft SPI. Conditionals-5-post.h covers the other cases.
+#if defined(DOGM_FORCE_SOFT_SPI) && !defined(FORCE_SOFT_SPI) && !defined(LCD_FORCE_SOFT_SPI)
   #define FORCE_SOFT_SPI
+  #ifndef LCD_USE_SOFT_SPI
+    #define LCD_USE_SOFT_SPI 1
+  #endif
 #endif
 #undef DOGM_FORCE_SOFT_SPI
 
@@ -255,7 +259,7 @@
 #ifndef U8G_PARAM
   #if IS_I2C_LCD
     #define U8G_PARAM U8G_I2C_OPT_NONE                              // I2C LCD
-  #elif ENABLED(FORCE_SOFT_SPI)
+  #elif ENABLED(LCD_USE_SOFT_SPI)
     #define U8G_PARAM DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0 // SW-SPI
   #else
     #define U8G_PARAM DOGLCD_CS, DOGLCD_A0                          // HW-SPI

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
@@ -108,15 +108,16 @@
 
 //
 // Default pins for TMC software SPI
+// SPI1 level-shifted to the driver sockets and shared with the onboard SD card
 //
 #ifndef TMC_SPI_MOSI
-  #define TMC_SPI_MOSI                      PB15
+  #define TMC_SPI_MOSI                      PA7
 #endif
 #ifndef TMC_SPI_MISO
-  #define TMC_SPI_MISO                      PB14
+  #define TMC_SPI_MISO                      PA6
 #endif
 #ifndef TMC_SPI_SCK
-  #define TMC_SPI_SCK                       PB13
+  #define TMC_SPI_SCK                       PA5
 #endif
 
 #if HAS_TMC_UART

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V2_1.h
@@ -177,9 +177,17 @@
 #define EXP2_08_PIN                         -1
 
 //
-// Onboard SD card
+// SD Card
 // Must use soft SPI because Marlin's default hardware SPI is tied to LCD's EXP2
 //
+#ifndef SDCARD_CONNECTION
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
+#endif
+
 #if SD_CONNECTION_IS(LCD)
   #define SD_SS_PIN                  EXP2_04_PIN
   #define SD_SCK_PIN                 EXP2_02_PIN
@@ -187,6 +195,7 @@
   #define SD_MOSI_PIN                EXP2_06_PIN
   #define SD_DETECT_PIN              EXP2_07_PIN
 #elif SD_CONNECTION_IS(ONBOARD)
+  #define SD_DETECT_PIN                     -1    // J52 leaves DET unwired
   #define SD_SCK_PIN                        PA5
   #define SD_MISO_PIN                       PA6
   #define SD_MOSI_PIN                       PA7
@@ -225,8 +234,15 @@
 
     #define DOGLCD_A0                EXP1_07_PIN
     #define DOGLCD_CS                EXP1_06_PIN
+    #define DOGLCD_SCK               EXP2_02_PIN
+    #define DOGLCD_MOSI              EXP2_06_PIN
     #define BTN_EN1                  EXP2_03_PIN
     #define BTN_EN2                  EXP2_05_PIN
+
+    #define LCD_FORCE_SOFT_SPI                  // Panel has its own pins on EXP2
+    #if SD_CONNECTION_IS(LCD)
+      #define FORCE_SOFT_SPI                    // SD shares EXP2 here
+    #endif
 
   #else
 
@@ -241,10 +257,14 @@
     #if ENABLED(FYSETC_MINI_12864)
       #define DOGLCD_CS              EXP1_03_PIN
       #define DOGLCD_A0              EXP1_04_PIN
+      #define DOGLCD_SCK             EXP2_02_PIN
+      #define DOGLCD_MOSI            EXP2_06_PIN
       //#define LCD_BACKLIGHT_PIN           -1
 
-      #define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
-                                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
+      #define LCD_FORCE_SOFT_SPI                  // Panel has its own pins on EXP2
+      #if SD_CONNECTION_IS(LCD)
+        #define FORCE_SOFT_SPI                    // SD shares EXP2 here
+      #endif
 
       #define LCD_RESET_PIN          EXP1_05_PIN  // Must be high or open for LCD to operate normally.
       #if ANY(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M5P_V1_0.h
@@ -203,9 +203,17 @@
 #define EXP2_08_PIN                         -1
 
 //
-// Onboard SD card
+// SD Card
 // Must use soft SPI because Marlin's default hardware SPI is tied to LCD's EXP2
 //
+#ifndef SDCARD_CONNECTION
+  #if HAS_WIRED_LCD && DISABLED(NO_LCD_SDCARD)
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
+#endif
+
 #if SD_CONNECTION_IS(LCD)
   #define SD_SS_PIN                  EXP2_04_PIN
   #define SD_SCK_PIN                 EXP2_02_PIN


### PR DESCRIPTION
### Description

Fixes several Manta M4P bugs dating back to the original PR (#25001)

- **Onboard SD never worked.** The pins file sets no default `SDCARD_CONNECTION`, so every `SD_CONNECTION_IS()` branch is false and no SD pins get defined. M4P and M5P are the only BTT G0 boards missing it.
- **LCD contrast only worked with `SDCARD_CONNECTION LCD`.** The DOGM panels had no `DOGLCD_SCK`/`DOGLCD_MOSI` and fell back to hardware SPI, which follows the SD pins. Selecting LCD just happened to put the SD on the panel's own EXP2 pins.
- **`M43 W` hung on pin 57.** `PF0` is OSC_IN and the PLL runs from HSE. Also fixes `NUMBER_PINS_TOTAL` overrunning `pin_xref[]`, and wrong `M42 P##` numbers for analog-capable pins.
- **TMC SPI pins were on EXP2 rather than the driver bus.** Page 7 of the [schematic](https://github.com/bigtreetech/Manta-M4P/blob/master/Hardware/bigtreetech_manta_m4p_v2.1_220608_SCH.pdf) shows driver SPI level-shifted off the onboard SD bus (PA7/PA6/PA5), and BTT's Klipper config agrees (`spi_bus: spi1`). SPI drivers have never worked on this board.

Once the onboard SD worked the drivers started reporting connection errors. `FORCE_SOFT_SPI` bit-bangs the SD card as well as the panel, and soft SPI disables interrupts per byte, which is enough to break TMC2209 software serial at 19200 baud. New `LCD_FORCE_SOFT_SPI` bit-bangs only the LCD. Confirmed on hardware with identical pins: soft SPI fails, hardware SPI works.

Page 13 of the schematic shows the onboard socket's DET pin unconnected, so the missing `SD_DETECT_PIN` is correct rather than an oversight. Now stated explicitly.

> [!NOTE]
> The M4P still reboots when inserting an SD card into the full-sized SD card slot.

Related to the note above, I spoke with Alan at BTT about this issue years ago & I vaguely remember something about a minor board rev, but I'm unsure if that ever happened.

### Requirements

Manta M4P V2.1 with a DOGM display on EXP1/EXP2. Tested on a BIQU Hurakan with a BTT Mini 12864. The M5P gets the same `SDCARD_CONNECTION` default since its pins file has the identical gap, though I haven't tested it on M5P hardware.

### Benefits

- Onboard SD works
- LCD contrast is correct whatever `SDCARD_CONNECTION` is set to
- `M43 W` no longer hangs on any STM32 clocked from HSE
- Power-on and brownout resets are reported on STM32G0, which uses `RCC_FLAG_PWRRST` rather than the `RCC_FLAG_PORRST` Marlin was checking
- SPI-mode drivers can work on the M4P
- `LCD_FORCE_SOFT_SPI` is available to any board whose panel has its own pins

### Configurations

BIQU Hurakan with `SDCARD_CONNECTION ONBOARD`. Fixed config PR: https://github.com/MarlinFirmware/Configurations/pull/1204

### Related Issues

- #25001
- https://github.com/MarlinFirmware/Configurations/pull/1204
