### PR TITLE
🐛 Skip hidden folders in ONE_CLICK_PRINT search

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1056,6 +1056,9 @@ void CardReader::write_command(char * const buf) {
     parent.rewind();
     for (dir_t p; parent.readDir(&p, longFilename) > 0;) {
 
+      // Skip hidden items, e.g., macOS .Spotlight-V100 and .fseventsd
+      if (p.attributes & DIR_ATT_HIDDEN) continue;
+
       // If the item is a dir, recurse into it
       if (DIR_IS_SUBDIR(&p)) {
         // Get the name of the dir for opening


### PR DESCRIPTION
### Description

`diveToNewestFile()` searched every subfolder, including hidden ones. A drive formatted on macOS gets a hidden `.Spotlight-V100` folder as soon as it's mounted, and one of its index files (`tmp.Glow`, 8.3 name `TM~7.GLO`) passes the `.G*` extension check. So even a freshly erased drive asked to print `tmp.Glow`. Hidden entries are now skipped.

### Requirements

`ONE_CLICK_PRINT` with an SD card or USB flash drive.

### Benefits

`ONE_CLICK_PRINT` no longer offers to print macOS metadata files.

### Configurations

Any config with `ONE_CLICK_PRINT`. Tested on a Prusa Buddy with a macOS-formatted USB flash drive.

### Related Issues

None
