### PR TITLE
Fix dogm soft spi link

### DIFF
--- a/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
+++ b/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
@@ -24,7 +24,12 @@
 
 #include "../../../inc/MarlinConfig.h"
 
+// DOGM display with software SPI
 #if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
+  #define HAS_DOGLCD_SW_SPI 1
+#endif
+
+#if HAS_DOGLCD_SW_SPI
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -125,5 +130,5 @@ uint8_t u8g_com_HAL_MFL_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
+#endif // HAS_DOGLCD_SW_SPI
 #endif // ARDUINO_ARCH_MFL

--- a/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
+++ b/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
@@ -34,8 +34,8 @@
 static inline uint8_t swSpiTransfer_mode_0(uint8_t b) {
   for (uint8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
-    WRITE(DOGLCD_SCK, HIGH);
     WRITE(DOGLCD_MOSI, state);
+    WRITE(DOGLCD_SCK, HIGH);      // Slave samples MOSI on the rising edge
     b <<= 1;
     WRITE(DOGLCD_SCK, LOW);
   }

--- a/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
+++ b/Marlin/src/HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -125,5 +125,5 @@ uint8_t u8g_com_HAL_MFL_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
 #endif // ARDUINO_ARCH_MFL

--- a/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
+++ b/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
 
 #warning "Software SPI for U8Glib is experimental on HC32F460. Please share your experiences at https://github.com/shadow578/Marlin-H32/issues/35"
 
@@ -159,5 +159,5 @@ uint8_t u8g_com_HAL_HC32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, voi
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
 #endif // ARDUINO_ARCH_HC32

--- a/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
+++ b/Marlin/src/HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp
@@ -24,7 +24,12 @@
 
 #include "../../../inc/MarlinConfig.h"
 
+// DOGM display with software SPI
 #if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
+  #define HAS_DOGLCD_SW_SPI 1
+#endif
+
+#if HAS_DOGLCD_SW_SPI
 
 #warning "Software SPI for U8Glib is experimental on HC32F460. Please share your experiences at https://github.com/shadow578/Marlin-H32/issues/35"
 
@@ -159,5 +164,5 @@ uint8_t u8g_com_HAL_HC32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, voi
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
+#endif // HAS_DOGLCD_SW_SPI
 #endif // ARDUINO_ARCH_HC32

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_hw_spi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_hw_spi.cpp
@@ -1,0 +1,101 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2026 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Hardware SPI for a DOGM display on its own SPI bus.
+ *
+ * U8glib-HAL's u8g_com_stm32duino_hw_spi_fn drives the shared 'SPI' object.
+ * Marlin's SD card code repoints that object at the card (HAL_SPI.cpp), so a
+ * display on different pins gets its output sent to the SD card's pins as soon
+ * as the card is initialized - the display draws its boot screen and then goes
+ * quiet. That is why marlinui_DOGM.h falls back to bit-banging whenever the
+ * DOGLCD pins differ from the SD pins.
+ *
+ * Where the board declares its display header's SPI pins (LCD_SPI_*), the
+ * display can instead have a MarlinSPI instance of its own, on its own
+ * peripheral, and keep hardware SPI. The same approach is used for the onboard
+ * SPI flash (libs/W25Qxx.cpp).
+ */
+
+#ifdef HAL_STM32
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_DOGLCD_HW_SPI
+
+#include <U8glib-HAL.h>
+#include <SPI.h>
+
+#ifndef DOGLCD_SPI_SPEED
+  #define DOGLCD_SPI_SPEED 2500000    // (Hz) Same base clock as the U8glib-HAL driver
+#endif
+
+// MISO is unused by the display, but the STM32 core refuses to bring up an SPI
+// peripheral whose MISO pin has no peripheral mapping (spi_com.c), so it has to
+// be a real pin on the same peripheral. Boards supply it as LCD_SPI_MISO_PIN.
+static SPIClass lcdSPI(DOGLCD_MOSI, DOGLCD_MISO, DOGLCD_SCK);
+static SPISettings spiConfig;
+
+uint8_t u8g_com_HAL_STM32_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
+  switch (msg) {
+    case U8G_COM_MSG_STOP:
+      break;
+
+    case U8G_COM_MSG_INIT:
+      u8g_SetPIOutput(u8g, U8G_PI_CS);
+      u8g_SetPIOutput(u8g, U8G_PI_A0);
+      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+
+      spiConfig = SPISettings(DOGLCD_SPI_SPEED, MSBFIRST, TERN(U8G_SPI_USE_MODE_3, SPI_MODE3, SPI_MODE0));
+      lcdSPI.begin();
+      break;
+
+    case U8G_COM_MSG_ADDRESS:                 // Command (arg_val = 0) or data (arg_val = 1)
+      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+      break;
+
+    case U8G_COM_MSG_CHIP_SELECT:             // arg_val == 0 means CS high
+      u8g_SetPILevel(u8g, U8G_PI_CS, arg_val ? LOW : HIGH);
+      break;
+
+    case U8G_COM_MSG_RESET:
+      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+      break;
+
+    case U8G_COM_MSG_WRITE_BYTE:
+      lcdSPI.beginTransaction(spiConfig);
+      lcdSPI.transfer(arg_val);
+      lcdSPI.endTransaction();
+      break;
+
+    case U8G_COM_MSG_WRITE_SEQ:
+      lcdSPI.beginTransaction(spiConfig);
+      lcdSPI.transfer((uint8_t *)arg_ptr, arg_val);
+      lcdSPI.endTransaction();
+      break;
+  }
+  return 1;
+}
+
+#endif // HAS_DOGLCD_HW_SPI
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_hw_spi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_hw_spi.cpp
@@ -51,7 +51,7 @@
 
 // MISO is unused by the display, but the STM32 core refuses to bring up an SPI
 // peripheral whose MISO pin has no peripheral mapping (spi_com.c), so it has to
