### PR TITLE
Enable Maple support for MKS Robin E3 V1.1

### DIFF
--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -80,8 +80,8 @@ typedef uint16_t hal_timer_t;
   //#define MF_TIMER_TEMP       4  // 2->4, Timer 2 for Stepper Current PWM
 #endif
 
-#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE, MKS_ROBIN_E3D, MKS_ROBIN_E3, VOXELAB_AQUILA)
-  // SKR Mini E3 boards use PA8 as FAN0_PIN, so TIMER 1 is used for Fan PWM.
+#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE, MKS_ROBIN_E3D, MKS_ROBIN_E3D_V1_1, MKS_ROBIN_E3, MKS_ROBIN_E3_V1_1, VOXELAB_AQUILA)
+  // These boards use PA8 as FAN0_PIN, so TIMER 1 is used for Fan PWM.
   #ifdef STM32_HIGH_DENSITY
     #define MF_TIMER_SERVO0  8  // tone.cpp uses Timer 4
   #else

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -595,9 +595,9 @@
 #elif MB(MKS_ROBIN_E3)
   #include "stm32f1/pins_MKS_ROBIN_E3.h"            // STM32F1                              env:mks_robin_e3 env:mks_robin_e3_maple
 #elif MB(MKS_ROBIN_E3_V1_1)
-  #include "stm32f1/pins_MKS_ROBIN_E3_V1_1.h"       // STM32F1                              env:mks_robin_e3
+  #include "stm32f1/pins_MKS_ROBIN_E3_V1_1.h"       // STM32F1                              env:mks_robin_e3 env:mks_robin_e3_maple
 #elif MB(MKS_ROBIN_E3D)
-  #include "stm32f1/pins_MKS_ROBIN_E3D.h"           // STM32F1                              env:mks_robin_e3
+  #include "stm32f1/pins_MKS_ROBIN_E3D.h"           // STM32F1                              env:mks_robin_e3 env:mks_robin_e3_maple
 #elif MB(MKS_ROBIN_E3D_V1_1)
   #include "stm32f1/pins_MKS_ROBIN_E3D_V1_1.h"      // STM32F1                              env:mks_robin_e3 env:mks_robin_e3_maple
 #elif MB(MKS_ROBIN_E3P)


### PR DESCRIPTION
Allow the MKS Robin E3/E3D family to consistently use the existing Maple environment.

### Description

Enable the existing `mks_robin_e3_maple` environment for MKS Robin E3 V1.1
and extend the existing Robin E3/E3D Maple servo-timer handling to both V1.1
variants.

MKS Robin E3/E3D V1.1 support was added in
`8c59212ca46a3a9f721b2216bb538c0b42a3992f` (#20216) using the
`mks_robin_e3` environment.

The BLTouch / fan PWM timer conflict on the original MKS Robin E3 and E3D
boards was later fixed in
`ebb75a529b8f9d3b53dac12ffc6301d515a1cdaa` (#21889). That change added
`MKS_ROBIN_E3` and `MKS_ROBIN_E3D` to the STM32F1 servo-timer exception
because these boards use PA8 for fan PWM, which otherwise conflicts with
servo / BLTouch timing on Timer 1. The V1.1 board variants were not included
in that exception.

Maple support for the original MKS Robin E3 was later added in
`ce95f56ac8755eff188001e12c88e01ae8e65f0e` (#21927), but E3 V1.1 was
not added to the Maple environment whitelist.

Although #21927 notes the goal of moving away from libmaple, #28576 documents
an EEPROM issue with the non-Maple environment on MKS Robin E3 V1.1. Maple
passes the same EEPROM stress test on the same hardware. The underlying
EEPROM issue is separate from this PR.

MKS Robin E3D V1.1 was later made Maple-enabled in
`769ad2764512b38e987ebbed1fe026d68a424bb1` (#25558), as part of the
"TMC SPI Pins" changes. However, the STM32F1 timer exception was not updated
at the same time.

This leaves two inconsistencies:

- `MKS_ROBIN_E3_V1_1` is not currently allowed to use the existing Maple
  environment.
- `MKS_ROBIN_E3D_V1_1` is already Maple-enabled, but is missing from the
  existing Robin E3/E3D servo-timer exception.

This PR enables Maple for E3 V1.1 and adds both V1.1 variants to the existing
timer exception. Both inherit PA8 as `FAN0_PIN`, so this keeps servo / BLTouch
timing off Timer 1, which is used for fan PWM.

This PR:

- Enables `mks_robin_e3_maple` for `MKS_ROBIN_E3_V1_1`.
- Adds `MKS_ROBIN_E3_V1_1` to the existing STM32F1 Maple servo timer exception.
- Adds `MKS_ROBIN_E3D_V1_1` to the same exception, since it inherits the same PA8 fan mapping and is already Maple-enabled.
- Updates the timer comment to apply to all boards in the condition.

On STM32F103RC / high-density targets this keeps:

- Timer 1 for PA8 fan PWM
- Timer 2 for the temperature ISR
- Timer 5 for the stepper ISR
- Timer 8 for servo / BLTouch timing


### Requirements

Tested on:

- MKS Robin E3 V1.1
- STM32F103RCT6
- `mks_robin_e3_maple`
- BLTouch
- PA8 part-cooling fan

Note that for the E3D variant, the timer-servo conflict was not seen nor was the fix tested on hardware, but implied through inference. I do not have an E3D.


### Benefits

- Enables Maple support for MKS Robin E3 V1.1.
- Prevents the fan PWM and servo / BLTouch from sharing Timer 1.
- Applies the existing Robin E3 / E3D timer handling to the corresponding V1.1 boards.

### Configurations

[Marlin-config.zip](https://github.com/user-attachments/files/32152789/Marlin-config.zip)

Mainly the below configuration is most relevant. Build with the _maple env
```cpp
#define MOTHERBOARD BOARD_MKS_ROBIN_E3_V1_1
```

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/28576



The Maple environment was being evaluated as part of the EEPROM investigation in that issue. During testing, the Timer 1 conflict between PA8 fan PWM and servo / BLTouch timing was identified. 
