### PR TITLE
✨ bd_pressure strain gauge over I2C

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1799,7 +1799,7 @@
   //#define BD_PRESSURE_PROBE             // Set the trigger threshold and re-tare before probing
   #if ENABLED(BD_PRESSURE_PROBE)
     #define BD_PRESSURE_THRESHOLD      4  // Probe trigger threshold
-    #define BD_PRESSURE_PROBE_SETTLE_MS 250 // (ms) Strain gauge settling time after a tare
+    #define BD_PRESSURE_PROBE_SETTLE_MS 250 // (ms) Quiet time before taring, so the baseline average is clean
   #endif
 
   //#define BD_PRESSURE_PA                // Automatic Pressure Advance calibration (M900 C). Needs LIN_ADVANCE.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1776,6 +1776,46 @@
 #endif
 
 /**
+ * bd_pressure - Strain gauge module on I2C (https://github.com/markniu/bd_pressure)
+ *
+ * A BF350-1EB strain gauge between the hotend and the toolhead, which does two
+ * unrelated jobs. As a nozzle probe it drives a plain endstop output and needs
+ * NO firmware support at all - just wire it to Z-MIN and set
+ * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN. As a Pressure Advance sensor it reports
+ * curve metrics that the host uses to sweep for the best K value.
+ *
+ * BD_PRESSURE therefore means "the I2C bus is wired up", and the two options
+ * below are what Marlin does over it. Enable neither and there is nothing to do.
+ *
+ * NOTE: This is NOT the BD_SENSOR bed distance sensor. Different device,
+ *       different protocol, though the two can share a bus.
+ */
+//#define BD_PRESSURE
+#if ENABLED(BD_PRESSURE)
+  #define BD_PRESSURE_I2C_SDA_PIN     -1  // Any free GPIO. Software I2C, so no pull-ups needed.
+  #define BD_PRESSURE_I2C_SCL_PIN     -1
+  #define BD_PRESSURE_I2C_DELAY       50  // (us) Half bit period. 50 = ~10kHz, the known-good rate.
+
+  //#define BD_PRESSURE_PROBE             // Set the trigger threshold and re-tare before probing
+  #if ENABLED(BD_PRESSURE_PROBE)
+    #define BD_PRESSURE_THRESHOLD      4  // Probe trigger threshold
+  #endif
+
+  //#define BD_PRESSURE_PA                // Automatic Pressure Advance calibration (M900 C). Needs LIN_ADVANCE.
+  #if ENABLED(BD_PRESSURE_PA)
+    #define BD_PRESSURE_PA_STEP    0.002  // PA increment per pass
+    #define BD_PRESSURE_PA_PASSES     50  // Maximum passes
+    #define BD_PRESSURE_PA_NOZZLE    0.4  // (mm) Nozzle size. Extrusion scales with its square.
+    #define BD_PRESSURE_PA_FLOW      1.0  // Flow ratio, to match the slicer
+    #define BD_PRESSURE_PA_VOLUMETRIC 25  // (mm^3/s) Maximum volumetric speed, sets the line speeds
+    #define BD_PRESSURE_PA_TEMP      210  // (°C) Nozzle temperature for the calibration
+    #define BD_PRESSURE_PA_Y_STEP    3.5  // (mm) Spacing between passes
+    #define BD_PRESSURE_PA_MARGIN      5  // (mm) Inset of the first line from X/Y minimum
+    #define BD_PRESSURE_PA_TRAVEL_SPEED 100 // (mm/s) Travel between passes
+  #endif
+#endif
+
+/**
  * Probe Enable / Disable
  * The probe only provides a triggered signal when enabled.
  */

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1799,6 +1799,7 @@
   //#define BD_PRESSURE_PROBE             // Set the trigger threshold and re-tare before probing
   #if ENABLED(BD_PRESSURE_PROBE)
     #define BD_PRESSURE_THRESHOLD      4  // Probe trigger threshold
+    #define BD_PRESSURE_PROBE_SETTLE_MS 250 // (ms) Strain gauge settling time after a tare
   #endif
 
   //#define BD_PRESSURE_PA                // Automatic Pressure Advance calibration (M900 C). Needs LIN_ADVANCE.

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -132,6 +132,10 @@
   #include "feature/bedlevel/bdl/bdl.h"
 #endif
 
+#if ENABLED(BD_PRESSURE)
+  #include "feature/bd_pressure.h"
+#endif
+
 #if ENABLED(POLL_JOG)
   #include "feature/joystick.h"
 #endif
@@ -1716,6 +1720,10 @@ void setup() {
 
   #if ENABLED(BD_SENSOR)
     SETUP_RUN(bdl.init(I2C_BD_SDA_PIN, I2C_BD_SCL_PIN, I2C_BD_DELAY));
+  #endif
+
+  #if ENABLED(BD_PRESSURE)
+    SETUP_RUN(bdp.init());
   #endif
 
   #if HAS_RS485_SERIAL

--- a/Marlin/src/feature/bd_pressure.cpp
+++ b/Marlin/src/feature/bd_pressure.cpp
@@ -71,6 +71,9 @@ uint8_t BDPressure::mode; // = 0 (neither, so the first probe_prep always writes
 // Bit periods to wait for the slave to release a stretched clock.
 #define BDP_STRETCH_TIMEOUT 2000
 
+// (ms) Time for the module's main loop to act on a tare request
+#define BDP_TARE_LATENCY_MS 20
+
 #define BDP_I2C_READ  1
 #define BDP_I2C_WRITE 0
 
@@ -261,14 +264,21 @@ void BDPressure::report() {
       safe_delay(BD_PRESSURE_PROBE_SETTLE_MS);
     }
 
-    // Tare with the machine at rest, as Klipper's PA_RESET does with its M400.
-    // Taring mid-move captures the moving load as the baseline.
+    // The tare is not an instantaneous reading. find_normal_endstop() sets the
+    // baseline to the mean of the last 30 samples already in the module's
+    // buffer (main.c:340-345), and the main loop calls it with force=1, so the
+    // usual "too noisy to tare" check is bypassed (main.c:338). Whatever is in
+    // that window becomes the baseline, disturbance included.
+    //
+    // So the settling time belongs BEFORE the write, not after: stop the
+    // machine, wait for the buffer to refill with quiet samples, then tare.
     planner.synchronize();
+    safe_delay(BD_PRESSURE_PROBE_SETTLE_MS);
     write_reg(BDP_REG_TARE, BDP_TARE_NOW);
 
-    // Let the strain gauge settle before probing. Users report this matters
-    // for repeatability; the reference macro leans on repeated resets instead.
-    safe_delay(BD_PRESSURE_PROBE_SETTLE_MS);
+    // The write only raises a flag; the module's main loop consumes it and
+    // clears it to 2 (main.c:514-518). Give it a moment to actually run.
+    safe_delay(BDP_TARE_LATENCY_MS);
   }
 
 #endif // BD_PRESSURE_PROBE