-// be a real pin on the same peripheral. Boards supply it as LCD_SPI_MISO_PIN.
+// be a real pin on the same peripheral. Boards supply it as LCD_HW_SPI_MISO_PIN.
 static SPIClass lcdSPI(DOGLCD_MOSI, DOGLCD_MISO, DOGLCD_SCK);
 static SPISettings spiConfig;
 

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -132,5 +132,5 @@ uint8_t u8g_com_HAL_STM32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, vo
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
@@ -34,8 +34,8 @@
 static inline uint8_t swSpiTransfer_mode_0(uint8_t b) {
   for (uint8_t i = 0; i < 8; ++i) {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
-    WRITE(DOGLCD_SCK, HIGH);
     WRITE(DOGLCD_MOSI, state);
+    WRITE(DOGLCD_SCK, HIGH);      // Slave samples MOSI on the rising edge
     b <<= 1;
     WRITE(DOGLCD_SCK, LOW);
   }

--- a/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,12 @@
 
 #include "../../../inc/MarlinConfig.h"
 
+// DOGM display with software SPI
 #if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
+  #define HAS_DOGLCD_SW_SPI 1
+#endif
+
+#if HAS_DOGLCD_SW_SPI
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -132,5 +137,5 @@ uint8_t u8g_com_HAL_STM32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, vo
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
+#endif // HAS_DOGLCD_SW_SPI
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -32,3 +32,28 @@
 #if ALL(STM32F4xx, FLASH_EEPROM_EMULATION) && PRINTCOUNTER_SAVE_INTERVAL > 0
   #define PRINTCOUNTER_SYNC
 #endif
+
+/**
+ * A DOGM display on its own hardware SPI bus
+ *
+ * The u8g hardware-SPI driver uses the shared 'SPI' object, which the SD card
+ * repoints to its own pins, so a display on other pins has to bit-bang instead.
+ * Where a board declares its display header's SPI pins and the configured
+ * DOGLCD pins match them, the display can be given a dedicated SPI instance
+ * and keep hardware SPI.
+ *
+ * There is no portable way to ask whether a pin is SPI-capable - the pin map is
+ * a runtime table - so this relies on the board saying so. Boards opt in by
+ * defining LCD_SPI_SCK_PIN / LCD_SPI_MOSI_PIN / LCD_SPI_MISO_PIN. e.g., MKS Robin Nano V3
+ */
+#if defined(DOGLCD_SCK) && defined(DOGLCD_MOSI)
+  #if defined(LCD_SPI_SCK_PIN) && defined(LCD_SPI_MOSI_PIN) && defined(LCD_SPI_MISO_PIN) \
+      && DOGLCD_SCK == LCD_SPI_SCK_PIN && DOGLCD_MOSI == LCD_SPI_MOSI_PIN
+    #define HAS_DOGLCD_HW_SPI 1
+    #define DOGLCD_MISO LCD_SPI_MISO_PIN
+  #elif defined(PIN_SPI_SCK) && defined(PIN_SPI_MOSI) && defined(PIN_SPI_MISO) \
+      && DOGLCD_SCK == PIN_SPI_SCK && DOGLCD_MOSI == PIN_SPI_MOSI
+    #define HAS_DOGLCD_HW_SPI 1
+    #define DOGLCD_MISO PIN_SPI_MISO
+  #endif
+#endif // DOGLCD_SCK && DOGLCD_MOSI

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -44,13 +44,13 @@
  *
  * There is no portable way to ask whether a pin is SPI-capable - the pin map is
  * a runtime table - so this relies on the board saying so. Boards opt in by
- * defining LCD_SPI_SCK_PIN / LCD_SPI_MOSI_PIN / LCD_SPI_MISO_PIN. e.g., MKS Robin Nano V3
+ * defining LCD_HW_SPI_SCK_PIN / LCD_HW_SPI_MOSI_PIN / LCD_HW_SPI_MISO_PIN. e.g., MKS Robin Nano V3
  */
 #if defined(DOGLCD_SCK) && defined(DOGLCD_MOSI)
-  #if defined(LCD_SPI_SCK_PIN) && defined(LCD_SPI_MOSI_PIN) && defined(LCD_SPI_MISO_PIN) \
-      && DOGLCD_SCK == LCD_SPI_SCK_PIN && DOGLCD_MOSI == LCD_SPI_MOSI_PIN
+  #if defined(LCD_HW_SPI_SCK_PIN) && defined(LCD_HW_SPI_MOSI_PIN) && defined(LCD_HW_SPI_MISO_PIN) \
+      && DOGLCD_SCK == LCD_HW_SPI_SCK_PIN && DOGLCD_MOSI == LCD_HW_SPI_MOSI_PIN
     #define HAS_DOGLCD_HW_SPI 1
-    #define DOGLCD_MISO LCD_SPI_MISO_PIN
+    #define DOGLCD_MISO LCD_HW_SPI_MISO_PIN
   #elif defined(PIN_SPI_SCK) && defined(PIN_SPI_MOSI) && defined(PIN_SPI_MISO) \
       && DOGLCD_SCK == PIN_SPI_SCK && DOGLCD_MOSI == PIN_SPI_MOSI
     #define HAS_DOGLCD_HW_SPI 1

--- a/Marlin/src/HAL/STM32/u8g/LCD_defines.h
+++ b/Marlin/src/HAL/STM32/u8g/LCD_defines.h
@@ -28,8 +28,15 @@
 uint8_t u8g_com_HAL_STM32_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   // u8g_com_stm32duino_swspi.cpp
 #define U8G_COM_HAL_SW_SPI_FN u8g_com_HAL_STM32_sw_spi_fn
 
-uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);  // See U8glib-HAL
-#define U8G_COM_HAL_HW_SPI_FN u8g_com_stm32duino_hw_spi_fn
+#if HAS_DOGLCD_HW_SPI
+  // The display has its own SPI instance, so it is unaffected by the SD card
+  // repointing the shared 'SPI' object.
+  uint8_t u8g_com_HAL_STM32_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr); // u8g_com_stm32duino_hw_spi.cpp
+  #define U8G_COM_HAL_HW_SPI_FN u8g_com_HAL_STM32_hw_spi_fn
+#else
+  uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);  // See U8glib-HAL
+  #define U8G_COM_HAL_HW_SPI_FN u8g_com_stm32duino_hw_spi_fn
+#endif
 
 uint8_t u8g_com_stm32duino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr); // u8g_com_stm32duino_ssd_i2c.cpp
 #define U8G_COM_SSD_I2C_HAL   u8g_com_stm32duino_ssd_i2c_fn

