### PR TITLE
🐛 Fix null parser state restore

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1239,7 +1239,7 @@ void GcodeSuite::process_subcommands_now(FSTR_P fgcode) {
     if (!delim) break;                                // Last command?
     pgcode = delim + 1;                               // Get the next command
   }
-  parser.parse(saved_cmd);                            // Restore the parser state
+  if (saved_cmd) parser.parse(saved_cmd);             // Restore the parser state (if any)
 }
 
 #pragma GCC diagnostic pop
@@ -1255,7 +1255,7 @@ void GcodeSuite::process_subcommands_now(char * gcode) {
     *delim = '\n';                                    // Put back the newline
     gcode = delim + 1;                                // Get the next command
   }
-  parser.parse(saved_cmd);                            // Restore the parser state
+  if (saved_cmd) parser.parse(saved_cmd);             // Restore the parser state (if any)
 }
 
 #if ENABLED(HOST_KEEPALIVE_FEATURE)


### PR DESCRIPTION
### Description

`GCodeParser::command_ptr` is null until the first call to `GCodeParser::parse()`. Both `GcodeSuite::process_subcommands_now()` overloads save it on entry and pass it back to `parser.parse()` on exit, and `parse()` dereferences its argument in its first statement (`while (*p == ' ') ++p;`). So any call to `process_subcommands_now()` made before a G-code has been parsed dereferences null.

This patch skips the restore when there is nothing to restore.

The most common way to hit it is `PSU_CONTROL` with `PSU_POWERUP_GCODE` defined and `PSU_DEFAULT_OFF` disabled. `powerManager.init()` runs from `setup()`, takes the power-on branch, and `Power::power_on()` calls `process_subcommands_now(F(PSU_POWERUP_GCODE))` before anything has been parsed — the board faults during startup, giving a boot loop.

`CUSTOM_USER_BUTTONS` with `BUTTON*_IMMEDIATE` hits it the same way on the first button press after boot. Any other caller reached as the first G-code activity after boot is equally exposed, including `PSU_POWEROFF_GCODE`, the `M810`-`M819` macros, `G12`, `G28`, `G29`, `G30`, `G34`, `G35`, `G425`, `M605`, `M1001` and power-loss recovery.

```
Thread ... received signal SIGSEGV, Segmentation fault.
#0  GCodeParser::parse (p=0x0)                        at gcode/parser.cpp:122
#1  GcodeSuite::process_subcommands_now (fgcode=...)  at gcode/gcode.cpp:1242
```

### Requirements

None.

### Benefits

Boards no longer crash at startup with `PSU_POWERUP_GCODE` set.

### Configurations

Reproduced and verified on `linux_native` with the default configuration plus:

```
#define MOTHERBOARD BOARD_SIMULATED
#define PSU_CONTROL
#define PSU_POWERUP_GCODE "M355 S1"
```

Before the patch the simulator segfaults during `setup()`; after it, startup completes.

### Related Issues

None.