--- a/Marlin/src/feature/bd_pressure.cpp
+++ b/Marlin/src/feature/bd_pressure.cpp
@@ -29,15 +29,17 @@
 #include "../HAL/shared/Delay.h"
 #include "../MarlinCore.h"
 
+#include "../module/planner.h"
+
 #if ENABLED(BD_PRESSURE_PA)
   #include "../gcode/gcode.h"
   #include "../module/motion.h"
-  #include "../module/planner.h"
   #include "../module/temperature.h"
 #endif
 
 BDPressure bdp;
-bool BDPressure::online; // = false
+bool BDPressure::online;  // = false
+uint8_t BDPressure::mode; // = 0 (neither, so the first probe_prep always writes)
 
 //#define DEBUG_OUT_BD_PRESSURE
 #define DEBUG_OUT ENABLED(DEBUG_OUT_BD_PRESSURE)
@@ -224,6 +226,7 @@ bool BDPressure::init() {
   #if ENABLED(BD_PRESSURE_PROBE)
     write_reg(BDP_REG_MODE, BDP_MODE_PROBE);
     write_reg(BDP_REG_THRESHOLD, BD_PRESSURE_THRESHOLD);
+    mode = BDP_MODE_PROBE;
   #endif
 
   return true;
@@ -245,12 +248,27 @@ void BDPressure::report() {
 
   void BDPressure::probe_prep() {
     if (!online) return;
-    // Not redundant: a PA calibration leaves the module in PA mode, where
-    // Pressure_advance() runs instead of process_triggered() and the endstop
-    // output stops being driven at all.
-    write_reg(BDP_REG_MODE, BDP_MODE_PROBE);
-    write_reg(BDP_REG_THRESHOLD, BD_PRESSURE_THRESHOLD);
+
+    // Only write the mode when it actually changes. Writing status_clk makes
+    // the module re-initialize its ADS1220, which then needs time to settle -
+    // pointless before every probe point. A PA calibration is what leaves it in
+    // PA mode, where Pressure_advance() runs instead of process_triggered() and
+    // the endstop output stops being driven at all.
+    if (mode != BDP_MODE_PROBE) {
+      write_reg(BDP_REG_MODE, BDP_MODE_PROBE);
+      write_reg(BDP_REG_THRESHOLD, BD_PRESSURE_THRESHOLD);
+      mode = BDP_MODE_PROBE;
+      safe_delay(BD_PRESSURE_PROBE_SETTLE_MS);
+    }
+
+    // Tare with the machine at rest, as Klipper's PA_RESET does with its M400.
+    // Taring mid-move captures the moving load as the baseline.
+    planner.synchronize();
     write_reg(BDP_REG_TARE, BDP_TARE_NOW);
+
+    // Let the strain gauge settle before probing. Users report this matters
+    // for repeatability; the reference macro leans on repeated resets instead.
+    safe_delay(BD_PRESSURE_PROBE_SETTLE_MS);
   }
 
 #endif // BD_PRESSURE_PROBE
@@ -354,6 +372,7 @@ void BDPressure::calibrate(const float step, const uint8_t passes) {
 
   write_reg(BDP_REG_MODE, BDP_MODE_PA);
   write_reg(BDP_REG_RAW_OUT, 0);
+  mode = BDP_MODE_PA;
 
   // Prime the nozzle in place, at a controlled speed.
   extrude_to(motion.position.x, motion.position.y, e_purge, fr_low);

--- a/Marlin/src/feature/bd_pressure.cpp
+++ b/Marlin/src/feature/bd_pressure.cpp
@@ -1,0 +1,461 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2026 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../inc/MarlinConfig.h"
+
+#if ENABLED(BD_PRESSURE)
+
+#include "bd_pressure.h"
+
+#include "../HAL/shared/Delay.h"
+#include "../MarlinCore.h"
+
+#if ENABLED(BD_PRESSURE_PA)
+  #include "../gcode/gcode.h"
+  #include "../module/motion.h"
+  #include "../module/planner.h"
+  #include "../module/temperature.h"
+#endif
+
+BDPressure bdp;
+bool BDPressure::online; // = false
+
+//#define DEBUG_OUT_BD_PRESSURE
+#define DEBUG_OUT ENABLED(DEBUG_OUT_BD_PRESSURE)
+#include "../core/debug_out.h"
+
+// ============================================================================
+// Software I2C
+// ============================================================================
+//
+// Neither of the software I2C libraries Marlin already carries fits this
+// device. Panda_SoftMasterI2C (used by BD_SENSOR) has a configurable bit
+// period but its only write helper hard-codes register 0 and stops at a NUL,
+// so it cannot set registers 48-53. SlowSoftWire has the full Wire API but a
+// hard-coded 4us bit period (~125kHz) and a setClock() that does nothing.
+//
+// Both also drive the clock unconditionally, with no clock stretching. This
+// module enables stretching (I2C_NOSTRETCH_DISABLE) and needs it: it services
+// the bus one byte per interrupt while running the ADC and the PA maths, so a
+// master that ignores stretching is relying on being slower than the slave's
+// worst-case interrupt latency. That is the only reason the reference driver
+// runs at 10kHz.
+//
+// So: a bit-banger with a configurable period that honours stretching.
+
+#define BDP_SDA   BD_PRESSURE_I2C_SDA_PIN
+#define BDP_SCL   BD_PRESSURE_I2C_SCL_PIN
+#define BDP_DELAY DELAY_US(BD_PRESSURE_I2C_DELAY)
+
+// Bit periods to wait for the slave to release a stretched clock.
+#define BDP_STRETCH_TIMEOUT 2000
+
+#define BDP_I2C_READ  1
+#define BDP_I2C_WRITE 0
+
+// Open-drain emulation. A line is released by making it an input with the
+// internal pull-up, and asserted by driving it low.
+static void bdp_sda_high() { SET_INPUT_PULLUP(BDP_SDA); }
+static void bdp_sda_low()  { OUT_WRITE(BDP_SDA, LOW); }
+static void bdp_scl_low()  { OUT_WRITE(BDP_SCL, LOW); }
+
+/**
+ * @brief Release SCL and wait for the slave to let it rise.
+ * @return FALSE if the slave held the clock down past the timeout.
+ */
+static bool bdp_scl_high() {
+  SET_INPUT_PULLUP(BDP_SCL);
+  BDP_DELAY;
+  uint16_t timeout = BDP_STRETCH_TIMEOUT;
+  while (!READ(BDP_SCL)) {         // Clock stretching
+    if (!--timeout) return false;
+    BDP_DELAY;
+  }
+  return true;
+}
+
+static void bdp_stop() {
+  bdp_sda_low();
+  BDP_DELAY;
+  bdp_scl_high();
+  BDP_DELAY;
+  bdp_sda_high();
+  BDP_DELAY;
+}
+
+/**
+ * @brief Write one byte and read back the slave's ACK.
+ * @return TRUE if the slave acknowledged.
+ */
+static bool bdp_write_byte(const uint8_t value) {
+  for (uint8_t mask = 0x80; mask; mask >>= 1) {
+    if (value & mask) bdp_sda_high(); else bdp_sda_low();
+    if (!bdp_scl_high()) return false;
+    BDP_DELAY;
+    bdp_scl_low();
+    BDP_DELAY;
+  }
+  bdp_sda_high();                  // Release SDA for the ACK bit
+  if (!bdp_scl_high()) return false;
+  BDP_DELAY;
+  const bool ack = !READ(BDP_SDA);
+  bdp_scl_low();
+  BDP_DELAY;
+  return ack;
+}
+
+static uint8_t bdp_read_byte(const bool nack) {
+  uint8_t b = 0;
+  bdp_sda_high();
+  for (uint8_t i = 0; i < 8; ++i) {
+    b <<= 1;
+    if (!bdp_scl_high()) return 0;
+    BDP_DELAY;
+    if (READ(BDP_SDA)) b |= 1;
+    bdp_scl_low();
+    BDP_DELAY;
+  }
+  if (nack) bdp_sda_high(); else bdp_sda_low();
+  bdp_scl_high();
+  BDP_DELAY;
+  bdp_scl_low();
+  BDP_DELAY;
+  bdp_sda_high();
+  return b;
+}
+
+static bool bdp_start(const uint8_t addr_rw) {
+  bdp_sda_high();
+  if (!bdp_scl_high()) return false;
+  BDP_DELAY;
+  bdp_sda_low();                   // START: SDA falls while SCL is high
+  BDP_DELAY;
+  bdp_scl_low();
+  BDP_DELAY;
+  return bdp_write_byte(addr_rw);
+}
+
+// ============================================================================
+// Register access
+// ============================================================================
+//
+// Write: START | addr<<1|W | offset | data... | STOP
+// Read:  START | addr<<1|W | offset | REP START | addr<<1|R | data... | STOP
+//
+// Reads need the repeated START - there is no separate "set pointer"
+// transaction, since the device only resets its offset latch on ListenCplt.
+
+bool BDPressure::write_reg(const uint8_t reg, const uint8_t * const data, const uint8_t len) {
+  bool ok = bdp_start((BDP_I2C_ADDRESS << 1) | BDP_I2C_WRITE) && bdp_write_byte(reg);
+  for (uint8_t i = 0; ok && i < len; ++i) ok = bdp_write_byte(data[i]);
+  bdp_stop();
+  if (!ok) DEBUG_ECHOLNPGM("BDP: write reg ", reg, " failed");
+  return ok;
+}
+
+bool BDPressure::read_reg(const uint8_t reg, uint8_t * const data, const uint8_t len) {
+  bool ok = bdp_start((BDP_I2C_ADDRESS << 1) | BDP_I2C_WRITE) && bdp_write_byte(reg);
+  if (ok) ok = bdp_start((BDP_I2C_ADDRESS << 1) | BDP_I2C_READ);  // Repeated START
+  if (ok) for (uint8_t i = 0; i < len; ++i) data[i] = bdp_read_byte(i == len - 1);
+  bdp_stop();
+  if (!ok) DEBUG_ECHOLNPGM("BDP: read reg ", reg, " failed");
+  return ok;
+}
+
+/**
+ * @brief Read a NUL-terminated string from the register file.
+ * @param len Buffer size including the terminator.
+ */
+bool BDPressure::read_str(const uint8_t reg, char * const str, const uint8_t len) {
+  str[0] = '\0';
+  if (!read_reg(reg, (uint8_t*)str, len - 1)) return false;
+  str[len - 1] = '\0';
+  // The device NUL-pads, but a partly-written field may not be terminated.
+  for (uint8_t i = 0; i < len; ++i) if (str[i] == '\n') { str[i] = '\0'; break; }
+  return true;
+}
+
+// ============================================================================
+// Setup and reporting
+// ============================================================================
+
+bool BDPressure::init() {
+  online = false;
+
+  bdp_sda_high();
+  SET_INPUT_PULLUP(BDP_SCL);
+  BDP_DELAY;
+
+  // A line stuck low is a wiring fault, not a missing device. Say which.
+  if (!READ(BDP_SDA) || !READ(BDP_SCL)) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: bus stuck low - check wiring/pull-ups");
+    return false;
+  }
+
+  char ver[17];
+  if (!read_str(BDP_REG_VERSION, ver, sizeof(ver)) || !strstr(ver, BDP_VERSION_ID)) {
+    SERIAL_ERROR_START();
+    SERIAL_ECHOLNPGM("BD_PRESSURE: no response on SDA:", BDP_SDA, " SCL:", BDP_SCL);
+    return false;
+  }
+
+  online = true;
+  SERIAL_ECHOLNPGM("BD_PRESSURE: ", ver);
+
+  #if ENABLED(BD_PRESSURE_PROBE)
+    write_reg(BDP_REG_MODE, BDP_MODE_PROBE);
+    write_reg(BDP_REG_THRESHOLD, BD_PRESSURE_THRESHOLD);
+  #endif
+
+  return true;
+}
+
+void BDPressure::report() {
+  if (!online && !init()) return;
+
+  char ver[17];
+  uint8_t thr = 0, range = 0;
+  read_str(BDP_REG_VERSION, ver, sizeof(ver));
+  read_reg(BDP_REG_THRESHOLD, &thr, 1);
+  read_reg(BDP_REG_RANGE, &range, 1);
+
+  SERIAL_ECHOLNPGM("BD_PRESSURE ", ver, " threshold:", thr, " range:", range);
+}
+
+#if ENABLED(BD_PRESSURE_PROBE)
+
+  void BDPressure::probe_prep() {
+    if (!online) return;
+    // Not redundant: a PA calibration leaves the module in PA mode, where
+    // Pressure_advance() runs instead of process_triggered() and the endstop
+    // output stops being driven at all.
+    write_reg(BDP_REG_MODE, BDP_MODE_PROBE);
+    write_reg(BDP_REG_THRESHOLD, BD_PRESSURE_THRESHOLD);
+    write_reg(BDP_REG_TARE, BDP_TARE_NOW);
+  }
+
+#endif // BD_PRESSURE_PROBE
+
+// ============================================================================
+// Pressure Advance calibration
+// ============================================================================
+
+#if ENABLED(BD_PRESSURE_PA)
+
+/**
+ * @brief Read and parse one "R:res,lk,rk,Hk,Ha" result.
+ * @details The device never clears this register between passes, so a read
+ *          that lands before the analysis finishes returns the previous
+ *          pass's numbers. The caller writes a NUL here first and polls, so
+ *          an empty string means "not ready yet" rather than "no data".
+ * @return TRUE if a complete result was parsed.
+ */
+bool BDPressure::read_sample(pa_sample_t &s) {
+  char buf[BDP_MEASURE_LEN + 1];
+  if (!read_str(BDP_REG_MEASURE, buf, sizeof(buf))) return false;
+
+  char * const p = strstr(buf, "R:");
+  if (!p) return false;
+
+  int res, lk, rk, hk, ha;
+  if (sscanf(p + 2, "%d,%d,%d,%d,%d", &res, &lk, &rk, &hk, &ha) != 5) return false;
+
+  s.res = res; s.lk = lk; s.rk = rk; s.hk = hk; s.ha = ha;
+  return true;
+}
+
+void BDPressure::calibrate(const float step, const uint8_t passes) {
+  if (!online && !init()) return;
+
+  if (!motion.all_axes_trusted()) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: home the printer first");
+    return;
+  }
+
+  // Line geometry. Distances are fixed - only the start point moves to suit
+  // the machine. 20mm accel / 40mm cruise / 20mm decel; the two speed changes
+  // are the events being measured.
+  constexpr float l_acc = 20.0f, l_cruise = 40.0f, l_dec = 20.0f,
+                  x_start = X_MIN_POS + BD_PRESSURE_PA_MARGIN,
+                  y_start = Y_MIN_POS + BD_PRESSURE_PA_MARGIN,
+                  x_mid1  = x_start + l_acc,
+                  x_mid2  = x_mid1 + l_cruise,
+                  x_end   = x_mid2 + l_dec;
+
+  const float y_end = y_start + (passes - 1) * (BD_PRESSURE_PA_Y_STEP);
+
+  if (x_end > X_MAX_POS) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: 80mm line does not fit in X");
+    return;
+  }
+  if (y_end > Y_MAX_POS) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: too many passes to fit in Y");
+    return;
+  }
+
+  // Extrusion amounts are for a 0.4mm nozzle at 100% flow and scale with the
+  // square of the nozzle diameter.
+  constexpr float e_scale = sq((BD_PRESSURE_PA_NOZZLE) / 0.4f) * (BD_PRESSURE_PA_FLOW),
+                  e_purge  = 9.92204f * e_scale,
+                  e_acc    = 0.92643f * e_scale,
+                  e_cruise = 1.85285f * e_scale,
+                  e_dec    = 0.92643f * e_scale;
+
+  // Feedrates in mm/s.
+  constexpr feedRate_t fr_low    = 51.0f * (BD_PRESSURE_PA_VOLUMETRIC) / 60.0f,
+                       fr_high   = 537.0f * (BD_PRESSURE_PA_VOLUMETRIC) / 60.0f,
+                       fr_travel = (BD_PRESSURE_PA_TRAVEL_SPEED);
+
+  // Take the machine off the user's overrides for the duration - a flow or
+  // feedrate percentage would scale the very thing being measured.
+  const int16_t old_feedrate_percentage = motion.feedrate_percentage;
+  const int16_t old_flow = planner.flow_percentage[motion.extruder];
+  const float old_k = planner.get_advance_k();
+  motion.feedrate_percentage = 100;
+  planner.set_flow(motion.extruder, 100);
+
+  auto cleanup = [&]() {
+    motion.feedrate_percentage = old_feedrate_percentage;
+    planner.set_flow(motion.extruder, old_flow);
+  };
+
+  auto extrude_to = [](const float x, const float y, const float e, const feedRate_t fr) {
+    motion.destination = motion.position;
+    motion.destination.x = x;
+    motion.destination.y = y;
+    motion.destination.e += e;
+    motion.feedrate_mm_s = fr;
+    motion.prepare_line_to_destination();
+  };
+
+  #if HAS_HOTEND
+    thermalManager.setTargetHotend(BD_PRESSURE_PA_TEMP, motion.extruder);
+    thermalManager.wait_for_hotend(motion.extruder);
+  #endif
+
+  write_reg(BDP_REG_MODE, BDP_MODE_PA);
+  write_reg(BDP_REG_RAW_OUT, 0);
+
+  // Prime the nozzle in place, at a controlled speed.
+  extrude_to(motion.position.x, motion.position.y, e_purge, fr_low);
+  planner.synchronize();
+  safe_delay(4000);
+
+  pa_sample_t samples[BD_PRESSURE_PA_PASSES];
+  uint8_t count = 0;
+
+  for (uint8_t i = 0; i < passes; ++i) {
+    const float pa = i * step;
+    planner.set_advance_k(pa);
+
+    const float y = y_start + i * (BD_PRESSURE_PA_Y_STEP);
+
+    motion.blocking_move(xy_pos_t({ x_start, y }), fr_travel);
+
+    // Clear the result register so a stale read is distinguishable from a
+    // fresh one. Nothing in the module's firmware reads this field.
+    const uint8_t nul = 0;
+    write_reg(BDP_REG_MEASURE, &nul, 1);
+
+    extrude_to(x_mid1, y, e_acc,    fr_low);
+    extrude_to(x_mid2, y, e_cruise, fr_high);
+    extrude_to(x_end,  y, e_dec,    fr_low);
+    planner.synchronize();
+
+    // Poll for the new result rather than assuming it is ready.
+    pa_sample_t s;
+    bool got = false;
+    for (uint8_t tries = 0; tries < 20; ++tries) {
+      if (read_sample(s)) { got = true; break; }
+      safe_delay(50);
+      marlin.idle();
+    }
+
+    if (!got) {
+      SERIAL_ERROR_MSG("BD_PRESSURE: no result for pass ", i);
+      cleanup();
+      planner.set_advance_k(old_k);
+      return;
+    }
+
+    s.pa = pa;
+    samples[count++] = s;
+
+    SERIAL_ECHOLNPGM("BD_PRESSURE pass ", i, " K", p_float_t(pa, 4),
+                     " res:", s.res, " lk:", s.lk, " rk:", s.rk,
+                     " Hk:", s.hk, " Ha:", s.ha);
+
+    // Stop once the pressure peak has flattened out - more PA is not doing
+    // anything. Needs a decent run of samples before it means much.
+    if (count >= 20) {
+      bool flat = true;
+      for (uint8_t j = count - 5; j < count; ++j)
+        if (!(samples[j].hk < 2 || samples[j].ha < 5)) { flat = false; break; }
+      if (flat) break;
+    }
+
+    marlin.idle();
+  }
+
+  cleanup();
+
+  // Choosing the value. Throw away the obviously under-compensated start,
+  // find where the curve goes flat, then take the best point in the flat
+  // region. This is what a human does eyeballing a PA tower.
+  constexpr uint8_t skip = 5;
+  if (count <= skip) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: not enough samples");
+    planner.set_advance_k(old_k);
+    return;
+  }
+
+  int8_t flat_from = -1;
+  for (int8_t i = count - 1; i >= skip; --i)
+    if (samples[i].hk < 5) { flat_from = i; break; }
+
+  if (flat_from < 0)
+    for (int8_t i = count - 1; i >= skip; --i)
+      if (samples[i].ha < 5) { flat_from = i; break; }
+
+  if (flat_from < 0) {
+    SERIAL_ERROR_MSG("BD_PRESSURE: no flat region found - PA not calibrated");
+    planner.set_advance_k(old_k);
+    return;
+  }
+
+  uint8_t best = flat_from;
+  int32_t best_score = INT32_MAX;
+  for (uint8_t i = flat_from; i < count; ++i) {
+    const int32_t score = samples[i].res + ABS(samples[i].ha);
+    if (score < best_score) { best_score = score; best = i; }
+  }
+
+  planner.set_advance_k(samples[best].pa);
+
+  SERIAL_ECHOLNPGM("BD_PRESSURE: K", p_float_t(samples[best].pa, 4),
+                   " (sample ", best, " of ", count, ")");
+  SERIAL_ECHOLNPGM("Use M900 K", p_float_t(samples[best].pa, 4), " and M500 to keep it.");
+}
+
+#endif // BD_PRESSURE_PA
+
+#endif // BD_PRESSURE