--- a/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,12 @@
 
 #include "../../../inc/MarlinConfig.h"
 
+// DOGM display with software SPI
 #if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
+  #define HAS_DOGLCD_SW_SPI 1
+#endif
+
+#if HAS_DOGLCD_SW_SPI
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -166,5 +171,5 @@ uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
+#endif // HAS_DOGLCD_SW_SPI
 #endif // __STM32F1__

--- a/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp
@@ -24,7 +24,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
+#if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
 
 #include <U8glib-HAL.h>
 #include "../../shared/HAL_SPI.h"
@@ -166,5 +166,5 @@ uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
+#endif // HAS_MARLINUI_U8GLIB && DOGLCD_SCK && DOGLCD_MOSI && DOGLCD_A0 && DOGLCD_CS
 #endif // __STM32F1__

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -3702,6 +3702,33 @@
   #define SPI_FLASH_BACKUP 1
 #endif
 
+/**
+ * A DOGM display on its own hardware SPI bus
+ *
+ * The u8g hardware-SPI driver uses the shared 'SPI' object, which the SD card
+ * repoints to its own pins, so a display on other pins has to bit-bang instead.
+ * Where a board declares its display header's SPI pins and the configured
+ * DOGLCD pins match them, the display can be given a dedicated SPI instance
+ * and keep hardware SPI.
+ *
+ * There is no portable way to ask whether a pin is SPI-capable - the pin map is
+ * a runtime table - so this relies on the board saying so. Boards opt in by
+ * defining LCD_SPI_SCK_PIN / LCD_SPI_MOSI_PIN / LCD_SPI_MISO_PIN.
+ */
+#ifdef HAL_STM32
+  #if defined(DOGLCD_SCK) && defined(DOGLCD_MOSI)
+    #if defined(LCD_SPI_SCK_PIN) && defined(LCD_SPI_MOSI_PIN) && defined(LCD_SPI_MISO_PIN) \
+        && DOGLCD_SCK == LCD_SPI_SCK_PIN && DOGLCD_MOSI == LCD_SPI_MOSI_PIN
+      #define HAS_DOGLCD_HW_SPI 1
+      #define DOGLCD_MISO LCD_SPI_MISO_PIN
+    #elif defined(PIN_SPI_SCK) && defined(PIN_SPI_MOSI) && defined(PIN_SPI_MISO) \
+        && DOGLCD_SCK == PIN_SPI_SCK && DOGLCD_MOSI == PIN_SPI_MOSI
+      #define HAS_DOGLCD_HW_SPI 1
+      #define DOGLCD_MISO PIN_SPI_MISO
+    #endif
+  #endif
+#endif
+
 // Fixed-Time Motion
 #if ENABLED(FT_MOTION)
   #define FTM_TS (1.0f / FTM_FS)  // (s) Time step for trajectory generation. (Reciprocal of FTM_FS)

