### PR TITLE
🐛 Recover I2C EEPROM from a stuck bus

### DIFF
--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -56,6 +56,13 @@ void eeprom_init() {
 #ifndef EEPROM_DEVICE_ADDRESS
   #define EEPROM_DEVICE_ADDRESS  0x50
 #endif
+#ifndef EEPROM_I2C_TRIES
+  #define EEPROM_I2C_TRIES       3
+#endif
+
+// Wire::endTransmission status for "no ACK on address", meaning no such device.
+// Any other non-zero status is a bus fault, which a re-init may clear.
+#define I2C_NO_ACK_ADDR          2
 
 static constexpr uint8_t eeprom_device_address = I2C_ADDRESS(EEPROM_DEVICE_ADDRESS);
 
@@ -83,21 +90,37 @@ static void _eeprom_begin(uint8_t * const pos) {
   eWire.write(uint8_t(eeprom_address & 0xFF));           // Address Low
 }
 
-void eeprom_write_byte(uint8_t *pos, uint8_t value) {
-  _eeprom_begin(pos);
-  eWire.write(value);
-  eWire.endTransmission();
+// A disturbed I2C bus can leave the peripheral stuck, and some Wire back-ends neither
+// recover from that nor report it, so a transfer can "succeed" with stale or no data.
+// Verify every transfer and re-initialize the bus before trying again.
 
-  // wait for write cycle to complete
-  // this could be done more efficiently with "acknowledge polling"
-  delay(EEPROM_WRITE_DELAY);
+void eeprom_write_byte(uint8_t *pos, uint8_t value) {
+  for (uint8_t t = EEPROM_I2C_TRIES; t--;) {
+    _eeprom_begin(pos);
+    eWire.write(value);
+    const uint8_t err = eWire.endTransmission();
+    if (err == I2C_NO_ACK_ADDR) break;           // Nothing is listening. Don't retry.
+    if (!err) {
+      // wait for write cycle to complete
+      // this could be done more efficiently with "acknowledge polling"
+      delay(EEPROM_WRITE_DELAY);
+      if (eeprom_read_byte(pos) == value) return;  // Confirm the byte was stored
+    }
+    eeprom_init();                               // Reset the bus and try again
+  }
 }
 
 uint8_t eeprom_read_byte(uint8_t *pos) {
-  _eeprom_begin(pos);
-  eWire.endTransmission();
-  eWire.requestFrom(_eeprom_calc_device_address(pos), (byte)1);
-  return eWire.available() ? eWire.read() : 0xFF;
+  for (uint8_t t = EEPROM_I2C_TRIES; t--;) {
+    _eeprom_begin(pos);
+    const uint8_t err = eWire.endTransmission();
+    if (err == I2C_NO_ACK_ADDR) break;           // Nothing is listening. Don't retry.
+    if (!err && eWire.requestFrom(_eeprom_calc_device_address(pos), (byte)1) && eWire.available())
+      return eWire.read();
+
+    eeprom_init();                               // Reset the bus and try again
+  }
+  return 0xFF;
 }
 
 #endif // USE_SHARED_EEPROM


### PR DESCRIPTION
### Description

`eeprom_write_byte()` and `eeprom_read_byte()` in `Marlin/src/HAL/shared/eeprom_if_i2c.cpp` discard the result of every Wire call and never attempt to recover the bus, so one disturbed I2C transaction corrupts the operation and `M500` aborts with `Error writing to EEPROM!`.

This patch verifies each transfer and, on failure, resets the I2C peripheral and retries (3 attempts). `endTransmission()` returning "no ACK on address" means no such device, and is not retried, so a board with no EEPROM fitted still fails immediately; any other non-zero status is a bus fault, which a reset may clear.

Two details matter for correctness. A failed read is reported separately from the byte it read, because 0xFF is valid EEPROM data and would otherwise be indistinguishable from the error return when verifying a write of 0xFF. And the reset calls `end()` before `eeprom_init()` on STM32duino, whose `TwoWire::begin()` nulls its heap buffer pointers without freeing them — `end()` is the only path that calls `free()`, so re-initializing without it would leak on every recovery. Back-ends that keep static buffers, and `SlowSoftWire` (which declares `end()` without defining it), are excluded.

The immediate case is #28576 on MKS Robin E3 V1.1 (STM32F103RC). Marlin's `common_stm32` environments pin `ststm32@~12.1`, which supplies `framework-arduinoststm32 4.10900.200819` (STM32duino core 1.9.0). In that core, `i2c_master_write()`/`i2c_master_read()` initialize `ret = I2C_OK` and only inspect the result inside `if (HAL_I2C_Master_Transmit_IT(...) == HAL_OK)`, with no `else` branch. When the STM32F1 HAL finds the I2C BUSY flag still set it returns `HAL_ERROR` with `State = HAL_I2C_STATE_READY` (0x20) and `ErrorCode = HAL_I2C_ERROR_TIMEOUT` (0x20) — the values captured under GDB in that report — and Wire reports success having moved no data. `TwoWire::requestFrom()` then sets `rxBufferLength` from the same false success, so `available()` returns 1 and `read()` hands back the previous byte still sitting in `rxBuffer`. That is the reported `expected 0x3F, actual 0x80`.

An STM32F1 BUSY flag that is stuck stays stuck until the peripheral is reset. libmaple's I2C driver disables and re-enables the peripheral after a protocol error; STM32duino never does, in 1.9.0 or in current releases. What leaves the bus BUSY in the first place is not established, and this patch does not claim to fix it — it recovers from it. Recovering in Marlin covers every Wire back-end rather than one board on one framework, and needs nothing from the framework, since a write that moved no data fails its read-back.

Updating the pinned framework is complementary rather than an alternative. STM32duino fixed the false success in [#1775](https://github.com/stm32duino/Arduino_Core_STM32/pull/1775), so a newer core would report the error instead of returning stale data — but no core version resets the peripheral outside `i2c_custom_init()`, so the bus would stay stuck and every following transfer would fail, honestly rather than silently. The pin is also `ststm32@~12.1` for every STM32 family, and Marlin's variants under `buildroot/share/PlatformIO/variants/` follow the 1.9.0 layout, so moving it is its own project.

The write path costs one extra read per changed byte, against the 5 ms write-cycle delay already spent on that byte. The absent-device path gets cheaper, because the address NACK now ends the operation instead of being ignored. The public `eeprom_read_byte()` signature is unchanged.

### Requirements

None. `EEPROM_I2C_TRIES` defaults to 3 and can be overridden by a board.

### Benefits

`M500` no longer aborts on a transient I2C fault, and the reported failure is fixed without restoring the obsolete Maple environment for this board.

### Configurations

Built with `I2C_EEPROM` active on four platforms covering the distinct Wire implementations:

| Environment | Board | Wire |
|---|---|---|
| `mks_robin_e3` | `BOARD_MKS_ROBIN_E3D_V1_1` | STM32duino hardware I2C |
| `STM32F103RC_btt` | `BOARD_BTT_SKR_MINI_E3_V2_0` | `SlowSoftWire` (`SOFT_I2C_EEPROM`) |
| `DUE` | `BOARD_RAMPS_SMART_EFB` | SAM |
| `LPC1768` | `BOARD_BTT_SKR_V1_4` | LPC |

Tested on MKS Robin E3D V1.1 hardware (STM32F103RCT6, onboard 4K I2C EEPROM — the same `pins_MKS_ROBIN_E3_V1_1_common.h` and the same `mks_robin_e3` environment as the reported board). One firmware carried both the current and patched driver, selectable at runtime, writing and immediately verifying all 256 bytes of the unused `0x0F00-0x0FFF` region, 0xFF among the values written since that doubles as the read-error return. The I2C1 peripheral was then wedged three ways — held in `SWRST`, and SDA or SCL held low — each confirmed stuck by reading `CR1`/`SR1`/`SR2` before and after. Holding SDA low reproduces the reported fault exactly: `SR2 = 2` (BUSY set) while `endTransmission()` still returns 0.

| After one disturbance | current | patched |
|---|---|---|
| peripheral held in `SWRST` | 255/256 fail, still wedged | 0/256, bus recovered |
| SDA held low | 255/256 fail, still stuck | 0/256, bus recovered |
| SCL held low | 255/256 fail, still stuck | 0/256, bus recovered |

The current driver never recovers: the peripheral is still wedged when the run ends, which is why the fault presents as a boot loop rather than a single bad save. On an undisturbed bus both drivers complete 1280 ops with no failures, and a missing EEPROM fails immediately under either.

### Related Issues

#28576
