### PR TITLE
🩹 Fix RESONANCE_TEST build with NO_STANDARD_MOTION

### DIFF
--- a/Marlin/src/feature/resonance/resonance_generator.h
+++ b/Marlin/src/feature/resonance/resonance_generator.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../../inc/MarlinConfigPre.h"
+#include "../../core/types.h"
 
 #include <math.h>
 


### PR DESCRIPTION
### Description

`Marlin/src/feature/resonance/resonance_generator.h` includes `planner.h` only under `#if HAS_STANDARD_MOTION`, but its `resonance_test_params_t` struct uses `AxisEnum`, `NO_AXIS_ENUM` and `xyze_pos_t` unconditionally. Those types come from `core/types.h`, which the header was picking up only as a transitive include of `planner.h`.

So with `FT_MOTION` + `NO_STANDARD_MOTION` + `RESONANCE_TEST` the header no longer sees those types and the build fails.

`core/types.h` is now included directly. `planner.h` stays conditional, since `block_t` is only referenced inside `HAS_STANDARD_MOTION` blocks.

### Requirements

Any board. Requires `FT_MOTION` with `NO_STANDARD_MOTION` and `RESONANCE_TEST` enabled.

### Benefits

`RESONANCE_TEST` builds when the standard motion system is disabled.

### Configurations

```cpp
// Configuration_adv.h
#define FT_MOTION
#define NO_STANDARD_MOTION
#define RESONANCE_TEST
```

### Related Issues

<li>MarlinFirmware/Marlin/issues/28571