--- a/Marlin/src/inc/Conditionals-5-post.h
+++ b/Marlin/src/inc/Conditionals-5-post.h
@@ -3702,33 +3702,6 @@
   #define SPI_FLASH_BACKUP 1
 #endif
 
-/**
- * A DOGM display on its own hardware SPI bus
- *
- * The u8g hardware-SPI driver uses the shared 'SPI' object, which the SD card
- * repoints to its own pins, so a display on other pins has to bit-bang instead.
- * Where a board declares its display header's SPI pins and the configured
- * DOGLCD pins match them, the display can be given a dedicated SPI instance
- * and keep hardware SPI.
- *
- * There is no portable way to ask whether a pin is SPI-capable - the pin map is
- * a runtime table - so this relies on the board saying so. Boards opt in by
- * defining LCD_SPI_SCK_PIN / LCD_SPI_MOSI_PIN / LCD_SPI_MISO_PIN.
- */
-#ifdef HAL_STM32
-  #if defined(DOGLCD_SCK) && defined(DOGLCD_MOSI)
-    #if defined(LCD_SPI_SCK_PIN) && defined(LCD_SPI_MOSI_PIN) && defined(LCD_SPI_MISO_PIN) \
-        && DOGLCD_SCK == LCD_SPI_SCK_PIN && DOGLCD_MOSI == LCD_SPI_MOSI_PIN
-      #define HAS_DOGLCD_HW_SPI 1
-      #define DOGLCD_MISO LCD_SPI_MISO_PIN
-    #elif defined(PIN_SPI_SCK) && defined(PIN_SPI_MOSI) && defined(PIN_SPI_MISO) \
-        && DOGLCD_SCK == PIN_SPI_SCK && DOGLCD_MOSI == PIN_SPI_MOSI
-      #define HAS_DOGLCD_HW_SPI 1
-      #define DOGLCD_MISO PIN_SPI_MISO
-    #endif
-  #endif
-#endif
-
 // Fixed-Time Motion
 #if ENABLED(FT_MOTION)
   #define FTM_TS (1.0f / FTM_FS)  // (s) Time step for trajectory generation. (Reciprocal of FTM_FS)

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.h
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.h
@@ -105,7 +105,9 @@
   #define SMART_RAMPS MB(RAMPS_SMART_EFB, RAMPS_SMART_EEB, RAMPS_SMART_EFF, RAMPS_SMART_EEF, RAMPS_SMART_SF)
   #define U8G_CLASS U8GLIB_64128N_2X_HAL                        // 4 stripes (HW-SPI)
 