--- a/Marlin/src/feature/bd_pressure.h
+++ b/Marlin/src/feature/bd_pressure.h
@@ -1,0 +1,129 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2026 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * feature/bd_pressure.h - bd_pressure strain gauge over I2C
+ *
+ * A BF350-1EB strain gauge on an STM32C0 with an ADS1220 ADC, which does two
+ * unrelated jobs: nozzle-contact detection (a plain endstop output, needing no
+ * firmware) and Pressure Advance calibration (all host-side).
+ *
+ * Not to be confused with BD_SENSOR, which is a different device by the same
+ * author with a different protocol.
+ */
+
+#include "../inc/MarlinConfig.h"
+
+// Register file. A flat byte array with an auto-incrementing pointer;
+// there is no command set. Offsets are into the device's `Receive_D` struct.
+enum BDPRegister : uint8_t {
+  BDP_REG_VERSION   =  0,   // 16 bytes, R  - "pandapi3dv1\n", NUL-padded
+  BDP_REG_MEASURE   = 16,   // 32 bytes, R  - latest result string, "R:res,lk,rk,Hk,Ha\n"
+  BDP_REG_MODE      = 48,   //  1 byte,  W  - BDP_MODE_PROBE or BDP_MODE_PA
+  BDP_REG_RAW_OUT   = 49,   //  1 byte,  W  - 1 = stream raw samples on the module's UART
+  BDP_REG_THRESHOLD = 50,   //  1 byte,  W  - probe trigger threshold
+  BDP_REG_RANGE     = 51,   //  1 byte,  R  - peak-to-peak of the last window
+  BDP_REG_TARE      = 52,   //  1 byte,  W  - BDP_TARE_*
+  BDP_REG_INVERT    = 53    //  1 byte,  W  - sign of the raw reading
+};
+
+// Mode values are ADC oversampling settings, not arbitrary ids.
+enum BDPMode : uint8_t {
+  BDP_MODE_PROBE = 2,       // CLOCK_OSR_512   - runs process_triggered()
+  BDP_MODE_PA    = 7        // CLOCK_OSR_16384 - runs Pressure_advance()
+};
+
+enum BDPTare : uint8_t {
+  BDP_TARE_AUTO     = 0,
+  BDP_TARE_NOW      = 1,
+  BDP_TARE_AUTO_OFF = 2
+};
+
+#define BDP_I2C_ADDRESS   0x04
+#define BDP_VERSION_ID    "pandapi3dv1"
+#define BDP_MEASURE_LEN     32
+
+class BDPressure {
+public:
+  /**
+   * @brief Bring up the I2C bus and check for the module.
+   * @details Reports a failure on the console rather than failing silently,
+   *          since two mistyped pins are otherwise indistinguishable from a
+   *          working bus with nothing on it.
+   * @return TRUE if the module answered with the expected version string.
+   */
+  static bool init();
+
+  static bool is_online() { return online; }
+
+  /**
+   * @brief Report the module version, threshold and range. (M900 D)
+   */
+  static void report();
+
+  #if ENABLED(BD_PRESSURE_PROBE)
+    /**
+     * @brief Put the module in probe mode and re-tare it before a probing move.
+     * @details Mirrors Klipper's handle_homing_move_begin. The mode write is
+     *          not redundant: a PA calibration leaves the module in PA mode,
+     *          where the endstop output stops being driven at all.
+     */
+    static void probe_prep();
+  #endif
+
+  #if ENABLED(BD_PRESSURE_PA)
+    /**
+     * @brief Run an automatic Pressure Advance calibration. (M900 C)
+     * @details Sweeps K from 0 in `step` increments, extruding one 80mm line
+     *          per pass, and reads the module's curve metrics after each.
+     *          Sets ADVANCE_K to the best value on success. Does not save.
+     * @param step   PA increment per pass
+     * @param passes Maximum number of passes
+     */
+    static void calibrate(const float step, const uint8_t passes);
+  #endif
+
+private:
+  static bool online;
+
+  // Transport
+  static bool write_reg(const uint8_t reg, const uint8_t * const data, const uint8_t len);
+  static bool write_reg(const uint8_t reg, const uint8_t value) { return write_reg(reg, &value, 1); }
+  static bool read_reg(const uint8_t reg, uint8_t * const data, const uint8_t len);
+  static bool read_str(const uint8_t reg, char * const str, const uint8_t len);
+
+  #if ENABLED(BD_PRESSURE_PA)
+    // One pass of the sweep. Fields are the module's own curve metrics.
+    struct pa_sample_t {
+      float pa;         // The K value this pass was run at
+      int16_t res;      // Combined residual - the figure of merit, lower is better
+      int16_t lk, rk;   // Width of the leading / trailing pressure ramp, in samples
+      int16_t hk;       // Peak height above baseline (x10)
+      int16_t ha;       // Difference between the two shoulder heights
+    };
+
+    static bool read_sample(pa_sample_t &s);
+  #endif
+};
+
+extern BDPressure bdp;

