### PR TITLE
🧑‍💻 Add pioarduino to unwanted recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     ],
     "unwantedRecommendations": [
         "ms-vscode-remote.remote-containers",
-        "ms-vscode.cpptools-extension-pack"
+        "ms-vscode.cpptools-extension-pack",
+        "pioarduino.pioarduino-ide"
     ]
 }


### PR DESCRIPTION
### Description

PlatformIO Core's `extensions.json` template now adds `pioarduino.pioarduino-ide` to `unwantedRecommendations`, so switching to Marlin leaves a dirty diff. Add it here so the file matches.

### Benefits

No more dirty `extensions.json` diffs

### Related Issues

- [PlatformIO Core `extensions.json` template](https://github.com/platformio/platformio-core/blob/develop/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl)
- https://community.platformio.org/t/platformio-shows-up-as-pioarduino/54216/8