-  #if (SMART_RAMPS && defined(__SAM3X8E__)) || (defined(DOGLCD_SCK) && (DOGLCD_SCK >= 0 && DOGLCD_SCK != SD_SCK_PIN)) || (defined(DOGLCD_MOSI) && (DOGLCD_MOSI >= 0 && DOGLCD_MOSI != SD_MOSI_PIN))
+  // Bit-bang a display that is on pins other than the SD card's, unless it has
+  // an SPI peripheral of its own (HAS_DOGLCD_HW_SPI).
+  #if !HAS_DOGLCD_HW_SPI && ((SMART_RAMPS && defined(__SAM3X8E__)) || (defined(DOGLCD_SCK) && (DOGLCD_SCK >= 0 && DOGLCD_SCK != SD_SCK_PIN)) || (defined(DOGLCD_MOSI) && (DOGLCD_MOSI >= 0 && DOGLCD_MOSI != SD_MOSI_PIN)))
     #define DOGM_FORCE_SOFT_SPI                                 // SW-SPI
   #endif
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -266,9 +266,9 @@
 // The EXP2 header is wired to SPI1, whether or not the SD card is on it.
 // Declaring the pins lets a display on this header use hardware SPI.
 //
-#define LCD_SPI_SCK_PIN              EXP2_02_PIN  // PA5
-#define LCD_SPI_MISO_PIN             EXP2_01_PIN  // PA6
-#define LCD_SPI_MOSI_PIN             EXP2_06_PIN  // PA7
+#define LCD_HW_SPI_SCK_PIN           EXP2_02_PIN  // PA5
+#define LCD_HW_SPI_MISO_PIN          EXP2_01_PIN  // PA6
+#define LCD_HW_SPI_MOSI_PIN          EXP2_06_PIN  // PA7
 
 //
 // SPI SD Card
@@ -276,9 +276,9 @@
 #if SD_CONNECTION_IS(LCD)
   #define ENABLE_SPI1
   #define SD_SS_PIN                  EXP2_04_PIN
-  #define SD_SCK_PIN                 EXP2_02_PIN
-  #define SD_MISO_PIN                EXP2_01_PIN
-  #define SD_MOSI_PIN                EXP2_06_PIN
+  #define SD_SCK_PIN          LCD_HW_SPI_SCK_PIN
+  #define SD_MISO_PIN        LCD_HW_SPI_MISO_PIN
+  #define SD_MOSI_PIN        LCD_HW_SPI_MOSI_PIN
   #define SD_DETECT_PIN              EXP2_07_PIN
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -263,6 +263,14 @@
 #define EXP2_08_PIN                         -1    // RESET
 
 //
+// The EXP2 header is wired to SPI1, whether or not the SD card is on it.
+// Declaring the pins lets a display on this header use hardware SPI.
+//
+#define LCD_SPI_SCK_PIN              EXP2_02_PIN  // PA5
+#define LCD_SPI_MISO_PIN             EXP2_01_PIN  // PA6
+#define LCD_SPI_MOSI_PIN             EXP2_06_PIN  // PA7
+
+//
 // SPI SD Card
 //
 #if SD_CONNECTION_IS(LCD)


### PR DESCRIPTION
### Description

Fixes #28569 — a DOGM display on SPI pins other than the SD card's fails to link:

```
u8g_dev_st7565_64128n_HAL.cpp.o:(.data.u8g_dev_st7565_64128n_HAL_2x_sw_spi+0x8):
  undefined reference to `u8g_com_HAL_STM32_sw_spi_fn(_u8g_t*, unsigned char, unsigned char, void*)'
```

The SW-SPI U8G communication function is compiled only under `FORCE_SOFT_SPI`,
but the U8G device tables that reference it are compiled unconditionally. When
`marlinui_DOGM.h` selects the SW-SPI device the reference is kept alive, while
the HAL never compiles the function to satisfy it.

Three changes. Fixes 1 and 2 make the software-SPI fallback work, which is what
2.1.2.7 did for this display — `marlinui_DOGM.h` has always forced SW SPI when
the DOGLCD pins differ from the SD card's. Fix 3 goes further and makes
**hardware** SPI work, which is what the reporter actually asked for
("Expected behavior: Screen should work, ideally with HW SPI").

### The mismatch

`u8g_dev_st7565_64128n_HAL.cpp` emits **both** device structs, with no condition
beyond `HAS_MARLINUI_U8GLIB`:

```cpp
u8g_dev_t u8g_dev_st7565_64128n_HAL_2x_sw_spi = { ..., U8G_COM_HAL_SW_SPI_FN };
u8g_dev_t u8g_dev_st7565_64128n_HAL_2x_hw_spi = { ..., U8G_COM_HAL_HW_SPI_FN };
```

`U8G_COM_HAL_HW_SPI_FN` always resolves. `U8G_COM_HAL_SW_SPI_FN` resolves only
when `FORCE_SOFT_SPI` is set, because the HAL guards it:

```cpp
#if ALL(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)     // u8g_com_stm32duino_swspi.cpp
```

Normally `--gc-sections` discards the unused `_sw_spi` struct along with its
relocation, so the missing symbol never surfaces. It surfaces as soon as
something actually selects that struct.

### Why the guard can't see the decision

For this display the choice is made in `marlinui_DOGM.h`:

```cpp
#elif IS_U8GLIB_ST7565_64128N
  #if (SMART_RAMPS && defined(__SAM3X8E__)) || (defined(DOGLCD_SCK) && (DOGLCD_SCK >= 0 && DOGLCD_SCK != SD_SCK_PIN)) || ...
    #define DOGM_FORCE_SOFT_SPI
  #endif