--- a/Marlin/src/feature/bd_pressure.h
+++ b/Marlin/src/feature/bd_pressure.h
@@ -105,6 +105,7 @@ public:
 
 private:
   static bool online;
+  static uint8_t mode;    // Last BDPMode written, to avoid needless ADC re-inits
 
   // Transport
   static bool write_reg(const uint8_t reg, const uint8_t * const data, const uint8_t len);

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -28,6 +28,10 @@
 #include "../../../module/planner.h"
 #include "../../../module/stepper.h"
 
+#if ENABLED(BD_PRESSURE_PA)
+  #include "../../../feature/bd_pressure.h"
+#endif
+
 #if ENABLED(ADVANCE_K_EXTRA)
   float other_extruder_advance_K[EXTRUDERS];
   uint8_t lin_adv_slot = 0;
@@ -44,8 +48,26 @@
  *
  * With SMOOTH_LIN_ADVANCE:
  *  U<tau>      Set a tau value for LA smoothing
+ *
+ * With BD_PRESSURE_PA:
+ *  C           Run an automatic calibration and set K to the result
+ *  V<step>     ...with this PA increment per pass
+ *  P<passes>   ...and at most this many passes
+ *  D           Report the bd_pressure module version and threshold
  */
 void GcodeSuite::M900() {
+
+  #if ENABLED(BD_PRESSURE_PA)
+    if (parser.seen('D')) { bdp.report(); return; }
+    if (parser.seen('C')) {
+      const float step = parser.floatval('V', BD_PRESSURE_PA_STEP);
+      const uint8_t passes = _MIN(parser.byteval('P', BD_PRESSURE_PA_PASSES), BD_PRESSURE_PA_PASSES);
+      if (step <= 0) { SERIAL_ECHOLNPGM("?V value out of range."); return; }
+      if (passes < 10) { SERIAL_ECHOLNPGM("?P value out of range (10-", BD_PRESSURE_PA_PASSES, ")."); return; }
+      bdp.calibrate(step, passes);
+      return;
+    }
+  #endif
 
   auto echo_value_oor = [](const char ltr, const bool ten=true) {
     SERIAL_CHAR('?', ltr);

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -848,6 +848,50 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
 #endif // LIN_ADVANCE
 
 /**
+ * bd_pressure
+ */
+#if ENABLED(BD_PRESSURE)
+  #if NONE(BD_PRESSURE_PROBE, BD_PRESSURE_PA)
+    #error "BD_PRESSURE requires BD_PRESSURE_PROBE and/or BD_PRESSURE_PA. (The endstop output needs no firmware support.)"
+  #elif !PINS_EXIST(BD_PRESSURE_I2C_SDA, BD_PRESSURE_I2C_SCL)
+    #error "BD_PRESSURE requires BD_PRESSURE_I2C_SDA_PIN and BD_PRESSURE_I2C_SCL_PIN."
+  #elif BD_PRESSURE_I2C_SDA_PIN == BD_PRESSURE_I2C_SCL_PIN
+    #error "BD_PRESSURE_I2C_SDA_PIN and BD_PRESSURE_I2C_SCL_PIN must be different."
+  #elif BD_PRESSURE_I2C_DELAY < 1
+    #error "BD_PRESSURE_I2C_DELAY must be at least 1."
+  #endif
+  #if ENABLED(BD_PRESSURE_PROBE)
+    #if !WITHIN(BD_PRESSURE_THRESHOLD, 1, 255)
+      #error "BD_PRESSURE_THRESHOLD must be from 1 to 255."
+    #elif HOMING_Z_WITH_PROBE && IS_CARTESIAN && DISABLED(Z_SAFE_HOMING)
+      // Not just recommended, as it is for an offset probe: the nozzle is the
+      // sensor, so Z homing at an arbitrary XY drives the nozzle into whatever
+      // is there. NO_Z_SAFE_HOMING_WARNING deliberately does not suppress this.
+      #error "BD_PRESSURE_PROBE with Z homing requires Z_SAFE_HOMING. (The nozzle is the probe, so Z must home over a known-safe spot.)"
+    #endif
+  #endif
+  #if ENABLED(BD_PRESSURE_PA)
+    #if DISABLED(LIN_ADVANCE)
+      #error "BD_PRESSURE_PA requires LIN_ADVANCE."
+    #elif !HAS_EXTRUDERS
+      #error "BD_PRESSURE_PA requires at least one extruder."
+    #elif !WITHIN(BD_PRESSURE_PA_PASSES, 10, 100)
+      #error "BD_PRESSURE_PA_PASSES must be from 10 to 100."
+    #endif
+    static_assert(BD_PRESSURE_PA_STEP > 0, "BD_PRESSURE_PA_STEP must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_NOZZLE > 0, "BD_PRESSURE_PA_NOZZLE must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_FLOW > 0, "BD_PRESSURE_PA_FLOW must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_VOLUMETRIC > 0, "BD_PRESSURE_PA_VOLUMETRIC must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_Y_STEP > 0, "BD_PRESSURE_PA_Y_STEP must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_TRAVEL_SPEED > 0, "BD_PRESSURE_PA_TRAVEL_SPEED must be greater than 0.");
+    static_assert(BD_PRESSURE_PA_STEP * (BD_PRESSURE_PA_PASSES) <= 10,
+                  "BD_PRESSURE_PA_STEP x BD_PRESSURE_PA_PASSES would exceed the ADVANCE_K limit of 10.");
+  #endif
+#elif ANY(BD_PRESSURE_PROBE, BD_PRESSURE_PA)
+  #error "BD_PRESSURE_PROBE and BD_PRESSURE_PA require BD_PRESSURE."
+#endif
+
+/**
  * S_CURVE_ACCELERATION
  */
 #if ENABLED(S_CURVE_ACCELERATION) && defined(S_CURVE_FACTOR)

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -46,6 +46,10 @@
   #include "../feature/bedlevel/bdl/bdl.h"
 #endif
 
+#if ENABLED(BD_PRESSURE_PROBE)
+  #include "../feature/bd_pressure.h"
+#endif
+
 #if ENABLED(DELTA)
   #include "delta.h"
 #endif
@@ -626,6 +630,11 @@ bool Probe::probe_down_to_z(const float z, const feedRate_t fr_mm_s) {
   #if ALL(HAS_TEMP_HOTEND, WAIT_FOR_HOTEND)
     thermalManager.wait_for_hotend_heating(motion.extruder);
   #endif
+
+  // Put the bd_pressure module in probe mode and re-tare it, as Klipper does
+  // on homing_move_begin. A PA calibration leaves it in PA mode, where it
+  // stops driving the endstop output altogether.
+  TERN_(BD_PRESSURE_PROBE, bdp.probe_prep());
 
   #if ENABLED(BLTOUCH)
     // Ensure the BLTouch is deployed. (Does nothing if already deployed.)

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -221,6 +221,7 @@ AUTO_BED_LEVELING_(3POINT|(BI)?LINEAR) = build_src_filter=+<src/gcode/bedlevel/a
 X_AXIS_TWIST_COMPENSATION              = build_src_filter=+<src/feature/x_twist.cpp> +<src/lcd/menu/menu_x_twist.cpp> +<src/gcode/probe/M423.cpp>
 BD_SENSOR                              = markyue/Panda_SoftMasterI2C
                                          build_src_filter=+<src/feature/bedlevel/bdl> +<src/gcode/probe/M102.cpp>
+BD_PRESSURE                            = build_src_filter=+<src/feature/bd_pressure.cpp>
 MESH_BED_LEVELING                      = build_src_filter=+<src/feature/bedlevel/mbl> +<src/gcode/bedlevel/mbl>
 AUTO_BED_LEVELING_UBL                  = build_src_filter=+<src/feature/bedlevel/ubl> +<src/gcode/bedlevel/ubl>
 UBL_HILBERT_CURVE                      = build_src_filter=+<src/feature/bedlevel/hilbert_curve.cpp>


### PR DESCRIPTION
### Not tested on hardware

**No part of this has run against a real module.** It is written from the
upstream firmware, the Klipper driver and the board schematic, all of which are
in the repository at <https://github.com/markniu/bd_pressure> — the wire protocol
is not documented anywhere else. The protocol work is verifiable with a logic
analyser; the calibration algorithm is not verifiable without printing. Treat
this as a review-ready implementation of a documented-by-reading protocol, not
as a proven feature.

The specific things a first hardware run would settle:

- Whether 10 kHz is required or merely conservative. It is the only rate the
  device is known to work at, so it is the rate this ships at.
- How long after `M400` the module needs before a new result string appears.
  The poll allows 1 s; that number is a guess.
- Whether Klipper's `ADVANCE_K` and Marlin's are numerically interchangeable.
  Both are seconds by dimensional analysis, and the swept range matches what
  Marlin users expect, but it has not been checked against a manual PA tower.
- Whether the module drives its endstop pin push-pull or open-drain, which
  decides only whether Z-STOP wants a pull-up.

---

### What the device is

A BF350-1EB strain gauge between the hotend and the toolhead, read by an
ADS1220 on an STM32C0. It does two unrelated jobs:

| Mode | What it does | Firmware needed |
|---|---|---|
| Probe | Nozzle-contact detection, driving a plain endstop output | **None** — it is a switch on Z-MIN |
| Pressure Advance | Reports curve metrics through an accel/decel move; the host sweeps K and picks the best | All of it |

This is **not** `BD_SENSOR`. Same author, different device, different protocol
(byte-addressed register file at 0x04 vs 16-bit words at 0x3C). The two can
share a bus; no code is shared.

### What this adds

`BD_PRESSURE` means "the I2C bus is wired up". Two sub-options are what Marlin
does over it, and neither implies the other:

- **`BD_PRESSURE_PROBE`** — sets the trigger threshold and re-tares the module
  before each probing move, from `Probe::probe_down_to_z()`. This mirrors
  Klipper's `handle_homing_move_begin`. The probe works without it; what it buys
  is a clean baseline per probe point, and it is what makes the two roles
  composable — a PA run leaves the module in PA mode, where the endstop output
  stops being driven at all.

- **`BD_PRESSURE_PA`** — automatic Pressure Advance calibration on `M900 C`.
  Sweeps K from 0, extrudes one 80 mm line per pass (20 mm slow / 40 mm fast /
  20 mm slow), reads the module's curve metrics after each, stops when the
  pressure peak flattens, and picks the best point in the flat region.
  Sets `ADVANCE_K` and reports it. Deliberately does **not** save to EEPROM —
  PA is per-filament.

New G-code, all on the existing `M900` under `BD_PRESSURE_PA`:

| Command | Action |
|---|---|
| `M900 C` | Calibrate and set K to the result |
| `M900 C V<step>` | ...with this K increment per pass |
| `M900 C P<passes>` | ...and at most this many passes |
| `M900 D` | Report module version, threshold and range — a connection test |

### Transport

Software I2C, ~100 lines in `bd_pressure.cpp`, on any two GPIOs. Neither
software I2C library Marlin already carries could be used:
`Panda_SoftMasterI2C` (the `BD_SENSOR` one) has the right bit period but its
only write helper hard-codes register 0 and stops at a NUL, so it cannot set
registers 48–53; `SlowSoftWire` has the full API but a hard-coded 4 µs period
and a `setClock()` that does nothing. Writing both instead of patching either
avoids an upstream dependency on someone else's repository — and it adds real
clock stretching, which neither library implements and which this device
enables and needs.

Hardware I2C is not an option here: `Wire.setClock(10000)` cannot produce
10 kHz on STM32 (anything ≤100 kHz buckets to standard mode), the I2C pins are
configured `GPIO_NOPULL` while the module carries no pull-ups either, and a bad
pin choice fails silently.

No pull-up resistors are needed — releasing a line is `SET_INPUT_PULLUP`, the
same as `BD_SENSOR`.

A failed bus is reported at boot rather than failing silently: a stuck line and
a missing device get different messages, and `M900 D` repeats the check on
demand.

### Configuration

New block in `Configuration.h`, after `PROBE_TARE` — whose own comment ("useful
for a strain gauge or piezo sensor…") describes this device exactly:

```cpp
//#define BD_PRESSURE
#if ENABLED(BD_PRESSURE)
  #define BD_PRESSURE_I2C_SDA_PIN     -1  // Any free GPIO. Software I2C, so no pull-ups needed.
  #define BD_PRESSURE_I2C_SCL_PIN     -1
  #define BD_PRESSURE_I2C_DELAY       50  // (us) Half bit period. 50 = ~10kHz, the known-good rate.

  //#define BD_PRESSURE_PROBE             // Set the trigger threshold and re-tare before probing
  //#define BD_PRESSURE_PA                // Automatic Pressure Advance calibration (M900 C). Needs LIN_ADVANCE.
#endif
```

(Sub-option settings elided; see the diff.)

Sanity checks cover: `BD_PRESSURE` with neither sub-option, unset or identical
pins, a sub-option without `BD_PRESSURE`, `BD_PRESSURE_PA` without
`LIN_ADVANCE` or without an extruder, out-of-range pass counts and step sizes,
and a sweep that would exceed the `ADVANCE_K` limit of 10.

One check is a hard `#error` rather than Marlin's suppressible warning:
`BD_PRESSURE_PROBE` with `HOMING_Z_WITH_PROBE` on a cartesian requires
`Z_SAFE_HOMING`, and `NO_Z_SAFE_HOMING_WARNING` does not lift it. With an
offset probe, homing Z at an arbitrary XY risks a bad reading; here the nozzle
*is* the sensor, so it drives a hot nozzle into whatever is under it.

### Two protocol details worth flagging in review

- **The result register is never cleared by the device.** Reading it after a
  pass can return the previous pass's numbers, which the host would then record
  against the wrong K value. The Klipper driver has this race on its I2C path.
  Here a NUL is written to the register before the move and the read polls until
  the string is non-empty, failing the run loudly on timeout rather than
  recording a guess.

- **The tare is not a snapshot.** The module averages the last 30 samples
  already in its buffer, bypassing its own "too noisy to tare" check. So the
  settling time has to come *before* the tare, not after: stop, wait for the
  buffer to refill with quiet samples, then write. This is what the reference
  config's three consecutive `PA_RESET` calls are doing by accident.

### What this does not do

- No USB/serial transport. I2C only; nothing is lost, as the Klipper driver's
  I2C path runs the whole calibration.
- No hardware I2C.
- No raw sample streaming — it only leaves the module's UART, and is a debug
  aid, not an input to the calibration.
- No `bd_width` support. Different device.
- No automatic per-filament storage of the calibrated K.
- No firmware for the plain endstop. The module drives Z-MIN on its own with
  `Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN`; `BD_PRESSURE_PROBE` improves that path,
  it is not required for it.
- No check that the two I2C pins collide with nothing else. Marlin has no
  reusable mechanism for it, and `BD_SENSOR` does not do it either.

### Files

```
Marlin/Configuration.h                      option block
Marlin/src/feature/bd_pressure.cpp/.h       transport, register access, both roles
Marlin/src/gcode/feature/advance/M900.cpp   C / V / P / D
Marlin/src/module/probe.cpp                 probe_prep() hook
Marlin/src/MarlinCore.cpp                   bdp.init()
Marlin/src/inc/SanityCheck.h                checks
ini/features.ini                            build_src_filter
```