...
#if defined(DOGM_FORCE_SOFT_SPI) && !defined(FORCE_SOFT_SPI)
  #define FORCE_SOFT_SPI
#endif
```

`marlinui_DOGM.h` is a UI header. The HAL file includes only `MarlinConfig.h`,
which never reaches it, so `FORCE_SOFT_SPI` is undefined there even though the UI
translation unit has just defined it and picked the SW-SPI device. The two
translation units disagree, and the linker is where it shows up.

This is why the reporter's workarounds behave the way they do:

| Reporter's change | Why it changes the outcome |
|---|---|
| Add `#define FORCE_SOFT_SPI` to the config | Now in `MarlinConfig.h` scope, so the HAL compiles the function. Links. |
| Undefine `DOGLCD_MOSI` / `DOGLCD_SCK` | `DOGM_FORCE_SOFT_SPI` is never set, so the HW-SPI device is selected. Links. |

Only a user-set `FORCE_SOFT_SPI`, or one from a pins file, was ever visible to
the HAL. A derived one was not.

### Not a recent regression

The reporter bisected to "the first commit after the 2.1.2.7 release". That is
consistent with what is happening, but the cause is older than it looks.

2.1.2.7 builds this configuration because it does not contain these files at all
— it pulls `marlinfirmware/U8glib-HAL@0.5.4`, where the device tables and the
SW-SPI COM function live together in the library and are always compiled as a
pair. `bugfix-2.1.x` vendored them into Marlin (`🧑‍💻 Move U8G defines to HALs`,
Dec 2023; `🚸🐛 SW SPI Mode 3 for U8G on STM32` #27111, Jun 2024), and the
vendored COM function was given the `FORCE_SOFT_SPI` guard from its first commit
while the vendored device tables kept the library's unconditional form.

So the defect has been latent in `bugfix-2.1.x` since mid-2024 and has never been
in a release. Every `bugfix-2.1.x` commit after the 2.1.2.7 tag reproduces it,
which is what the bisect was showing. `🔧 Allow override DOGM FORCE_SOFT_SPI`
(`63ca8f0a42`), which renamed the flag to `DOGM_FORCE_SOFT_SPI`, is not the
cause — the failure reproduces identically on its parent.

### Fix 1 — the link error

Compile the SW-SPI COM function whenever the pins it needs are defined, instead
of when `FORCE_SOFT_SPI` happens to be visible:

```cpp
#if HAS_MARLINUI_U8GLIB && defined(DOGLCD_SCK) && defined(DOGLCD_MOSI) && defined(DOGLCD_A0) && defined(DOGLCD_CS)
```

This restores the contract the U8glib-HAL library provided: the COM function is
available wherever a device table can reference it, and `--gc-sections` drops it
when nothing does. Device selection stays entirely in `marlinui_DOGM.h`, which is
the only place that has the information to make it.

Applied to all four HALs that carry a vendored copy:

- `HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp`
- `HAL/STM32F1/u8g/u8g_com_stm32duino_swspi.cpp`
- `HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp`
- `HAL/HC32/u8g/u8g_com_HAL_HC32_sw_spi.cpp`

Guarding on the pins rather than on `FORCE_SOFT_SPI` also means no config can
reach the SW-SPI path without the pins that path writes to.

### Fix 2 — SW-SPI mode 0 clocks the wrong bit

The reporter's blank screen when forcing SW SPI is a second, independent bug.

`U8G_SPI_USE_MODE_3` is set only for `FYSETC_MINI_12864`, `MKS_MINI_12864` and
NATIVE_SIM ST7920 (`Conditionals-2-LCD.h:325-327`). VIKI2 is ST7565, so it takes
`swSpiTransfer_mode_0`, which on STM32 and GD32_MFL writes the clock before the
data:

```cpp
WRITE(DOGLCD_SCK, HIGH);      // rising edge - slave samples here
WRITE(DOGLCD_MOSI, state);    // ...but the bit is only presented now
```

In mode 0 the slave samples MOSI on the rising edge, so each edge latches the
*previous* bit; the first samples whatever MOSI held and the eighth is never
clocked in. Every other HAL has it the right way round — AVR
(`u8g_com_HAL_AVR_sw_spi.cpp:95-99`), STM32F1, HC32 and LPC1768 all set MOSI
first. The `mode_3` function in the same file is also correct, which is why the
FYSETC/MKS mini 12864 displays work.

This has been wrong since the file was added in #27111 and was never noticed,
because the mode-0 path could not link (above) for exactly the displays that
use it.

Fixed in the two affected HALs by putting MOSI first, matching the other four:

- `HAL/STM32/dogm/u8g_com_stm32duino_swspi.cpp`
- `HAL/GD32_MFL/dogm/u8g_com_mfl_swspi.cpp`

The two bugs were hiding each other: the mode-0 path could not link, so the
broken shifter behind it was never reached.

### Fix 3 — hardware SPI for a display on its own bus

This is the reporter's actual request, and the reason his third observation
looks so strange: boot splash then nothing on HW SPI, but a fully working LCD
once `SDSUPPORT` is off.

The u8g hardware-SPI driver uses the **global `SPI` object**, and Marlin's SD
init repoints that same object at the card:

```cpp
SPI.setMISO(SD_MISO_PIN);     // HAL_SPI.cpp:168-172
SPI.setMOSI(SD_MOSI_PIN);
SPI.setSCLK(SD_SCK_PIN);
SPI.begin();
```

The splash is drawn while `SPI` still has its default pins. `spiInit()` then
repoints it to the SD card and every later LCD write goes out on the card's
pins. Forcing SW SPI is Marlin's existing answer, and it is why 2.1.2.7 works
here — but it is a fallback, not the goal.

Given its own `SPIClass` instance the display keeps hardware SPI and is
unaffected by the SD card. `u8g_com_stm32duino_hw_spi.cpp` does that:

```cpp
static SPIClass lcdSPI(DOGLCD_MOSI, DOGLCD_MISO, DOGLCD_SCK);
```

Selected through `U8G_COM_HAL_HW_SPI_FN` in `LCD_defines.h` when the new
`HAS_DOGLCD_HW_SPI` is set; otherwise the U8glib-HAL shared-`SPI` version is
used exactly as before. The onboard SPI flash already works this way
(`libs/W25Qxx.cpp`), so the pattern is not new.

**How Marlin decides.** There is no portable compile-time way to ask whether a
pin is SPI-capable — the pin map is a runtime table — so the board has to say
so. Boards opt in by declaring their display header's SPI pins, and
`Conditionals-5-post.h` sets `HAS_DOGLCD_HW_SPI` when the configured DOGLCD pins
match them (or match the variant's `PIN_SPI_*`). If they match neither, nothing
changes and the display still falls back to SW SPI.

The MKS Robin Nano V3 family knew this already, but only in a branch this
reporter isn't using:

```cpp
#if SD_CONNECTION_IS(LCD)        // ...V3_common.h, before
  #define ENABLE_SPI1
  #define SD_SCK_PIN   EXP2_02_PIN   // PA5
  #define SD_MOSI_PIN  EXP2_06_PIN   // PA7
#endif
```

He runs `SD_CONNECTION_IS(ONBOARD)`, so the knowledge was thrown away. The pins
file now states it unconditionally:

```cpp
#define LCD_SPI_SCK_PIN   EXP2_02_PIN  // PA5
#define LCD_SPI_MISO_PIN  EXP2_01_PIN  // PA6
#define LCD_SPI_MOSI_PIN  EXP2_06_PIN  // PA7
```

`LCD_SPI_MISO_PIN` is not optional even though a display never drives MISO: the
STM32 core refuses to bring up an SPI peripheral whose MISO has no peripheral
mapping (`spi_com.c`: *"at least one SPI pin has no peripheral"*, then it
returns). Passing `NC` would leave the bus silently dead — the same class of
failure as the bug this PR started with.

Other boards opt in by adding those three defines. Nothing changes for boards
that don't.

### Configuring it

Both paths, in the same `opt_set`/`opt_add` form the reporter used.

**Hardware SPI** — DOGLCD pins on the EXP2 header, which is SPI1, while the SD
card stays on SPI3:

```
python .\buildroot\bin\opt_set MOTHERBOARD BOARD_MKS_ROBIN_NANO_V3_1
python .\buildroot\bin\opt_set LCD_CONTRAST_DEFAULT 210
python .\buildroot\bin\opt_add VIKI2 XYZ_HOLLOW_FRAME REVERSE_ENCODER_DIRECTION SDCARD_READONLY SDSUPPORT REINIT_NOISY_LCD

python .\buildroot\bin\opt_set DOGLCD_CS EXP2_07_PIN
python .\buildroot\bin\opt_set DOGLCD_A0 EXP1_04_PIN
python .\buildroot\bin\opt_set DOGLCD_MOSI EXP2_06_PIN
python .\buildroot\bin\opt_set DOGLCD_SCK EXP2_02_PIN
python .\buildroot\bin\opt_set LCD_RESET_PIN EXP1_03_PIN
```

That is the reporter's own configuration, unchanged. Because `DOGLCD_SCK` /
`DOGLCD_MOSI` now match `LCD_SPI_SCK_PIN` / `LCD_SPI_MOSI_PIN`,
`HAS_DOGLCD_HW_SPI` is set and the display gets SPI1 to itself. No new option to
set. Add `DOGLCD_SPI_SPEED` to change the 2.5 MHz default.

**Software SPI** — any two GPIOs, for a display not wired to a SPI header:

```
python .\buildroot\bin\opt_set DOGLCD_CS EXP2_07_PIN
python .\buildroot\bin\opt_set DOGLCD_A0 EXP1_04_PIN
python .\buildroot\bin\opt_set DOGLCD_MOSI PA2
python .\buildroot\bin\opt_set DOGLCD_SCK PA1
python .\buildroot\bin\opt_set LCD_RESET_PIN EXP1_03_PIN
```

The pins match no declared SPI header, so `marlinui_DOGM.h` forces SW SPI as it
always has — now linkable (Fix 1) and shifting bits correctly (Fix 2).

### Testing

The reporter's own configuration, verified by inspecting the linked objects
rather than just the exit status:

| Build | Before | After |
|---|---|---|
| Robin Nano V3.1 + VIKI2, DOGLCD on EXP2/SPI1 (#28569) | undefined reference | **SUCCESS, hardware SPI** |
| ...same, DOGLCD moved to arbitrary GPIOs (PA1/PA2) | undefined reference | **SUCCESS, software SPI** |
| Robin Nano V3.1 + REPRAP_DISCOUNT_FULL_GRAPHIC (ST7920) | SUCCESS | SUCCESS |
| Robin Nano V3.1 + FYSETC_MINI_12864_2_1 | SUCCESS | SUCCESS |
| Robin Nano V3.1 + MKS_MINI_12864 | SUCCESS | SUCCESS |
| Robin Nano V3.1, SD on the LCD header | SUCCESS | SUCCESS |
| HC32F460C_aquila_101 | SUCCESS | SUCCESS |
| GD32F103RC_aquila_mfl | SUCCESS | SUCCESS |
| mega2560 default config | SUCCESS | SUCCESS |

The first two rows are the point of the change, and `nm` confirms the split:

```
EXP2 pins:       U u8g_dev_st7565_64128n_HAL_2x_hw_spi   + u8g_com_HAL_STM32_hw_spi_fn
arbitrary GPIOs: U u8g_dev_st7565_64128n_HAL_2x_sw_spi   + u8g_com_HAL_STM32_sw_spi_fn
```

Two limits on what this table proves. It says nothing about Fix 2 — a bit-order
change is invisible to the compiler, so these builds pass either way. And on
GD32 the SW-SPI translation unit compiles to an empty object: no in-tree
`GD32_MFL` board defines `DOGLCD_CS`/`DOGLCD_A0`, so the guard is false and the
body is never reached. Substituting `MKS_MINI_12864` or `ZONESTAR_12864OLED`
fails on that board for those same missing pins, before and after this patch. So
the two GD32 edits are unexercised by any build I can construct - they are
textually identical to the STM32 ones, which are exercised, but that is the only
assurance behind them.

### Scope and testing limits

Everything here is verified by build and by reading the linked objects; **none
of it is tested on hardware** — I have no VIKI2 or Robin Nano V3.1.

- Fix 1 and the build results are certain.
- Fix 2 is a straightforward reading of SPI mode 0 against four other HALs that
  do it the other way round, but whether the display then produces a picture
  needs the bench.
- Fix 3 selects the right code path, provably. Whether SPI1 then drives that
  display correctly — clock polarity, the 2.5 MHz default over a ribbon cable,
  CS timing — has not been observed on hardware and should be confirmed before
  this is merged.

@kinsi55 — if you can build this branch and report back, the hardware-SPI path
is the part that most needs a second pair of eyes.
